### PR TITLE
feat(playtest): support multi-action preview flow

### DIFF
--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -34,4 +34,12 @@ describe('App', () => {
     expect(screen.getByRole('heading', { name: '资产库' })).toBeTruthy()
     expect(screen.queryByRole('heading', { name: '历史记录' })).toBeNull()
   })
+
+  it('provides a dedicated Playtest entry', () => {
+    window.history.replaceState({}, '', '/playtest')
+
+    render(<App />)
+
+    expect(screen.getByRole('heading', { name: 'Playtest' })).toBeTruthy()
+  })
 })

--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Routes } from 'react-router'
 import {
   createCharacterApis,
   createGenerationApis,
+  createPlaytestInspectionApis,
   createProjectApis,
   createWorkflowRunStore,
 } from '@/entities'
@@ -14,6 +15,7 @@ import { HistoryPage } from '@/pages/history'
 import { NotFoundPage } from '@/pages/not-found'
 import { PlaytestDemoPage } from '@/pages/playtest/demo-page'
 import { PlaytestPage } from '@/pages/playtest'
+import { PlaytestCatalogPage } from '@/pages/playtest/catalog'
 import { ProjectDetailPage } from '@/pages/project-detail'
 import { ProjectCreatePage } from '@/pages/project-create'
 import { ProjectsPage } from '@/pages/projects'
@@ -24,7 +26,14 @@ import { createAutoPrepareProject, createQuickStartService } from '@/pages/quick
 import { createWorkflowEditorService } from '@/pages/workflow-editor/service'
 
 function PlaytestFromBackend() {
-  const apis = useMemo(() => ({ characters: createCharacterApis() }), [])
+  const apis = useMemo(
+    () => ({
+      characters: createCharacterApis(),
+      projects: createProjectApis(),
+      inspections: createPlaytestInspectionApis(),
+    }),
+    [],
+  )
   return <PlaytestPage apis={apis} />
 }
 
@@ -72,7 +81,8 @@ export function App() {
         return { id: project.id, spriteSize: project.spriteSize }
       },
     })
-    return { projectApis, characterApis, quickStart, workflowEditor, store }
+    const playtestCatalog = { projects: projectApis, characters: characterApis }
+    return { projectApis, characterApis, quickStart, workflowEditor, store, playtestCatalog }
   }, [])
 
   return (
@@ -113,6 +123,10 @@ export function App() {
             element={<WorkflowEditorPage service={services.workflowEditor} />}
           />
           <Route path="/playtest/demo" element={<PlaytestDemoPage />} />
+          <Route
+            path="/playtest"
+            element={<PlaytestCatalogPage apis={services.playtestCatalog} />}
+          />
           <Route path="/playtest/:characterId/:outfitId" element={<PlaytestFromBackend />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -8,7 +8,7 @@ import { AppHeader } from './app-header'
 afterEach(cleanup)
 
 describe('AppHeader', () => {
-  it('保留三个产品入口，并将工作流路由归入创作', () => {
+  it('保留产品入口，并将工作流路由归入创作', () => {
     render(
       <MemoryRouter initialEntries={['/workflow-editor/run-1']}>
         <AppHeader />
@@ -18,5 +18,36 @@ describe('AppHeader', () => {
     expect(screen.getByRole('link', { name: '返回 Windup 首页' }).getAttribute('href')).toBe('/')
     expect(screen.getByRole('link', { name: '项目' }).getAttribute('href')).toBe('/projects')
     expect(screen.getByRole('link', { name: '创作' }).getAttribute('aria-current')).toBe('page')
+  })
+
+  it('在 Playtest 中随页面滚动，其余页面继续悬浮', () => {
+    const { container, unmount } = render(
+      <MemoryRouter initialEntries={['/playtest/25/outfit-25-default']}>
+        <AppHeader />
+      </MemoryRouter>,
+    )
+
+    expect(container.querySelector('header')?.className.split(' ')).toContain('relative')
+    expect(container.querySelector('header')?.className.split(' ')).not.toContain('fixed')
+    unmount()
+
+    const projects = render(
+      <MemoryRouter initialEntries={['/projects']}>
+        <AppHeader />
+      </MemoryRouter>,
+    )
+
+    expect(projects.container.querySelector('header')?.className.split(' ')).toContain('fixed')
+  })
+
+  it('将 Playtest 标记为独立核验工作区', () => {
+    render(
+      <MemoryRouter initialEntries={['/playtest/25/outfit-25-default']}>
+        <AppHeader />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('动作预览与质量核验')).toBeTruthy()
+    expect(screen.queryByText('项目与历史记录')).toBeNull()
   })
 })

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -16,7 +16,12 @@ const productNavigation: ProductNavigationItem[] = [
   {
     to: '/projects',
     label: '项目',
-    isActive: (pathname) => pathname.startsWith('/projects') || pathname.startsWith('/playtest'),
+    isActive: (pathname) => pathname.startsWith('/projects'),
+  },
+  {
+    to: '/playtest',
+    label: '预览台',
+    isActive: (pathname) => pathname.startsWith('/playtest'),
   },
   {
     to: '/quick-start',
@@ -27,7 +32,11 @@ const productNavigation: ProductNavigationItem[] = [
 ]
 
 function getWorkspaceLabel(pathname: string): { title: string; detail: string } {
-  if (pathname.startsWith('/projects') || pathname.startsWith('/playtest')) {
+  if (pathname.startsWith('/playtest')) {
+    return { title: 'Playtest', detail: '动作预览与质量核验' }
+  }
+
+  if (pathname.startsWith('/projects')) {
     return { title: '项目与历史记录', detail: '角色、动作与完成版本' }
   }
 
@@ -42,9 +51,14 @@ function getWorkspaceLabel(pathname: string): { title: string; detail: string } 
 export function AppHeader() {
   const { pathname } = useLocation()
   const workspace = getWorkspaceLabel(pathname)
+  const isPlaytest = pathname.startsWith('/playtest')
 
   return (
-    <header className="pointer-events-none fixed inset-x-0 top-3.5 z-50 flex items-start justify-between gap-2 px-3 text-[#1c231e] sm:gap-4 sm:px-[18px]">
+    <header
+      className={`pointer-events-none z-50 flex items-start justify-between gap-2 px-3 text-[#1c231e] sm:gap-4 sm:px-[18px] ${
+        isPlaytest ? 'relative pt-3.5' : 'fixed inset-x-0 top-3.5'
+      }`}
+    >
       <div className="pointer-events-auto flex min-h-[3.625rem] min-w-0 items-center gap-3 rounded-xl border border-[#171817]/14 bg-[#dfe3df] px-2.5 py-[7px] sm:min-w-[min(26rem,42vw)] sm:px-3.5">
         <Link
           to="/"

--- a/frontend/src/app/layout/index.test.tsx
+++ b/frontend/src/app/layout/index.test.tsx
@@ -10,6 +10,7 @@ afterEach(cleanup)
 describe('AppShell', () => {
   it.each([
     ['/', '首页'],
+    ['/playtest', 'Playtest'],
     ['/playtest/demo', 'Playtest'],
     ['/workflow-editor/run-1', 'Workflow Editor'],
   ])('为%s 使用全宽页面容器', (pathname) => {

--- a/frontend/src/app/layout/index.tsx
+++ b/frontend/src/app/layout/index.tsx
@@ -13,7 +13,7 @@ export interface AppShellProps {
 /** 全站外壳，全局导航常驻。 */
 export function AppShell({ children }: AppShellProps) {
   const { pathname } = useLocation()
-  const isPlaytestWorkspace = pathname.startsWith('/playtest/')
+  const isPlaytestWorkspace = pathname.startsWith('/playtest')
   const isWorkflowWorkspace = pathname.startsWith('/workflow-editor')
   const isHomePage = pathname === '/'
 

--- a/frontend/src/entities/character/api.ts
+++ b/frontend/src/entities/character/api.ts
@@ -8,7 +8,7 @@ import type {
   Outfit,
 } from '.'
 
-import { get, patch, post } from '@/shared/api'
+import { del, get, patch, post } from '@/shared/api'
 
 /* ─── 后端 DTO ─── */
 
@@ -16,6 +16,7 @@ interface BackendFrame {
   index: number
   image_url: string
   duration_ms: number | null
+  root_motion?: { dx: number; dy: number } | null
 }
 
 interface BackendAction {
@@ -62,7 +63,7 @@ function toFrame(raw: BackendFrame): Frame {
   return {
     imageUrl: raw.image_url,
     durationMs: raw.duration_ms,
-    rootMotion: null, // 后端不提供根位移
+    rootMotion: raw.root_motion ?? null,
   }
 }
 
@@ -114,7 +115,7 @@ export function createCharacterApis(): CharacterApis {
     async listByProject(projectId: string): Promise<Character[]> {
       // http-client 已解包 ApiEnvelope，data 字段就是角色数组本身
       const raw = await get<BackendCharacter[]>(
-        `/characters?project_id=${encodeURIComponent(projectId)}`,
+        `/characters?project_id=${encodeURIComponent(projectId)}&page_size=100`,
       )
       return raw.map(toCharacter)
     },
@@ -130,6 +131,7 @@ export function createCharacterApis(): CharacterApis {
 
     async update(character: Character): Promise<Character> {
       const payload = {
+        project_id: Number(character.projectId),
         character_data: {
           version: 1,
           outfits: character.outfits.map((outfit) => ({
@@ -148,13 +150,22 @@ export function createCharacterApis(): CharacterApis {
                 index,
                 image_url: frame.imageUrl,
                 duration_ms: frame.durationMs,
+                root_motion: frame.rootMotion,
               })),
             })),
           })),
         },
       }
       const raw = await patch<BackendCharacter>(`/characters/${character.id}`, payload)
-      return toCharacter(raw)
+      const saved = toCharacter(raw)
+      if (saved.projectId !== character.projectId) {
+        throw new Error('后端未保存新的项目归属')
+      }
+      return saved
+    },
+
+    async remove(id: string): Promise<void> {
+      await del(`/characters/${id}`)
     },
   }
 }

--- a/frontend/src/entities/character/index.ts
+++ b/frontend/src/entities/character/index.ts
@@ -134,4 +134,5 @@ export interface CharacterApis {
   listByProject(projectId: string): Promise<Character[]>
   create(input: CreateCharacterInput): Promise<Character>
   update(character: Character): Promise<Character>
+  remove(id: Character['id']): Promise<void>
 }

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -57,6 +57,16 @@ export type {
 export { createMediaApis } from './media/api'
 export type { MediaApis, MediaCategory, MediaReference } from './media'
 
+/* Playtest 核验 —— 每个动作当前最新的核验结论，不形成历史版本 */
+export { createPlaytestInspectionApis } from './playtest-inspection/api'
+export type {
+  PlaytestInspection,
+  PlaytestInspectionApis,
+  PlaytestInspectionStatus,
+  PlaytestInspectionTarget,
+  SavePlaytestInspectionInput,
+} from './playtest-inspection'
+
 /* 工作流 —— 节点与运行状态都由前端管理 */
 export { createWorkflowRunStore, WORKFLOW_STEP_ORDER } from './workflow-run'
 export type {

--- a/frontend/src/entities/playtest-inspection/api.ts
+++ b/frontend/src/entities/playtest-inspection/api.ts
@@ -1,0 +1,65 @@
+import { ApiError, get, post } from '@/shared/api'
+
+import type {
+  PlaytestInspection,
+  PlaytestInspectionApis,
+  PlaytestInspectionTarget,
+  SavePlaytestInspectionInput,
+} from '.'
+
+interface BackendPlaytestInspection {
+  id: number
+  character_id: number
+  outfit_id: string
+  action_id: string
+  status: PlaytestInspection['status']
+  create_at: string
+  update_at: string
+}
+
+function toInspection(raw: BackendPlaytestInspection): PlaytestInspection {
+  return {
+    id: String(raw.id),
+    characterId: String(raw.character_id),
+    outfitId: raw.outfit_id,
+    actionId: raw.action_id,
+    status: raw.status,
+    createdAt: raw.create_at,
+    updatedAt: raw.update_at,
+  }
+}
+
+function queryFor(target: PlaytestInspectionTarget): string {
+  const query = new URLSearchParams({
+    character_id: target.characterId,
+    outfit_id: target.outfitId,
+    action_id: target.actionId,
+  })
+  return query.toString()
+}
+
+export function createPlaytestInspectionApis(): PlaytestInspectionApis {
+  return {
+    async get(target) {
+      try {
+        const raw = await get<BackendPlaytestInspection>(
+          `/playtest-inspections?${queryFor(target)}`,
+        )
+        return toInspection(raw)
+      } catch (cause) {
+        if (cause instanceof ApiError && cause.code === 404) return null
+        throw cause
+      }
+    },
+
+    async save(input: SavePlaytestInspectionInput) {
+      const raw = await post<BackendPlaytestInspection>('/playtest-inspections', {
+        character_id: Number(input.characterId),
+        outfit_id: input.outfitId,
+        action_id: input.actionId,
+        status: input.status,
+      })
+      return toInspection(raw)
+    },
+  }
+}

--- a/frontend/src/entities/playtest-inspection/index.ts
+++ b/frontend/src/entities/playtest-inspection/index.ts
@@ -1,0 +1,24 @@
+/** Playtest 对某个动作保存的当前核验结论，不属于资产或创作历史。 */
+export type PlaytestInspectionStatus = 'passed' | 'issues_found'
+
+export interface PlaytestInspectionTarget {
+  characterId: string
+  outfitId: string
+  actionId: string
+}
+
+export interface PlaytestInspection extends PlaytestInspectionTarget {
+  id: string
+  status: PlaytestInspectionStatus
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SavePlaytestInspectionInput extends PlaytestInspectionTarget {
+  status: PlaytestInspectionStatus
+}
+
+export interface PlaytestInspectionApis {
+  get(target: PlaytestInspectionTarget): Promise<PlaytestInspection | null>
+  save(input: SavePlaytestInspectionInput): Promise<PlaytestInspection>
+}

--- a/frontend/src/features/publish/index.ts
+++ b/frontend/src/features/publish/index.ts
@@ -19,6 +19,11 @@ const ACTION_NAMES: Record<ActionType, string> = {
   custom: '自定义动作',
 }
 
+/** 动作 ID 绑定本次运行，允许同一角色保存多个 custom 或同类型动作。 */
+export function buildPublishedActionId(characterId: string, runId: string): string {
+  return `${characterId}-${runId}`
+}
+
 /** 审核通过时才把 WorkflowRun 中的完整动画写入正式 Character 资产树。 */
 export async function publishWorkflowRun(
   characterApis: CharacterApis,
@@ -34,11 +39,14 @@ export async function publishWorkflowRun(
   const character = await characterApis.get(run.characterId)
   const outfit = character.outfits.find((item) => item.id === run.outfitId)
   if (!outfit) throw new Error('角色中没有找到工作流关联的造型')
-  const actionId = `${character.id}-${result.actionType}`
+  const actionId = buildPublishedActionId(character.id, run.id)
   const action = {
     id: actionId,
     outfitId: outfit.id,
-    name: ACTION_NAMES[result.actionType],
+    name:
+      result.actionType === 'custom'
+        ? run.prompt?.trim() || '自定义动作'
+        : ACTION_NAMES[result.actionType],
     kind: 'custom' as const,
     type: result.actionType,
     fps: 8,

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -24,7 +24,7 @@ import {
   type CreateWorkflowRunStateInput,
 } from './workflow-state'
 
-/** 首个纵切只开放创建角色；增加动作进入对应步骤实现时再加入 Controller。 */
+/** 创建角色与给已有角色增加动作共用同一条运行状态机。 */
 export type CreateWorkflowControllerInput = CreateWorkflowRunStateInput
 
 export interface WorkflowController {

--- a/frontend/src/features/workflow-controller/store-invariants.test.ts
+++ b/frontend/src/features/workflow-controller/store-invariants.test.ts
@@ -110,6 +110,27 @@ function expectRefreshable(
 }
 
 describe('store invariants across every state transition', () => {
+  it('an add_action run survives refresh before generation starts', () => {
+    const harness = createHarness()
+    const created = harness.controller.create({
+      projectId: 'project-1',
+      purpose: 'add_action',
+      driver: 'ai',
+      prompt: '挥手',
+      characterId: 'character-1',
+      outfitId: 'outfit-1',
+      characterTemplateUrl: 'https://example.com/template.png',
+      baseFrameUrls: [],
+    })
+
+    const restored = expectRefreshable(harness, created.id, '增加动作运行创建后')
+    expect(restored.characterId).toBe('character-1')
+    expect(restored.outfitId).toBe('outfit-1')
+    expect(
+      restored.revisions[0]?.steps.find((step) => step.type === 'action-generation')?.status,
+    ).toBe('active')
+  })
+
   it('every step of the happy path survives a refresh', async () => {
     const harness = createHarness()
 

--- a/frontend/src/features/workflow-controller/workflow-state.test.ts
+++ b/frontend/src/features/workflow-controller/workflow-state.test.ts
@@ -52,6 +52,40 @@ describe('workflow state transitions', () => {
     })
   })
 
+  it('starts add_action directly at action generation for the existing outfit', () => {
+    const run = createWorkflowRunState(
+      {
+        projectId: 'project-1',
+        purpose: 'add_action',
+        driver: 'ai',
+        prompt: '挥手打招呼',
+        characterId: 'character-1',
+        outfitId: 'outfit-1',
+        characterTemplateUrl: 'https://example.com/template.png',
+        baseFrameUrls: [],
+      },
+      {
+        runId: 'run-action-1',
+        revisionId: 'revision-action-1',
+        createdAt: CREATED_AT,
+      },
+    )
+
+    expect(run).toMatchObject({
+      purpose: 'add_action',
+      characterId: 'character-1',
+      outfitId: 'outfit-1',
+      prompt: '挥手打招呼',
+    })
+    expect(run.revisions[0]?.steps.map(({ type, status }) => ({ type, status }))).toEqual([
+      { type: 'character-setup', status: 'passed' },
+      { type: 'character-template', status: 'passed' },
+      { type: 'template-candidate', status: 'passed' },
+      { type: 'action-generation', status: 'active' },
+      { type: 'review', status: 'locked' },
+    ])
+  })
+
   it('normalizes character setup input before storing it', () => {
     const updated = updateCharacterSetupState(createRun(), {
       description: '  revised knight  ',

--- a/frontend/src/features/workflow-controller/workflow-state.ts
+++ b/frontend/src/features/workflow-controller/workflow-state.ts
@@ -12,10 +12,7 @@ import {
   type WorkflowStepType,
 } from '@/entities'
 
-export type CreateWorkflowRunStateInput = Extract<
-  CreateWorkflowRunInput,
-  { purpose: 'create_character' }
->
+export type CreateWorkflowRunStateInput = CreateWorkflowRunInput
 
 export interface CreateWorkflowRunStateOptions {
   runId: WorkflowRun['id']
@@ -38,12 +35,13 @@ export function createWorkflowRunState(
   { runId, revisionId, createdAt }: CreateWorkflowRunStateOptions,
 ): WorkflowRun {
   const prompt = input.prompt?.trim() || null
+  const steps = createInitialSteps(input, revisionId, prompt)
 
   return {
     id: runId,
     projectId: input.projectId,
-    characterId: null,
-    outfitId: null,
+    characterId: input.purpose === 'add_action' ? input.characterId : null,
+    outfitId: input.purpose === 'add_action' ? input.outfitId : null,
     purpose: input.purpose,
     driver: input.driver,
     status: 'active',
@@ -54,9 +52,7 @@ export function createWorkflowRunState(
         basedOnRevisionId: null,
         restartStepId: null,
         status: 'active',
-        steps: WORKFLOW_STEP_ORDER.map((type, index) =>
-          createInitialStep(type, revisionId, index, prompt),
-        ),
+        steps,
         generationStatus: 'not_started',
         exportStatus: 'not_exported',
         createdAt,
@@ -64,6 +60,51 @@ export function createWorkflowRunState(
     ],
     prompt,
   }
+}
+
+function createInitialSteps(
+  input: CreateWorkflowRunStateInput,
+  revisionId: string,
+  prompt: string | null,
+): WorkflowStep[] {
+  const steps = WORKFLOW_STEP_ORDER.map((type, index) =>
+    createInitialStep(type, revisionId, index, prompt),
+  )
+  if (input.purpose === 'create_character') return steps
+
+  return steps.map((step) => {
+    if (step.type === 'character-setup') {
+      return {
+        ...step,
+        status: 'passed' as const,
+        input: {
+          description: prompt ?? '为已有角色添加动作',
+          referenceMedia: [],
+        },
+      }
+    }
+    if (step.type === 'character-template') {
+      return {
+        ...step,
+        status: 'passed' as const,
+        output: {
+          type: 'character_template' as const,
+          images: [{ url: input.characterTemplateUrl }],
+        },
+      }
+    }
+    if (step.type === 'template-candidate') {
+      return {
+        ...step,
+        status: 'passed' as const,
+        output: { selectedImageUrl: input.characterTemplateUrl },
+      }
+    }
+    if (step.type === 'action-generation') {
+      return { ...step, status: 'active' as const }
+    }
+    return step
+  })
 }
 
 export function getCurrentRevision(run: WorkflowRun): WorkflowRevision {

--- a/frontend/src/pages/playtest/catalog.test.tsx
+++ b/frontend/src/pages/playtest/catalog.test.tsx
@@ -1,0 +1,279 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Character } from '@/entities/character'
+import type { Project } from '@/entities/project'
+
+import { PlaytestCatalogPage, type PlaytestCatalogApis } from './catalog'
+
+const project: Project = {
+  id: '37',
+  ownerId: '1',
+  name: '灯笼守夜人',
+  perspective: 'side',
+  directionalMovement: 'single',
+  spriteSize: { width: 256, height: 256 },
+  gameStyle: null,
+  sampleImageUrl: null,
+  createdAt: '2026-08-03T00:00:00.000Z',
+  updatedAt: '2026-08-03T00:00:00.000Z',
+}
+
+const targetProject: Project = {
+  ...project,
+  id: '38',
+  name: '第二个项目',
+}
+
+const character: Character = {
+  id: '25',
+  projectId: project.id,
+  createdAt: '',
+  updatedAt: '',
+  outfits: [
+    {
+      id: 'outfit-25-default',
+      characterId: '25',
+      name: '默认造型',
+      candidateCharacterTemplates: [],
+      characterTemplateUrl: 'https://cdn.example.test/character.png',
+      baseFrames: [],
+      actions: [
+        {
+          id: '25-custom',
+          outfitId: 'outfit-25-default',
+          name: '挥舞灯笼',
+          kind: 'custom',
+          type: 'custom',
+          fps: 8,
+          keyFrameIndex: 0,
+          frames: [
+            { imageUrl: 'https://cdn.example.test/frame.png', durationMs: 125, rootMotion: null },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+function renderCatalog(apis: PlaytestCatalogApis) {
+  render(
+    <MemoryRouter>
+      <PlaytestCatalogPage apis={apis} />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('PlaytestCatalogPage', () => {
+  it('loads published assets across projects and links directly to each action', async () => {
+    const apis: PlaytestCatalogApis = {
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([character]),
+        update: vi.fn(),
+        remove: vi.fn(),
+      },
+    }
+
+    renderCatalog(apis)
+
+    expect(await screen.findByRole('heading', { name: 'Playtest' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: '返回项目' }).getAttribute('href')).toBe('/projects')
+    expect(screen.getByRole('heading', { name: '灯笼守夜人' })).toBeTruthy()
+    expect(screen.getByText('挥舞灯笼')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '载入挥舞灯笼' }).getAttribute('href')).toBe(
+      '/playtest/25/outfit-25-default?actionId=25-custom',
+    )
+  })
+
+  it('does not treat an outfit without actions as an importable asset', async () => {
+    const emptyCharacter: Character = {
+      ...character,
+      outfits: [{ ...character.outfits[0]!, actions: [] }],
+    }
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([emptyCharacter]),
+        update: vi.fn(),
+        remove: vi.fn(),
+      },
+    })
+
+    expect(await screen.findByText('空文件夹')).toBeTruthy()
+  })
+
+  it('opens projects as folders and persists a dragged character in the target project', async () => {
+    const update = vi.fn().mockImplementation(async (next: Character) => next)
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({
+          items: [project, targetProject],
+          total: 2,
+          page: 1,
+          pageSize: 2,
+        }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi
+          .fn()
+          .mockImplementation(async (projectId: string) =>
+            projectId === project.id ? [character] : [],
+          ),
+        update,
+        remove: vi.fn(),
+      },
+    })
+
+    const cardTitle = await screen.findByText('默认造型')
+    const card = cardTitle.closest('article')
+    const targetFolder = screen.getByRole('region', { name: '第二个项目项目文件夹' })
+    const transfer = {
+      effectAllowed: '',
+      setData: vi.fn(),
+      getData: vi.fn().mockReturnValue(character.id),
+    }
+
+    fireEvent.dragStart(card!, { dataTransfer: transfer })
+    fireEvent.dragEnter(targetFolder, { dataTransfer: transfer })
+    fireEvent.drop(targetFolder, { dataTransfer: transfer })
+
+    await waitFor(() => expect(update).toHaveBeenCalled())
+    expect(update.mock.calls[0]?.[0].projectId).toBe(targetProject.id)
+    expect(await screen.findByText('已将角色资产移动到“第二个项目”')).toBeTruthy()
+  })
+
+  it('does not report a move as successful when the backend keeps the old project', async () => {
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({
+          items: [project, targetProject],
+          total: 2,
+          page: 1,
+          pageSize: 2,
+        }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi
+          .fn()
+          .mockImplementation(async (projectId: string) =>
+            projectId === project.id ? [character] : [],
+          ),
+        update: vi.fn().mockResolvedValue(character),
+        remove: vi.fn(),
+      },
+    })
+
+    const card = (await screen.findByText('默认造型')).closest('article')
+    const targetFolder = screen.getByRole('region', { name: '第二个项目项目文件夹' })
+    const transfer = {
+      effectAllowed: '',
+      setData: vi.fn(),
+      getData: vi.fn().mockReturnValue(character.id),
+    }
+
+    fireEvent.dragStart(card!, { dataTransfer: transfer })
+    fireEvent.drop(targetFolder, { dataTransfer: transfer })
+
+    expect(await screen.findByText('后端未保存新的项目归属')).toBeTruthy()
+    expect(screen.queryByText('已将角色资产移动到“第二个项目”')).toBeNull()
+    expect(screen.getByRole('heading', { name: project.name })).toBeTruthy()
+  })
+
+  it('renames an asset and an action through the character update API', async () => {
+    const update = vi.fn().mockImplementation(async (next: Character) => next)
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([character]),
+        update,
+        remove: vi.fn(),
+      },
+    })
+
+    await screen.findByText('默认造型')
+    fireEvent.click(screen.getByRole('button', { name: '重命名资产名称 默认造型' }))
+    fireEvent.change(screen.getByRole('textbox', { name: '资产名称' }), {
+      target: { value: '夜巡造型' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '保存资产名称' }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1))
+    expect(update.mock.calls[0]?.[0].outfits[0].name).toBe('夜巡造型')
+
+    fireEvent.click(screen.getByRole('button', { name: '重命名动作名称 挥舞灯笼' }))
+    fireEvent.change(screen.getByRole('textbox', { name: '动作名称' }), {
+      target: { value: '举起灯笼' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '保存动作名称' }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2))
+    expect(update.mock.calls[1]?.[0].outfits[0].actions[0].name).toBe('举起灯笼')
+  })
+
+  it('deletes a single asset after confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const remove = vi.fn().mockResolvedValue(undefined)
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([character]),
+        update: vi.fn(),
+        remove,
+      },
+    })
+
+    await screen.findByText('默认造型')
+    fireEvent.click(screen.getByRole('button', { name: '删除资产 默认造型' }))
+
+    await waitFor(() => expect(remove).toHaveBeenCalledWith(character.id))
+    expect(await screen.findByText('已删除资产“默认造型”')).toBeTruthy()
+    expect(screen.queryByText('默认造型')).toBeNull()
+  })
+
+  it('delegates atomic project cleanup to one backend request', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const removeCharacter = vi.fn().mockResolvedValue(undefined)
+    const removeProject = vi.fn().mockResolvedValue(undefined)
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: removeProject,
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([character]),
+        update: vi.fn(),
+        remove: removeCharacter,
+      },
+    })
+
+    await screen.findByText('默认造型')
+    fireEvent.click(screen.getByRole('button', { name: `删除项目文件夹 ${project.name}` }))
+
+    await waitFor(() => expect(removeProject).toHaveBeenCalledWith(project.id))
+    expect(removeCharacter).not.toHaveBeenCalled()
+    expect(await screen.findByText(`已删除项目“${project.name}”`)).toBeTruthy()
+    expect(screen.queryByRole('region', { name: `${project.name}项目文件夹` })).toBeNull()
+  })
+})

--- a/frontend/src/pages/playtest/catalog.tsx
+++ b/frontend/src/pages/playtest/catalog.tsx
@@ -1,0 +1,665 @@
+import { type DragEvent, type FormEvent, type ReactNode, useEffect, useState } from 'react'
+import { Link } from 'react-router'
+
+import type { Action, Character, CharacterApis, Outfit } from '@/entities/character'
+import type { Project, ProjectApis } from '@/entities/project'
+import { buildPlaytestPath } from '@/features/publish'
+
+export interface PlaytestCatalogApis {
+  projects: Pick<ProjectApis, 'list' | 'remove'>
+  characters: Pick<CharacterApis, 'listByProject' | 'update' | 'remove'>
+}
+
+interface CatalogAsset {
+  project: Project
+  character: Character
+  outfit: Outfit
+}
+
+interface CatalogState {
+  projects: Project[]
+  assets: CatalogAsset[]
+  error: string | null
+  loading: boolean
+}
+
+interface CatalogData {
+  projects: Project[]
+  assets: CatalogAsset[]
+}
+
+const INITIAL_STATE: CatalogState = { projects: [], assets: [], error: null, loading: true }
+
+/** Playtest 入口按项目组织可核验角色，移动和改名通过 Character 整树接口持久化。 */
+export function PlaytestCatalogPage({ apis }: { apis: PlaytestCatalogApis }) {
+  const [state, setState] = useState<CatalogState>(INITIAL_STATE)
+  const [reloadKey, setReloadKey] = useState(0)
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null)
+  const [busyCharacterIds, setBusyCharacterIds] = useState<Set<string>>(new Set())
+  const [busyProjectIds, setBusyProjectIds] = useState<Set<string>>(new Set())
+  const [draggedCharacterId, setDraggedCharacterId] = useState<string | null>(null)
+  const [dropProjectId, setDropProjectId] = useState<string | null>(null)
+  const [operationMessage, setOperationMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setState(INITIAL_STATE)
+
+    void loadCatalog(apis).then(
+      ({ projects, assets }) => {
+        if (!active) return
+        setState({ projects, assets, error: null, loading: false })
+        setSelectedProjectId((current) =>
+          current && projects.some((project) => project.id === current)
+            ? current
+            : (projects[0]?.id ?? null),
+        )
+      },
+      (cause: unknown) =>
+        active &&
+        setState({
+          projects: [],
+          assets: [],
+          error: errorMessage(cause, '资产加载失败'),
+          loading: false,
+        }),
+    )
+
+    return () => {
+      active = false
+    }
+  }, [apis, reloadKey])
+
+  const setCharacterBusy = (characterId: string, busy: boolean) => {
+    setBusyCharacterIds((current) => {
+      const next = new Set(current)
+      if (busy) next.add(characterId)
+      else next.delete(characterId)
+      return next
+    })
+  }
+
+  const persistCharacter = async (character: Character, successMessage: string) => {
+    setCharacterBusy(character.id, true)
+    setOperationMessage(null)
+    try {
+      const saved = await apis.characters.update(character)
+      if (saved.projectId !== character.projectId) {
+        throw new Error('后端未保存新的项目归属')
+      }
+      setState((current) => replaceCharacter(current, saved))
+      setOperationMessage(successMessage)
+    } catch (cause) {
+      setOperationMessage(errorMessage(cause, '保存失败，请重试'))
+      throw cause
+    } finally {
+      setCharacterBusy(character.id, false)
+    }
+  }
+
+  const moveCharacter = async (characterId: string, projectId: string) => {
+    const source = state.assets.find((asset) => asset.character.id === characterId)
+    const target = state.projects.find((project) => project.id === projectId)
+    if (!source || !target || source.character.projectId === projectId) return
+
+    try {
+      await persistCharacter(
+        { ...source.character, projectId },
+        `已将角色资产移动到“${target.name}”`,
+      )
+      setSelectedProjectId(projectId)
+    } catch {
+      // persistCharacter 已在页面上保留具体错误。
+    }
+  }
+
+  const renameOutfit = async (character: Character, outfitId: string, name: string) => {
+    await persistCharacter(
+      {
+        ...character,
+        outfits: character.outfits.map((outfit) =>
+          outfit.id === outfitId ? { ...outfit, name } : outfit,
+        ),
+      },
+      `资产已改名为“${name}”`,
+    )
+  }
+
+  const renameAction = async (
+    character: Character,
+    outfitId: string,
+    actionId: string,
+    name: string,
+  ) => {
+    await persistCharacter(
+      {
+        ...character,
+        outfits: character.outfits.map((outfit) =>
+          outfit.id === outfitId
+            ? {
+                ...outfit,
+                actions: outfit.actions.map((action) =>
+                  action.id === actionId ? { ...action, name } : action,
+                ),
+              }
+            : outfit,
+        ),
+      },
+      `动作已改名为“${name}”`,
+    )
+  }
+
+  const deleteAsset = async (character: Character, outfit: Outfit) => {
+    if (!window.confirm(`确定删除资产“${outfit.name}”吗？此操作无法撤销。`)) return
+
+    setCharacterBusy(character.id, true)
+    setOperationMessage(null)
+    try {
+      if (character.outfits.length === 1) {
+        await apis.characters.remove(character.id)
+        setState((current) => ({
+          ...current,
+          assets: current.assets.filter((asset) => asset.character.id !== character.id),
+        }))
+      } else {
+        const saved = await apis.characters.update({
+          ...character,
+          outfits: character.outfits.filter((candidate) => candidate.id !== outfit.id),
+        })
+        setState((current) => replaceCharacter(current, saved))
+      }
+      setOperationMessage(`已删除资产“${outfit.name}”`)
+    } catch (cause) {
+      setOperationMessage(errorMessage(cause, '资产删除失败，请重试'))
+    } finally {
+      setCharacterBusy(character.id, false)
+    }
+  }
+
+  const deleteProject = async (project: Project) => {
+    if (!window.confirm(`确定删除项目“${project.name}”及其中全部角色资产吗？此操作无法撤销。`)) {
+      return
+    }
+
+    setBusyProjectIds((current) => new Set(current).add(project.id))
+    setOperationMessage(null)
+    try {
+      await apis.projects.remove(project.id)
+      setState((current) => ({
+        ...current,
+        projects: current.projects.filter((candidate) => candidate.id !== project.id),
+        assets: current.assets.filter((asset) => asset.project.id !== project.id),
+      }))
+      setSelectedProjectId((current) =>
+        current === project.id
+          ? (state.projects.find((candidate) => candidate.id !== project.id)?.id ?? null)
+          : current,
+      )
+      setOperationMessage(`已删除项目“${project.name}”`)
+    } catch (cause) {
+      setOperationMessage(errorMessage(cause, '项目删除失败，请重试'))
+    } finally {
+      setBusyProjectIds((current) => {
+        const next = new Set(current)
+        next.delete(project.id)
+        return next
+      })
+    }
+  }
+
+  const selectedProject = state.projects.find((project) => project.id === selectedProjectId) ?? null
+  const selectedAssets = selectedProject
+    ? state.assets.filter((asset) => asset.project.id === selectedProject.id)
+    : []
+
+  return (
+    <section className="mx-auto w-full max-w-6xl py-8 text-[#1d251f]">
+      <Link
+        to="/projects"
+        className="mb-4 inline-flex min-h-9 items-center gap-1 rounded-lg border border-[#b9c1ba] px-3 text-xs font-semibold text-[#4f5b52] hover:border-[#758078] hover:text-[#26372c]"
+      >
+        <span aria-hidden="true" className="text-base leading-none">
+          ‹
+        </span>
+        返回项目
+      </Link>
+
+      <header className="flex flex-wrap items-end justify-between gap-4 border-b border-[#d5dad5] pb-5">
+        <div>
+          <p className="font-mono text-[10px] font-bold tracking-[0.16em] text-[#747973]">
+            PLAYTEST
+          </p>
+          <h1 className="mt-2 font-serif text-3xl">Playtest</h1>
+          <p className="mt-2 text-sm text-[#687069]">选择项目和角色动作进行核验。</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setReloadKey((value) => value + 1)}
+          disabled={state.loading}
+          className="min-h-10 rounded-lg border border-[#aeb8b0] px-4 text-xs font-semibold text-[#35583f] disabled:opacity-50"
+        >
+          {state.loading ? '正在同步' : '刷新资产'}
+        </button>
+      </header>
+
+      {state.error ? <CatalogAlert tone="error">{state.error}</CatalogAlert> : null}
+      {operationMessage ? <CatalogAlert tone="status">{operationMessage}</CatalogAlert> : null}
+
+      {!state.error && !state.loading && state.projects.length === 0 ? (
+        <div className="mt-8 border border-dashed border-[#c9d0ca] px-6 py-12 text-center">
+          <p className="text-sm text-[#687069]">还没有项目。</p>
+          <Link
+            to="/quick-start"
+            className="mt-4 inline-flex min-h-10 items-center rounded-lg bg-[#35583f] px-4 text-sm font-semibold text-white"
+          >
+            创建角色动作
+          </Link>
+        </div>
+      ) : null}
+
+      <div className="mt-6 grid items-start gap-5 lg:grid-cols-[280px_minmax(0,1fr)]">
+        <aside
+          aria-label="项目文件夹"
+          className="max-h-72 overflow-y-auto border border-[#ced5cf] bg-white lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)]"
+        >
+          <div className="border-b border-[#dde2de] px-4 py-3">
+            <h2 className="text-xs font-semibold">项目文件夹</h2>
+            <p className="mt-1 text-[10px] text-[#747973]">{state.projects.length} 个项目</p>
+          </div>
+          <div className="grid gap-px bg-[#e2e6e2]">
+            {state.projects.map((project) => {
+              const assetCount = state.assets.filter(
+                (asset) => asset.project.id === project.id,
+              ).length
+              const selected = selectedProjectId === project.id
+              const projectBusy = busyProjectIds.has(project.id)
+              const dropActive = dropProjectId === project.id && draggedCharacterId !== null
+
+              return (
+                <section
+                  key={project.id}
+                  aria-label={`${project.name}项目文件夹`}
+                  onDragEnter={(event) => {
+                    event.preventDefault()
+                    setDropProjectId(project.id)
+                  }}
+                  onDragOver={(event) => event.preventDefault()}
+                  onDrop={(event) => {
+                    event.preventDefault()
+                    const characterId =
+                      event.dataTransfer.getData('application/x-windup-character') ||
+                      draggedCharacterId
+                    setDropProjectId(null)
+                    setDraggedCharacterId(null)
+                    if (characterId) void moveCharacter(characterId, project.id)
+                  }}
+                  className={`grid grid-cols-[minmax(0,1fr)_36px] items-center bg-white p-1 transition-colors ${
+                    dropActive ? 'bg-[#e1eee4]' : ''
+                  }`}
+                >
+                  <button
+                    type="button"
+                    aria-pressed={selected}
+                    disabled={projectBusy}
+                    onClick={() => setSelectedProjectId(project.id)}
+                    className={`grid min-h-14 min-w-0 grid-cols-[18px_minmax(0,1fr)_auto] items-center gap-2 px-2 text-left disabled:opacity-50 ${
+                      selected ? 'bg-[#edf3ee] text-[#294c33]' : 'hover:bg-[#f4f6f4]'
+                    }`}
+                  >
+                    <span aria-hidden="true" className="text-sm text-[#526258]">
+                      {selected ? '▾' : '▸'}
+                    </span>
+                    <span className="min-w-0">
+                      <strong className="block truncate text-xs">{project.name}</strong>
+                      <small className="mt-0.5 block text-[9px] text-[#747973]">
+                        {project.spriteSize.width} × {project.spriteSize.height}
+                      </small>
+                    </span>
+                    <span className="rounded-md bg-[#e8ece8] px-1.5 py-1 text-[9px] font-semibold text-[#59635b]">
+                      {assetCount}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`删除项目文件夹 ${project.name}`}
+                    title="删除项目文件夹"
+                    disabled={projectBusy}
+                    onClick={() => void deleteProject(project)}
+                    className="grid h-9 w-9 place-items-center rounded-md text-[10px] font-semibold text-[#973d34] hover:bg-[#faeeec] disabled:opacity-40"
+                  >
+                    删除
+                  </button>
+                </section>
+              )
+            })}
+          </div>
+        </aside>
+
+        <section aria-label="当前项目资产" className="min-w-0 border border-[#ced5cf] bg-[#f7f8f7]">
+          {selectedProject ? (
+            <>
+              <header className="border-b border-[#dde2de] bg-white px-5 py-4">
+                <p className="text-[10px] font-semibold text-[#747973]">当前文件夹</p>
+                <div className="mt-1 flex items-center justify-between gap-3">
+                  <h2 className="min-w-0 truncate text-lg font-semibold">{selectedProject.name}</h2>
+                  <span className="shrink-0 text-[10px] text-[#747973]">
+                    {selectedAssets.length} 项资产
+                  </span>
+                </div>
+              </header>
+              <div className="grid gap-4 p-4 xl:grid-cols-2">
+                {selectedAssets.length === 0 ? (
+                  <p className="col-span-full py-16 text-center text-xs text-[#858c86]">空文件夹</p>
+                ) : (
+                  selectedAssets.map((asset) => (
+                    <AssetCard
+                      key={`${asset.character.id}:${asset.outfit.id}`}
+                      asset={asset}
+                      busy={busyCharacterIds.has(asset.character.id)}
+                      onDragStart={(event) => {
+                        event.dataTransfer.effectAllowed = 'move'
+                        event.dataTransfer.setData(
+                          'application/x-windup-character',
+                          asset.character.id,
+                        )
+                        setDraggedCharacterId(asset.character.id)
+                      }}
+                      onDragEnd={() => {
+                        setDraggedCharacterId(null)
+                        setDropProjectId(null)
+                      }}
+                      onRenameOutfit={(name) =>
+                        renameOutfit(asset.character, asset.outfit.id, name)
+                      }
+                      onRenameAction={(actionId, name) =>
+                        renameAction(asset.character, asset.outfit.id, actionId, name)
+                      }
+                      onDelete={() => deleteAsset(asset.character, asset.outfit)}
+                    />
+                  ))
+                )}
+              </div>
+            </>
+          ) : (
+            <p className="py-16 text-center text-xs text-[#858c86]">请选择项目文件夹</p>
+          )}
+        </section>
+      </div>
+    </section>
+  )
+}
+
+function AssetCard({
+  asset,
+  busy,
+  onDragStart,
+  onDragEnd,
+  onRenameOutfit,
+  onRenameAction,
+  onDelete,
+}: {
+  asset: CatalogAsset
+  busy: boolean
+  onDragStart(event: DragEvent<HTMLElement>): void
+  onDragEnd(): void
+  onRenameOutfit(name: string): Promise<void>
+  onRenameAction(actionId: string, name: string): Promise<void>
+  onDelete(): Promise<void>
+}) {
+  const { character, outfit } = asset
+
+  return (
+    <article
+      draggable={!busy}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      className={`grid min-h-[240px] grid-cols-[112px_minmax(0,1fr)] overflow-hidden rounded-lg border border-[#d1d7d2] bg-white ${
+        busy ? 'opacity-60' : 'cursor-grab active:cursor-grabbing'
+      }`}
+    >
+      <div className="grid min-h-full place-items-center bg-[#edf0ec] p-2">
+        {outfit.characterTemplateUrl ? (
+          <img
+            src={outfit.characterTemplateUrl}
+            alt={`${outfit.name} 角色图`}
+            className="aspect-square w-full object-contain [image-rendering:pixelated]"
+          />
+        ) : (
+          <span className="text-xs text-[#8b918c]">暂无角色图</span>
+        )}
+      </div>
+      <div className="min-w-0 p-4">
+        <div className="flex items-center justify-between gap-2">
+          <p className="truncate text-[10px] font-semibold text-[#747973]">角色 {character.id}</p>
+          <button
+            type="button"
+            aria-label={`删除资产 ${outfit.name}`}
+            title="删除资产"
+            disabled={busy}
+            draggable={false}
+            onClick={() => void onDelete()}
+            className="min-h-8 rounded-md px-2 text-[10px] font-semibold text-[#973d34] hover:bg-[#faeeec] disabled:opacity-40"
+          >
+            删除
+          </button>
+        </div>
+        <EditableName
+          value={outfit.name}
+          label="资产名称"
+          disabled={busy}
+          onSave={onRenameOutfit}
+          className="mt-1"
+        >
+          <h2 className="min-w-0 flex-1 truncate text-base font-semibold">{outfit.name}</h2>
+        </EditableName>
+        <p className="mt-1 text-[11px] text-[#747973]">{outfit.actions.length} 个动作</p>
+        <div className="mt-4 grid gap-2">
+          {outfit.actions.map((action) => (
+            <ActionRow
+              key={action.id}
+              character={character}
+              outfit={outfit}
+              action={action}
+              disabled={busy}
+              onRename={(name) => onRenameAction(action.id, name)}
+            />
+          ))}
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function ActionRow({
+  character,
+  outfit,
+  action,
+  disabled,
+  onRename,
+}: {
+  character: Character
+  outfit: Outfit
+  action: Action
+  disabled: boolean
+  onRename(name: string): Promise<void>
+}) {
+  return (
+    <EditableName value={action.name} label="动作名称" disabled={disabled} onSave={onRename}>
+      <Link
+        aria-label={`载入${action.name}`}
+        to={buildPlaytestPath({
+          characterId: character.id,
+          outfitId: outfit.id,
+          actionId: action.id,
+        })}
+        draggable={false}
+        className="flex min-h-9 min-w-0 flex-1 items-center justify-between gap-2 rounded-lg border border-[#cbd3cc] px-3 text-xs font-semibold text-[#35583f] hover:border-[#78917e] hover:bg-[#eef4ef]"
+      >
+        <span className="truncate">{action.name}</span>
+        <span className="shrink-0 font-mono text-[9px] text-[#747973]">
+          {action.frames.length} 帧
+        </span>
+      </Link>
+    </EditableName>
+  )
+}
+
+function EditableName({
+  value,
+  label,
+  disabled,
+  onSave,
+  className = '',
+  children,
+}: {
+  value: string
+  label: string
+  disabled: boolean
+  onSave(value: string): Promise<void>
+  className?: string
+  children: ReactNode
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => setDraft(value), [value])
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    const name = draft.trim()
+    if (!name) {
+      setError('名称不能为空')
+      return
+    }
+    if (name === value) {
+      setEditing(false)
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+    try {
+      await onSave(name)
+      setEditing(false)
+    } catch (cause) {
+      setError(errorMessage(cause, '保存失败'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (editing) {
+    return (
+      <form
+        onSubmit={(event) => void submit(event)}
+        onDragStart={(event) => event.stopPropagation()}
+        className={`grid min-w-0 grid-cols-[minmax(0,1fr)_32px_32px] gap-1 ${className}`}
+      >
+        <input
+          aria-label={label}
+          autoFocus
+          value={draft}
+          maxLength={80}
+          onChange={(event) => setDraft(event.target.value)}
+          disabled={saving}
+          className="h-8 min-w-0 rounded-md border border-[#829087] px-2 text-xs outline-none focus:border-[#35583f]"
+        />
+        <button
+          type="submit"
+          aria-label={`保存${label}`}
+          title="保存"
+          disabled={saving}
+          className="h-8 rounded-md bg-[#35583f] text-sm text-white disabled:opacity-50"
+        >
+          ✓
+        </button>
+        <button
+          type="button"
+          aria-label={`取消修改${label}`}
+          title="取消"
+          disabled={saving}
+          onClick={() => {
+            setDraft(value)
+            setError(null)
+            setEditing(false)
+          }}
+          className="h-8 rounded-md border border-[#c5ccc6] text-sm text-[#687069]"
+        >
+          ×
+        </button>
+        {error ? <small className="col-span-full text-[10px] text-[#983c32]">{error}</small> : null}
+      </form>
+    )
+  }
+
+  return (
+    <div className={`flex min-w-0 items-center gap-1 ${className}`}>
+      {children}
+      <button
+        type="button"
+        aria-label={`重命名${label} ${value}`}
+        title={`重命名${label}`}
+        disabled={disabled}
+        draggable={false}
+        onClick={() => setEditing(true)}
+        className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-sm text-[#687069] hover:bg-[#edf1ed] hover:text-[#35583f] disabled:opacity-40"
+      >
+        ✎
+      </button>
+    </div>
+  )
+}
+
+function CatalogAlert({ children, tone }: { children: string; tone: 'error' | 'status' }) {
+  return (
+    <div
+      role={tone === 'error' ? 'alert' : 'status'}
+      className={`mt-4 border-l-4 px-4 py-3 ${
+        tone === 'error'
+          ? 'border-[#a54438] bg-[#f8ece9] text-[#7d3028]'
+          : 'border-[#4f7759] bg-[#edf5ef] text-[#35583f]'
+      }`}
+    >
+      <p className="text-sm">{children}</p>
+    </div>
+  )
+}
+
+function replaceCharacter(state: CatalogState, character: Character): CatalogState {
+  const project = state.projects.find((candidate) => candidate.id === character.projectId)
+  if (!project) return state
+
+  const otherAssets = state.assets.filter((asset) => asset.character.id !== character.id)
+  const updatedAssets = character.outfits
+    .filter((outfit) => outfit.actions.length > 0)
+    .map((outfit) => ({ project, character, outfit }))
+
+  return { ...state, assets: [...otherAssets, ...updatedAssets] }
+}
+
+function errorMessage(cause: unknown, fallback: string): string {
+  return cause instanceof Error && cause.message.trim() ? cause.message : fallback
+}
+
+async function loadCatalog(apis: PlaytestCatalogApis): Promise<CatalogData> {
+  const page = await apis.projects.list({ page: 1, pageSize: 100 })
+  const charactersByProject = await Promise.all(
+    page.items.map(async (project) => ({
+      project,
+      characters: await apis.characters.listByProject(project.id),
+    })),
+  )
+
+  return {
+    projects: page.items,
+    assets: charactersByProject.flatMap(({ project, characters }) =>
+      characters.flatMap((character) =>
+        character.outfits
+          .filter((outfit) => outfit.actions.length > 0)
+          .map((outfit) => ({ project, character, outfit })),
+      ),
+    ),
+  }
+}

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes, useNavigate, type NavigateFunction } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -63,7 +63,10 @@ describe('PlaytestPage', () => {
 
   it('loads the requested character through the standard skeleton API only', async () => {
     const apis: PlaytestPageApis = {
-      characters: { get: vi.fn().mockResolvedValue(character) },
+      characters: {
+        get: vi.fn().mockResolvedValue(character),
+        listByProject: vi.fn().mockResolvedValue([character]),
+      },
     }
 
     renderPage(apis, '/playtest/character-1/outfit-1?actionId=idle')
@@ -76,7 +79,9 @@ describe('PlaytestPage', () => {
   it.each([{ code: 404 }, { status: 404 }])(
     'maps a missing character response to a stable message',
     async (error) => {
-      renderPage({ characters: { get: vi.fn().mockRejectedValue(error) } })
+      renderPage({
+        characters: { get: vi.fn().mockRejectedValue(error), listByProject: vi.fn() },
+      })
 
       expect(await screen.findByText('角色不存在')).toBeTruthy()
     },
@@ -84,7 +89,10 @@ describe('PlaytestPage', () => {
 
   it('does not mislabel a transport failure as not found', async () => {
     renderPage({
-      characters: { get: vi.fn().mockRejectedValue(new Error('network unavailable')) },
+      characters: {
+        get: vi.fn().mockRejectedValue(new Error('network unavailable')),
+        listByProject: vi.fn(),
+      },
     })
 
     expect(await screen.findByText('角色读取失败')).toBeTruthy()
@@ -101,6 +109,7 @@ describe('PlaytestPage', () => {
       outfits: [{ ...character.outfits[0], characterId: 'character-2' }],
     }
     const get = vi.fn().mockReturnValueOnce(firstRequest).mockResolvedValueOnce(secondCharacter)
+    const listByProject = vi.fn().mockResolvedValue([character, secondCharacter])
     let navigate: NavigateFunction | undefined
 
     function NavigationProbe() {
@@ -114,7 +123,7 @@ describe('PlaytestPage', () => {
         <Routes>
           <Route
             path="/playtest/:characterId/:outfitId"
-            element={<PlaytestPage apis={{ characters: { get } }} />}
+            element={<PlaytestPage apis={{ characters: { get, listByProject } }} />}
           />
         </Routes>
       </MemoryRouter>,
@@ -129,5 +138,43 @@ describe('PlaytestPage', () => {
     )
     expect(get).toHaveBeenNthCalledWith(1, 'character-1')
     expect(get).toHaveBeenNthCalledWith(2, 'character-2')
+  })
+
+  it('switches assets from the action sidebar without returning to the catalog', async () => {
+    const secondCharacter: Character = {
+      ...character,
+      id: 'character-2',
+      outfits: [
+        {
+          ...character.outfits[0]!,
+          id: 'outfit-2',
+          characterId: 'character-2',
+          name: 'Knight',
+          actions: character.outfits[0]!.actions.map((action) => ({
+            ...action,
+            outfitId: 'outfit-2',
+            name: 'Guard',
+          })),
+        },
+      ],
+    }
+    const get = vi
+      .fn()
+      .mockImplementation(async (id: string) =>
+        id === secondCharacter.id ? secondCharacter : character,
+      )
+    const listByProject = vi.fn().mockResolvedValue([character, secondCharacter])
+
+    renderPage({ characters: { get, listByProject } })
+
+    const selector = await screen.findByRole('combobox', { name: '同项目资产' })
+    fireEvent.click(selector)
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(2)
+    fireEvent.click(screen.getByRole('option', { name: /Knight/ }))
+
+    expect(await screen.findByRole('heading', { name: 'character-2 · Knight' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Guard/ })).toBeTruthy()
+    expect(get).toHaveBeenLastCalledWith('character-2')
   })
 })

--- a/frontend/src/pages/playtest/index.tsx
+++ b/frontend/src/pages/playtest/index.tsx
@@ -1,12 +1,17 @@
 import { useEffect, useState } from 'react'
-import { useParams, useSearchParams } from 'react-router'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router'
 
 import type { Character, CharacterApis } from '@/entities/character'
+import type { PlaytestInspectionApis } from '@/entities/playtest-inspection'
+import type { ProjectApis } from '@/entities/project'
+import { buildPlaytestPath } from '@/features/publish'
 
-import { PlaytestWorkbench } from './workbench'
+import { PlaytestWorkbench, type PlaytestAssetOption } from './workbench'
 
 export interface PlaytestPageApis {
-  characters: Pick<CharacterApis, 'get'>
+  characters: Pick<CharacterApis, 'get' | 'listByProject'>
+  projects?: Pick<ProjectApis, 'get'>
+  inspections?: Pick<PlaytestInspectionApis, 'get' | 'save'>
 }
 
 export interface PlaytestPageProps {
@@ -15,11 +20,19 @@ export interface PlaytestPageProps {
 
 interface PageData {
   character: Character | null
+  projectCharacters: Character[]
+  expectedCanvas: { width: number; height: number } | null
   error: string | null
   loading: boolean
 }
 
-const initialPageData: PageData = { character: null, error: null, loading: false }
+const initialPageData: PageData = {
+  character: null,
+  projectCharacters: [],
+  expectedCanvas: null,
+  error: null,
+  loading: false,
+}
 
 function isNotFoundError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false
@@ -40,6 +53,7 @@ function isNotFoundError(error: unknown): boolean {
 export function PlaytestPage({ apis }: PlaytestPageProps) {
   const { characterId, outfitId } = useParams()
   const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
   const initialActionId = searchParams.get('actionId')
   const [data, setData] = useState<PageData>(initialPageData)
 
@@ -48,6 +62,8 @@ export function PlaytestPage({ apis }: PlaytestPageProps) {
     if (apis === undefined) {
       setData({
         character: null,
+        projectCharacters: [],
+        expectedCanvas: null,
         error: 'Playtest 角色接口尚未配置',
         loading: false,
       })
@@ -61,8 +77,20 @@ export function PlaytestPage({ apis }: PlaytestPageProps) {
     let cancelled = false
     setData({ ...initialPageData, loading: true })
     void apis.characters.get(characterId).then(
-      (character) => {
-        if (!cancelled) setData({ character, error: null, loading: false })
+      async (character) => {
+        let projectCharacters = [character]
+        let expectedCanvas: PageData['expectedCanvas'] = null
+        const [charactersResult, projectResult] = await Promise.allSettled([
+          apis.characters.listByProject(character.projectId),
+          apis.projects?.get(character.projectId) ?? Promise.resolve(null),
+        ])
+        if (charactersResult.status === 'fulfilled') projectCharacters = charactersResult.value
+        if (projectResult.status === 'fulfilled' && projectResult.value !== null) {
+          expectedCanvas = projectResult.value.spriteSize
+        }
+        if (!cancelled) {
+          setData({ character, projectCharacters, expectedCanvas, error: null, loading: false })
+        }
       },
       (error: unknown) => {
         if (!cancelled) {
@@ -83,13 +111,59 @@ export function PlaytestPage({ apis }: PlaytestPageProps) {
   if (data.loading || data.character === null)
     return <PlaytestPageMessage>加载 Playtest 数据中</PlaytestPageMessage>
 
+  const assetOptions = buildAssetOptions(data.projectCharacters)
+
   return (
-    <PlaytestWorkbench
-      key={initialActionId ?? ''}
-      character={data.character}
-      outfitId={outfitId ?? ''}
-      initialActionId={initialActionId}
-    />
+    <div className="bg-[#eef0ed] pt-2">
+      <div className="px-3 sm:px-5">
+        <Link
+          to="/playtest"
+          aria-label="返回全部 Playtest"
+          className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-[11px] font-semibold text-[#59635b] hover:bg-[#e1e5e1] hover:text-[#2f4e38]"
+        >
+          <span aria-hidden="true">←</span>
+          全部 Playtest
+        </Link>
+      </div>
+      <PlaytestWorkbench
+        key={`${data.character.id}:${outfitId}:${initialActionId ?? ''}`}
+        character={data.character}
+        outfitId={outfitId ?? ''}
+        assetOptions={assetOptions}
+        expectedCanvas={data.expectedCanvas}
+        inspectionApis={apis?.inspections}
+        initialActionId={initialActionId}
+        onSelectAsset={(asset) =>
+          navigate(
+            buildPlaytestPath({
+              characterId: asset.characterId,
+              outfitId: asset.outfitId,
+            }),
+          )
+        }
+        onAddAction={() => {
+          const params = new URLSearchParams({
+            characterId: data.character!.id,
+            outfitId: outfitId ?? '',
+          })
+          navigate(`/quick-start?${params.toString()}`)
+        }}
+      />
+    </div>
+  )
+}
+
+function buildAssetOptions(characters: Character[]): PlaytestAssetOption[] {
+  return characters.flatMap((character) =>
+    character.outfits
+      .filter((outfit) => outfit.actions.length > 0)
+      .map((outfit) => ({
+        key: `${character.id}:${outfit.id}`,
+        characterId: character.id,
+        outfitId: outfit.id,
+        name: `${outfit.name}（角色 ${character.id}）`,
+        actionCount: outfit.actions.length,
+      })),
   )
 }
 

--- a/frontend/src/pages/playtest/playtest-boundaries.test.ts
+++ b/frontend/src/pages/playtest/playtest-boundaries.test.ts
@@ -12,7 +12,11 @@ const prohibitedImports = [
   'entities/workflow-run',
   'entities/generation',
 ] as const
-const allowedEntityImports = ['@/entities/character'] as const
+const allowedEntityImports = [
+  '@/entities/character',
+  '@/entities/playtest-inspection',
+  '@/entities/project',
+] as const
 
 function sourceFiles(directory: string): readonly string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {

--- a/frontend/src/pages/playtest/workbench/acceptance.tsx
+++ b/frontend/src/pages/playtest/workbench/acceptance.tsx
@@ -1,10 +1,14 @@
 import { StatusPanel } from './status-panel'
 
-export type PlaytestInspectionStatus = 'passed' | 'issues_found'
+import type { PlaytestInspectionStatus } from '@/entities/playtest-inspection'
 
 export interface AcceptanceProps {
   inspectionStatus: PlaytestInspectionStatus | null
-  onRecordStatus(status: PlaytestInspectionStatus): void
+  available: boolean
+  loading: boolean
+  saving: boolean
+  error: string | null
+  onRecordStatus(status: PlaytestInspectionStatus): Promise<void>
 }
 
 function statusText(status: PlaytestInspectionStatus | null): string {
@@ -13,8 +17,27 @@ function statusText(status: PlaytestInspectionStatus | null): string {
   return '尚未核验'
 }
 
-/** 本次浏览会话的临时核验结论，不写回 Character 或任何后端记录。 */
-export function Acceptance({ inspectionStatus, onRecordStatus }: AcceptanceProps) {
+/** Playtest 自己的动作核验结论，不写回 Character 或创作历史。 */
+export function Acceptance({
+  inspectionStatus,
+  available,
+  loading,
+  saving,
+  error,
+  onRecordStatus,
+}: AcceptanceProps) {
+  const detail = !available
+    ? '当前预览未连接核验记录'
+    : loading
+      ? '正在读取核验记录'
+      : saving
+        ? '正在保存核验记录'
+        : error
+          ? error
+          : inspectionStatus === null
+            ? '尚未保存核验结论'
+            : '已保存到 Playtest 核验记录'
+
   return (
     <section
       aria-label="核验状态"
@@ -25,23 +48,25 @@ export function Acceptance({ inspectionStatus, onRecordStatus }: AcceptanceProps
         <h2 className="mt-1 text-sm font-semibold text-slate-900">本次核验</h2>
       </header>
       <StatusPanel
-        title="会话内核验"
+        title="Playtest 核验记录"
         tone={inspectionStatus === 'issues_found' ? 'warning' : 'neutral'}
       >
         <p>{statusText(inspectionStatus)}</p>
-        <p className="mt-1 text-xs">仅保存在当前页面，不写入后端</p>
+        <p className="mt-1 text-xs">{detail}</p>
       </StatusPanel>
       <div className="grid grid-cols-2 gap-2">
         <button
           type="button"
-          onClick={() => onRecordStatus('passed')}
+          disabled={!available || loading || saving}
+          onClick={() => void onRecordStatus('passed')}
           className="rounded-lg bg-emerald-900 px-3 py-2 text-xs font-semibold text-white"
         >
           核验通过
         </button>
         <button
           type="button"
-          onClick={() => onRecordStatus('issues_found')}
+          disabled={!available || loading || saving}
+          onClick={() => void onRecordStatus('issues_found')}
           className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-900"
         >
           发现问题

--- a/frontend/src/pages/playtest/workbench/action-selector.tsx
+++ b/frontend/src/pages/playtest/workbench/action-selector.tsx
@@ -1,23 +1,185 @@
+import { useId, useState } from 'react'
+
 import type { PreviewAction } from './model/types'
 
+export interface PlaytestAssetOption {
+  key: string
+  characterId: string
+  outfitId: string
+  name: string
+  actionCount: number
+}
+
 export interface ActionSelectorProps {
+  assets: readonly PlaytestAssetOption[]
+  selectedAssetKey: string
   actions: readonly PreviewAction[]
   selectedActionId: string | null
+  onSelectAsset(asset: PlaytestAssetOption): void
   onSelectAction(actionId: string): void
+  onAddAction?(): void
 }
 
 function frameCount(action: PreviewAction): number {
   return action.sequences.reduce((total, sequence) => total + sequence.frames.length, 0)
 }
 
-export function ActionSelector({ actions, selectedActionId, onSelectAction }: ActionSelectorProps) {
+function assetDisplayName(asset: PlaytestAssetOption): string {
+  const generatedSuffix = `（角色 ${asset.characterId}）`
+  return asset.name.endsWith(generatedSuffix)
+    ? asset.name.slice(0, -generatedSuffix.length)
+    : asset.name
+}
+
+function AssetIdentity({
+  asset,
+  menuOpen = false,
+  showCaret = false,
+}: {
+  asset: PlaytestAssetOption | null
+  menuOpen?: boolean
+  showCaret?: boolean
+}) {
   return (
-    <aside
-      aria-label="动作列表"
-      className="h-full overflow-y-auto border-r border-slate-200 bg-[#171918] p-3 text-white"
-    >
-      <p className="text-[10px] font-semibold tracking-[0.18em] text-white/35">动作实例</p>
-      <div className="mt-3 space-y-2">
+    <>
+      <span
+        aria-hidden="true"
+        className="grid h-8 w-8 place-items-center rounded bg-[#dce9df] font-mono text-[10px] font-bold text-[#294331]"
+      >
+        {asset?.characterId.slice(-3) ?? '—'}
+      </span>
+      <span className="min-w-0">
+        <strong className="block truncate text-xs font-semibold text-white">
+          {asset === null ? '没有可预览角色' : assetDisplayName(asset)}
+        </strong>
+        {asset !== null ? (
+          <small className="mt-0.5 block truncate text-[9px] text-white/40">
+            角色 {asset.characterId} · {asset.actionCount} 个动作
+          </small>
+        ) : null}
+      </span>
+      <span
+        aria-hidden="true"
+        className={`text-center text-xs text-white/45 transition-transform ${menuOpen ? 'rotate-180' : ''}`}
+      >
+        {showCaret ? '⌄' : ''}
+      </span>
+    </>
+  )
+}
+
+export function ActionSelector({
+  assets,
+  selectedAssetKey,
+  actions,
+  selectedActionId,
+  onSelectAsset,
+  onSelectAction,
+  onAddAction,
+}: ActionSelectorProps) {
+  const [assetMenuOpen, setAssetMenuOpen] = useState(false)
+  const assetMenuId = useId()
+  const selectedAsset =
+    assets.find((candidate) => candidate.key === selectedAssetKey) ?? assets[0] ?? null
+  const canSwitchAsset = assets.length > 1
+
+  return (
+    <div aria-label="动作列表" className="flex h-full min-h-0 flex-col bg-[#202522] p-3 text-white">
+      <div
+        className="relative"
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) setAssetMenuOpen(false)
+        }}
+      >
+        <div className="mb-2 flex items-center justify-between gap-2 px-0.5">
+          <span className="text-[9px] font-semibold text-white/40">
+            {canSwitchAsset ? '角色 / 造型' : '当前角色'}
+          </span>
+          {canSwitchAsset ? (
+            <span className="font-mono text-[8px] text-white/30">{assets.length} ITEMS</span>
+          ) : null}
+        </div>
+        {canSwitchAsset ? (
+          <button
+            type="button"
+            role="combobox"
+            aria-label="同项目资产"
+            aria-expanded={assetMenuOpen}
+            aria-controls={assetMenuId}
+            aria-haspopup="listbox"
+            onClick={() => setAssetMenuOpen((open) => !open)}
+            className="grid min-h-14 w-full grid-cols-[32px_minmax(0,1fr)_18px] items-center gap-2 rounded-md border border-white/10 bg-white/6 px-2 text-left outline-none transition-colors hover:border-white/20 hover:bg-white/9 focus-visible:border-[#a7c5ae]"
+          >
+            <AssetIdentity asset={selectedAsset} menuOpen={assetMenuOpen} showCaret />
+          </button>
+        ) : (
+          <div
+            aria-label="当前角色"
+            className="grid min-h-14 w-full grid-cols-[32px_minmax(0,1fr)_18px] items-center gap-2 rounded-md border border-white/8 bg-white/4 px-2 text-left"
+          >
+            <AssetIdentity asset={selectedAsset} />
+          </div>
+        )}
+        {canSwitchAsset && assetMenuOpen ? (
+          <div
+            id={assetMenuId}
+            role="listbox"
+            aria-label="可切换角色"
+            className="absolute inset-x-0 top-[calc(100%+6px)] z-40 max-h-64 overflow-y-auto rounded-md border border-[#cbd2cc] bg-white p-1 text-[#253029] shadow-[0_12px_28px_rgba(10,20,13,0.2)]"
+          >
+            {assets.map((asset) => {
+              const selected = asset.key === selectedAssetKey
+
+              return (
+                <button
+                  key={asset.key}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  onClick={() => {
+                    setAssetMenuOpen(false)
+                    if (!selected) onSelectAsset(asset)
+                  }}
+                  className={`grid min-h-12 w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded px-2 text-left ${
+                    selected ? 'bg-[#e1ebe3] text-[#294331]' : 'hover:bg-[#f0f3f0]'
+                  }`}
+                >
+                  <span className="min-w-0">
+                    <strong className="block truncate text-[11px]">
+                      {assetDisplayName(asset)}
+                    </strong>
+                    <small className="mt-0.5 block truncate text-[9px] text-[#707971]">
+                      角色 {asset.characterId}
+                    </small>
+                  </span>
+                  <span className="font-mono text-[9px] text-[#69736b]">
+                    {asset.actionCount} ACT
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        ) : null}
+      </div>
+      <div className="my-3 border-t border-white/8" />
+      <div className="flex items-center justify-between gap-2 px-0.5">
+        <p className="text-[9px] font-semibold text-white/40">动作</p>
+        <span className="flex items-center gap-2">
+          <span className="font-mono text-[8px] text-white/30">{actions.length} TOTAL</span>
+          {onAddAction ? (
+            <button
+              type="button"
+              aria-label="添加动作"
+              title="给当前角色添加动作"
+              onClick={onAddAction}
+              className="grid h-7 w-7 place-items-center rounded border border-white/12 text-base text-[#b7d0bd] hover:border-white/25 hover:bg-white/8 hover:text-white"
+            >
+              +
+            </button>
+          ) : null}
+        </span>
+      </div>
+      <div className="mt-2 flex min-h-0 gap-1.5 overflow-x-auto pb-1 lg:flex-1 lg:flex-col lg:overflow-x-hidden lg:overflow-y-auto lg:pb-0">
         {actions.map((action) => {
           const count = frameCount(action)
           const selected = action.id === selectedActionId
@@ -29,23 +191,33 @@ export function ActionSelector({ actions, selectedActionId, onSelectAction }: Ac
               aria-pressed={selected}
               disabled={count === 0}
               onClick={() => onSelectAction(action.id)}
-              className={`flex w-full items-center justify-between rounded-lg border px-3 py-3 text-left transition-colors ${
+              className={`grid min-h-12 w-36 shrink-0 grid-cols-[4px_minmax(0,1fr)_auto] items-center gap-2 rounded-md border px-2 py-1.5 text-left transition-colors lg:w-full ${
                 selected
-                  ? 'border-white/25 bg-white/12 text-white'
-                  : 'border-transparent text-white/65 hover:bg-white/5 hover:text-white'
+                  ? 'border-white/12 bg-white/9 text-white'
+                  : 'border-transparent text-white/60 hover:bg-white/5 hover:text-white'
               } disabled:cursor-not-allowed disabled:opacity-40`}
             >
-              <span>
-                <strong className="block text-sm">{action.name}</strong>
-                <span className="mt-1 block text-[10px] uppercase text-white/45">
+              <span
+                aria-hidden="true"
+                className={`h-5 w-1 rounded-sm ${selected ? 'bg-[#a7c5ae]' : 'bg-transparent'}`}
+              />
+              <span className="min-w-0">
+                <strong className="block truncate text-xs">{action.name}</strong>
+                <span
+                  className={`mt-0.5 block text-[8px] uppercase ${selected ? 'text-[#a7c5ae]' : 'text-white/35'}`}
+                >
                   {action.fps} FPS
                 </span>
               </span>
-              <span className="text-xs tabular-nums text-emerald-300">{count} 帧</span>
+              <span
+                className={`text-[9px] tabular-nums ${selected ? 'text-white/75' : 'text-white/40'}`}
+              >
+                {count} 帧
+              </span>
             </button>
           )
         })}
       </div>
-    </aside>
+    </div>
   )
 }

--- a/frontend/src/pages/playtest/workbench/analysis/frame-geometry.test.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/frame-geometry.test.ts
@@ -45,6 +45,7 @@ describe('measureFrameGeometry', () => {
       opaquePixels: 4,
       coverageRatio: 0.25,
       fingerprint: expect.any(Array),
+      contentHash: expect.any(String),
     })
     expect(geometry?.fingerprint).toHaveLength(64)
   })

--- a/frontend/src/pages/playtest/workbench/analysis/frame-geometry.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/frame-geometry.ts
@@ -26,6 +26,17 @@ export interface FrameGeometry {
   coverageRatio: number
   /** Compact 8×8 alpha/luminance signature used for adjacent-frame similarity checks. */
   fingerprint?: readonly number[]
+  /** Exact RGBA content hash used to identify genuinely duplicated frames. */
+  contentHash?: string
+}
+
+function hashPixels(data: Uint8ClampedArray): string {
+  let hash = 0x811c9dc5
+  for (const value of data) {
+    hash ^= value
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
 }
 
 function createFingerprint(
@@ -181,5 +192,6 @@ export function measureFrameGeometry(pixels: FramePixelData): FrameGeometry | nu
       width: subjectWidth,
       height: subjectHeight,
     }),
+    contentHash: hashPixels(data),
   }
 }

--- a/frontend/src/pages/playtest/workbench/analysis/image-geometry.test.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/image-geometry.test.ts
@@ -84,6 +84,7 @@ describe('readImageGeometry', () => {
         opaquePixels: 1,
         coverageRatio: 0.25,
         fingerprint: expect.any(Array),
+        contentHash: expect.any(String),
       },
     })
   })

--- a/frontend/src/pages/playtest/workbench/analysis/quality-policy.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/quality-policy.ts
@@ -11,8 +11,6 @@ export interface LocalQualityPolicy {
   edgeMargin: { x: number; y: number }
   minimumCoverageRatio: number
   maximumCoverageRatio: number
-  /** 相邻帧指纹平均距离 ≤ 该值时判定为重复帧（duplicate_frame）。 */
-  duplicateDistance: number
   footDriftThreshold: number | null
   heightDriftThreshold: number | null
   heightAttentionThreshold: number | null
@@ -26,7 +24,6 @@ export interface LocalQualityPolicy {
 const REFERENCE_CANVAS_SIZE = 256
 const MINIMUM_COVERAGE_RATIO = 0.005
 const MAXIMUM_COVERAGE_RATIO = 0.65
-const DUPLICATE_DISTANCE = 0.02
 const AREA_DELTA_THRESHOLD_PERCENT = 28
 
 function scaledPixels(referencePixels: number, scale: number): number {
@@ -80,16 +77,15 @@ function movementCeilingReferencePixels(actionType: PlaytestActionType): number 
 export function deriveLocalQualityPolicy(
   geometries: readonly FrameGeometry[],
   actionType: PlaytestActionType,
+  expectedCanvasOverride: CanvasBaseline | null = null,
 ): LocalQualityPolicy {
-  const expectedCanvas = inferCanvasBaseline(geometries)
+  const expectedCanvas = expectedCanvasOverride ?? inferCanvasBaseline(geometries)
   if (expectedCanvas === null) {
     return {
       expectedCanvas: null,
       edgeMargin: { x: 1, y: 1 },
       minimumCoverageRatio: MINIMUM_COVERAGE_RATIO,
       maximumCoverageRatio: MAXIMUM_COVERAGE_RATIO,
-      duplicateDistance: DUPLICATE_DISTANCE,
-
       footDriftThreshold: null,
       heightDriftThreshold: null,
       heightAttentionThreshold: null,
@@ -114,7 +110,6 @@ export function deriveLocalQualityPolicy(
     },
     minimumCoverageRatio: MINIMUM_COVERAGE_RATIO,
     maximumCoverageRatio: MAXIMUM_COVERAGE_RATIO,
-    duplicateDistance: DUPLICATE_DISTANCE,
     footDriftThreshold: scaledPixels(3, verticalScale),
     heightDriftThreshold:
       heightReference === null ? null : scaledPixels(heightReference, verticalScale),

--- a/frontend/src/pages/playtest/workbench/analysis/sequence-evidence.test.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/sequence-evidence.test.ts
@@ -9,7 +9,13 @@ function geometry(
       FrameGeometry,
       'width' | 'height' | 'footY' | 'subjectHeight' | 'opaquePixels' | 'coverageRatio'
     >
-  > & { x?: number; y?: number; fingerprint?: readonly number[]; cropped?: boolean } = {},
+  > & {
+    x?: number
+    y?: number
+    fingerprint?: readonly number[]
+    contentHash?: string
+    cropped?: boolean
+  } = {},
 ): FrameGeometry {
   const subjectHeight = overrides.subjectHeight ?? 20
 
@@ -30,6 +36,7 @@ function geometry(
     opaquePixels: overrides.opaquePixels ?? 100,
     coverageRatio: overrides.coverageRatio ?? 0.25,
     fingerprint: overrides.fingerprint,
+    contentHash: overrides.contentHash,
   }
 }
 
@@ -42,11 +49,11 @@ function ready(
 
 describe('buildSequenceEvidence', () => {
   it('returns structured findings for incomplete, cropped and duplicate frames', () => {
-    const fingerprint = Array.from({ length: 64 }, (_, index) => index / 64)
+    const contentHash = 'same-frame'
     const evidence = buildSequenceEvidence(
       [
-        ready(geometry({ cropped: true, fingerprint })),
-        ready(geometry({ fingerprint })),
+        ready(geometry({ cropped: true, contentHash })),
+        ready(geometry({ contentHash })),
         { geometry: { status: 'unavailable', reason: '图片没有可见主体' }, rootMotion: null },
       ],
       'walk',
@@ -189,7 +196,7 @@ describe('buildSequenceEvidence', () => {
         ready(geometry({ width: 512, height: 512, x: 4 })),
         ready(geometry({ width: 512, height: 512, x: 14 })),
       ],
-      'walk',
+      'attack',
     )
 
     expect(evidence.summary).toMatchObject({
@@ -352,5 +359,49 @@ describe('buildSequenceEvidence', () => {
 
     expect(evidence.frames[2]?.expectedRootDelta).toMatchObject({ dx: 3, dy: 2 })
     expect(evidence.frames[2]?.composedPreviewDelta).toMatchObject({ dx: 5, dy: 1 })
+  })
+
+  it('does not mislabel merely similar adjacent frames as duplicates', () => {
+    const fingerprint = Array.from({ length: 64 }, () => 0.5)
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ fingerprint, contentHash: 'frame-a' })),
+        ready(geometry({ fingerprint, contentHash: 'frame-b' })),
+      ],
+      'attack',
+    )
+
+    expect(evidence.findings.map((finding) => finding.code)).not.toContain('duplicate_frame')
+  })
+
+  it('checks a loop boundary against the ordinary adjacent-frame baseline', () => {
+    const evidence = buildSequenceEvidence(
+      [ready(geometry({ x: 0 })), ready(geometry({ x: 20 })), ready(geometry({ x: 40 }))],
+      'walk',
+    )
+
+    expect(evidence.summary.movementThreshold).toBe(24)
+    expect(evidence.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'motion_spike',
+          frameIndex: 0,
+          message: '循环首尾出现异常位移突变',
+        }),
+      ]),
+    )
+  })
+
+  it('uses the project canvas contract instead of accepting a consistently wrong sequence', () => {
+    const evidence = buildSequenceEvidence(
+      [ready(geometry({ width: 256, height: 256 })), ready(geometry({ width: 256, height: 256 }))],
+      'idle',
+      { width: 512, height: 512 },
+    )
+
+    expect(evidence.summary.expectedCanvas).toEqual({ width: 512, height: 512 })
+    expect(
+      evidence.findings.filter((finding) => finding.code === 'canvas_size_mismatch'),
+    ).toHaveLength(2)
   })
 })

--- a/frontend/src/pages/playtest/workbench/analysis/sequence-evidence.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/sequence-evidence.ts
@@ -91,23 +91,8 @@ function medianAbsoluteDeviation(values: readonly number[], center: number | nul
   return median(values.map((value) => Math.abs(value - center)))
 }
 
-function fingerprintDistance(
-  left: readonly number[] | undefined,
-  right: readonly number[] | undefined,
-): number | null {
-  if (
-    left === undefined ||
-    right === undefined ||
-    left.length === 0 ||
-    left.length !== right.length
-  )
-    return null
-
-  const total = left.reduce(
-    (sum, value, index) => sum + Math.abs(value - (right[index] ?? value)),
-    0,
-  )
-  return total / left.length
+function framesAreIdentical(left: FrameGeometry, right: FrameGeometry): boolean {
+  return left.contentHash !== undefined && left.contentHash === right.contentHash
 }
 
 function isCropped(geometry: FrameGeometry, margin: { x: number; y: number }): boolean {
@@ -164,12 +149,13 @@ function rootMotion(frame: FrameEvidenceInput): { dx: number; dy: number } {
 export function buildSequenceEvidence(
   inputs: readonly FrameEvidenceInput[],
   actionType: PlaytestActionType,
+  expectedCanvas: CanvasBaseline | null = null,
 ): SequenceReviewEvidence {
   const results = inputs.map((input) => input.geometry)
   const readyGeometries = results.flatMap((result) =>
     result.status === 'ready' ? [result.geometry] : [],
   )
-  const policy = deriveLocalQualityPolicy(readyGeometries, actionType)
+  const policy = deriveLocalQualityPolicy(readyGeometries, actionType, expectedCanvas)
   const isBaselineGeometry = (geometry: FrameGeometry): boolean =>
     policy.expectedCanvas !== null &&
     geometry.width === policy.expectedCanvas.width &&
@@ -180,6 +166,19 @@ export function buildSequenceEvidence(
     if (!isBaselineGeometry(previous.geometry) || !isBaselineGeometry(result.geometry)) return null
     return adjacentDelta(previous.geometry, result.geometry)
   })
+  const checksLoopBoundary = actionType === 'idle' || actionType === 'walk'
+  const firstResult = results[0]
+  const lastResult = results.at(-1)
+  const closingDelta =
+    checksLoopBoundary &&
+    results.length > 1 &&
+    results.every((result) => result.status === 'ready') &&
+    firstResult?.status === 'ready' &&
+    lastResult?.status === 'ready' &&
+    isBaselineGeometry(firstResult.geometry) &&
+    isBaselineGeometry(lastResult.geometry)
+      ? adjacentDelta(lastResult.geometry, firstResult.geometry)
+      : null
   const rootDeltas = inputs.map((input, index): MotionVector | null => {
     if (index === 0) return null
 
@@ -331,17 +330,13 @@ export function buildSequenceEvidence(
 
     const previous = results[index - 1]
     if (previous?.status !== 'ready') return
-    const duplicateDistance = fingerprintDistance(
-      previous.geometry.fingerprint,
-      geometry.fingerprint,
-    )
-    if (duplicateDistance !== null && duplicateDistance <= policy.duplicateDistance) {
+    if (framesAreIdentical(previous.geometry, geometry)) {
       findings.push({
         code: 'duplicate_frame',
         severity: 'warning',
         frameIndex: index,
-        message: '当前帧与上一帧高度相似',
-        metrics: { distance: duplicateDistance },
+        message: '当前帧与上一帧完全相同',
+        metrics: {},
       })
     }
 
@@ -384,6 +379,36 @@ export function buildSequenceEvidence(
       }
     }
   })
+
+  if (closingDelta !== null && firstResult?.status === 'ready' && lastResult?.status === 'ready') {
+    if (framesAreIdentical(lastResult.geometry, firstResult.geometry)) {
+      findings.push({
+        code: 'duplicate_frame',
+        severity: 'warning',
+        frameIndex: 0,
+        message: '循环首帧与尾帧完全相同，可能产生停顿',
+        metrics: {},
+      })
+    }
+    if (movementThreshold !== null && closingDelta.distance > movementThreshold) {
+      findings.push({
+        code: 'motion_spike',
+        severity: 'error',
+        frameIndex: 0,
+        message: '循环首尾出现异常位移突变',
+        metrics: { distance: closingDelta.distance, threshold: movementThreshold },
+      })
+    }
+    if (closingDelta.areaDeltaPercent > policy.areaDeltaThresholdPercent) {
+      findings.push({
+        code: 'area_spike',
+        severity: 'warning',
+        frameIndex: 0,
+        message: '循环首尾轮廓面积变化过大',
+        metrics: { percent: closingDelta.areaDeltaPercent },
+      })
+    }
+  }
 
   if (
     footDrift !== null &&

--- a/frontend/src/pages/playtest/workbench/analysis/use-frame-review-evidence.test.tsx
+++ b/frontend/src/pages/playtest/workbench/analysis/use-frame-review-evidence.test.tsx
@@ -107,7 +107,7 @@ describe('useFrameReviewEvidence', () => {
     expect(reader.mock.calls[1]?.[1]).toBeInstanceOf(AbortSignal)
   })
 
-  it('reuses settled image results when frames are selected or revisited', async () => {
+  it('rereads revisited image URLs so regenerated content cannot reuse stale geometry', async () => {
     // Catches frame navigation repeatedly decoding every image in the same review session.
     const reader = vi.fn<ImageGeometryReader>(async (imageUrl) =>
       geometry(imageUrl.includes('one') ? 1 : 2),
@@ -127,7 +127,7 @@ describe('useFrameReviewEvidence', () => {
     await waitFor(() => expect(result.current.evidence?.frames[0]?.geometry?.centroid.x).toBe(2))
     rerender({ current: first })
     await waitFor(() => expect(result.current.evidence?.frames[0]?.geometry?.centroid.x).toBe(1))
-    expect(reader).toHaveBeenCalledTimes(2)
+    expect(reader).toHaveBeenCalledTimes(3)
   })
 
   it('retries an unavailable image when its sequence is revisited', async () => {

--- a/frontend/src/pages/playtest/workbench/analysis/use-frame-review-evidence.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/use-frame-review-evidence.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import type { PlaytestActionType, PreviewFrame, PreviewSequence } from '../model/types'
 import { readImageGeometry } from './image-geometry'
+import type { CanvasBaseline } from './quality-policy'
 import {
   buildSequenceEvidence,
   type FrameGeometryResult,
@@ -18,11 +19,6 @@ export type ImageGeometryReader = (
   signal?: AbortSignal,
 ) => Promise<FrameGeometryResult>
 
-interface CachedReads {
-  reader: ImageGeometryReader
-  entries: Map<string, FrameGeometryResult>
-}
-
 interface ResolvedState {
   key: string | null
   value: FrameReviewEvidenceState
@@ -35,23 +31,20 @@ export function useFrameReviewEvidence(
   sequence: PreviewSequence | null,
   actionType: PlaytestActionType | null,
   reader: ImageGeometryReader = readImageGeometry,
+  expectedCanvas: CanvasBaseline | null = null,
 ): FrameReviewEvidenceState {
   const sequenceKey =
     sequence === null || actionType === null
       ? null
       : JSON.stringify([
           actionType,
+          expectedCanvas,
           ...sequence.frames.map((frame) => ({
             imageUrl: frame.imageUrl,
             rootMotion: frame.rootMotion,
           })),
         ])
-  const cache = useRef<CachedReads | null>(null)
   const [resolved, setResolved] = useState<ResolvedState>({ key: null, value: IDLE_STATE })
-
-  if (cache.current === null || cache.current.reader !== reader) {
-    cache.current = { reader, entries: new Map() }
-  }
 
   useEffect(() => {
     if (sequenceKey === null || actionType === null) {
@@ -59,32 +52,26 @@ export function useFrameReviewEvidence(
       return
     }
 
-    const [, ...frameDescriptors] = JSON.parse(sequenceKey) as [
+    const [, , ...frameDescriptors] = JSON.parse(sequenceKey) as [
       PlaytestActionType,
+      CanvasBaseline | null,
       ...Array<{ imageUrl: string; rootMotion: PreviewFrame['rootMotion'] }>,
     ]
     const imageUrls = frameDescriptors.map((frame) => frame.imageUrl)
 
     const controller = new AbortController()
     let active = true
-    const reads = cache.current?.entries
     const inFlight = new Map<string, Promise<FrameGeometryResult>>()
 
     setResolved({ key: sequenceKey, value: LOADING_STATE })
 
     const results = imageUrls.map((imageUrl) => {
-      const cached = reads?.get(imageUrl)
-      if (cached !== undefined) return Promise.resolve(cached)
-
       const existing = inFlight.get(imageUrl)
       if (existing !== undefined) return existing
 
-      const pending = reader(imageUrl, controller.signal)
-        .catch((): FrameGeometryResult => ({ status: 'unavailable', reason: '图片分析失败' }))
-        .then((result) => {
-          if (!controller.signal.aborted && result.status === 'ready') reads?.set(imageUrl, result)
-          return result
-        })
+      const pending = reader(imageUrl, controller.signal).catch(
+        (): FrameGeometryResult => ({ status: 'unavailable', reason: '图片分析失败' }),
+      )
       inFlight.set(imageUrl, pending)
       return pending
     })
@@ -102,6 +89,7 @@ export function useFrameReviewEvidence(
               rootMotion: frameDescriptors[index]?.rootMotion ?? null,
             })),
             actionType,
+            expectedCanvas,
           ),
         },
       })
@@ -111,7 +99,7 @@ export function useFrameReviewEvidence(
       active = false
       controller.abort()
     }
-  }, [actionType, reader, sequenceKey])
+  }, [actionType, expectedCanvas, reader, sequenceKey])
 
   if (sequenceKey === null) return IDLE_STATE
   return resolved.key === sequenceKey ? resolved.value : LOADING_STATE

--- a/frontend/src/pages/playtest/workbench/animation-stage.test.tsx
+++ b/frontend/src/pages/playtest/workbench/animation-stage.test.tsx
@@ -51,7 +51,22 @@ describe('playtest visual primitives', () => {
     const onSelectAction = vi.fn()
 
     render(
-      <ActionSelector actions={actions} selectedActionId="walk" onSelectAction={onSelectAction} />,
+      <ActionSelector
+        assets={[
+          {
+            key: 'character-1:outfit-1',
+            characterId: 'character-1',
+            outfitId: 'outfit-1',
+            name: '默认造型',
+            actionCount: actions.length,
+          },
+        ]}
+        selectedAssetKey="character-1:outfit-1"
+        actions={actions}
+        selectedActionId="walk"
+        onSelectAsset={vi.fn()}
+        onSelectAction={onSelectAction}
+      />,
     )
 
     expect(screen.getByRole('button', { name: /行走/ }).textContent).toContain('12 FPS')
@@ -161,9 +176,9 @@ describe('playtest visual primitives', () => {
     fireEvent.click(screen.getByRole('button', { name: '下一帧' }))
     expect(onTogglePlaying).toHaveBeenCalledTimes(1)
     expect(onNextFrame).toHaveBeenCalledTimes(1)
-    expect(screen.getByText('A 左行走')).toBeTruthy()
-    expect(screen.getByText('D 右行走')).toBeTruthy()
-    expect(screen.getByText('未提供跳跃动作')).toBeTruthy()
-    expect(screen.getByText('下蹲动作可用')).toBeTruthy()
+    expect(screen.getByText('跳跃不可用，下蹲可用')).toBeTruthy()
+    expect(screen.getByRole('button', { name: '循环播放' }).getAttribute('aria-pressed')).toBe(
+      'true',
+    )
   })
 })

--- a/frontend/src/pages/playtest/workbench/animation-stage.tsx
+++ b/frontend/src/pages/playtest/workbench/animation-stage.tsx
@@ -102,7 +102,7 @@ export function AnimationStage({
     <section
       ref={stageRef}
       aria-label="动画预览舞台"
-      className={`relative grid h-full min-h-[320px] place-items-center overflow-hidden rounded-2xl border border-slate-300 ${
+      className={`relative grid h-full min-h-[360px] place-items-center overflow-hidden rounded-lg border border-[#c8cec9] ${
         showChecker
           ? 'bg-[linear-gradient(45deg,#e5e7eb_25%,transparent_25%),linear-gradient(-45deg,#e5e7eb_25%,transparent_25%),linear-gradient(45deg,transparent_75%,#e5e7eb_75%),linear-gradient(-45deg,transparent_75%,#e5e7eb_75%)] bg-[length:24px_24px] bg-[position:0_0,0_12px,12px_-12px,-12px_0px]'
           : 'bg-slate-100'
@@ -149,7 +149,7 @@ export function AnimationStage({
       )}
 
       {/* Zoom controls */}
-      <div className="absolute bottom-3 right-3 z-20 flex items-center gap-1 rounded-lg border border-slate-300 bg-white/90 px-1.5 py-1 text-xs shadow-sm">
+      <div className="absolute bottom-3 right-3 z-20 flex items-center gap-1 rounded-md border border-[#bfc7c0] bg-white/90 px-1.5 py-1 text-xs">
         <button
           type="button"
           onClick={zoomOut}

--- a/frontend/src/pages/playtest/workbench/frame-timeline.tsx
+++ b/frontend/src/pages/playtest/workbench/frame-timeline.tsx
@@ -10,23 +10,17 @@ export function FrameTimeline({ sequence, currentFrameIndex, onSelectFrame }: Fr
   const frames = sequence?.frames ?? []
 
   return (
-    <section
-      aria-label="逐帧时间线"
-      className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm"
-    >
-      <header className="mb-3 flex items-center justify-between gap-4">
-        <span>
-          <strong className="block text-xs">逐帧预览</strong>
-          <small className="text-[10px] text-slate-400">点击帧定位；Playtest 不写入审核结论</small>
-        </span>
-        <span className="text-[10px] font-semibold text-emerald-900">READ ONLY</span>
+    <section aria-label="逐帧时间线" className="rounded-lg border border-[#d2d8d3] bg-white p-2">
+      <header className="mb-2 flex items-center justify-between gap-4 px-1">
+        <strong className="text-[10px] text-[#59635b]">逐帧</strong>
+        <span className="font-mono text-[9px] text-[#7a827c]">{frames.length} FRAMES</span>
       </header>
       {frames.length === 0 ? (
         <p className="rounded-lg border border-dashed border-slate-300 p-4 text-sm text-slate-500">
           当前方向没有帧
         </p>
       ) : (
-        <div className="flex gap-2 overflow-x-auto pb-1">
+        <div className="flex gap-1.5 overflow-x-auto pb-1">
           {frames.map((frame, index) => (
             <button
               key={`${frame.imageUrl}-${index}`}
@@ -34,7 +28,7 @@ export function FrameTimeline({ sequence, currentFrameIndex, onSelectFrame }: Fr
               aria-label={`第 ${index + 1} 帧`}
               aria-pressed={index === currentFrameIndex}
               onClick={() => onSelectFrame(index)}
-              className={`w-28 shrink-0 overflow-hidden rounded-lg border p-1 text-left transition-colors ${
+              className={`w-20 shrink-0 overflow-hidden rounded-md border p-1 text-left transition-colors ${
                 index === currentFrameIndex
                   ? 'border-emerald-900 bg-emerald-50'
                   : 'border-slate-200 bg-slate-50 hover:border-slate-400'

--- a/frontend/src/pages/playtest/workbench/index.test.tsx
+++ b/frontend/src/pages/playtest/workbench/index.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { Character } from '@/entities/character'
+import type { PlaytestInspectionApis } from '@/entities/playtest-inspection'
 
 import type { FrameGeometryResult } from './analysis/sequence-evidence'
 import { PlaytestWorkbench } from './index'
@@ -146,13 +147,41 @@ describe('PlaytestWorkbench on the PR #70 character contract', () => {
     expect(screen.getByRole('button', { name: /Crouch/ }).getAttribute('aria-pressed')).toBe('true')
   })
 
-  it('keeps acceptance as session-only state without a persistence API', () => {
-    render(<PlaytestWorkbench character={character} outfitId="outfit-1" />)
+  it('loads and saves the current action inspection through the Playtest API', async () => {
+    const inspections: Pick<PlaytestInspectionApis, 'get' | 'save'> = {
+      get: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockImplementation(async (input) => ({
+        id: 'inspection-1',
+        ...input,
+        createdAt: '2026-08-03T00:00:00.000Z',
+        updatedAt: '2026-08-03T00:00:00.000Z',
+      })),
+    }
+    render(
+      <PlaytestWorkbench character={character} outfitId="outfit-1" inspectionApis={inspections} />,
+    )
 
+    await waitFor(() =>
+      expect(inspections.get).toHaveBeenCalledWith({
+        characterId: 'character-1',
+        outfitId: 'outfit-1',
+        actionId: 'walk',
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '打开检查工具' }))
     fireEvent.click(screen.getByRole('button', { name: '发现问题' }))
+    await waitFor(() =>
+      expect(inspections.save).toHaveBeenCalledWith({
+        characterId: 'character-1',
+        outfitId: 'outfit-1',
+        actionId: 'walk',
+        status: 'issues_found',
+      }),
+    )
     const acceptance = screen.getByRole('region', { name: '核验状态' })
     expect(within(acceptance).getAllByText('发现问题')).toHaveLength(2)
-    expect(within(acceptance).getByText('仅保存在当前页面，不写入后端')).toBeTruthy()
+    expect(within(acceptance).getByText('已保存到 Playtest 核验记录')).toBeTruthy()
   })
 
   it('reports a missing outfit instead of falling back to another asset', () => {
@@ -164,10 +193,22 @@ describe('PlaytestWorkbench on the PR #70 character contract', () => {
   it('keeps inspect, audit, and export in the same workbench', () => {
     render(<PlaytestWorkbench character={character} outfitId="outfit-1" />)
 
+    expect(screen.queryByRole('tab', { name: '帧检查' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: '打开检查工具' }))
     expect(screen.getByRole('tab', { name: '帧检查' })).toBeTruthy()
     fireEvent.click(screen.getByRole('tab', { name: '问题记录' }))
     expect(screen.getByRole('tabpanel', { name: '问题记录' })).toBeTruthy()
     fireEvent.click(screen.getByRole('tab', { name: '资产导出' }))
     expect(screen.getByRole('button', { name: '导出游戏资产包' })).toBeTruthy()
+  })
+
+  it('delegates adding an action for the current character', () => {
+    const onAddAction = vi.fn()
+    render(
+      <PlaytestWorkbench character={character} outfitId="outfit-1" onAddAction={onAddAction} />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '添加动作' }))
+    expect(onAddAction).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/pages/playtest/workbench/index.tsx
+++ b/frontend/src/pages/playtest/workbench/index.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useMemo, useReducer, useState, type KeyboardEvent } from 'react'
+import { useMemo, useReducer, useState, type KeyboardEvent } from 'react'
 
 import type { Character } from '@/entities/character'
+import type { PlaytestInspectionApis } from '@/entities/playtest-inspection'
+import type { CanvasBaseline } from './analysis/quality-policy'
 
-import { ActionSelector } from './action-selector'
-import { Acceptance, type PlaytestInspectionStatus } from './acceptance'
+import { ActionSelector, type PlaytestAssetOption } from './action-selector'
+import { Acceptance } from './acceptance'
 import { useFrameReviewEvidence } from './analysis/use-frame-review-evidence'
 import { AnimationStage } from './animation-stage'
 import { AuditPanel } from './audit/audit-panel'
@@ -18,12 +20,20 @@ import { usePlaybackController } from './playback/use-playback-controller'
 import { useStageMotion } from './stage-motion'
 import { StatusPanel } from './status-panel'
 import { usePlaytestKeyboard } from './use-playtest-keyboard'
+import { usePlaytestInspection } from './use-playtest-inspection'
 
 export interface PlaytestWorkbenchProps {
   character: Character
   outfitId: string
+  assetOptions?: readonly PlaytestAssetOption[]
+  expectedCanvas?: CanvasBaseline | null
+  inspectionApis?: Pick<PlaytestInspectionApis, 'get' | 'save'>
   initialActionId?: string | null
+  onSelectAsset?(asset: PlaytestAssetOption): void
+  onAddAction?(): void
 }
+
+export type { PlaytestAssetOption } from './action-selector'
 
 const EMPTY_PREVIEW_ACTIONS: readonly PreviewAction[] = []
 const RIGHT_PANELS = [
@@ -36,7 +46,12 @@ type RightPanel = (typeof RIGHT_PANELS)[number][0]
 export function PlaytestWorkbench({
   character,
   outfitId,
+  assetOptions = [],
+  expectedCanvas = null,
+  inspectionApis,
   initialActionId = null,
+  onSelectAsset = () => undefined,
+  onAddAction,
 }: PlaytestWorkbenchProps) {
   const previewResult = useMemo(
     () => createPreviewModel(character, outfitId),
@@ -71,18 +86,35 @@ export function PlaytestWorkbench({
       (action) =>
         action.type === 'crouch' && action.sequences.some((sequence) => sequence.frames.length > 0),
     ) ?? false
-  const reviewEvidence = useFrameReviewEvidence(playback.sequence, playback.action?.type ?? null)
-  const [demoInspectionStatus, setDemoInspectionStatus] = useState<PlaytestInspectionStatus | null>(
-    null,
+  const reviewEvidence = useFrameReviewEvidence(
+    playback.sequence,
+    playback.action?.type ?? null,
+    undefined,
+    expectedCanvas,
   )
+  const inspectionTarget = useMemo(
+    () =>
+      playback.action === null
+        ? null
+        : {
+            characterId: character.id,
+            outfitId,
+            actionId: playback.action.id,
+          },
+    [character.id, outfitId, playback.action],
+  )
+  const inspection = usePlaytestInspection(inspectionApis, inspectionTarget)
   const [activeRightPanel, setActiveRightPanel] = useState<RightPanel>('inspect')
-  const [actionSidebarCollapsed, setActionSidebarCollapsed] = useState(false)
+  const [toolsOpen, setToolsOpen] = useState(false)
   const [manualIssues, dispatchAudit] = useReducer(reduceAuditSession, [])
 
   const frameCount = playback.sequence?.frames.length ?? 0
   const automaticFindings =
     reviewEvidence.status === 'ready' ? reviewEvidence.evidence.findings : []
-  const qualityIssueCount = automaticFindings.length + manualIssues.length
+  const automaticErrorCount = automaticFindings.filter(
+    (finding) => finding.severity === 'error',
+  ).length
+  const qualityIssueCount = automaticErrorCount + manualIssues.length
 
   const movePanelFocus = (event: KeyboardEvent<HTMLButtonElement>, current: RightPanel) => {
     const currentIndex = RIGHT_PANELS.findIndex(([value]) => value === current)
@@ -150,10 +182,6 @@ export function PlaytestWorkbench({
   )
   usePlaytestKeyboard(keyboardCommands, preview !== null)
 
-  const recordStatus = useCallback((status: PlaytestInspectionStatus) => {
-    setDemoInspectionStatus(status)
-  }, [])
-
   if (preview === null) {
     return (
       <main aria-label="Playtest">
@@ -164,91 +192,78 @@ export function PlaytestWorkbench({
     )
   }
 
+  const selectedAssetKey = `${character.id}:${outfitId}`
+  const availableAssets =
+    assetOptions.length > 0
+      ? assetOptions
+      : [
+          {
+            key: selectedAssetKey,
+            characterId: character.id,
+            outfitId,
+            name: preview.outfitName,
+            actionCount: preview.actions.length,
+          },
+        ]
+
   return (
     <main
       aria-label="Playtest"
-      className="mx-auto w-full max-w-[1920px] space-y-3 p-2 text-slate-900 sm:p-4"
+      className="mx-auto min-h-[calc(100vh-5rem)] w-full max-w-[1920px] space-y-3 bg-[#eef0ed] px-3 pb-4 pt-2 text-[#202722] sm:px-5"
     >
-      <header className="flex flex-wrap items-end justify-between gap-3">
-        <div>
-          <p className="text-[10px] font-semibold tracking-[0.18em] text-slate-400">PLAYTEST</p>
-          <h1 className="mt-1 text-xl font-semibold">
+      <header className="flex min-h-14 flex-wrap items-center justify-between gap-3 border-b border-[#d3d8d4] pb-3">
+        <div className="min-w-0">
+          <p className="font-mono text-[9px] font-semibold text-[#79817b]">PLAYTEST</p>
+          <h1 className="mt-1 truncate text-lg font-semibold">
             {preview.characterName} · {preview.outfitName}
           </h1>
         </div>
-        <p className="text-xs text-slate-500">只读预览，不写入角色、动作或帧</p>
+        <div className="flex items-center gap-3">
+          <p className="hidden text-[10px] text-[#727a74] sm:block">
+            只读预览，不写入角色、动作或帧
+          </p>
+          <button
+            type="button"
+            aria-label={toolsOpen ? '关闭检查工具' : '打开检查工具'}
+            aria-expanded={toolsOpen}
+            aria-controls="playtest-tools"
+            onClick={() => setToolsOpen((open) => !open)}
+            className={`inline-flex min-h-9 items-center gap-2 rounded-md border px-3 text-xs font-semibold transition-colors ${
+              toolsOpen
+                ? 'border-[#35583f] bg-[#35583f] text-white'
+                : 'border-[#aeb7b0] bg-white text-[#35583f] hover:border-[#718278]'
+            }`}
+          >
+            检查
+            {qualityIssueCount > 0 ? (
+              <span className="min-w-5 rounded bg-[#f7e2de] px-1 py-0.5 text-[9px] text-[#8d352d]">
+                {qualityIssueCount}
+              </span>
+            ) : null}
+          </button>
+        </div>
       </header>
       <div
-        className={`grid items-stretch gap-4 lg:h-[calc(100vh-112px)] lg:min-h-[720px] lg:max-h-[920px] ${
-          actionSidebarCollapsed
-            ? 'lg:grid-cols-[48px_minmax(0,1fr)_300px]'
-            : 'lg:grid-cols-[190px_minmax(0,1fr)_300px]'
+        className={`grid items-stretch gap-3 lg:min-h-[680px] lg:grid-cols-[208px_minmax(0,1fr)] ${
+          toolsOpen ? 'xl:grid-cols-[208px_minmax(0,1fr)_320px]' : ''
         }`}
       >
         <nav
           aria-label="动作列表"
-          className={
-            actionSidebarCollapsed ? 'h-full min-h-0 w-12' : 'flex h-full min-h-0 min-w-0 flex-col'
-          }
+          className="min-h-0 min-w-0 overflow-hidden rounded-lg lg:h-[calc(100vh-9.5rem)] lg:min-h-[680px] lg:max-h-[900px]"
         >
-          <button
-            type="button"
-            aria-label={actionSidebarCollapsed ? '展开动作栏' : '收起动作栏'}
-            aria-expanded={!actionSidebarCollapsed}
-            aria-controls="playtest-action-list"
-            onClick={() => setActionSidebarCollapsed((collapsed) => !collapsed)}
-            className="mb-2 grid h-10 w-full shrink-0 place-items-center rounded-lg border border-slate-300 bg-white text-lg font-semibold text-slate-600 shadow-sm hover:border-slate-500"
-          >
-            {actionSidebarCollapsed ? '›' : '‹'}
-          </button>
-          <div id="playtest-action-list" hidden={actionSidebarCollapsed} className="min-h-0 flex-1">
-            <ActionSelector
-              actions={preview.actions}
-              selectedActionId={playback.state.actionId}
-              onSelectAction={playback.selectAction}
-            />
-          </div>
+          <ActionSelector
+            assets={availableAssets}
+            selectedAssetKey={selectedAssetKey}
+            actions={preview.actions}
+            selectedActionId={playback.state.actionId}
+            onSelectAsset={onSelectAsset}
+            onSelectAction={playback.selectAction}
+            onAddAction={onAddAction}
+          />
         </nav>
-        <section
-          aria-label="调试工作台"
-          className="flex h-full min-h-0 min-w-0 flex-col gap-4 overflow-hidden"
-        >
-          <div
-            role="group"
-            aria-label="方向选择"
-            className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm"
-          >
-            <span className="mr-1 text-xs font-semibold text-slate-500">方向</span>
-            <button
-              type="button"
-              onClick={() => setMirrored(!stageMotion.mirrored)}
-              className={`rounded-lg border px-3 py-2 text-xs font-semibold transition-colors ${
-                stageMotion.mirrored
-                  ? 'border-sky-600 bg-sky-600 text-white'
-                  : 'border-slate-200 bg-white text-slate-600 hover:border-slate-400'
-              }`}
-              title="翻转水平方向 (F)"
-            >
-              ⇄ 翻转
-            </button>
-            {playback.action?.sequences.map((sequence) => (
-              <button
-                key={sequence.direction}
-                type="button"
-                aria-pressed={sequence.direction === playback.state.direction}
-                disabled={sequence.frames.length === 0}
-                onClick={() => playback.selectDirection(sequence.direction)}
-                className={`rounded-lg border px-3 py-2 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
-                  sequence.direction === playback.state.direction
-                    ? 'border-emerald-900 bg-emerald-950 text-white'
-                    : 'border-slate-200 bg-white text-slate-600 hover:border-slate-400'
-                }`}
-              >
-                {sequence.direction}
-              </button>
-            ))}
-          </div>
-          <div className="min-h-[320px] flex-1">
+        <section aria-label="预览工作台" className="flex min-h-0 min-w-0 flex-col gap-2">
+          <div className="relative min-h-[360px] flex-1 lg:min-h-[480px]">
             <AnimationStage
               currentFrame={playback.frame}
               motionOffset={stageMotion.offset}
@@ -257,6 +272,42 @@ export function PlaytestWorkbench({
               showGrid
               showChecker
             />
+            <div
+              role="group"
+              aria-label="方向选择"
+              className="absolute left-3 top-3 z-20 flex max-w-[calc(100%-1.5rem)] flex-wrap items-center gap-1 rounded-md border border-[#aeb7b0] bg-white/90 p-1 backdrop-blur-sm"
+            >
+              <button
+                type="button"
+                aria-label="翻转方向"
+                aria-pressed={stageMotion.mirrored}
+                onClick={() => setMirrored(!stageMotion.mirrored)}
+                className={`grid h-8 w-8 place-items-center rounded text-base transition-colors ${
+                  stageMotion.mirrored
+                    ? 'bg-[#35583f] text-white'
+                    : 'text-[#59635b] hover:bg-[#e7ebe7]'
+                }`}
+                title="翻转水平方向 (F)"
+              >
+                ⇄
+              </button>
+              {playback.action?.sequences.map((sequence) => (
+                <button
+                  key={sequence.direction}
+                  type="button"
+                  aria-pressed={sequence.direction === playback.state.direction}
+                  disabled={sequence.frames.length === 0}
+                  onClick={() => playback.selectDirection(sequence.direction)}
+                  className={`min-h-8 rounded px-2 text-[10px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                    sequence.direction === playback.state.direction
+                      ? 'bg-[#252a27] text-white'
+                      : 'text-[#59635b] hover:bg-[#e7ebe7]'
+                  }`}
+                >
+                  {sequence.direction}
+                </button>
+              ))}
+            </div>
           </div>
           <div role="group" aria-label="播放控制">
             <PlaybackControls
@@ -281,84 +332,105 @@ export function PlaytestWorkbench({
             onSelectFrame={playback.selectFrame}
           />
         </section>
-        <aside
-          aria-label="Playtest 工具栏"
-          className="flex h-full min-h-0 flex-col gap-4 overflow-hidden"
-        >
-          <div
-            role="tablist"
-            aria-label="Playtest 工具"
-            className="grid grid-cols-3 gap-1 rounded-xl border border-slate-200 bg-white p-1 shadow-sm"
+        {toolsOpen ? (
+          <aside
+            id="playtest-tools"
+            aria-label="Playtest 工具栏"
+            className="flex min-h-0 flex-col gap-3 rounded-lg border border-[#cdd4ce] bg-[#f8f9f7] p-2 lg:col-span-2 xl:col-span-1 xl:h-[calc(100vh-9.5rem)] xl:min-h-[680px] xl:max-h-[900px]"
           >
-            {RIGHT_PANELS.map(([value, label]) => (
+            <header className="flex min-h-9 items-center justify-between border-b border-[#d9ded9] px-1 pb-2">
+              <strong className="text-xs">检查工具</strong>
               <button
-                key={value}
-                id={`playtest-tool-tab-${value}`}
                 type="button"
-                role="tab"
-                aria-selected={activeRightPanel === value}
-                aria-controls={`playtest-tool-panel-${value}`}
-                tabIndex={activeRightPanel === value ? 0 : -1}
-                onClick={() => setActiveRightPanel(value)}
-                onKeyDown={(event) => movePanelFocus(event, value)}
-                className={`rounded-lg px-2 py-2 text-[11px] font-semibold ${
-                  activeRightPanel === value
-                    ? 'bg-slate-900 text-white'
-                    : 'text-slate-500 hover:bg-slate-50'
-                }`}
+                aria-label="关闭检查工具"
+                onClick={() => setToolsOpen(false)}
+                className="grid h-8 w-8 place-items-center rounded text-lg text-[#687069] hover:bg-[#e8ece8]"
               >
-                {label}
+                ×
               </button>
-            ))}
-          </div>
-          <div
-            id="playtest-tool-panel-inspect"
-            role="tabpanel"
-            aria-labelledby="playtest-tool-tab-inspect"
-            hidden={activeRightPanel !== 'inspect'}
-            className="min-h-0 flex-1 overflow-y-auto pr-1"
-          >
-            <Inspector
-              action={playback.action}
-              sequence={playback.sequence}
-              frame={playback.frame}
-              frameIndex={playback.state.frameIndex}
-              reviewEvidence={reviewEvidence}
+            </header>
+            <div
+              role="tablist"
+              aria-label="Playtest 工具"
+              className="grid grid-cols-3 gap-1 rounded-md bg-[#e7ebe7] p-1"
+            >
+              {RIGHT_PANELS.map(([value, label]) => (
+                <button
+                  key={value}
+                  id={`playtest-tool-tab-${value}`}
+                  type="button"
+                  role="tab"
+                  aria-selected={activeRightPanel === value}
+                  aria-controls={`playtest-tool-panel-${value}`}
+                  tabIndex={activeRightPanel === value ? 0 : -1}
+                  onClick={() => setActiveRightPanel(value)}
+                  onKeyDown={(event) => movePanelFocus(event, value)}
+                  className={`rounded px-2 py-2 text-[10px] font-semibold ${
+                    activeRightPanel === value
+                      ? 'bg-white text-[#26372c] shadow-sm'
+                      : 'text-[#667068] hover:text-[#26372c]'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <div
+              id="playtest-tool-panel-inspect"
+              role="tabpanel"
+              aria-labelledby="playtest-tool-tab-inspect"
+              hidden={activeRightPanel !== 'inspect'}
+              className="min-h-0 flex-1 overflow-y-auto"
+            >
+              <Inspector
+                action={playback.action}
+                sequence={playback.sequence}
+                frame={playback.frame}
+                frameIndex={playback.state.frameIndex}
+                reviewEvidence={reviewEvidence}
+              />
+            </div>
+            <div
+              id="playtest-tool-panel-audit"
+              role="tabpanel"
+              aria-labelledby="playtest-tool-tab-audit"
+              hidden={activeRightPanel !== 'audit'}
+              className="min-h-0 flex-1 overflow-y-auto"
+            >
+              <AuditPanel
+                actionId={playback.action?.id ?? null}
+                actionName={playback.action?.name ?? null}
+                direction={playback.sequence?.direction ?? null}
+                frameIndex={playback.state.frameIndex}
+                frame={playback.frame}
+                automaticFindings={automaticFindings}
+                issues={manualIssues}
+                onAdd={(issue) => dispatchAudit({ type: 'add', issue })}
+                onUpdate={(id, category, note) =>
+                  dispatchAudit({ type: 'update', id, category, note })
+                }
+                onRemove={(id) => dispatchAudit({ type: 'remove', id })}
+              />
+            </div>
+            <div
+              id="playtest-tool-panel-export"
+              role="tabpanel"
+              aria-labelledby="playtest-tool-tab-export"
+              hidden={activeRightPanel !== 'export'}
+              className="min-h-0 flex-1 overflow-y-auto"
+            >
+              <ExportPanel model={preview} qualityIssueCount={qualityIssueCount} />
+            </div>
+            <Acceptance
+              inspectionStatus={inspection.status}
+              available={inspection.available}
+              loading={inspection.loading}
+              saving={inspection.saving}
+              error={inspection.error}
+              onRecordStatus={inspection.save}
             />
-          </div>
-          <div
-            id="playtest-tool-panel-audit"
-            role="tabpanel"
-            aria-labelledby="playtest-tool-tab-audit"
-            hidden={activeRightPanel !== 'audit'}
-            className="min-h-0 flex-1 overflow-y-auto pr-1"
-          >
-            <AuditPanel
-              actionId={playback.action?.id ?? null}
-              actionName={playback.action?.name ?? null}
-              direction={playback.sequence?.direction ?? null}
-              frameIndex={playback.state.frameIndex}
-              frame={playback.frame}
-              automaticFindings={automaticFindings}
-              issues={manualIssues}
-              onAdd={(issue) => dispatchAudit({ type: 'add', issue })}
-              onUpdate={(id, category, note) =>
-                dispatchAudit({ type: 'update', id, category, note })
-              }
-              onRemove={(id) => dispatchAudit({ type: 'remove', id })}
-            />
-          </div>
-          <div
-            id="playtest-tool-panel-export"
-            role="tabpanel"
-            aria-labelledby="playtest-tool-tab-export"
-            hidden={activeRightPanel !== 'export'}
-            className="min-h-0 flex-1 overflow-y-auto pr-1"
-          >
-            <ExportPanel model={preview} qualityIssueCount={qualityIssueCount} />
-          </div>
-          <Acceptance inspectionStatus={demoInspectionStatus} onRecordStatus={recordStatus} />
-        </aside>
+          </aside>
+        ) : null}
       </div>
     </main>
   )

--- a/frontend/src/pages/playtest/workbench/playback-controls.tsx
+++ b/frontend/src/pages/playtest/workbench/playback-controls.tsx
@@ -14,20 +14,6 @@ export interface PlaybackControlsProps {
   onToggleLoop(): void
 }
 
-function AvailabilityBadge({ available, label }: { available: boolean; label: string }) {
-  return (
-    <span
-      className={`rounded-full border px-2 py-1 text-[11px] font-semibold ${
-        available
-          ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
-          : 'border-amber-200 bg-amber-50 text-amber-800'
-      }`}
-    >
-      {label}
-    </span>
-  )
-}
-
 interface ControlButtonProps {
   label: string
   text: string
@@ -42,7 +28,7 @@ function ControlButton({ label, text, disabled = false, onPress }: ControlButton
       aria-label={label}
       disabled={disabled}
       onClick={onPress}
-      className="grid h-9 w-9 place-items-center rounded-lg border border-slate-200 bg-white text-sm hover:border-slate-400 disabled:cursor-not-allowed disabled:opacity-40"
+      className="grid h-9 w-9 place-items-center rounded-md border border-white/15 bg-white/6 text-sm text-white hover:bg-white/12 disabled:cursor-not-allowed disabled:opacity-35"
     >
       {text}
     </button>
@@ -65,12 +51,14 @@ export function PlaybackControls({
   onToggleLoop,
 }: PlaybackControlsProps) {
   const disabled = frameCount === 0
+  const keyboardStatus = `跳跃${jumpAvailable ? '可用' : '不可用'}，下蹲${crouchAvailable ? '可用' : '不可用'}`
 
   return (
     <section
       aria-label="播放控制"
-      className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm"
+      className="flex min-h-12 flex-wrap items-center gap-1.5 rounded-lg bg-[#252a27] px-2 py-1.5 text-white"
     >
+      <span className="sr-only">{keyboardStatus}</span>
       <ControlButton label="第一帧" text="|‹" disabled={disabled} onPress={onFirstFrame} />
       <ControlButton label="上一帧" text="‹" disabled={disabled} onPress={onPreviousFrame} />
       <button
@@ -78,46 +66,29 @@ export function PlaybackControls({
         aria-label={playing ? '暂停' : '播放'}
         disabled={disabled}
         onClick={onTogglePlaying}
-        className="min-w-20 rounded-lg bg-orange-500 px-4 py-2 text-xs font-semibold text-white hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-40"
+        className="grid h-9 w-12 place-items-center rounded-md bg-[#dce9df] text-sm font-semibold text-[#24402d] hover:bg-[#cce0d1] disabled:cursor-not-allowed disabled:opacity-40"
       >
-        {playing ? '暂停' : '播放'}
+        <span aria-hidden="true">{playing ? 'Ⅱ' : '▶'}</span>
       </button>
       <ControlButton label="下一帧" text="›" disabled={disabled} onPress={onNextFrame} />
       <ControlButton label="最后一帧" text="›|" disabled={disabled} onPress={onLastFrame} />
-      <span className="ml-1 border-l border-slate-200 pl-3 text-xs tabular-nums">
+      <span className="ml-1 border-l border-white/15 pl-2 text-[11px] tabular-nums text-white/80">
         {frameCount === 0
           ? '00 / 00'
           : `${String(frameIndex + 1).padStart(2, '0')} / ${String(frameCount).padStart(2, '0')}`}
       </span>
-      <span className="ml-auto text-[10px] font-semibold text-slate-500">FPS {fps || '—'}</span>
+      <span className="ml-auto text-[9px] font-semibold text-white/45">{fps || '—'} FPS</span>
       <button
         type="button"
+        aria-label="循环播放"
         aria-pressed={loop}
         onClick={onToggleLoop}
-        className={`rounded-lg border px-3 py-2 text-[10px] font-semibold ${
-          loop ? 'border-emerald-900 bg-emerald-950 text-white' : 'border-slate-200 text-slate-500'
+        className={`grid h-9 w-9 place-items-center rounded-md border text-base ${
+          loop ? 'border-[#a7c5ae] bg-[#dce9df] text-[#24402d]' : 'border-white/15 text-white/55'
         }`}
       >
-        循环
+        <span aria-hidden="true">↻</span>
       </button>
-      <div className="flex w-full flex-wrap items-center justify-between gap-3 border-t border-slate-100 pt-3">
-        <div className="flex flex-wrap gap-2 text-xs font-semibold text-slate-700">
-          <span>A 左行走</span>
-          <span>D 右行走</span>
-          <span>W 跳跃</span>
-          <span>S 下蹲</span>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <AvailabilityBadge
-            available={jumpAvailable}
-            label={jumpAvailable ? '跳跃动作可用' : '未提供跳跃动作'}
-          />
-          <AvailabilityBadge
-            available={crouchAvailable}
-            label={crouchAvailable ? '下蹲动作可用' : '未提供下蹲动作'}
-          />
-        </div>
-      </div>
     </section>
   )
 }

--- a/frontend/src/pages/playtest/workbench/use-playtest-inspection.ts
+++ b/frontend/src/pages/playtest/workbench/use-playtest-inspection.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type {
+  PlaytestInspectionApis,
+  PlaytestInspectionStatus,
+  PlaytestInspectionTarget,
+} from '@/entities/playtest-inspection'
+
+interface PlaytestInspectionState {
+  status: PlaytestInspectionStatus | null
+  loading: boolean
+  saving: boolean
+  error: string | null
+}
+
+const EMPTY_STATE: PlaytestInspectionState = {
+  status: null,
+  loading: false,
+  saving: false,
+  error: null,
+}
+
+function errorMessage(cause: unknown, fallback: string): string {
+  return cause instanceof Error && cause.message.trim() ? cause.message : fallback
+}
+
+export function usePlaytestInspection(
+  apis: Pick<PlaytestInspectionApis, 'get' | 'save'> | undefined,
+  target: PlaytestInspectionTarget | null,
+) {
+  const [state, setState] = useState<PlaytestInspectionState>(EMPTY_STATE)
+  const operationId = useRef(0)
+
+  useEffect(() => {
+    const currentOperation = ++operationId.current
+    if (apis === undefined || target === null) {
+      setState(EMPTY_STATE)
+      return
+    }
+
+    let active = true
+    setState({ ...EMPTY_STATE, loading: true })
+    void apis.get(target).then(
+      (inspection) => {
+        if (active && operationId.current === currentOperation) {
+          setState({ ...EMPTY_STATE, status: inspection?.status ?? null })
+        }
+      },
+      (cause: unknown) => {
+        if (active && operationId.current === currentOperation) {
+          setState({
+            ...EMPTY_STATE,
+            error: errorMessage(cause, '核验记录读取失败'),
+          })
+        }
+      },
+    )
+
+    return () => {
+      active = false
+    }
+  }, [apis, target])
+
+  const save = useCallback(
+    async (status: PlaytestInspectionStatus) => {
+      if (apis === undefined || target === null) return
+
+      const currentOperation = ++operationId.current
+      setState((current) => ({ ...current, saving: true, error: null }))
+      try {
+        const inspection = await apis.save({ ...target, status })
+        if (operationId.current === currentOperation) {
+          setState({ ...EMPTY_STATE, status: inspection.status })
+        }
+      } catch (cause) {
+        if (operationId.current === currentOperation) {
+          setState((current) => ({
+            ...current,
+            saving: false,
+            error: errorMessage(cause, '核验记录保存失败'),
+          }))
+        }
+      }
+    },
+    [apis, target],
+  )
+
+  return { ...state, save, available: apis !== undefined && target !== null }
+}

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 
@@ -15,6 +15,7 @@ import {
 import { createWorkflowController } from '@/features/workflow-controller'
 import { QuickStartPage } from '.'
 import { createQuickStartService } from './service'
+import type { QuickStartService } from './service'
 
 afterEach(cleanup)
 
@@ -101,12 +102,16 @@ function currentStep(run: WorkflowRun, type: WorkflowStep['type']) {
 }
 
 function LocationProbe() {
-  return <output aria-label="当前路径">{useLocation().pathname}</output>
+  const location = useLocation()
+  return <output aria-label="当前路径">{location.pathname + location.search}</output>
 }
 
-function renderQuickStart(service: ReturnType<typeof createHarness>['service']) {
+function renderQuickStart(
+  service: ReturnType<typeof createHarness>['service'] | QuickStartService,
+  initialEntry = '/quick-start',
+) {
   return render(
-    <MemoryRouter initialEntries={['/quick-start']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route
           path="/quick-start"
@@ -127,6 +132,7 @@ function renderQuickStart(service: ReturnType<typeof createHarness>['service']) 
           }
         />
         <Route path="/workflow-editor/:runId" element={<h1>工作流画布</h1>} />
+        <Route path="/playtest/:characterId/:outfitId" element={<LocationProbe />} />
       </Routes>
     </MemoryRouter>,
   )
@@ -229,4 +235,134 @@ describe('QuickStartPage', () => {
     expect(currentStep(run!, 'character-template')?.status).toBe('passed')
     expect(currentStep(run!, 'template-candidate')?.status).toBe('active')
   })
+
+  it('publishes once and opens the generated action in Playtest', async () => {
+    const run = completedActionRun()
+    const service: QuickStartService = {
+      unavailableReason: null,
+      start: vi.fn(),
+      startAction: vi.fn(),
+      getWorkflow: vi.fn(() => run),
+      subscribe: vi.fn(() => () => undefined),
+      resume: vi.fn(async () => run),
+      interrupt: vi.fn(() => run),
+      confirmCandidate: vi.fn(),
+      approveReview: vi.fn(async () => ({ ...run, status: 'completed' as const })),
+      getCharacterInfo: vi.fn(() => ({ characterId: '25', outfitId: 'outfit-25-default' })),
+      resolveCharacterInfo: vi.fn(),
+    }
+
+    renderQuickStart(service, '/quick-start/run-1')
+    fireEvent.click(await screen.findByRole('button', { name: '一键导入 Playtest' }))
+
+    await waitFor(() =>
+      expect(screen.getByLabelText('当前路径').textContent).toBe(
+        '/playtest/25/outfit-25-default?actionId=25-run-1',
+      ),
+    )
+    expect(service.approveReview).toHaveBeenCalledExactlyOnceWith('run-1')
+  })
+
+  it('starts an action-only run for the character selected in Playtest', async () => {
+    const run = completedActionRun()
+    const service: QuickStartService = {
+      unavailableReason: null,
+      start: vi.fn(),
+      startAction: vi.fn(async () => run),
+      getWorkflow: vi.fn(() => run),
+      subscribe: vi.fn(() => () => undefined),
+      resume: vi.fn(async () => run),
+      interrupt: vi.fn(() => run),
+      confirmCandidate: vi.fn(),
+      approveReview: vi.fn(async () => run),
+      getCharacterInfo: vi.fn(() => ({ characterId: '25', outfitId: 'outfit-25-default' })),
+      resolveCharacterInfo: vi.fn(),
+    }
+
+    renderQuickStart(service, '/quick-start?characterId=25&outfitId=outfit-25-default')
+    fireEvent.change(screen.getByLabelText('动作描述'), {
+      target: { value: '挥手打招呼' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '开始生成新动作' }))
+
+    await waitFor(() =>
+      expect(service.startAction).toHaveBeenCalledWith(
+        { characterId: '25', outfitId: 'outfit-25-default' },
+        '挥手打招呼',
+      ),
+    )
+    await waitFor(() =>
+      expect(screen.getByLabelText('当前路径').textContent).toBe('/quick-start/run-1'),
+    )
+  })
 })
+
+function completedActionRun(): WorkflowRun {
+  const common = {
+    taskId: null,
+    submissionId: null,
+    error: null,
+    referenceStepIds: [],
+  }
+  return {
+    id: 'run-1',
+    projectId: '37',
+    characterId: '25',
+    outfitId: 'outfit-25-default',
+    purpose: 'create_character',
+    driver: 'ai',
+    status: 'active',
+    currentRevisionId: 'revision-1',
+    prompt: '提着灯笼的守夜人',
+    revisions: [
+      {
+        id: 'revision-1',
+        basedOnRevisionId: null,
+        restartStepId: null,
+        status: 'active',
+        generationStatus: 'completed',
+        exportStatus: 'not_exported',
+        createdAt: '2026-08-03T00:00:00.000Z',
+        steps: [
+          {
+            ...common,
+            id: 'setup',
+            type: 'character-setup',
+            status: 'passed',
+            input: null,
+            output: null,
+          },
+          {
+            ...common,
+            id: 'template',
+            type: 'character-template',
+            status: 'passed',
+            input: null,
+            output: { type: 'character_template', images: [{ url: 'character.png' }] },
+          },
+          {
+            ...common,
+            id: 'candidate',
+            type: 'template-candidate',
+            status: 'passed',
+            input: null,
+            output: null,
+          },
+          {
+            ...common,
+            id: 'action',
+            type: 'action-generation',
+            status: 'passed',
+            input: null,
+            output: {
+              type: 'complete_animation',
+              actionType: 'custom',
+              frames: [{ url: 'frame.png', durationMs: 125 }],
+            },
+          },
+          { ...common, id: 'review', type: 'review', status: 'active', input: null, output: null },
+        ],
+      },
+    ],
+  }
+}

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type FormEvent } from 'react'
-import { useNavigate, useParams } from 'react-router'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router'
 
 import {
   WORKFLOW_STEP_ORDER,
@@ -9,7 +9,7 @@ import {
   type WorkflowStep,
   type WorkflowStepType,
 } from '@/entities'
-import { buildPlaytestPath } from '@/features/publish'
+import { buildPlaytestPath, buildPublishedActionId } from '@/features/publish'
 import { unavailableQuickStartService, type QuickStartService } from './service'
 
 export type {
@@ -48,11 +48,86 @@ export interface QuickStartPageProps {
 /** Quick Start 独立完成 AI 入口；它不跳转 Workflow Editor。 */
 export function QuickStartPage({ service = unavailableQuickStartService }: QuickStartPageProps) {
   const { runId } = useParams()
+  const [searchParams] = useSearchParams()
+  const characterId = searchParams.get('characterId')
+  const outfitId = searchParams.get('outfitId')
 
   return runId ? (
     <QuickStartRun service={service} runId={runId} />
+  ) : characterId && outfitId ? (
+    <QuickStartActionInput service={service} target={{ characterId, outfitId }} />
   ) : (
     <QuickStartInput service={service} />
+  )
+}
+
+function QuickStartActionInput({
+  service,
+  target,
+}: {
+  service: QuickStartService
+  target: { characterId: string; outfitId: string }
+}) {
+  const navigate = useNavigate()
+  const [description, setDescription] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const prompt = description.trim()
+    if (!prompt || submitting || service.unavailableReason) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const run = await service.startAction(target, prompt)
+      navigate(`/quick-start/${encodeURIComponent(run.id)}`)
+    } catch (cause) {
+      setError(errorMessage(cause, '创建动作失败，请稍后重试'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className="min-h-[560px] border border-[#c9d0ca] bg-[#dfe3df] p-6 text-[#171817] sm:p-10">
+      <Link
+        to={buildPlaytestPath(target)}
+        className="text-xs font-semibold text-[#59635b] hover:text-[#2f4e38]"
+      >
+        ← 返回当前 Playtest
+      </Link>
+      <div className="mx-auto mt-14 max-w-2xl">
+        <p className="font-mono text-[10px] font-bold text-[#687069]">ADD ACTION</p>
+        <h1 className="mt-3 font-serif text-4xl">给当前角色增加动作</h1>
+        <p className="mt-3 text-sm text-[#687069]">
+          新动作会追加到角色 {target.characterId} 的当前造型，不会新建角色或覆盖已有动作。
+        </p>
+        <form onSubmit={submit} className="mt-8 space-y-4">
+          <label className="block text-xs font-semibold text-[#4f5b52]">
+            动作描述
+            <textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="例如：挥手打招呼、蹲下查看地面、举起画笔作画"
+              className="mt-2 min-h-32 w-full resize-y rounded-lg border border-[#aeb8b0] bg-white p-4 text-base outline-none focus:border-[#35583f]"
+            />
+          </label>
+          {error ? (
+            <p role="alert" className="text-sm text-[#983c32]">
+              {error}
+            </p>
+          ) : null}
+          <button
+            type="submit"
+            disabled={!description.trim() || submitting || Boolean(service.unavailableReason)}
+            className="min-h-11 rounded-lg bg-[#35583f] px-5 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {submitting ? '正在开始生成…' : '开始生成新动作'}
+          </button>
+        </form>
+      </div>
+    </section>
   )
 }
 
@@ -205,6 +280,7 @@ function QuickStartRun({ service, runId }: { service: QuickStartService; runId: 
   const [error, setError] = useState<string | null>(null)
   const [selectedCandidate, setSelectedCandidate] = useState<string | null>(null)
   const [actionDescription, setActionDescription] = useState('')
+  const [publishing, setPublishing] = useState(false)
 
   useEffect(() => {
     let active = true
@@ -309,14 +385,31 @@ function QuickStartRun({ service, runId }: { service: QuickStartService; runId: 
   }
 
   async function publishToPlaytest() {
-    await service.approveReview(runId)
-    // 内存 Map / 持久化引用缺失时（动作生成中或旧运行记录），从后端按项目反查
-    const info = service.getCharacterInfo(runId) ?? (await service.resolveCharacterInfo(runId))
-    if (info) {
-      navigate(buildPlaytestPath(info))
-      return
+    if (publishing) return
+    setPublishing(true)
+    setError(null)
+    try {
+      const approved = await service.approveReview(runId)
+      setRun(approved)
+      // 内存 Map / 持久化引用缺失时（旧运行记录），从后端按项目反查。
+      const info = service.getCharacterInfo(runId) ?? (await service.resolveCharacterInfo(runId))
+      if (!info) throw new Error('动作已生成，但没有找到对应的角色资产')
+      const approvedRevision = approved.revisions.find(
+        (item) => item.id === approved.currentRevisionId,
+      )
+      const approvedAction = approvedRevision?.steps.find(
+        (step) => step.type === 'action-generation',
+      )
+      const actionId =
+        approvedAction?.type === 'action-generation' && approvedAction.output
+          ? buildPublishedActionId(info.characterId, approved.id)
+          : undefined
+      navigate(buildPlaytestPath({ ...info, actionId }))
+    } catch (cause) {
+      setError(errorMessage(cause, '导入 Playtest 失败'))
+    } finally {
+      setPublishing(false)
     }
-    setError('尚未找到可导出的角色，请等待动作生成完成后再试')
   }
 
   return (
@@ -517,12 +610,11 @@ function QuickStartRun({ service, runId }: { service: QuickStartService; runId: 
               {canPublish ? (
                 <button
                   type="button"
-                  onClick={() => {
-                    void publishToPlaytest()
-                  }}
-                  className="rounded-xl bg-[#2a5284] px-4 py-2 text-xs font-bold text-white transition hover:bg-[#3668a0]"
+                  onClick={() => void publishToPlaytest()}
+                  disabled={publishing}
+                  className="rounded-lg bg-[#2a5284] px-4 py-2 text-xs font-bold text-white transition hover:bg-[#3668a0] disabled:cursor-wait disabled:opacity-60"
                 >
-                  发布到预览台
+                  {publishing ? '正在导入…' : '一键导入 Playtest'}
                 </button>
               ) : null}
               {candidates.length || run.status === 'failed' || run.status === 'interrupted' ? (
@@ -590,6 +682,29 @@ function describeRun(run: WorkflowRun, revision: WorkflowRevision) {
     }
   }
 
+  const actionStep = revision.steps.find((step) => step.type === 'action-generation')
+  if (actionStep?.status === 'active') {
+    return {
+      title: '正在生成动作',
+      description: '角色图已确认，正在生成动作帧…',
+      error: null,
+    }
+  }
+  if (actionStep?.status === 'passed') {
+    return {
+      title: '动作生成完成',
+      description: '动作帧已回传，可以一键写入资产并载入 Playtest。',
+      error: null,
+    }
+  }
+  if (actionStep?.status === 'failed') {
+    return {
+      title: '动作生成失败',
+      description: typeof actionStep.error === 'string' ? actionStep.error : '动作生成失败',
+      error: typeof actionStep.error === 'string' ? actionStep.error : '动作生成失败',
+    }
+  }
+
   const templateStep = revision.steps.find(
     (step): step is CharacterTemplateWorkflowStep => step.type === 'character-template',
   )
@@ -607,28 +722,6 @@ function describeRun(run: WorkflowRun, revision: WorkflowRevision) {
         ? '任务 ID 已保存，刷新页面后仍可恢复同一次生成。'
         : '正在等待生成服务返回可追踪的任务 ID。',
       error: null,
-    }
-  }
-  const actionStep = revision.steps.find((step) => step.type === 'action-generation')
-  if (actionStep?.status === 'active') {
-    return {
-      title: '正在生成动作',
-      description: '角色图已确认，正在生成 idle 动作帧…',
-      error: null,
-    }
-  }
-  if (actionStep?.status === 'passed') {
-    return {
-      title: '动作生成完成',
-      description: '角色动作已生成，可以导出到预览台。',
-      error: null,
-    }
-  }
-  if (actionStep?.status === 'failed') {
-    return {
-      title: '动作生成失败',
-      description: typeof actionStep.error === 'string' ? actionStep.error : '动作生成失败',
-      error: typeof actionStep.error === 'string' ? actionStep.error : '动作生成失败',
     }
   }
 

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -135,6 +135,7 @@ describe('createQuickStartService export recovery', () => {
       listByProject: vi.fn(async () => [character]),
       create: vi.fn(async () => character),
       update: vi.fn(async (input) => input),
+      remove: vi.fn(async () => undefined),
     }
     const { service, store } = createHarness(characterApis)
     const run: WorkflowRun = {
@@ -170,6 +171,7 @@ describe('createQuickStartService export recovery', () => {
       update: vi.fn(async () => {
         throw new Error('not used')
       }),
+      remove: vi.fn(async () => undefined),
     }
     const { service, store } = createHarness(characterApis)
     const run: WorkflowRun = {
@@ -193,6 +195,64 @@ describe('createQuickStartService export recovery', () => {
 })
 
 describe('createQuickStartService action generation', () => {
+  it('adds a new custom action to the existing outfit without replacing another custom action', async () => {
+    const character = makeCharacter('42', 'outfit-42-default')
+    character.outfits[0]!.actions.push({
+      id: '42-older-run',
+      outfitId: 'outfit-42-default',
+      name: '画画',
+      kind: 'custom',
+      type: 'custom',
+      fps: 8,
+      keyFrameIndex: 0,
+      frames: [{ imageUrl: 'https://example.com/old.png', durationMs: 125, rootMotion: null }],
+    })
+    const characterApis: CharacterApis = {
+      get: vi.fn(async () => character),
+      listByProject: vi.fn(async () => [character]),
+      create: vi.fn(async () => character),
+      update: vi.fn(async (input) => input),
+      remove: vi.fn(async () => undefined),
+    }
+    const harness = createHarness(characterApis)
+
+    const started = await harness.service.startAction(
+      { characterId: '42', outfitId: 'outfit-42-default' },
+      '挥手打招呼',
+    )
+
+    expect(started.purpose).toBe('add_action')
+    expect(characterApis.create).not.toHaveBeenCalled()
+    expect(harness.generationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'complete_animation',
+        characterId: '42',
+        outfitId: 'outfit-42-default',
+        actionType: 'custom',
+        prompt: '挥手打招呼',
+      }),
+    )
+
+    harness.taskListeners.get('task-complete_animation')?.({
+      taskId: 'task-complete_animation',
+      type: 'complete_animation',
+      status: 'completed',
+      error: null,
+      result: {
+        type: 'complete_animation',
+        actionType: 'custom',
+        frames: [{ url: 'https://example.com/new.png', durationMs: 125 }],
+      },
+    })
+    await harness.service.approveReview(started.id)
+
+    const saved = vi.mocked(characterApis.update).mock.calls[0]?.[0]
+    expect(saved?.outfits[0]?.actions.map(({ id, name }) => ({ id, name }))).toEqual([
+      { id: '42-older-run', name: '画画' },
+      { id: '42-id-run-1', name: '挥手打招呼' },
+    ])
+  })
+
   it('does not enter action generation before character preparation can be persisted', async () => {
     const character = makeCharacter('42', 'outfit-42-default')
     let resolveCharacter!: (value: Character) => void
@@ -204,6 +264,7 @@ describe('createQuickStartService action generation', () => {
       listByProject: vi.fn(async () => [character]),
       create: vi.fn(() => pendingCharacter),
       update: vi.fn(async (input) => input),
+      remove: vi.fn(async () => undefined),
     }
     const harness = createHarness(characterApis)
     await advanceToCandidate(harness)
@@ -238,6 +299,7 @@ describe('createQuickStartService action generation', () => {
       listByProject: vi.fn(async () => [character]),
       create: vi.fn(async () => character),
       update: vi.fn(async (input) => input),
+      remove: vi.fn(async () => undefined),
     }
     const harness = createHarness(characterApis)
     await advanceToCandidate(harness)
@@ -264,6 +326,7 @@ describe('createQuickStartService action generation', () => {
       listByProject: vi.fn(async () => [character]),
       create: vi.fn(async () => character),
       update: vi.fn(async (input) => input),
+      remove: vi.fn(async () => undefined),
     }
     const harness = createHarness(characterApis)
     await advanceToCandidate(harness)

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -24,6 +24,11 @@ export interface QuickStartService {
   /** 为 null 时可以创建；非 null 时页面必须明确阻止提交，不能回退到假数据。 */
   readonly unavailableReason: string | null
   start(prompt: string): Promise<WorkflowRun>
+  /** 复用已有角色和造型，直接开始一条增加动作的运行。 */
+  startAction(
+    target: { characterId: string; outfitId: string },
+    actionDescription: string,
+  ): Promise<WorkflowRun>
   getWorkflow(runId: WorkflowRun['id']): WorkflowRun | null
   subscribe(runId: WorkflowRun['id'], listener: (run: WorkflowRun) => void): () => void
   resume(runId: WorkflowRun['id']): Promise<WorkflowRun | null>
@@ -112,6 +117,43 @@ export function createQuickStartService({
         if (stored?.status === 'failed') return stored
         throw cause
       }
+    },
+
+    async startAction(target, actionDescription) {
+      if (!characterApis || !generationApis) {
+        throw new Error('角色或生成服务尚未配置，不能增加动作')
+      }
+      const prompt = actionDescription.trim()
+      if (!prompt) throw new Error('请先描述要添加的动作')
+
+      const character = await characterApis.get(target.characterId)
+      const outfit = character.outfits.find((item) => item.id === target.outfitId)
+      if (!outfit) throw new Error('当前角色中没有找到目标造型')
+      const firstFrameUrl = outfit.characterTemplateUrl ?? outfit.baseFrames[0]?.imageUrl ?? null
+      if (!firstFrameUrl) throw new Error('当前造型没有可用于生成动作的角色图')
+
+      const created = controller.create({
+        projectId: character.projectId,
+        purpose: 'add_action',
+        driver: 'ai',
+        prompt,
+        characterId: character.id,
+        outfitId: outfit.id,
+        characterTemplateUrl: firstFrameUrl,
+        baseFrameUrls: outfit.baseFrames.map((frame) => frame.imageUrl),
+      })
+      characterMap.set(created.id, { characterId: character.id, outfitId: outfit.id })
+
+      return controller.startActionGeneration(created.id, {
+        type: 'complete_animation',
+        projectId: character.projectId,
+        characterId: character.id,
+        outfitId: outfit.id,
+        actionType: 'custom',
+        firstFrameUrl,
+        prompt,
+        referenceMedia: [firstFrameUrl as MediaReference],
+      })
     },
 
     getWorkflow(runId) {
@@ -274,6 +316,10 @@ export const unavailableQuickStartService: QuickStartService = {
   unavailableReason: UNAVAILABLE_REASON,
 
   async start() {
+    throw new Error(UNAVAILABLE_REASON)
+  },
+
+  async startAction() {
     throw new Error(UNAVAILABLE_REASON)
   },
 

--- a/frontend/src/shared/api/http-client.test.ts
+++ b/frontend/src/shared/api/http-client.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { get, post } from './http-client'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('http client request headers', () => {
+  it('does not force a CORS preflight for a bodyless GET request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await get('/projects')
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(new Headers(init.headers).has('Content-Type')).toBe(false)
+  })
+
+  it('marks a JSON request body with the correct content type', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await post('/projects', { name: 'Windup' })
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(new Headers(init.headers).get('Content-Type')).toBe('application/json')
+  })
+})
+
+function jsonResponse(data: unknown) {
+  return new Response(JSON.stringify({ code: 200, message: 'success', data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/frontend/src/shared/api/http-client.ts
+++ b/frontend/src/shared/api/http-client.ts
@@ -24,7 +24,12 @@ export async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const url = `${BASE_URL}${path}`
   const headers = new Headers(init?.headers)
 
-  if (!headers.has('Content-Type') && !(init?.body instanceof FormData)) {
+  if (
+    init?.body !== undefined &&
+    init.body !== null &&
+    !headers.has('Content-Type') &&
+    !(init.body instanceof FormData)
+  ) {
     headers.set('Content-Type', 'application/json')
   }
 


### PR DESCRIPTION
## 改动内容

- 将 `/playtest` 明确为独立预览台入口，提供项目、角色、造型和动作选择。
- 简化预览台布局，并允许同一角色的多个动作在“动作实例”中直接切换。
- 从 Playtest 的新增动作入口进入 Quick Start `add_action` 流程，跳过角色形象生成，直接为当前角色与造型生成动作。
- 使用 WorkflowRun ID 生成唯一动作 ID，发布新动作时保留已有同类型动作，不再发生覆盖。
- 保存每个动作当前最新的 Playtest 核验结论，并修正透明边界、位移和序列质量证据计算。
- 补齐 Playtest 目录操作需要的角色移动、改名和删除接口。

## 问题原因

此前 Quick Start 只初始化“创建角色”流程，Playtest 没有给已有角色增加动作的入口；发布动作又使用“角色 ID + 动作类型”作为固定 ID，导致多个 custom 动作互相覆盖，最终表现为不同动作无法同时导入和切换。

## 范围说明

- 仅包含前端代码。
- 不包含后端实现、Projects 页面整合、数据库、日志、截图或构建产物。
- 这是堆叠 PR，基于 `feat/playtest-on-module-skeleton` 评审 Playtest 增量；不会在此操作中合并。

## 验证

- `npm run test`：36 个测试文件、219 项测试通过
- `npm run typecheck`：通过
- `npm run build`：通过
- `npm run lint`：通过
- 本 PR 44 个改动文件的 `oxfmt --check`：通过
- `git diff --cached --check`：通过
- 已实测同一角色保留并切换两个 16 帧动作