### PR TITLE
feat(playtest): add standalone multi-action preview

### DIFF
--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { App } from './app'
+
+afterEach(() => {
+  cleanup()
+  window.history.replaceState({}, '', '/')
+})
+
+describe('App Playtest route', () => {
+  it('routes /playtest to the standalone Playtest catalog', () => {
+    window.history.replaceState({}, '', '/playtest')
+
+    render(<App />)
+
+    expect(screen.getByRole('heading', { name: 'Playtest' })).toBeTruthy()
+  })
+})

--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -1,20 +1,41 @@
+import { useMemo } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router'
 
+import { createCharacterApis, createPlaytestInspectionApis, createProjectApis } from '@/entities'
 import { AssetLibraryPage } from '@/pages/asset-library'
 import { HomePage } from '@/pages/home'
 import { NotFoundPage } from '@/pages/not-found'
 import { PlaytestPage } from '@/pages/playtest'
+import { PlaytestCatalogPage } from '@/pages/playtest/catalog'
 import { ProjectDetailPage } from '@/pages/project-detail'
 import { ProjectsPage } from '@/pages/projects'
 import { QuickStartPage } from '@/pages/quick-start'
 import { WorkflowEditorPage } from '@/pages/workflow-editor'
 import { AppShell } from './layout'
 
+function PlaytestFromBackend() {
+  const apis = useMemo(
+    () => ({
+      characters: createCharacterApis(),
+      projects: createProjectApis(),
+      inspections: createPlaytestInspectionApis(),
+    }),
+    [],
+  )
+
+  return <PlaytestPage apis={apis} />
+}
+
 /**
  * 路由表与全局外壳。
  * 页面自己获取所需数据，不再由 app 层构造服务后逐层传入。
  */
 export function App() {
+  const catalogApis = useMemo(
+    () => ({ projects: createProjectApis(), characters: createCharacterApis() }),
+    [],
+  )
+
   return (
     <BrowserRouter>
       <AppShell>
@@ -27,7 +48,8 @@ export function App() {
           <Route path="/projects/:projectId/assets" element={<AssetLibraryPage />} />
           <Route path="/workflow-editor/:runId" element={<WorkflowEditorPage />} />
           <Route path="/workflow-editor/:runId/:stage" element={<WorkflowEditorPage />} />
-          <Route path="/playtest/:characterId/:outfitId" element={<PlaytestPage />} />
+          <Route path="/playtest" element={<PlaytestCatalogPage apis={catalogApis} />} />
+          <Route path="/playtest/:characterId/:outfitId" element={<PlaytestFromBackend />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </AppShell>

--- a/frontend/src/app/layout/index.tsx
+++ b/frontend/src/app/layout/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { Link } from 'react-router'
+import { Link, useLocation } from 'react-router'
 
 /** 跨页面常驻导航属于应用外壳，由 app 层统一承载。 */
 
@@ -10,6 +10,9 @@ export interface AppShellProps {
 
 /** 全站外壳，全局导航常驻。 */
 export function AppShell({ children }: AppShellProps) {
+  const { pathname } = useLocation()
+  const isPlaytest = pathname.startsWith('/playtest')
+
   return (
     <div className="min-h-screen bg-white text-slate-900">
       <nav className="flex items-center justify-between border-b border-slate-200 px-6 py-3">
@@ -21,9 +24,12 @@ export function AppShell({ children }: AppShellProps) {
           <Link to="/projects" className="hover:text-slate-900">
             项目
           </Link>
+          <Link to="/playtest" className="hover:text-slate-900">
+            Playtest
+          </Link>
         </div>
       </nav>
-      <main className="mx-auto max-w-5xl px-6 py-8">{children}</main>
+      <main className={isPlaytest ? 'w-full' : 'mx-auto max-w-5xl px-6 py-8'}>{children}</main>
     </div>
   )
 }

--- a/frontend/src/entities/character/api.test.ts
+++ b/frontend/src/entities/character/api.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createCharacterApis } from './api'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('character API adapter', () => {
+  it('preserves an action loop flag when saving the complete character tree', async () => {
+    const backendCharacter = {
+      id: 25,
+      project_id: 3,
+      description: null,
+      reference_image_url: null,
+      status: 1,
+      character_data: {
+        version: 1,
+        outfits: [
+          {
+            id: 'outfit-default',
+            name: 'Default',
+            description: null,
+            preview_url: null,
+            actions: [
+              {
+                id: 'idle',
+                type: 'idle',
+                name: 'Idle',
+                loop: true,
+                fps: 8,
+                frame_count: 1,
+                frames: [
+                  { index: 0, image_url: '/idle-0.png', duration_ms: 125, root_motion: null },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(backendCharacter))
+      .mockResolvedValueOnce(jsonResponse(backendCharacter))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const apis = createCharacterApis()
+    const character = await apis.get('25')
+    await apis.update(character)
+
+    expect(character.outfits[0]?.actions[0]?.loop).toBe(true)
+    const updateRequest = fetchMock.mock.calls[1]?.[1] as RequestInit
+    const updateBody = JSON.parse(String(updateRequest.body)) as {
+      character_data: { outfits: Array<{ actions: Array<{ loop: boolean }> }> }
+    }
+    expect(updateBody.character_data.outfits[0]?.actions[0]?.loop).toBe(true)
+  })
+})
+
+function jsonResponse(data: unknown) {
+  return new Response(JSON.stringify({ code: 200, message: 'success', data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/frontend/src/entities/character/api.ts
+++ b/frontend/src/entities/character/api.ts
@@ -1,0 +1,158 @@
+import type { Action, ActionType, Character, CharacterApis, Frame, Outfit } from '.'
+
+import { del, get, patch } from '@/shared/api'
+
+/* ─── 后端 DTO ─── */
+
+interface BackendFrame {
+  index: number
+  image_url: string
+  duration_ms: number | null
+  root_motion?: { dx: number; dy: number } | null
+}
+
+interface BackendAction {
+  id: string
+  type: string
+  name: string
+  loop: boolean
+  fps: number
+  frame_count: number
+  frames: BackendFrame[]
+}
+
+interface BackendOutfit {
+  id: string
+  name: string
+  description: string | null
+  preview_url: string | null
+  actions: BackendAction[]
+}
+
+interface BackendCharacterData {
+  version: number
+  outfits: BackendOutfit[]
+}
+
+interface BackendCharacter {
+  id: number
+  project_id: number
+  description: string | null
+  reference_image_url: string | null
+  character_data: BackendCharacterData
+  status: number
+}
+
+/* ─── 映射 ─── */
+
+const ACTION_TYPE_SET = new Set<string>(['walk', 'idle', 'attack', 'jump', 'custom'])
+
+function toActionType(raw: string): ActionType {
+  return ACTION_TYPE_SET.has(raw) ? (raw as ActionType) : 'custom'
+}
+
+function toFrame(raw: BackendFrame): Frame {
+  return {
+    imageUrl: raw.image_url,
+    durationMs: raw.duration_ms,
+    rootMotion: raw.root_motion ?? null,
+  }
+}
+
+function toAction(raw: BackendAction, outfitId: string): Action {
+  return {
+    id: raw.id,
+    outfitId,
+    name: raw.name,
+    loop: raw.loop,
+    kind: 'custom', // 后端不区分 preset/custom
+    type: toActionType(raw.type),
+    fps: raw.fps,
+    keyFrameIndex: null, // 后端不提供关键帧索引
+    frames: raw.frames.sort((a, b) => a.index - b.index).map(toFrame),
+  }
+}
+
+function toOutfit(raw: BackendOutfit, characterId: string): Outfit {
+  return {
+    id: raw.id,
+    characterId,
+    name: raw.name,
+    candidateCharacterTemplates: [], // 后端 character_data 不含候选
+    characterTemplateUrl: raw.preview_url,
+    baseFrames: [],
+    actions: raw.actions.map((a) => toAction(a, raw.id)),
+  }
+}
+
+function toCharacter(raw: BackendCharacter): Character {
+  const id = String(raw.id)
+  return {
+    id,
+    projectId: String(raw.project_id),
+    createdAt: '', // 后端列表不返回时间戳
+    updatedAt: '',
+    outfits: (raw.character_data?.outfits ?? []).map((o) => toOutfit(o, id)),
+  }
+}
+
+/* ─── 适配器 ─── */
+
+export function createCharacterApis(): Pick<
+  CharacterApis,
+  'get' | 'listByProject' | 'update' | 'remove'
+> {
+  return {
+    async get(id: string): Promise<Character> {
+      const raw = await get<BackendCharacter>(`/characters/${id}`)
+      return toCharacter(raw)
+    },
+
+    async listByProject(projectId: string): Promise<Character[]> {
+      // http-client 已解包 ApiEnvelope，data 字段就是角色数组本身
+      const raw = await get<BackendCharacter[]>(
+        `/characters?project_id=${encodeURIComponent(projectId)}&page_size=100`,
+      )
+      return raw.map(toCharacter)
+    },
+
+    async update(character: Character): Promise<Character> {
+      const payload = {
+        project_id: Number(character.projectId),
+        character_data: {
+          version: 1,
+          outfits: character.outfits.map((outfit) => ({
+            id: outfit.id,
+            name: outfit.name,
+            description: null,
+            preview_url: outfit.characterTemplateUrl,
+            actions: outfit.actions.map((action) => ({
+              id: action.id,
+              type: action.type,
+              name: action.name,
+              loop: action.loop ?? false,
+              fps: action.fps,
+              frame_count: action.frames.length,
+              frames: action.frames.map((frame, index) => ({
+                index,
+                image_url: frame.imageUrl,
+                duration_ms: frame.durationMs,
+                root_motion: frame.rootMotion,
+              })),
+            })),
+          })),
+        },
+      }
+      const raw = await patch<BackendCharacter>(`/characters/${character.id}`, payload)
+      const saved = toCharacter(raw)
+      if (saved.projectId !== character.projectId) {
+        throw new Error('后端未保存新的项目归属')
+      }
+      return saved
+    },
+
+    async remove(id: string): Promise<void> {
+      await del(`/characters/${id}`)
+    },
+  }
+}

--- a/frontend/src/entities/character/index.ts
+++ b/frontend/src/entities/character/index.ts
@@ -61,6 +61,8 @@ export interface Action {
   id: string
   outfitId: Outfit['id']
   name: string
+  /** 是否在播放到末帧后从首帧继续；整树更新时必须原样保存。 */
+  loop?: boolean
   /** 定义来源方式；与 type 正交，不用于推断动作业务语义。 */
   kind: ActionKind
   /** 动作业务语义；与 kind 的 preset/custom 来源维度相互独立。 */
@@ -134,4 +136,5 @@ export interface CharacterApis {
   listByProject(projectId: string): Promise<Character[]>
   create(input: CreateCharacterInput): Promise<Character>
   update(character: Character): Promise<Character>
+  remove(id: Character['id']): Promise<void>
 }

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -5,6 +5,7 @@
 
 /* 项目 —— 全局约束：视角、朝向、精灵尺寸、画风 */
 export { CHARACTER_PERSPECTIVE, DIRECTIONAL_MOVEMENT, SPRITE_SIZES } from './project'
+export { createProjectApis } from './project/api'
 export type {
   CharacterPerspective,
   CreateProjectInput,
@@ -29,6 +30,7 @@ export type {
   FrameRootMotion,
   Outfit,
 } from './character'
+export { createCharacterApis } from './character/api'
 
 /* 动作模板 —— 能跨角色复用的配方 */
 export type { ActionTemplate, ActionTemplateApis } from './action-template'
@@ -54,6 +56,16 @@ export type {
 
 /* 媒体引用 —— 不承诺 URL 或后端 Media ID 的具体表示 */
 export type { MediaReference } from './media'
+
+/* Playtest 核验 —— 只保存某个动作当前的核验结论，不承担历史记录。 */
+export { createPlaytestInspectionApis } from './playtest-inspection/api'
+export type {
+  PlaytestInspection,
+  PlaytestInspectionApis,
+  PlaytestInspectionStatus,
+  PlaytestInspectionTarget,
+  SavePlaytestInspectionInput,
+} from './playtest-inspection'
 
 /* 工作流 —— 节点与运行状态都由前端管理 */
 export { WORKFLOW_STEP_ORDER } from './workflow-run'

--- a/frontend/src/entities/playtest-inspection/api.ts
+++ b/frontend/src/entities/playtest-inspection/api.ts
@@ -1,0 +1,65 @@
+import { ApiError, get, post } from '@/shared/api'
+
+import type {
+  PlaytestInspection,
+  PlaytestInspectionApis,
+  PlaytestInspectionTarget,
+  SavePlaytestInspectionInput,
+} from '.'
+
+interface BackendPlaytestInspection {
+  id: number
+  character_id: number
+  outfit_id: string
+  action_id: string
+  status: PlaytestInspection['status']
+  create_at: string
+  update_at: string
+}
+
+function toInspection(raw: BackendPlaytestInspection): PlaytestInspection {
+  return {
+    id: String(raw.id),
+    characterId: String(raw.character_id),
+    outfitId: raw.outfit_id,
+    actionId: raw.action_id,
+    status: raw.status,
+    createdAt: raw.create_at,
+    updatedAt: raw.update_at,
+  }
+}
+
+function queryFor(target: PlaytestInspectionTarget): string {
+  const query = new URLSearchParams({
+    character_id: target.characterId,
+    outfit_id: target.outfitId,
+    action_id: target.actionId,
+  })
+  return query.toString()
+}
+
+export function createPlaytestInspectionApis(): PlaytestInspectionApis {
+  return {
+    async get(target) {
+      try {
+        const raw = await get<BackendPlaytestInspection>(
+          `/playtest-inspections?${queryFor(target)}`,
+        )
+        return toInspection(raw)
+      } catch (cause) {
+        if (cause instanceof ApiError && cause.code === 404) return null
+        throw cause
+      }
+    },
+
+    async save(input: SavePlaytestInspectionInput) {
+      const raw = await post<BackendPlaytestInspection>('/playtest-inspections', {
+        character_id: Number(input.characterId),
+        outfit_id: input.outfitId,
+        action_id: input.actionId,
+        status: input.status,
+      })
+      return toInspection(raw)
+    },
+  }
+}

--- a/frontend/src/entities/playtest-inspection/index.ts
+++ b/frontend/src/entities/playtest-inspection/index.ts
@@ -1,0 +1,24 @@
+/** Playtest 对某个动作保存的当前核验结论，不属于资产或创作历史。 */
+export type PlaytestInspectionStatus = 'passed' | 'issues_found'
+
+export interface PlaytestInspectionTarget {
+  characterId: string
+  outfitId: string
+  actionId: string
+}
+
+export interface PlaytestInspection extends PlaytestInspectionTarget {
+  id: string
+  status: PlaytestInspectionStatus
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SavePlaytestInspectionInput extends PlaytestInspectionTarget {
+  status: PlaytestInspectionStatus
+}
+
+export interface PlaytestInspectionApis {
+  get(target: PlaytestInspectionTarget): Promise<PlaytestInspection | null>
+  save(input: SavePlaytestInspectionInput): Promise<PlaytestInspection>
+}

--- a/frontend/src/entities/project/api.ts
+++ b/frontend/src/entities/project/api.ts
@@ -1,0 +1,80 @@
+import type { Project, ProjectApis } from '.'
+import type { Paged, PageQuery } from '@/shared/pagination'
+
+import { del, get } from '@/shared/api'
+
+/* ─── 后端 DTO ─── */
+
+interface BackendProject {
+  id: number
+  user_id: number
+  project_name: string
+  character_perspective: number
+  directional_movement: number
+  sprite_width: number
+  sprite_height: number
+  workflow_id: number | null
+  game_style: string | null
+  sprite_sample_url: string | null
+  create_at: string
+  update_at: string
+}
+
+/* ─── 映射 ─── */
+
+const PERSPECTIVE_MAP: Record<number, Project['perspective']> = {
+  1: 'side',
+  2: 'top-down',
+  3: 'isometric',
+}
+
+const MOVEMENT_MAP: Record<number, Project['directionalMovement']> = {
+  1: 'single',
+  2: 'four-way',
+  3: 'eight-way',
+}
+
+function toProject(raw: BackendProject): Project {
+  return {
+    id: String(raw.id),
+    ownerId: String(raw.user_id),
+    name: raw.project_name,
+    perspective: PERSPECTIVE_MAP[raw.character_perspective] ?? 'side',
+    directionalMovement: MOVEMENT_MAP[raw.directional_movement] ?? 'single',
+    spriteSize: { width: raw.sprite_width, height: raw.sprite_height },
+    gameStyle: raw.game_style,
+    sampleImageUrl: raw.sprite_sample_url,
+    createdAt: raw.create_at,
+    updatedAt: raw.update_at,
+  }
+}
+
+/* ─── 适配器 ─── */
+
+export function createProjectApis(): Pick<ProjectApis, 'list' | 'get' | 'remove'> {
+  return {
+    async list(query?: PageQuery): Promise<Paged<Project>> {
+      const params = new URLSearchParams()
+      if (query?.page) params.set('page', String(query.page))
+      if (query?.pageSize) params.set('page_size', String(query.pageSize))
+      const qs = params.toString()
+      // http-client 已解包 ApiEnvelope，data 字段就是项目数组本身
+      const raw = await get<BackendProject[]>(`/projects${qs ? `?${qs}` : ''}`)
+      return {
+        items: raw.map(toProject),
+        total: raw.length,
+        page: query?.page ?? 1,
+        pageSize: query?.pageSize ?? raw.length,
+      }
+    },
+
+    async get(id: string): Promise<Project> {
+      const raw = await get<BackendProject>(`/projects/${id}`)
+      return toProject(raw)
+    },
+
+    async remove(id: string): Promise<void> {
+      await del(`/projects/${id}`)
+    },
+  }
+}

--- a/frontend/src/pages/playtest/catalog.test.tsx
+++ b/frontend/src/pages/playtest/catalog.test.tsx
@@ -1,0 +1,279 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Character } from '@/entities/character'
+import type { Project } from '@/entities/project'
+
+import { PlaytestCatalogPage, type PlaytestCatalogApis } from './catalog'
+
+const project: Project = {
+  id: '37',
+  ownerId: '1',
+  name: '灯笼守夜人',
+  perspective: 'side',
+  directionalMovement: 'single',
+  spriteSize: { width: 256, height: 256 },
+  gameStyle: null,
+  sampleImageUrl: null,
+  createdAt: '2026-08-03T00:00:00.000Z',
+  updatedAt: '2026-08-03T00:00:00.000Z',
+}
+
+const targetProject: Project = {
+  ...project,
+  id: '38',
+  name: '第二个项目',
+}
+
+const character: Character = {
+  id: '25',
+  projectId: project.id,
+  createdAt: '',
+  updatedAt: '',
+  outfits: [
+    {
+      id: 'outfit-25-default',
+      characterId: '25',
+      name: '默认造型',
+      candidateCharacterTemplates: [],
+      characterTemplateUrl: 'https://cdn.example.test/character.png',
+      baseFrames: [],
+      actions: [
+        {
+          id: '25-custom',
+          outfitId: 'outfit-25-default',
+          name: '挥舞灯笼',
+          kind: 'custom',
+          type: 'custom',
+          fps: 8,
+          keyFrameIndex: 0,
+          frames: [
+            { imageUrl: 'https://cdn.example.test/frame.png', durationMs: 125, rootMotion: null },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+function renderCatalog(apis: PlaytestCatalogApis) {
+  render(
+    <MemoryRouter>
+      <PlaytestCatalogPage apis={apis} />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('PlaytestCatalogPage', () => {
+  it('loads published assets across projects and links directly to each action', async () => {
+    const apis: PlaytestCatalogApis = {
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([character]),
+        update: vi.fn(),
+        remove: vi.fn(),
+      },
+    }
+
+    renderCatalog(apis)
+
+    expect(await screen.findByRole('heading', { name: 'Playtest' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: '返回项目' }).getAttribute('href')).toBe('/projects')
+    expect(screen.getByRole('heading', { name: '灯笼守夜人' })).toBeTruthy()
+    expect(screen.getByText('挥舞灯笼')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '载入挥舞灯笼' }).getAttribute('href')).toBe(
+      '/playtest/25/outfit-25-default?actionId=25-custom',
+    )
+  })
+
+  it('does not treat an outfit without actions as an importable asset', async () => {
+    const emptyCharacter: Character = {
+      ...character,
+      outfits: [{ ...character.outfits[0]!, actions: [] }],
+    }
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([emptyCharacter]),
+        update: vi.fn(),
+        remove: vi.fn(),
+      },
+    })
+
+    expect(await screen.findByText('空文件夹')).toBeTruthy()
+  })
+
+  it('opens projects as folders and persists a dragged character in the target project', async () => {
+    const update = vi.fn().mockImplementation(async (next: Character) => next)
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({
+          items: [project, targetProject],
+          total: 2,
+          page: 1,
+          pageSize: 2,
+        }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi
+          .fn()
+          .mockImplementation(async (projectId: string) =>
+            projectId === project.id ? [character] : [],
+          ),
+        update,
+        remove: vi.fn(),
+      },
+    })
+
+    const cardTitle = await screen.findByText('默认造型')
+    const card = cardTitle.closest('article')
+    const targetFolder = screen.getByRole('region', { name: '第二个项目项目文件夹' })
+    const transfer = {
+      effectAllowed: '',
+      setData: vi.fn(),
+      getData: vi.fn().mockReturnValue(character.id),
+    }
+
+    fireEvent.dragStart(card!, { dataTransfer: transfer })
+    fireEvent.dragEnter(targetFolder, { dataTransfer: transfer })
+    fireEvent.drop(targetFolder, { dataTransfer: transfer })
+
+    await waitFor(() => expect(update).toHaveBeenCalled())
+    expect(update.mock.calls[0]?.[0].projectId).toBe(targetProject.id)
+    expect(await screen.findByText('已将角色资产移动到“第二个项目”')).toBeTruthy()
+  })
+
+  it('does not report a move as successful when the backend keeps the old project', async () => {
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({
+          items: [project, targetProject],
+          total: 2,
+          page: 1,
+          pageSize: 2,
+        }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi
+          .fn()
+          .mockImplementation(async (projectId: string) =>
+            projectId === project.id ? [character] : [],
+          ),
+        update: vi.fn().mockResolvedValue(character),
+        remove: vi.fn(),
+      },
+    })
+
+    const card = (await screen.findByText('默认造型')).closest('article')
+    const targetFolder = screen.getByRole('region', { name: '第二个项目项目文件夹' })
+    const transfer = {
+      effectAllowed: '',
+      setData: vi.fn(),
+      getData: vi.fn().mockReturnValue(character.id),
+    }
+
+    fireEvent.dragStart(card!, { dataTransfer: transfer })
+    fireEvent.drop(targetFolder, { dataTransfer: transfer })
+
+    expect(await screen.findByText('后端未保存新的项目归属')).toBeTruthy()
+    expect(screen.queryByText('已将角色资产移动到“第二个项目”')).toBeNull()
+    expect(screen.getByRole('heading', { name: project.name })).toBeTruthy()
+  })
+
+  it('renames an asset and an action through the character update API', async () => {
+    const update = vi.fn().mockImplementation(async (next: Character) => next)
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([character]),
+        update,
+        remove: vi.fn(),
+      },
+    })
+
+    await screen.findByText('默认造型')
+    fireEvent.click(screen.getByRole('button', { name: '重命名资产名称 默认造型' }))
+    fireEvent.change(screen.getByRole('textbox', { name: '资产名称' }), {
+      target: { value: '夜巡造型' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '保存资产名称' }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1))
+    expect(update.mock.calls[0]?.[0].outfits[0].name).toBe('夜巡造型')
+
+    fireEvent.click(screen.getByRole('button', { name: '重命名动作名称 挥舞灯笼' }))
+    fireEvent.change(screen.getByRole('textbox', { name: '动作名称' }), {
+      target: { value: '举起灯笼' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '保存动作名称' }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(2))
+    expect(update.mock.calls[1]?.[0].outfits[0].actions[0].name).toBe('举起灯笼')
+  })
+
+  it('deletes a single asset after confirmation', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const remove = vi.fn().mockResolvedValue(undefined)
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: vi.fn(),
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([character]),
+        update: vi.fn(),
+        remove,
+      },
+    })
+
+    await screen.findByText('默认造型')
+    fireEvent.click(screen.getByRole('button', { name: '删除资产 默认造型' }))
+
+    await waitFor(() => expect(remove).toHaveBeenCalledWith(character.id))
+    expect(await screen.findByText('已删除资产“默认造型”')).toBeTruthy()
+    expect(screen.queryByText('默认造型')).toBeNull()
+  })
+
+  it('delegates atomic project cleanup to one backend request', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const removeCharacter = vi.fn().mockResolvedValue(undefined)
+    const removeProject = vi.fn().mockResolvedValue(undefined)
+    renderCatalog({
+      projects: {
+        list: vi.fn().mockResolvedValue({ items: [project], total: 1, page: 1, pageSize: 1 }),
+        remove: removeProject,
+      },
+      characters: {
+        listByProject: vi.fn().mockResolvedValue([character]),
+        update: vi.fn(),
+        remove: removeCharacter,
+      },
+    })
+
+    await screen.findByText('默认造型')
+    fireEvent.click(screen.getByRole('button', { name: `删除项目文件夹 ${project.name}` }))
+
+    await waitFor(() => expect(removeProject).toHaveBeenCalledWith(project.id))
+    expect(removeCharacter).not.toHaveBeenCalled()
+    expect(await screen.findByText(`已删除项目“${project.name}”`)).toBeTruthy()
+    expect(screen.queryByRole('region', { name: `${project.name}项目文件夹` })).toBeNull()
+  })
+})

--- a/frontend/src/pages/playtest/catalog.tsx
+++ b/frontend/src/pages/playtest/catalog.tsx
@@ -1,0 +1,659 @@
+import { type DragEvent, type FormEvent, type ReactNode, useEffect, useState } from 'react'
+import { Link } from 'react-router'
+
+import type { Action, Character, CharacterApis, Outfit } from '@/entities/character'
+import type { Project, ProjectApis } from '@/entities/project'
+import { buildPlaytestPath } from './path'
+
+export interface PlaytestCatalogApis {
+  projects: Pick<ProjectApis, 'list' | 'remove'>
+  characters: Pick<CharacterApis, 'listByProject' | 'update' | 'remove'>
+}
+
+interface CatalogAsset {
+  project: Project
+  character: Character
+  outfit: Outfit
+}
+
+interface CatalogState {
+  projects: Project[]
+  assets: CatalogAsset[]
+  error: string | null
+  loading: boolean
+}
+
+interface CatalogData {
+  projects: Project[]
+  assets: CatalogAsset[]
+}
+
+const INITIAL_STATE: CatalogState = { projects: [], assets: [], error: null, loading: true }
+
+/** Playtest 入口按项目组织可核验角色，移动和改名通过 Character 整树接口持久化。 */
+export function PlaytestCatalogPage({ apis }: { apis: PlaytestCatalogApis }) {
+  const [state, setState] = useState<CatalogState>(INITIAL_STATE)
+  const [reloadKey, setReloadKey] = useState(0)
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null)
+  const [busyCharacterIds, setBusyCharacterIds] = useState<Set<string>>(new Set())
+  const [busyProjectIds, setBusyProjectIds] = useState<Set<string>>(new Set())
+  const [draggedCharacterId, setDraggedCharacterId] = useState<string | null>(null)
+  const [dropProjectId, setDropProjectId] = useState<string | null>(null)
+  const [operationMessage, setOperationMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    setState(INITIAL_STATE)
+
+    void loadCatalog(apis).then(
+      ({ projects, assets }) => {
+        if (!active) return
+        setState({ projects, assets, error: null, loading: false })
+        setSelectedProjectId((current) =>
+          current && projects.some((project) => project.id === current)
+            ? current
+            : (projects[0]?.id ?? null),
+        )
+      },
+      (cause: unknown) =>
+        active &&
+        setState({
+          projects: [],
+          assets: [],
+          error: errorMessage(cause, '资产加载失败'),
+          loading: false,
+        }),
+    )
+
+    return () => {
+      active = false
+    }
+  }, [apis, reloadKey])
+
+  const setCharacterBusy = (characterId: string, busy: boolean) => {
+    setBusyCharacterIds((current) => {
+      const next = new Set(current)
+      if (busy) next.add(characterId)
+      else next.delete(characterId)
+      return next
+    })
+  }
+
+  const persistCharacter = async (character: Character, successMessage: string) => {
+    setCharacterBusy(character.id, true)
+    setOperationMessage(null)
+    try {
+      const saved = await apis.characters.update(character)
+      if (saved.projectId !== character.projectId) {
+        throw new Error('后端未保存新的项目归属')
+      }
+      setState((current) => replaceCharacter(current, saved))
+      setOperationMessage(successMessage)
+    } catch (cause) {
+      setOperationMessage(errorMessage(cause, '保存失败，请重试'))
+      throw cause
+    } finally {
+      setCharacterBusy(character.id, false)
+    }
+  }
+
+  const moveCharacter = async (characterId: string, projectId: string) => {
+    const source = state.assets.find((asset) => asset.character.id === characterId)
+    const target = state.projects.find((project) => project.id === projectId)
+    if (!source || !target || source.character.projectId === projectId) return
+
+    try {
+      await persistCharacter(
+        { ...source.character, projectId },
+        `已将角色资产移动到“${target.name}”`,
+      )
+      setSelectedProjectId(projectId)
+    } catch {
+      // persistCharacter 已在页面上保留具体错误。
+    }
+  }
+
+  const renameOutfit = async (character: Character, outfitId: string, name: string) => {
+    await persistCharacter(
+      {
+        ...character,
+        outfits: character.outfits.map((outfit) =>
+          outfit.id === outfitId ? { ...outfit, name } : outfit,
+        ),
+      },
+      `资产已改名为“${name}”`,
+    )
+  }
+
+  const renameAction = async (
+    character: Character,
+    outfitId: string,
+    actionId: string,
+    name: string,
+  ) => {
+    await persistCharacter(
+      {
+        ...character,
+        outfits: character.outfits.map((outfit) =>
+          outfit.id === outfitId
+            ? {
+                ...outfit,
+                actions: outfit.actions.map((action) =>
+                  action.id === actionId ? { ...action, name } : action,
+                ),
+              }
+            : outfit,
+        ),
+      },
+      `动作已改名为“${name}”`,
+    )
+  }
+
+  const deleteAsset = async (character: Character, outfit: Outfit) => {
+    if (!window.confirm(`确定删除资产“${outfit.name}”吗？此操作无法撤销。`)) return
+
+    setCharacterBusy(character.id, true)
+    setOperationMessage(null)
+    try {
+      if (character.outfits.length === 1) {
+        await apis.characters.remove(character.id)
+        setState((current) => ({
+          ...current,
+          assets: current.assets.filter((asset) => asset.character.id !== character.id),
+        }))
+      } else {
+        const saved = await apis.characters.update({
+          ...character,
+          outfits: character.outfits.filter((candidate) => candidate.id !== outfit.id),
+        })
+        setState((current) => replaceCharacter(current, saved))
+      }
+      setOperationMessage(`已删除资产“${outfit.name}”`)
+    } catch (cause) {
+      setOperationMessage(errorMessage(cause, '资产删除失败，请重试'))
+    } finally {
+      setCharacterBusy(character.id, false)
+    }
+  }
+
+  const deleteProject = async (project: Project) => {
+    if (!window.confirm(`确定删除项目“${project.name}”及其中全部角色资产吗？此操作无法撤销。`)) {
+      return
+    }
+
+    setBusyProjectIds((current) => new Set(current).add(project.id))
+    setOperationMessage(null)
+    try {
+      await apis.projects.remove(project.id)
+      setState((current) => ({
+        ...current,
+        projects: current.projects.filter((candidate) => candidate.id !== project.id),
+        assets: current.assets.filter((asset) => asset.project.id !== project.id),
+      }))
+      setSelectedProjectId((current) =>
+        current === project.id
+          ? (state.projects.find((candidate) => candidate.id !== project.id)?.id ?? null)
+          : current,
+      )
+      setOperationMessage(`已删除项目“${project.name}”`)
+    } catch (cause) {
+      setOperationMessage(errorMessage(cause, '项目删除失败，请重试'))
+    } finally {
+      setBusyProjectIds((current) => {
+        const next = new Set(current)
+        next.delete(project.id)
+        return next
+      })
+    }
+  }
+
+  const selectedProject = state.projects.find((project) => project.id === selectedProjectId) ?? null
+  const selectedAssets = selectedProject
+    ? state.assets.filter((asset) => asset.project.id === selectedProject.id)
+    : []
+
+  return (
+    <section className="mx-auto w-full max-w-6xl py-8 text-[#1d251f]">
+      <Link
+        to="/projects"
+        className="mb-4 inline-flex min-h-9 items-center gap-1 rounded-lg border border-[#b9c1ba] px-3 text-xs font-semibold text-[#4f5b52] hover:border-[#758078] hover:text-[#26372c]"
+      >
+        <span aria-hidden="true" className="text-base leading-none">
+          ‹
+        </span>
+        返回项目
+      </Link>
+
+      <header className="flex flex-wrap items-end justify-between gap-4 border-b border-[#d5dad5] pb-5">
+        <div>
+          <p className="font-mono text-[10px] font-bold tracking-[0.16em] text-[#747973]">
+            PLAYTEST
+          </p>
+          <h1 className="mt-2 font-serif text-3xl">Playtest</h1>
+          <p className="mt-2 text-sm text-[#687069]">选择项目和角色动作进行核验。</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setReloadKey((value) => value + 1)}
+          disabled={state.loading}
+          className="min-h-10 rounded-lg border border-[#aeb8b0] px-4 text-xs font-semibold text-[#35583f] disabled:opacity-50"
+        >
+          {state.loading ? '正在同步' : '刷新资产'}
+        </button>
+      </header>
+
+      {state.error ? <CatalogAlert tone="error">{state.error}</CatalogAlert> : null}
+      {operationMessage ? <CatalogAlert tone="status">{operationMessage}</CatalogAlert> : null}
+
+      {!state.error && !state.loading && state.projects.length === 0 ? (
+        <div className="mt-8 border border-dashed border-[#c9d0ca] px-6 py-12 text-center">
+          <p className="text-sm text-[#687069]">还没有项目。</p>
+        </div>
+      ) : null}
+
+      <div className="mt-6 grid items-start gap-5 lg:grid-cols-[280px_minmax(0,1fr)]">
+        <aside
+          aria-label="项目文件夹"
+          className="max-h-72 overflow-y-auto border border-[#ced5cf] bg-white lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)]"
+        >
+          <div className="border-b border-[#dde2de] px-4 py-3">
+            <h2 className="text-xs font-semibold">项目文件夹</h2>
+            <p className="mt-1 text-[10px] text-[#747973]">{state.projects.length} 个项目</p>
+          </div>
+          <div className="grid gap-px bg-[#e2e6e2]">
+            {state.projects.map((project) => {
+              const assetCount = state.assets.filter(
+                (asset) => asset.project.id === project.id,
+              ).length
+              const selected = selectedProjectId === project.id
+              const projectBusy = busyProjectIds.has(project.id)
+              const dropActive = dropProjectId === project.id && draggedCharacterId !== null
+
+              return (
+                <section
+                  key={project.id}
+                  aria-label={`${project.name}项目文件夹`}
+                  onDragEnter={(event) => {
+                    event.preventDefault()
+                    setDropProjectId(project.id)
+                  }}
+                  onDragOver={(event) => event.preventDefault()}
+                  onDrop={(event) => {
+                    event.preventDefault()
+                    const characterId =
+                      event.dataTransfer.getData('application/x-windup-character') ||
+                      draggedCharacterId
+                    setDropProjectId(null)
+                    setDraggedCharacterId(null)
+                    if (characterId) void moveCharacter(characterId, project.id)
+                  }}
+                  className={`grid grid-cols-[minmax(0,1fr)_36px] items-center bg-white p-1 transition-colors ${
+                    dropActive ? 'bg-[#e1eee4]' : ''
+                  }`}
+                >
+                  <button
+                    type="button"
+                    aria-pressed={selected}
+                    disabled={projectBusy}
+                    onClick={() => setSelectedProjectId(project.id)}
+                    className={`grid min-h-14 min-w-0 grid-cols-[18px_minmax(0,1fr)_auto] items-center gap-2 px-2 text-left disabled:opacity-50 ${
+                      selected ? 'bg-[#edf3ee] text-[#294c33]' : 'hover:bg-[#f4f6f4]'
+                    }`}
+                  >
+                    <span aria-hidden="true" className="text-sm text-[#526258]">
+                      {selected ? '▾' : '▸'}
+                    </span>
+                    <span className="min-w-0">
+                      <strong className="block truncate text-xs">{project.name}</strong>
+                      <small className="mt-0.5 block text-[9px] text-[#747973]">
+                        {project.spriteSize.width} × {project.spriteSize.height}
+                      </small>
+                    </span>
+                    <span className="rounded-md bg-[#e8ece8] px-1.5 py-1 text-[9px] font-semibold text-[#59635b]">
+                      {assetCount}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`删除项目文件夹 ${project.name}`}
+                    title="删除项目文件夹"
+                    disabled={projectBusy}
+                    onClick={() => void deleteProject(project)}
+                    className="grid h-9 w-9 place-items-center rounded-md text-[10px] font-semibold text-[#973d34] hover:bg-[#faeeec] disabled:opacity-40"
+                  >
+                    删除
+                  </button>
+                </section>
+              )
+            })}
+          </div>
+        </aside>
+
+        <section aria-label="当前项目资产" className="min-w-0 border border-[#ced5cf] bg-[#f7f8f7]">
+          {selectedProject ? (
+            <>
+              <header className="border-b border-[#dde2de] bg-white px-5 py-4">
+                <p className="text-[10px] font-semibold text-[#747973]">当前文件夹</p>
+                <div className="mt-1 flex items-center justify-between gap-3">
+                  <h2 className="min-w-0 truncate text-lg font-semibold">{selectedProject.name}</h2>
+                  <span className="shrink-0 text-[10px] text-[#747973]">
+                    {selectedAssets.length} 项资产
+                  </span>
+                </div>
+              </header>
+              <div className="grid gap-4 p-4 xl:grid-cols-2">
+                {selectedAssets.length === 0 ? (
+                  <p className="col-span-full py-16 text-center text-xs text-[#858c86]">空文件夹</p>
+                ) : (
+                  selectedAssets.map((asset) => (
+                    <AssetCard
+                      key={`${asset.character.id}:${asset.outfit.id}`}
+                      asset={asset}
+                      busy={busyCharacterIds.has(asset.character.id)}
+                      onDragStart={(event) => {
+                        event.dataTransfer.effectAllowed = 'move'
+                        event.dataTransfer.setData(
+                          'application/x-windup-character',
+                          asset.character.id,
+                        )
+                        setDraggedCharacterId(asset.character.id)
+                      }}
+                      onDragEnd={() => {
+                        setDraggedCharacterId(null)
+                        setDropProjectId(null)
+                      }}
+                      onRenameOutfit={(name) =>
+                        renameOutfit(asset.character, asset.outfit.id, name)
+                      }
+                      onRenameAction={(actionId, name) =>
+                        renameAction(asset.character, asset.outfit.id, actionId, name)
+                      }
+                      onDelete={() => deleteAsset(asset.character, asset.outfit)}
+                    />
+                  ))
+                )}
+              </div>
+            </>
+          ) : (
+            <p className="py-16 text-center text-xs text-[#858c86]">请选择项目文件夹</p>
+          )}
+        </section>
+      </div>
+    </section>
+  )
+}
+
+function AssetCard({
+  asset,
+  busy,
+  onDragStart,
+  onDragEnd,
+  onRenameOutfit,
+  onRenameAction,
+  onDelete,
+}: {
+  asset: CatalogAsset
+  busy: boolean
+  onDragStart(event: DragEvent<HTMLElement>): void
+  onDragEnd(): void
+  onRenameOutfit(name: string): Promise<void>
+  onRenameAction(actionId: string, name: string): Promise<void>
+  onDelete(): Promise<void>
+}) {
+  const { character, outfit } = asset
+
+  return (
+    <article
+      draggable={!busy}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      className={`grid min-h-[240px] grid-cols-[112px_minmax(0,1fr)] overflow-hidden rounded-lg border border-[#d1d7d2] bg-white ${
+        busy ? 'opacity-60' : 'cursor-grab active:cursor-grabbing'
+      }`}
+    >
+      <div className="grid min-h-full place-items-center bg-[#edf0ec] p-2">
+        {outfit.characterTemplateUrl ? (
+          <img
+            src={outfit.characterTemplateUrl}
+            alt={`${outfit.name} 角色图`}
+            className="aspect-square w-full object-contain [image-rendering:pixelated]"
+          />
+        ) : (
+          <span className="text-xs text-[#8b918c]">暂无角色图</span>
+        )}
+      </div>
+      <div className="min-w-0 p-4">
+        <div className="flex items-center justify-between gap-2">
+          <p className="truncate text-[10px] font-semibold text-[#747973]">角色 {character.id}</p>
+          <button
+            type="button"
+            aria-label={`删除资产 ${outfit.name}`}
+            title="删除资产"
+            disabled={busy}
+            draggable={false}
+            onClick={() => void onDelete()}
+            className="min-h-8 rounded-md px-2 text-[10px] font-semibold text-[#973d34] hover:bg-[#faeeec] disabled:opacity-40"
+          >
+            删除
+          </button>
+        </div>
+        <EditableName
+          value={outfit.name}
+          label="资产名称"
+          disabled={busy}
+          onSave={onRenameOutfit}
+          className="mt-1"
+        >
+          <h2 className="min-w-0 flex-1 truncate text-base font-semibold">{outfit.name}</h2>
+        </EditableName>
+        <p className="mt-1 text-[11px] text-[#747973]">{outfit.actions.length} 个动作</p>
+        <div className="mt-4 grid gap-2">
+          {outfit.actions.map((action) => (
+            <ActionRow
+              key={action.id}
+              character={character}
+              outfit={outfit}
+              action={action}
+              disabled={busy}
+              onRename={(name) => onRenameAction(action.id, name)}
+            />
+          ))}
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function ActionRow({
+  character,
+  outfit,
+  action,
+  disabled,
+  onRename,
+}: {
+  character: Character
+  outfit: Outfit
+  action: Action
+  disabled: boolean
+  onRename(name: string): Promise<void>
+}) {
+  return (
+    <EditableName value={action.name} label="动作名称" disabled={disabled} onSave={onRename}>
+      <Link
+        aria-label={`载入${action.name}`}
+        to={buildPlaytestPath({
+          characterId: character.id,
+          outfitId: outfit.id,
+          actionId: action.id,
+        })}
+        draggable={false}
+        className="flex min-h-9 min-w-0 flex-1 items-center justify-between gap-2 rounded-lg border border-[#cbd3cc] px-3 text-xs font-semibold text-[#35583f] hover:border-[#78917e] hover:bg-[#eef4ef]"
+      >
+        <span className="truncate">{action.name}</span>
+        <span className="shrink-0 font-mono text-[9px] text-[#747973]">
+          {action.frames.length} 帧
+        </span>
+      </Link>
+    </EditableName>
+  )
+}
+
+function EditableName({
+  value,
+  label,
+  disabled,
+  onSave,
+  className = '',
+  children,
+}: {
+  value: string
+  label: string
+  disabled: boolean
+  onSave(value: string): Promise<void>
+  className?: string
+  children: ReactNode
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(value)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => setDraft(value), [value])
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    const name = draft.trim()
+    if (!name) {
+      setError('名称不能为空')
+      return
+    }
+    if (name === value) {
+      setEditing(false)
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+    try {
+      await onSave(name)
+      setEditing(false)
+    } catch (cause) {
+      setError(errorMessage(cause, '保存失败'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (editing) {
+    return (
+      <form
+        onSubmit={(event) => void submit(event)}
+        onDragStart={(event) => event.stopPropagation()}
+        className={`grid min-w-0 grid-cols-[minmax(0,1fr)_32px_32px] gap-1 ${className}`}
+      >
+        <input
+          aria-label={label}
+          autoFocus
+          value={draft}
+          maxLength={80}
+          onChange={(event) => setDraft(event.target.value)}
+          disabled={saving}
+          className="h-8 min-w-0 rounded-md border border-[#829087] px-2 text-xs outline-none focus:border-[#35583f]"
+        />
+        <button
+          type="submit"
+          aria-label={`保存${label}`}
+          title="保存"
+          disabled={saving}
+          className="h-8 rounded-md bg-[#35583f] text-sm text-white disabled:opacity-50"
+        >
+          ✓
+        </button>
+        <button
+          type="button"
+          aria-label={`取消修改${label}`}
+          title="取消"
+          disabled={saving}
+          onClick={() => {
+            setDraft(value)
+            setError(null)
+            setEditing(false)
+          }}
+          className="h-8 rounded-md border border-[#c5ccc6] text-sm text-[#687069]"
+        >
+          ×
+        </button>
+        {error ? <small className="col-span-full text-[10px] text-[#983c32]">{error}</small> : null}
+      </form>
+    )
+  }
+
+  return (
+    <div className={`flex min-w-0 items-center gap-1 ${className}`}>
+      {children}
+      <button
+        type="button"
+        aria-label={`重命名${label} ${value}`}
+        title={`重命名${label}`}
+        disabled={disabled}
+        draggable={false}
+        onClick={() => setEditing(true)}
+        className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-sm text-[#687069] hover:bg-[#edf1ed] hover:text-[#35583f] disabled:opacity-40"
+      >
+        ✎
+      </button>
+    </div>
+  )
+}
+
+function CatalogAlert({ children, tone }: { children: string; tone: 'error' | 'status' }) {
+  return (
+    <div
+      role={tone === 'error' ? 'alert' : 'status'}
+      className={`mt-4 border-l-4 px-4 py-3 ${
+        tone === 'error'
+          ? 'border-[#a54438] bg-[#f8ece9] text-[#7d3028]'
+          : 'border-[#4f7759] bg-[#edf5ef] text-[#35583f]'
+      }`}
+    >
+      <p className="text-sm">{children}</p>
+    </div>
+  )
+}
+
+function replaceCharacter(state: CatalogState, character: Character): CatalogState {
+  const project = state.projects.find((candidate) => candidate.id === character.projectId)
+  if (!project) return state
+
+  const otherAssets = state.assets.filter((asset) => asset.character.id !== character.id)
+  const updatedAssets = character.outfits
+    .filter((outfit) => outfit.actions.length > 0)
+    .map((outfit) => ({ project, character, outfit }))
+
+  return { ...state, assets: [...otherAssets, ...updatedAssets] }
+}
+
+function errorMessage(cause: unknown, fallback: string): string {
+  return cause instanceof Error && cause.message.trim() ? cause.message : fallback
+}
+
+async function loadCatalog(apis: PlaytestCatalogApis): Promise<CatalogData> {
+  const page = await apis.projects.list({ page: 1, pageSize: 100 })
+  const charactersByProject = await Promise.all(
+    page.items.map(async (project) => ({
+      project,
+      characters: await apis.characters.listByProject(project.id),
+    })),
+  )
+
+  return {
+    projects: page.items,
+    assets: charactersByProject.flatMap(({ project, characters }) =>
+      characters.flatMap((character) =>
+        character.outfits
+          .filter((outfit) => outfit.actions.length > 0)
+          .map((outfit) => ({ project, character, outfit })),
+      ),
+    ),
+  }
+}

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -1,0 +1,180 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useNavigate, type NavigateFunction } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Character } from '@/entities/character'
+
+import { PlaytestPage, type PlaytestPageApis } from './index'
+
+const character: Character = {
+  id: 'character-1',
+  projectId: 'project-1',
+  createdAt: '2026-07-30T00:00:00.000Z',
+  updatedAt: '2026-07-30T00:00:00.000Z',
+  outfits: [
+    {
+      id: 'outfit-1',
+      characterId: 'character-1',
+      name: 'Explorer',
+      candidateCharacterTemplates: [],
+      characterTemplateUrl: 'https://cdn.example.test/aster.png',
+      baseFrames: [{ imageUrl: 'https://cdn.example.test/base.png' }],
+      actions: [
+        {
+          id: 'idle',
+          outfitId: 'outfit-1',
+          name: 'Idle',
+          kind: 'preset',
+          type: 'idle',
+          fps: 8,
+          keyFrameIndex: 0,
+          frames: [
+            {
+              imageUrl: 'https://cdn.example.test/idle.png',
+              durationMs: 125,
+              rootMotion: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+function renderPage(apis?: PlaytestPageApis, initialEntry = '/playtest/character-1/outfit-1') {
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/playtest/:characterId/:outfitId" element={<PlaytestPage apis={apis} />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('PlaytestPage', () => {
+  it('shows an explicit unconfigured boundary instead of inventing character data', () => {
+    renderPage()
+
+    expect(screen.getByText('Playtest 角色接口尚未配置')).toBeTruthy()
+  })
+
+  it('loads the requested character through the standard skeleton API only', async () => {
+    const apis: PlaytestPageApis = {
+      characters: {
+        get: vi.fn().mockResolvedValue(character),
+        listByProject: vi.fn().mockResolvedValue([character]),
+      },
+    }
+
+    renderPage(apis, '/playtest/character-1/outfit-1?actionId=idle')
+
+    expect(screen.getByText('加载 Playtest 数据中')).toBeTruthy()
+    expect(await screen.findByRole('heading', { name: 'character-1 · Explorer' })).toBeTruthy()
+    expect(apis.characters.get).toHaveBeenCalledExactlyOnceWith('character-1')
+  })
+
+  it.each([{ code: 404 }, { status: 404 }])(
+    'maps a missing character response to a stable message',
+    async (error) => {
+      renderPage({
+        characters: { get: vi.fn().mockRejectedValue(error), listByProject: vi.fn() },
+      })
+
+      expect(await screen.findByText('角色不存在')).toBeTruthy()
+    },
+  )
+
+  it('does not mislabel a transport failure as not found', async () => {
+    renderPage({
+      characters: {
+        get: vi.fn().mockRejectedValue(new Error('network unavailable')),
+        listByProject: vi.fn(),
+      },
+    })
+
+    expect(await screen.findByText('角色读取失败')).toBeTruthy()
+  })
+
+  it('ignores a stale character response after the route identity changes', async () => {
+    let resolveFirst: ((value: Character) => void) | undefined
+    const firstRequest = new Promise<Character>((resolve) => {
+      resolveFirst = resolve
+    })
+    const secondCharacter: Character = {
+      ...character,
+      id: 'character-2',
+      outfits: [{ ...character.outfits[0], characterId: 'character-2' }],
+    }
+    const get = vi.fn().mockReturnValueOnce(firstRequest).mockResolvedValueOnce(secondCharacter)
+    const listByProject = vi.fn().mockResolvedValue([character, secondCharacter])
+    let navigate: NavigateFunction | undefined
+
+    function NavigationProbe() {
+      navigate = useNavigate()
+      return null
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/playtest/character-1/outfit-1']}>
+        <NavigationProbe />
+        <Routes>
+          <Route
+            path="/playtest/:characterId/:outfitId"
+            element={<PlaytestPage apis={{ characters: { get, listByProject } }} />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await act(async () => navigate?.('/playtest/character-2/outfit-1'))
+    expect(await screen.findByRole('heading', { name: 'character-2 · Explorer' })).toBeTruthy()
+
+    await act(async () => resolveFirst?.(character))
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'character-2 · Explorer' })).toBeTruthy(),
+    )
+    expect(get).toHaveBeenNthCalledWith(1, 'character-1')
+    expect(get).toHaveBeenNthCalledWith(2, 'character-2')
+  })
+
+  it('switches assets from the action sidebar without returning to the catalog', async () => {
+    const secondCharacter: Character = {
+      ...character,
+      id: 'character-2',
+      outfits: [
+        {
+          ...character.outfits[0]!,
+          id: 'outfit-2',
+          characterId: 'character-2',
+          name: 'Knight',
+          actions: character.outfits[0]!.actions.map((action) => ({
+            ...action,
+            outfitId: 'outfit-2',
+            name: 'Guard',
+          })),
+        },
+      ],
+    }
+    const get = vi
+      .fn()
+      .mockImplementation(async (id: string) =>
+        id === secondCharacter.id ? secondCharacter : character,
+      )
+    const listByProject = vi.fn().mockResolvedValue([character, secondCharacter])
+
+    renderPage({ characters: { get, listByProject } })
+
+    const selector = await screen.findByRole('combobox', { name: '同项目资产' })
+    fireEvent.click(selector)
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(2)
+    fireEvent.click(screen.getByRole('option', { name: /Knight/ }))
+
+    expect(await screen.findByRole('heading', { name: 'character-2 · Knight' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Guard/ })).toBeTruthy()
+    expect(get).toHaveBeenLastCalledWith('character-2')
+  })
+})

--- a/frontend/src/pages/playtest/index.tsx
+++ b/frontend/src/pages/playtest/index.tsx
@@ -1,9 +1,168 @@
-/** 核验台。 */
-export function PlaytestPage() {
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router'
+
+import type { Character, CharacterApis } from '@/entities/character'
+import type { PlaytestInspectionApis } from '@/entities/playtest-inspection'
+import type { ProjectApis } from '@/entities/project'
+import { buildPlaytestPath } from './path'
+import { PlaytestWorkbench, type PlaytestAssetOption } from './workbench'
+
+export interface PlaytestPageApis {
+  characters: Pick<CharacterApis, 'get' | 'listByProject'>
+  projects?: Pick<ProjectApis, 'get'>
+  inspections?: Pick<PlaytestInspectionApis, 'get' | 'save'>
+}
+
+export interface PlaytestPageProps {
+  apis?: PlaytestPageApis
+}
+
+interface PageData {
+  character: Character | null
+  projectCharacters: Character[]
+  expectedCanvas: { width: number; height: number } | null
+  error: string | null
+  loading: boolean
+}
+
+const initialPageData: PageData = {
+  character: null,
+  projectCharacters: [],
+  expectedCanvas: null,
+  error: null,
+  loading: false,
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  const identifiable = error as { code?: unknown; status?: unknown }
   return (
-    <section className="border border-dashed border-slate-300 p-6">
-      <h1 className="font-medium">核验台</h1>
-      <p className="mt-2 text-sm text-slate-500">本次只提交模块划分与接口，页面实现进后续 PR。</p>
-    </section>
+    identifiable.code === 404 ||
+    identifiable.code === '404' ||
+    identifiable.status === 404 ||
+    identifiable.status === '404'
+  )
+}
+
+/**
+ * 正式 Playtest 页面只读取 #70 已定义的 Character 接口。
+ * 当接口未配置时，自动回退到内置 demo 角色素材。
+ * 核验与自动分析结果均停留在页面会话，不写回资产树。
+ */
+export function PlaytestPage({ apis }: PlaytestPageProps) {
+  const { characterId, outfitId } = useParams()
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const initialActionId = searchParams.get('actionId')
+  const [data, setData] = useState<PageData>(initialPageData)
+
+  useEffect(() => {
+    // 正式入口未配置角色接口时明确提示，不加载也不回退到 Demo 少年数据
+    if (apis === undefined) {
+      setData({
+        character: null,
+        projectCharacters: [],
+        expectedCanvas: null,
+        error: 'Playtest 角色接口尚未配置',
+        loading: false,
+      })
+      return
+    }
+    if (characterId === undefined || outfitId === undefined) {
+      setData({ ...initialPageData, error: 'Playtest 路由参数不完整' })
+      return
+    }
+
+    let cancelled = false
+    setData({ ...initialPageData, loading: true })
+    void apis.characters.get(characterId).then(
+      async (character) => {
+        let projectCharacters = [character]
+        let expectedCanvas: PageData['expectedCanvas'] = null
+        const [charactersResult, projectResult] = await Promise.allSettled([
+          apis.characters.listByProject(character.projectId),
+          apis.projects?.get(character.projectId) ?? Promise.resolve(null),
+        ])
+        if (charactersResult.status === 'fulfilled') projectCharacters = charactersResult.value
+        if (projectResult.status === 'fulfilled' && projectResult.value !== null) {
+          expectedCanvas = projectResult.value.spriteSize
+        }
+        if (!cancelled) {
+          setData({ character, projectCharacters, expectedCanvas, error: null, loading: false })
+        }
+      },
+      (error: unknown) => {
+        if (!cancelled) {
+          setData({
+            ...initialPageData,
+            error: isNotFoundError(error) ? '角色不存在' : '角色读取失败',
+          })
+        }
+      },
+    )
+
+    return () => {
+      cancelled = true
+    }
+  }, [apis, characterId, outfitId])
+
+  if (data.error !== null) return <PlaytestPageMessage>{data.error}</PlaytestPageMessage>
+  if (data.loading || data.character === null)
+    return <PlaytestPageMessage>加载 Playtest 数据中</PlaytestPageMessage>
+
+  const assetOptions = buildAssetOptions(data.projectCharacters)
+
+  return (
+    <div className="bg-[#eef0ed] pt-2">
+      <div className="px-3 sm:px-5">
+        <Link
+          to="/playtest"
+          aria-label="返回全部 Playtest"
+          className="inline-flex min-h-8 items-center gap-1 rounded-md px-2 text-[11px] font-semibold text-[#59635b] hover:bg-[#e1e5e1] hover:text-[#2f4e38]"
+        >
+          <span aria-hidden="true">←</span>
+          全部 Playtest
+        </Link>
+      </div>
+      <PlaytestWorkbench
+        key={`${data.character.id}:${outfitId}:${initialActionId ?? ''}`}
+        character={data.character}
+        outfitId={outfitId ?? ''}
+        assetOptions={assetOptions}
+        expectedCanvas={data.expectedCanvas}
+        inspectionApis={apis?.inspections}
+        initialActionId={initialActionId}
+        onSelectAsset={(asset) =>
+          navigate(
+            buildPlaytestPath({
+              characterId: asset.characterId,
+              outfitId: asset.outfitId,
+            }),
+          )
+        }
+      />
+    </div>
+  )
+}
+
+function buildAssetOptions(characters: Character[]): PlaytestAssetOption[] {
+  return characters.flatMap((character) =>
+    character.outfits
+      .filter((outfit) => outfit.actions.length > 0)
+      .map((outfit) => ({
+        key: `${character.id}:${outfit.id}`,
+        characterId: character.id,
+        outfitId: outfit.id,
+        name: `${outfit.name}（角色 ${character.id}）`,
+        actionCount: outfit.actions.length,
+      })),
+  )
+}
+
+function PlaytestPageMessage({ children }: { children: string }) {
+  return (
+    <main aria-label="Playtest" className="grid min-h-screen place-items-center bg-slate-100 p-6">
+      <p className="text-sm font-medium text-slate-700">{children}</p>
+    </main>
   )
 }

--- a/frontend/src/pages/playtest/path.test.ts
+++ b/frontend/src/pages/playtest/path.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPlaytestPath } from './path'
+
+describe('buildPlaytestPath', () => {
+  it('encodes resource identities and keeps the selected action in the query string', () => {
+    expect(
+      buildPlaytestPath({
+        characterId: 'character/1',
+        outfitId: 'default outfit',
+        actionId: 'walk left',
+      }),
+    ).toBe('/playtest/character%2F1/default%20outfit?actionId=walk+left')
+  })
+})

--- a/frontend/src/pages/playtest/path.ts
+++ b/frontend/src/pages/playtest/path.ts
@@ -1,0 +1,16 @@
+interface PlaytestPathTarget {
+  characterId: string
+  outfitId: string
+  actionId?: string
+}
+
+/**
+ * 统一生成 Playtest 地址，避免目录页和工作台各自拼接路径。
+ * actionId 放在查询参数中，因为它只决定当前预览动作，不改变角色和造型的资源身份。
+ */
+export function buildPlaytestPath({ characterId, outfitId, actionId }: PlaytestPathTarget): string {
+  const pathname = `/playtest/${encodeURIComponent(characterId)}/${encodeURIComponent(outfitId)}`
+  if (actionId === undefined) return pathname
+
+  return `${pathname}?${new URLSearchParams({ actionId }).toString()}`
+}

--- a/frontend/src/pages/playtest/playtest-boundaries.test.ts
+++ b/frontend/src/pages/playtest/playtest-boundaries.test.ts
@@ -1,0 +1,116 @@
+/// <reference types="node" />
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const playtestDirectory = fileURLToPath(new URL('.', import.meta.url))
+const entitiesDirectory = fileURLToPath(new URL('../../entities/', import.meta.url))
+const prohibitedImports = [
+  'live-demo-ui-components',
+  'entities/workflow-run',
+  'entities/generation',
+] as const
+const allowedEntityImports = [
+  '@/entities/character',
+  '@/entities/playtest-inspection',
+  '@/entities/project',
+] as const
+
+function sourceFiles(directory: string): readonly string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return sourceFiles(path)
+    if (!entry.isFile() || !/\.(?:ts|tsx)$/.test(entry.name) || entry.name.includes('.test.')) {
+      return []
+    }
+    return [path]
+  })
+}
+
+function allTypeScriptFiles(directory: string): readonly string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return allTypeScriptFiles(path)
+    if (!entry.isFile() || !/\.(?:ts|tsx)$/.test(entry.name)) return []
+    return [path]
+  })
+}
+
+function moduleSpecifiers(source: string): readonly string[] {
+  return [...source.matchAll(/(?:from\s+|import\s*)["']([^"']+)["']/g)].map(
+    (match) => match[1] ?? '',
+  )
+}
+
+function entityEntry(file: string, dependency: string): string | null {
+  if (dependency === '@/entities') return ''
+  if (dependency.startsWith('@/entities/')) return dependency.slice('@/entities/'.length)
+  if (!dependency.startsWith('.')) return null
+
+  const relativeEntry = relative(entitiesDirectory, resolve(dirname(file), dependency))
+  if (relativeEntry.startsWith('..') || isAbsolute(relativeEntry)) return null
+
+  return relativeEntry.replaceAll('\\', '/').replace(/\/index$/, '')
+}
+
+describe('Playtest architecture boundaries', () => {
+  it('does not import forbidden application or live-demo implementation layers', () => {
+    // Catches the isolated Playtest slice reaching into unrelated product layers.
+    for (const file of sourceFiles(playtestDirectory)) {
+      const source = readFileSync(file, 'utf8')
+      for (const fragment of prohibitedImports) {
+        expect(source, `${file} must not contain ${fragment}`).not.toContain(fragment)
+      }
+    }
+  })
+
+  it('does not import application or capabilities roots or subpaths', () => {
+    // Catches bypassing the isolated Page through either a barrel or a deep implementation path.
+    for (const file of sourceFiles(playtestDirectory)) {
+      const dependencies = moduleSpecifiers(readFileSync(file, 'utf8'))
+      expect(
+        dependencies.filter(
+          (dependency) =>
+            dependency === '@/application' ||
+            dependency.startsWith('@/application/') ||
+            dependency === '@/capabilities' ||
+            dependency.startsWith('@/capabilities/'),
+        ),
+        `${file} must not import application or capabilities`,
+      ).toEqual([])
+    }
+  })
+
+  it('imports Entity contracts only from the approved direct entrypoints', () => {
+    // Catches alias or relative root barrels and deep paths that hide Playtest's dependencies.
+    for (const file of sourceFiles(playtestDirectory)) {
+      const entityImports = moduleSpecifiers(readFileSync(file, 'utf8'))
+        .map((dependency) => ({ dependency, entry: entityEntry(file, dependency) }))
+        .filter((candidate) => candidate.entry !== null)
+
+      for (const { dependency, entry } of entityImports) {
+        expect(allowedEntityImports, `${file} imports ${dependency}`).toContain(
+          `@/entities/${entry}`,
+        )
+      }
+    }
+  })
+
+  it('keeps the demo fixture out of formal Playtest source', () => {
+    // Catches a formal route silently importing the demo character as an API fallback.
+    const importers = allTypeScriptFiles(playtestDirectory).filter((file) =>
+      readFileSync(file, 'utf8').includes('testing/demo-character'),
+    )
+
+    expect(
+      importers.every(
+        (file) => file === join(playtestDirectory, 'demo-page.tsx') || file.includes('.test.'),
+      ),
+    ).toBe(true)
+    expect(readFileSync(join(playtestDirectory, 'index.tsx'), 'utf8')).not.toContain(
+      'testing/demo-character',
+    )
+  })
+})

--- a/frontend/src/pages/playtest/workbench/acceptance.tsx
+++ b/frontend/src/pages/playtest/workbench/acceptance.tsx
@@ -1,0 +1,81 @@
+import { StatusPanel } from './status-panel'
+
+import type { PlaytestInspectionStatus } from '@/entities/playtest-inspection'
+
+export interface AcceptanceProps {
+  inspectionStatus: PlaytestInspectionStatus | null
+  available: boolean
+  canPass: boolean
+  loading: boolean
+  saving: boolean
+  error: string | null
+  onRecordStatus(status: PlaytestInspectionStatus): Promise<void>
+}
+
+function statusText(status: PlaytestInspectionStatus | null): string {
+  if (status === 'passed') return '通过'
+  if (status === 'issues_found') return '发现问题'
+  return '尚未核验'
+}
+
+/** Playtest 自己的动作核验结论，不写回 Character 或创作历史。 */
+export function Acceptance({
+  inspectionStatus,
+  available,
+  canPass,
+  loading,
+  saving,
+  error,
+  onRecordStatus,
+}: AcceptanceProps) {
+  const detail = !available
+    ? '当前预览未连接核验记录'
+    : loading
+      ? '正在读取核验记录'
+      : saving
+        ? '正在保存核验记录'
+        : error
+          ? error
+          : inspectionStatus === null
+            ? canPass
+              ? '尚未保存核验结论'
+              : '当前帧尚未成功加载，不能标记通过'
+            : '已保存到 Playtest 核验记录'
+
+  return (
+    <section
+      aria-label="核验状态"
+      className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+    >
+      <header>
+        <p className="text-[10px] font-semibold tracking-[0.18em] text-slate-400">ACCEPTANCE</p>
+        <h2 className="mt-1 text-sm font-semibold text-slate-900">本次核验</h2>
+      </header>
+      <StatusPanel
+        title="Playtest 核验记录"
+        tone={inspectionStatus === 'issues_found' ? 'warning' : 'neutral'}
+      >
+        <p>{statusText(inspectionStatus)}</p>
+        <p className="mt-1 text-xs">{detail}</p>
+      </StatusPanel>
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          disabled={!available || !canPass || loading || saving}
+          onClick={() => void onRecordStatus('passed')}
+          className="rounded-lg bg-emerald-900 px-3 py-2 text-xs font-semibold text-white"
+        >
+          核验通过
+        </button>
+        <button
+          type="button"
+          disabled={!available || loading || saving}
+          onClick={() => void onRecordStatus('issues_found')}
+          className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-900"
+        >
+          发现问题
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/action-selector.tsx
+++ b/frontend/src/pages/playtest/workbench/action-selector.tsx
@@ -1,0 +1,208 @@
+import { useId, useState } from 'react'
+
+import type { PreviewAction } from './model/types'
+
+export interface PlaytestAssetOption {
+  key: string
+  characterId: string
+  outfitId: string
+  name: string
+  actionCount: number
+}
+
+export interface ActionSelectorProps {
+  assets: readonly PlaytestAssetOption[]
+  selectedAssetKey: string
+  actions: readonly PreviewAction[]
+  selectedActionId: string | null
+  onSelectAsset(asset: PlaytestAssetOption): void
+  onSelectAction(actionId: string): void
+}
+
+function frameCount(action: PreviewAction): number {
+  return action.sequences.reduce((total, sequence) => total + sequence.frames.length, 0)
+}
+
+function assetDisplayName(asset: PlaytestAssetOption): string {
+  const generatedSuffix = `（角色 ${asset.characterId}）`
+  return asset.name.endsWith(generatedSuffix)
+    ? asset.name.slice(0, -generatedSuffix.length)
+    : asset.name
+}
+
+function AssetIdentity({
+  asset,
+  menuOpen = false,
+  showCaret = false,
+}: {
+  asset: PlaytestAssetOption | null
+  menuOpen?: boolean
+  showCaret?: boolean
+}) {
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className="grid h-8 w-8 place-items-center rounded bg-[#dce9df] font-mono text-[10px] font-bold text-[#294331]"
+      >
+        {asset?.characterId.slice(-3) ?? '—'}
+      </span>
+      <span className="min-w-0">
+        <strong className="block truncate text-xs font-semibold text-white">
+          {asset === null ? '没有可预览角色' : assetDisplayName(asset)}
+        </strong>
+        {asset !== null ? (
+          <small className="mt-0.5 block truncate text-[9px] text-white/40">
+            角色 {asset.characterId} · {asset.actionCount} 个动作
+          </small>
+        ) : null}
+      </span>
+      <span
+        aria-hidden="true"
+        className={`text-center text-xs text-white/45 transition-transform ${menuOpen ? 'rotate-180' : ''}`}
+      >
+        {showCaret ? '⌄' : ''}
+      </span>
+    </>
+  )
+}
+
+export function ActionSelector({
+  assets,
+  selectedAssetKey,
+  actions,
+  selectedActionId,
+  onSelectAsset,
+  onSelectAction,
+}: ActionSelectorProps) {
+  const [assetMenuOpen, setAssetMenuOpen] = useState(false)
+  const assetMenuId = useId()
+  const selectedAsset =
+    assets.find((candidate) => candidate.key === selectedAssetKey) ?? assets[0] ?? null
+  const canSwitchAsset = assets.length > 1
+
+  return (
+    <div aria-label="动作列表" className="flex h-full min-h-0 flex-col bg-[#202522] p-3 text-white">
+      <div
+        className="relative"
+        onBlur={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget)) setAssetMenuOpen(false)
+        }}
+      >
+        <div className="mb-2 flex items-center justify-between gap-2 px-0.5">
+          <span className="text-[9px] font-semibold text-white/40">
+            {canSwitchAsset ? '角色 / 造型' : '当前角色'}
+          </span>
+          {canSwitchAsset ? (
+            <span className="font-mono text-[8px] text-white/30">{assets.length} ITEMS</span>
+          ) : null}
+        </div>
+        {canSwitchAsset ? (
+          <button
+            type="button"
+            role="combobox"
+            aria-label="同项目资产"
+            aria-expanded={assetMenuOpen}
+            aria-controls={assetMenuId}
+            aria-haspopup="listbox"
+            onClick={() => setAssetMenuOpen((open) => !open)}
+            className="grid min-h-14 w-full grid-cols-[32px_minmax(0,1fr)_18px] items-center gap-2 rounded-md border border-white/10 bg-white/6 px-2 text-left outline-none transition-colors hover:border-white/20 hover:bg-white/9 focus-visible:border-[#a7c5ae]"
+          >
+            <AssetIdentity asset={selectedAsset} menuOpen={assetMenuOpen} showCaret />
+          </button>
+        ) : (
+          <div
+            aria-label="当前角色"
+            className="grid min-h-14 w-full grid-cols-[32px_minmax(0,1fr)_18px] items-center gap-2 rounded-md border border-white/8 bg-white/4 px-2 text-left"
+          >
+            <AssetIdentity asset={selectedAsset} />
+          </div>
+        )}
+        {canSwitchAsset && assetMenuOpen ? (
+          <div
+            id={assetMenuId}
+            role="listbox"
+            aria-label="可切换角色"
+            className="absolute inset-x-0 top-[calc(100%+6px)] z-40 max-h-64 overflow-y-auto rounded-md border border-[#cbd2cc] bg-white p-1 text-[#253029] shadow-[0_12px_28px_rgba(10,20,13,0.2)]"
+          >
+            {assets.map((asset) => {
+              const selected = asset.key === selectedAssetKey
+
+              return (
+                <button
+                  key={asset.key}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  onClick={() => {
+                    setAssetMenuOpen(false)
+                    if (!selected) onSelectAsset(asset)
+                  }}
+                  className={`grid min-h-12 w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded px-2 text-left ${
+                    selected ? 'bg-[#e1ebe3] text-[#294331]' : 'hover:bg-[#f0f3f0]'
+                  }`}
+                >
+                  <span className="min-w-0">
+                    <strong className="block truncate text-[11px]">
+                      {assetDisplayName(asset)}
+                    </strong>
+                    <small className="mt-0.5 block truncate text-[9px] text-[#707971]">
+                      角色 {asset.characterId}
+                    </small>
+                  </span>
+                  <span className="font-mono text-[9px] text-[#69736b]">
+                    {asset.actionCount} ACT
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        ) : null}
+      </div>
+      <div className="my-3 border-t border-white/8" />
+      <div className="flex items-center justify-between gap-2 px-0.5">
+        <p className="text-[9px] font-semibold text-white/40">动作</p>
+        <span className="font-mono text-[8px] text-white/30">{actions.length} TOTAL</span>
+      </div>
+      <div className="mt-2 flex min-h-0 gap-1.5 overflow-x-auto pb-1 lg:flex-1 lg:flex-col lg:overflow-x-hidden lg:overflow-y-auto lg:pb-0">
+        {actions.map((action) => {
+          const count = frameCount(action)
+          const selected = action.id === selectedActionId
+
+          return (
+            <button
+              key={action.id}
+              type="button"
+              aria-pressed={selected}
+              disabled={count === 0}
+              onClick={() => onSelectAction(action.id)}
+              className={`grid min-h-12 w-36 shrink-0 grid-cols-[4px_minmax(0,1fr)_auto] items-center gap-2 rounded-md border px-2 py-1.5 text-left transition-colors lg:w-full ${
+                selected
+                  ? 'border-white/12 bg-white/9 text-white'
+                  : 'border-transparent text-white/60 hover:bg-white/5 hover:text-white'
+              } disabled:cursor-not-allowed disabled:opacity-40`}
+            >
+              <span
+                aria-hidden="true"
+                className={`h-5 w-1 rounded-sm ${selected ? 'bg-[#a7c5ae]' : 'bg-transparent'}`}
+              />
+              <span className="min-w-0">
+                <strong className="block truncate text-xs">{action.name}</strong>
+                <span
+                  className={`mt-0.5 block text-[8px] uppercase ${selected ? 'text-[#a7c5ae]' : 'text-white/35'}`}
+                >
+                  {action.fps} FPS
+                </span>
+              </span>
+              <span
+                className={`text-[9px] tabular-nums ${selected ? 'text-white/75' : 'text-white/40'}`}
+              >
+                {count} 帧
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/analysis/frame-geometry.test.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/frame-geometry.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import { measureFrameGeometry, type FramePixelData } from './frame-geometry'
+
+function createPixels(
+  width: number,
+  height: number,
+  visible: readonly { x: number; y: number; alpha: number }[],
+): FramePixelData {
+  const data = new Uint8ClampedArray(width * height * 4)
+
+  for (const pixel of visible) data[(pixel.y * width + pixel.x) * 4 + 3] = pixel.alpha
+
+  return { data, width, height }
+}
+
+describe('measureFrameGeometry', () => {
+  it('treats only alpha values greater than 24 as visible', () => {
+    // Catches the review algorithm including matte noise at the old Alpha cutoff.
+    expect(measureFrameGeometry(createPixels(1, 1, [{ x: 0, y: 0, alpha: 24 }]))).toBeNull()
+    expect(measureFrameGeometry(createPixels(1, 1, [{ x: 0, y: 0, alpha: 25 }]))).toMatchObject({
+      opaquePixels: 1,
+      coverageRatio: 1,
+    })
+  })
+
+  it('measures bounds, centroid, foot line, height, area and coverage from visible pixels', () => {
+    // Catches off-by-one bounds or a centroid derived from the box instead of real visible pixels.
+    const geometry = measureFrameGeometry(
+      createPixels(4, 4, [
+        { x: 1, y: 1, alpha: 255 },
+        { x: 2, y: 1, alpha: 255 },
+        { x: 1, y: 2, alpha: 255 },
+        { x: 2, y: 2, alpha: 255 },
+      ]),
+    )
+
+    expect(geometry).toEqual({
+      width: 4,
+      height: 4,
+      bounds: { left: 1, top: 1, right: 2, bottom: 2, width: 2, height: 2 },
+      centroid: { x: 1.5, y: 1.5 },
+      footY: 2,
+      subjectHeight: 2,
+      opaquePixels: 4,
+      coverageRatio: 0.25,
+      fingerprint: expect.any(Array),
+      contentHash: expect.any(String),
+    })
+    expect(geometry?.fingerprint).toHaveLength(64)
+  })
+
+  it('produces different compact fingerprints for different silhouettes with equal bounds', () => {
+    const leftTop = measureFrameGeometry(
+      createPixels(4, 4, [
+        { x: 0, y: 0, alpha: 255 },
+        { x: 1, y: 0, alpha: 255 },
+        { x: 2, y: 0, alpha: 255 },
+        { x: 3, y: 0, alpha: 255 },
+        { x: 3, y: 1, alpha: 255 },
+        { x: 3, y: 2, alpha: 255 },
+        { x: 3, y: 3, alpha: 255 },
+      ]),
+    )
+    const leftBottom = measureFrameGeometry(
+      createPixels(4, 4, [
+        { x: 0, y: 0, alpha: 255 },
+        { x: 0, y: 1, alpha: 255 },
+        { x: 0, y: 2, alpha: 255 },
+        { x: 0, y: 3, alpha: 255 },
+        { x: 1, y: 3, alpha: 255 },
+        { x: 2, y: 3, alpha: 255 },
+        { x: 3, y: 3, alpha: 255 },
+      ]),
+    )
+
+    expect(leftTop?.bounds).toEqual(leftBottom?.bounds)
+    expect(leftTop?.fingerprint).not.toEqual(leftBottom?.fingerprint)
+  })
+
+  it('keeps small dark silhouettes distinguishable instead of diluting them across the canvas', () => {
+    const topLeft: Array<{ x: number; y: number; alpha: number }> = []
+    const bottomRight: Array<{ x: number; y: number; alpha: number }> = []
+    for (let y = 96; y < 160; y += 1) {
+      for (let x = 96; x < 160; x += 1) {
+        if (y < 128 || x < 112) topLeft.push({ x, y, alpha: 255 })
+        if (y >= 128 || x >= 144) bottomRight.push({ x, y, alpha: 255 })
+      }
+    }
+    const first = measureFrameGeometry(createPixels(256, 256, topLeft))
+    const second = measureFrameGeometry(createPixels(256, 256, bottomRight))
+    const distance =
+      first?.fingerprint?.reduce(
+        (total, value, index) => total + Math.abs(value - (second?.fingerprint?.[index] ?? value)),
+        0,
+      ) ?? 0
+
+    expect(first?.bounds).toEqual(second?.bounds)
+    expect(distance / 64).toBeGreaterThan(0.02)
+  })
+
+  it('rejects an RGBA buffer whose dimensions do not match its length', () => {
+    // Catches silent geometry corruption when Canvas data and dimensions diverge.
+    expect(() =>
+      measureFrameGeometry({ data: new Uint8ClampedArray(4), width: 2, height: 2 }),
+    ).toThrowError('RGBA 像素长度与画布尺寸不一致')
+  })
+
+  it('ignores a tiny isolated Alpha component outside the visible subject', () => {
+    // Catches one stray generated pixel moving the measured foot line and centroid.
+    const geometry = measureFrameGeometry(
+      createPixels(4, 4, [
+        { x: 0, y: 0, alpha: 255 },
+        { x: 1, y: 0, alpha: 255 },
+        { x: 0, y: 1, alpha: 255 },
+        { x: 1, y: 1, alpha: 255 },
+        { x: 3, y: 3, alpha: 255 },
+      ]),
+    )
+
+    expect(geometry).toMatchObject({
+      bounds: { left: 0, top: 0, right: 1, bottom: 1, width: 2, height: 2 },
+      centroid: { x: 0.5, y: 0.5 },
+      footY: 1,
+      opaquePixels: 4,
+      coverageRatio: 0.25,
+    })
+  })
+})

--- a/frontend/src/pages/playtest/workbench/analysis/frame-geometry.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/frame-geometry.ts
@@ -1,0 +1,197 @@
+export const ALPHA_THRESHOLD = 24
+const MIN_COMPONENT_PIXELS = 4
+const RELATIVE_COMPONENT_RATIO = 0.002
+
+export interface FramePixelData {
+  data: Uint8ClampedArray
+  width: number
+  height: number
+}
+
+export interface FrameGeometry {
+  width: number
+  height: number
+  bounds: {
+    left: number
+    top: number
+    right: number
+    bottom: number
+    width: number
+    height: number
+  }
+  centroid: { x: number; y: number }
+  footY: number
+  subjectHeight: number
+  opaquePixels: number
+  coverageRatio: number
+  /** Compact 8×8 alpha/luminance signature used for adjacent-frame similarity checks. */
+  fingerprint?: readonly number[]
+  /** Exact RGBA content hash used to identify genuinely duplicated frames. */
+  contentHash?: string
+}
+
+function hashPixels(data: Uint8ClampedArray): string {
+  let hash = 0x811c9dc5
+  for (const value of data) {
+    hash ^= value
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+function createFingerprint(
+  data: Uint8ClampedArray,
+  width: number,
+  subjectPixels: readonly number[],
+  bounds: { left: number; top: number; width: number; height: number },
+): readonly number[] {
+  const sums = new Float64Array(64)
+  const cellPixels = new Uint32Array(64)
+
+  for (const index of subjectPixels) {
+    const x = index % width
+    const y = Math.floor(index / width)
+    const offset = index * 4
+    const red = data[offset] ?? 0
+    const green = data[offset + 1] ?? 0
+    const blue = data[offset + 2] ?? 0
+    const alpha = (data[offset + 3] ?? 0) / 255
+    const luminance = (red * 0.2126 + green * 0.7152 + blue * 0.0722) / 255
+    const cellX = Math.min(7, Math.floor(((x - bounds.left) * 8) / bounds.width))
+    const cellY = Math.min(7, Math.floor(((y - bounds.top) * 8) / bounds.height))
+    const cell = cellY * 8 + cellX
+    sums[cell] += alpha * (0.25 + luminance * 0.75)
+    cellPixels[cell] += 1
+  }
+
+  return Array.from(sums, (sum, index) => {
+    const count = cellPixels[index] ?? 0
+    return count === 0 ? 0 : Number((sum / count).toFixed(4))
+  })
+}
+
+interface VisibleComponentsResult {
+  components: number[][]
+  largestSize: number
+}
+
+function visibleComponents(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+): VisibleComponentsResult {
+  const pixelCount = width * height
+  const visible = new Uint8Array(pixelCount)
+  const visited = new Uint8Array(pixelCount)
+  const components: number[][] = []
+  const queue = new Int32Array(pixelCount)
+  let largestSize = 0
+
+  for (let index = 0; index < pixelCount; index += 1) {
+    const alpha = data[index * 4 + 3]
+    if (alpha !== undefined && alpha > ALPHA_THRESHOLD) visible[index] = 1
+  }
+
+  for (let start = 0; start < pixelCount; start += 1) {
+    if (visible[start] === 0 || visited[start] === 1) continue
+
+    const component: number[] = []
+    let head = 0
+    let tail = 0
+    queue[tail++] = start
+    visited[start] = 1
+
+    while (head < tail) {
+      const index = queue[head++]
+      component.push(index)
+
+      const x = index % width
+      const y = Math.floor(index / width)
+      for (let offsetY = -1; offsetY <= 1; offsetY += 1) {
+        for (let offsetX = -1; offsetX <= 1; offsetX += 1) {
+          if (offsetX === 0 && offsetY === 0) continue
+          const nextX = x + offsetX
+          const nextY = y + offsetY
+          if (nextX < 0 || nextX >= width || nextY < 0 || nextY >= height) continue
+
+          const next = nextY * width + nextX
+          if (visible[next] === 0 || visited[next] === 1) continue
+          visited[next] = 1
+          queue[tail++] = next
+        }
+      }
+    }
+
+    if (component.length > largestSize) largestSize = component.length
+    components.push(component)
+  }
+
+  return { components, largestSize }
+}
+
+export function measureFrameGeometry(pixels: FramePixelData): FrameGeometry | null {
+  const { data, width, height } = pixels
+
+  if (data.length !== width * height * 4) {
+    throw new RangeError('RGBA 像素长度与画布尺寸不一致')
+  }
+
+  const { components, largestSize } = visibleComponents(data, width, height)
+  if (components.length === 0) return null
+
+  const minimumSize = Math.min(
+    largestSize,
+    Math.max(MIN_COMPONENT_PIXELS, Math.ceil(largestSize * RELATIVE_COMPONENT_RATIO)),
+  )
+  const subjectPixels = components.flatMap((component) =>
+    component.length === largestSize || component.length >= minimumSize ? component : [],
+  )
+
+  let left = width
+  let top = height
+  let right = -1
+  let bottom = -1
+  let opaquePixels = 0
+  let sumX = 0
+  let sumY = 0
+
+  for (const index of subjectPixels) {
+    const x = index % width
+    const y = Math.floor(index / width)
+    left = Math.min(left, x)
+    top = Math.min(top, y)
+    right = Math.max(right, x)
+    bottom = Math.max(bottom, y)
+    opaquePixels += 1
+    sumX += x
+    sumY += y
+  }
+
+  const subjectWidth = right - left + 1
+  const subjectHeight = bottom - top + 1
+
+  return {
+    width,
+    height,
+    bounds: {
+      left,
+      top,
+      right,
+      bottom,
+      width: subjectWidth,
+      height: subjectHeight,
+    },
+    centroid: { x: sumX / opaquePixels, y: sumY / opaquePixels },
+    footY: bottom,
+    subjectHeight,
+    opaquePixels,
+    coverageRatio: opaquePixels / (width * height),
+    fingerprint: createFingerprint(data, width, subjectPixels, {
+      left,
+      top,
+      width: subjectWidth,
+      height: subjectHeight,
+    }),
+    contentHash: hashPixels(data),
+  }
+}

--- a/frontend/src/pages/playtest/workbench/analysis/image-geometry.test.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/image-geometry.test.ts
@@ -1,0 +1,146 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { readImageGeometry } from './image-geometry'
+
+type ImageBehavior = 'load' | 'error' | 'pending'
+
+let imageBehavior: ImageBehavior
+let crossOriginAtSourceAssignment: string | null
+let lastAssignedSource: string
+let canvasContext: Pick<CanvasRenderingContext2D, 'drawImage' | 'getImageData'> | null
+
+class FakeImage {
+  crossOrigin: string | null = null
+  naturalWidth = 2
+  naturalHeight = 2
+  onerror: OnErrorEventHandler | null = null
+  onload: ((this: GlobalEventHandlers, event: Event) => unknown) | null = null
+  private source = ''
+
+  get src(): string {
+    return this.source
+  }
+
+  set src(value: string) {
+    this.source = value
+    crossOriginAtSourceAssignment = this.crossOrigin
+    lastAssignedSource = value
+    if (value === '' || imageBehavior === 'pending') return
+
+    queueMicrotask(() => {
+      if (imageBehavior === 'load') this.onload?.call(this as never, new Event('load'))
+      else this.onerror?.call(this as never, 'error', '', 0, 0, new Error('load failed'))
+    })
+  }
+}
+
+function pixelsWithAlpha(alpha: number): ImageData {
+  const data = new Uint8ClampedArray(2 * 2 * 4)
+  data[3] = alpha
+  return { data, width: 2, height: 2, colorSpace: 'srgb' } as ImageData
+}
+
+beforeEach(() => {
+  imageBehavior = 'load'
+  crossOriginAtSourceAssignment = null
+  lastAssignedSource = ''
+  canvasContext = {
+    drawImage: vi.fn(),
+    getImageData: vi.fn(() => pixelsWithAlpha(255)),
+  }
+  vi.stubGlobal('Image', FakeImage)
+  vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+    if (tagName !== 'canvas')
+      return document.createElementNS('http://www.w3.org/1999/xhtml', tagName)
+    return {
+      width: 0,
+      height: 0,
+      getContext: () => canvasContext,
+    } as unknown as HTMLCanvasElement
+  }) as typeof document.createElement)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('readImageGeometry', () => {
+  it('requests anonymous image access before reading real Canvas pixels', async () => {
+    // Catches crossOrigin being assigned after src or a placeholder geometry replacing actual pixels.
+    const result = await readImageGeometry('https://cdn.example.test/frame.png')
+
+    expect(crossOriginAtSourceAssignment).toBe('anonymous')
+    expect(result).toEqual({
+      status: 'ready',
+      geometry: {
+        width: 2,
+        height: 2,
+        bounds: { left: 0, top: 0, right: 0, bottom: 0, width: 1, height: 1 },
+        centroid: { x: 0, y: 0 },
+        footY: 0,
+        subjectHeight: 1,
+        opaquePixels: 1,
+        coverageRatio: 0.25,
+        fingerprint: expect.any(Array),
+        contentHash: expect.any(String),
+      },
+    })
+  })
+
+  it('reports asset, Canvas and transparent-frame failures instead of zero evidence', async () => {
+    // Catches unavailable evidence being silently presented as a successful zero measurement.
+    imageBehavior = 'error'
+    await expect(readImageGeometry('/missing.png')).resolves.toEqual({
+      status: 'unavailable',
+      reason: '图片加载失败',
+    })
+
+    imageBehavior = 'load'
+    canvasContext = null
+    await expect(readImageGeometry('/no-canvas.png')).resolves.toEqual({
+      status: 'unavailable',
+      reason: '浏览器无法读取图片像素',
+    })
+
+    canvasContext = {
+      drawImage: vi.fn(),
+      getImageData: vi.fn(() => pixelsWithAlpha(24)),
+    }
+    await expect(readImageGeometry('/transparent.png')).resolves.toEqual({
+      status: 'unavailable',
+      reason: '图片没有可见主体',
+    })
+  })
+
+  it('reports a tainted Canvas as a cross-origin pixel failure', async () => {
+    // Catches signed remote images being mislabelled as transparent or valid when CORS blocks inspection.
+    canvasContext = {
+      drawImage: vi.fn(),
+      getImageData: vi.fn(() => {
+        throw new DOMException('tainted', 'SecurityError')
+      }),
+    }
+
+    await expect(readImageGeometry('https://remote.example.test/frame.png')).resolves.toEqual({
+      status: 'unavailable',
+      reason: '图片跨域，无法计算像素',
+    })
+  })
+
+  it('cancels a pending image read through AbortSignal', async () => {
+    // Catches a stale sequence load surviving a direction switch and updating the new review.
+    imageBehavior = 'pending'
+    const controller = new AbortController()
+    const result = readImageGeometry('/slow.png', controller.signal)
+
+    controller.abort()
+
+    await expect(result).resolves.toEqual({
+      status: 'unavailable',
+      reason: '分析已取消',
+    })
+    expect(lastAssignedSource).toBe('')
+  })
+})

--- a/frontend/src/pages/playtest/workbench/analysis/image-geometry.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/image-geometry.ts
@@ -1,0 +1,76 @@
+import { measureFrameGeometry } from './frame-geometry'
+import type { FrameGeometryResult } from './sequence-evidence'
+
+function unavailable(reason: string): FrameGeometryResult {
+  return { status: 'unavailable', reason }
+}
+
+function pixelReadFailure(error: unknown): FrameGeometryResult {
+  if (error instanceof DOMException && error.name === 'SecurityError') {
+    return unavailable('图片跨域，无法计算像素')
+  }
+
+  return unavailable('浏览器无法读取图片像素')
+}
+
+/**
+ * 每次读取创建独立 canvas。帧检查是低频操作（每帧 onload 一次），
+ * 不缓存可避免模块级状态在测试间泄漏（mock 无法重置）。
+ */
+function getSharedContext(width: number, height: number): CanvasRenderingContext2D | null {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  return canvas.getContext('2d', { willReadFrequently: true })
+}
+
+export function readImageGeometry(
+  imageUrl: string,
+  signal?: AbortSignal,
+): Promise<FrameGeometryResult> {
+  return new Promise((resolve) => {
+    const image = new Image()
+    let settled = false
+
+    const finish = (result: FrameGeometryResult) => {
+      if (settled) return
+      settled = true
+      image.onload = null
+      image.onerror = null
+      signal?.removeEventListener('abort', abort)
+      resolve(result)
+    }
+    const abort = () => {
+      image.src = ''
+      finish(unavailable('分析已取消'))
+    }
+
+    image.crossOrigin = 'anonymous'
+    image.onload = () => {
+      const context = getSharedContext(image.naturalWidth, image.naturalHeight)
+
+      if (context === null) {
+        finish(unavailable('浏览器无法读取图片像素'))
+        return
+      }
+
+      try {
+        context.drawImage(image, 0, 0)
+        const imageData = context.getImageData(0, 0, image.naturalWidth, image.naturalHeight)
+        const geometry = measureFrameGeometry(imageData)
+        finish(geometry === null ? unavailable('图片没有可见主体') : { status: 'ready', geometry })
+      } catch (error) {
+        finish(pixelReadFailure(error))
+      }
+    }
+    image.onerror = () => finish(unavailable('图片加载失败'))
+
+    if (signal?.aborted) {
+      abort()
+      return
+    }
+
+    signal?.addEventListener('abort', abort, { once: true })
+    image.src = imageUrl
+  })
+}

--- a/frontend/src/pages/playtest/workbench/analysis/quality-policy.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/quality-policy.ts
@@ -1,0 +1,123 @@
+import type { PlaytestActionType } from '../model/types'
+import type { FrameGeometry } from './frame-geometry'
+
+export interface CanvasBaseline {
+  width: number
+  height: number
+}
+
+export interface LocalQualityPolicy {
+  expectedCanvas: CanvasBaseline | null
+  edgeMargin: { x: number; y: number }
+  minimumCoverageRatio: number
+  maximumCoverageRatio: number
+  footDriftThreshold: number | null
+  heightDriftThreshold: number | null
+  heightAttentionThreshold: number | null
+  areaDeltaThresholdPercent: number
+  movementPadding: number
+  movementFloor: number
+  movementCeiling: number
+  rootMotionDirectionMinimum: number
+}
+
+const REFERENCE_CANVAS_SIZE = 256
+const MINIMUM_COVERAGE_RATIO = 0.005
+const MAXIMUM_COVERAGE_RATIO = 0.65
+const AREA_DELTA_THRESHOLD_PERCENT = 28
+
+function scaledPixels(referencePixels: number, scale: number): number {
+  return Number((referencePixels * scale).toFixed(4))
+}
+
+function inferCanvasBaseline(geometries: readonly FrameGeometry[]): CanvasBaseline | null {
+  const candidates = new Map<
+    string,
+    { canvas: CanvasBaseline; count: number; firstIndex: number }
+  >()
+
+  geometries.forEach((geometry, index) => {
+    const key = `${geometry.width}x${geometry.height}`
+    const existing = candidates.get(key)
+    if (existing) existing.count += 1
+    else {
+      candidates.set(key, {
+        canvas: { width: geometry.width, height: geometry.height },
+        count: 1,
+        firstIndex: index,
+      })
+    }
+  })
+
+  const selected = [...candidates.values()].sort(
+    (left, right) => right.count - left.count || left.firstIndex - right.firstIndex,
+  )[0]
+  return selected?.canvas ?? null
+}
+
+function heightReferencePixels(actionType: PlaytestActionType): number | null {
+  if (actionType === 'jump' || actionType === 'crouch') return null
+  if (actionType === 'idle') return 7
+  if (actionType === 'walk') return 12
+  return 20
+}
+
+function movementCeilingReferencePixels(actionType: PlaytestActionType): number {
+  if (actionType === 'idle') return 6
+  if (actionType === 'walk') return 24
+  if (actionType === 'crouch') return 16
+  if (actionType === 'jump') return 64
+  return 48
+}
+
+/**
+ * Keeps the existing local heuristics, but scales pixel thresholds from the sequence's dominant
+ * canvas size. The 256px values are calibration references, not a required asset contract.
+ */
+export function deriveLocalQualityPolicy(
+  geometries: readonly FrameGeometry[],
+  actionType: PlaytestActionType,
+  expectedCanvasOverride: CanvasBaseline | null = null,
+): LocalQualityPolicy {
+  const expectedCanvas = expectedCanvasOverride ?? inferCanvasBaseline(geometries)
+  if (expectedCanvas === null) {
+    return {
+      expectedCanvas: null,
+      edgeMargin: { x: 1, y: 1 },
+      minimumCoverageRatio: MINIMUM_COVERAGE_RATIO,
+      maximumCoverageRatio: MAXIMUM_COVERAGE_RATIO,
+      footDriftThreshold: null,
+      heightDriftThreshold: null,
+      heightAttentionThreshold: null,
+      areaDeltaThresholdPercent: AREA_DELTA_THRESHOLD_PERCENT,
+      movementPadding: 2,
+      movementFloor: 6,
+      movementCeiling: movementCeilingReferencePixels(actionType),
+      rootMotionDirectionMinimum: 2,
+    }
+  }
+
+  const horizontalScale = expectedCanvas.width / REFERENCE_CANVAS_SIZE
+  const verticalScale = expectedCanvas.height / REFERENCE_CANVAS_SIZE
+  const distanceScale = Math.sqrt(horizontalScale * verticalScale)
+  const heightReference = heightReferencePixels(actionType)
+
+  return {
+    expectedCanvas,
+    edgeMargin: {
+      x: Math.max(1, scaledPixels(2, horizontalScale)),
+      y: Math.max(1, scaledPixels(2, verticalScale)),
+    },
+    minimumCoverageRatio: MINIMUM_COVERAGE_RATIO,
+    maximumCoverageRatio: MAXIMUM_COVERAGE_RATIO,
+    footDriftThreshold: scaledPixels(3, verticalScale),
+    heightDriftThreshold:
+      heightReference === null ? null : scaledPixels(heightReference, verticalScale),
+    heightAttentionThreshold: scaledPixels(7, verticalScale),
+    areaDeltaThresholdPercent: AREA_DELTA_THRESHOLD_PERCENT,
+    movementPadding: scaledPixels(2, distanceScale),
+    movementFloor: scaledPixels(6, distanceScale),
+    movementCeiling: scaledPixels(movementCeilingReferencePixels(actionType), distanceScale),
+    rootMotionDirectionMinimum: scaledPixels(2, distanceScale),
+  }
+}

--- a/frontend/src/pages/playtest/workbench/analysis/sequence-evidence.test.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/sequence-evidence.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, it } from 'vitest'
+
+import type { FrameGeometry } from './frame-geometry'
+import { buildSequenceEvidence, type FrameEvidenceInput } from './sequence-evidence'
+
+function geometry(
+  overrides: Partial<
+    Pick<
+      FrameGeometry,
+      'width' | 'height' | 'footY' | 'subjectHeight' | 'opaquePixels' | 'coverageRatio'
+    >
+  > & {
+    x?: number
+    y?: number
+    fingerprint?: readonly number[]
+    contentHash?: string
+    cropped?: boolean
+  } = {},
+): FrameGeometry {
+  const subjectHeight = overrides.subjectHeight ?? 20
+
+  return {
+    width: overrides.width ?? 256,
+    height: overrides.height ?? 256,
+    bounds: {
+      left: overrides.cropped ? 0 : 100,
+      top: overrides.cropped ? 0 : 100,
+      right: overrides.cropped ? 9 : 109,
+      bottom: overrides.cropped ? subjectHeight - 1 : 100 + subjectHeight - 1,
+      width: 10,
+      height: subjectHeight,
+    },
+    centroid: { x: overrides.x ?? 0, y: overrides.y ?? 0 },
+    footY: overrides.footY ?? 100,
+    subjectHeight,
+    opaquePixels: overrides.opaquePixels ?? 100,
+    coverageRatio: overrides.coverageRatio ?? 0.25,
+    fingerprint: overrides.fingerprint,
+    contentHash: overrides.contentHash,
+  }
+}
+
+function ready(
+  value: FrameGeometry,
+  rootMotion: FrameEvidenceInput['rootMotion'] = null,
+): FrameEvidenceInput {
+  return { geometry: { status: 'ready', geometry: value }, rootMotion }
+}
+
+describe('buildSequenceEvidence', () => {
+  it('returns structured findings for incomplete, cropped and duplicate frames', () => {
+    const contentHash = 'same-frame'
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ cropped: true, contentHash })),
+        ready(geometry({ contentHash })),
+        { geometry: { status: 'unavailable', reason: '图片没有可见主体' }, rootMotion: null },
+      ],
+      'walk',
+    )
+
+    expect(evidence.complete).toBe(false)
+    expect(evidence.findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(['subject_cropped', 'duplicate_frame', 'blank_subject']),
+    )
+    expect(evidence.findings.find((finding) => finding.code === 'duplicate_frame')).toMatchObject({
+      frameIndex: 1,
+      severity: 'warning',
+    })
+  })
+
+  it('uses action-aware findings for foot and height changes', () => {
+    const frames = [
+      ready(geometry({ footY: 100, subjectHeight: 30 })),
+      ready(geometry({ footY: 112, subjectHeight: 15 })),
+    ]
+
+    expect(buildSequenceEvidence(frames, 'idle').findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(['foot_drift', 'height_drift']),
+    )
+    expect(
+      buildSequenceEvidence(frames, 'jump').findings.map((finding) => finding.code),
+    ).not.toContain('foot_drift')
+    expect(
+      buildSequenceEvidence(frames, 'crouch').findings.map((finding) => finding.code),
+    ).not.toContain('height_drift')
+  })
+
+  it('flags motion outliers and root-motion direction contradictions', () => {
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ x: 0 })),
+        ready(geometry({ x: 1 }), { dx: 1, dy: 0 }),
+        ready(geometry({ x: 2 }), { dx: 1, dy: 0 }),
+        ready(geometry({ x: -18 }), { dx: 5, dy: 0 }),
+      ],
+      'walk',
+    )
+
+    expect(evidence.findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(['motion_spike', 'root_motion_mismatch']),
+    )
+  })
+
+  it('calculates a selected frame delta and the hand-derived sequence baseline', () => {
+    // Catches image-derived offsets being calculated from bounds or against the first frame instead of the previous frame.
+    const evidence = buildSequenceEvidence(
+      [ready(geometry()), ready(geometry({ x: 3, y: 4, opaquePixels: 80 }))],
+      'walk',
+    )
+
+    expect(evidence.frames[0]?.previousDelta).toBeNull()
+    expect(evidence.frames[1]?.previousDelta).toEqual({
+      dx: 3,
+      dy: 4,
+      distance: 5,
+      areaDeltaPercent: 20,
+    })
+    expect(evidence.summary).toMatchObject({
+      medianStep: 5,
+      maxStep: 5,
+      movementThreshold: 15,
+      maxAreaDeltaPercent: 20,
+      movementState: 'normal',
+      areaState: 'normal',
+    })
+  })
+
+  it('infers a consistent canvas baseline instead of requiring 256 pixels', () => {
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ width: 512, height: 512, footY: 200, subjectHeight: 40 })),
+        ready(geometry({ width: 512, height: 512, footY: 205, subjectHeight: 60 })),
+      ],
+      'walk',
+    )
+
+    expect(evidence.findings.map((finding) => finding.code)).not.toContain('canvas_size_mismatch')
+    expect(evidence.summary).toMatchObject({
+      expectedCanvas: { width: 512, height: 512 },
+      footThreshold: 6,
+      heightThreshold: 24,
+      footState: 'normal',
+      heightState: 'normal',
+    })
+  })
+
+  it('flags only frames that disagree with the locally inferred canvas baseline', () => {
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ width: 512, height: 512 })),
+        ready(geometry({ width: 512, height: 512 })),
+        ready(geometry({ width: 256, height: 256 })),
+      ],
+      'idle',
+    )
+
+    expect(
+      evidence.findings
+        .filter((finding) => finding.code === 'canvas_size_mismatch')
+        .map((finding) => finding.frameIndex),
+    ).toEqual([2])
+    expect(evidence.summary.expectedCanvas).toEqual({ width: 512, height: 512 })
+    expect(evidence.frames[2]?.previousDelta).toBeNull()
+    expect(evidence.findings.map((finding) => finding.code)).not.toContain('motion_spike')
+  })
+
+  it('excludes non-baseline canvas frames from sequence-level measurements', () => {
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ width: 512, height: 512, footY: 200, subjectHeight: 40 })),
+        ready(geometry({ width: 512, height: 512, footY: 205, subjectHeight: 42 })),
+        ready(geometry({ width: 512, height: 512, footY: 202, subjectHeight: 41 })),
+        ready(geometry({ width: 256, height: 256, footY: 100, subjectHeight: 10 })),
+        ready(geometry({ width: 256, height: 256, footY: 120, subjectHeight: 20 })),
+      ],
+      'walk',
+    )
+
+    expect(evidence.summary).toMatchObject({
+      expectedCanvas: { width: 512, height: 512 },
+      footDrift: 5,
+      heightDrift: 2,
+    })
+    expect(evidence.findings.map((finding) => finding.code)).toEqual(
+      expect.arrayContaining(['canvas_size_mismatch']),
+    )
+    expect(evidence.findings.map((finding) => finding.code)).not.toContain('foot_drift')
+  })
+
+  it('scales the local motion floor with the inferred canvas size', () => {
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ width: 512, height: 512, x: 0 })),
+        ready(geometry({ width: 512, height: 512, x: 2 })),
+        ready(geometry({ width: 512, height: 512, x: 4 })),
+        ready(geometry({ width: 512, height: 512, x: 14 })),
+      ],
+      'attack',
+    )
+
+    expect(evidence.summary).toMatchObject({
+      maxStep: 10,
+      movementThreshold: 12,
+      movementState: 'normal',
+    })
+    expect(evidence.findings.map((finding) => finding.code)).not.toContain('motion_spike')
+  })
+
+  it('does not compare across an unreadable middle frame', () => {
+    // Catches filtered valid frames becoming false neighbours and producing a misleading offset.
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry()),
+        { geometry: { status: 'unavailable', reason: '图片加载失败' }, rootMotion: null },
+        ready(geometry({ x: 20, y: 20 })),
+      ],
+      'walk',
+    )
+
+    expect(evidence.complete).toBe(false)
+    expect(evidence.unavailableFrameCount).toBe(1)
+    expect(evidence.frames.map((frame) => frame.previousDelta)).toEqual([null, null, null])
+    expect(evidence.summary.medianStep).toBeNull()
+    expect(evidence.summary.movementState).toBe('not_applicable')
+  })
+
+  it('marks excessive coverage, foot drift and height drift with action-aware states', () => {
+    // Catches jump lift being rejected as foot drift or foreground/background problems being hidden.
+    const frames = [
+      ready(geometry({ footY: 100, subjectHeight: 20, coverageRatio: 0.66 })),
+      ready(geometry({ footY: 104, subjectHeight: 28 })),
+    ]
+
+    const walk = buildSequenceEvidence(frames, 'walk')
+    const jump = buildSequenceEvidence(frames, 'jump')
+
+    expect(walk.frames[0]?.coverageState).toBe('anomaly')
+    expect(walk.summary).toMatchObject({
+      footDrift: 4,
+      heightDrift: 8,
+      footState: 'anomaly',
+      heightThreshold: 12,
+      heightState: 'normal',
+    })
+    expect(jump.summary.footState).toBe('attention')
+  })
+
+  it('flags a single movement spike against the sequence median', () => {
+    // Catches a sudden position jump being normalized away by the animation's ordinary movement.
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ x: 0 })),
+        ready(geometry({ x: 1 })),
+        ready(geometry({ x: 2 })),
+        ready(geometry({ x: 22 })),
+      ],
+      'walk',
+    )
+
+    expect(evidence.summary).toMatchObject({
+      medianStep: 1,
+      maxStep: 20,
+      movementThreshold: 6,
+      movementState: 'anomaly',
+    })
+    expect(evidence.frames.map((frame) => frame.movementState)).toEqual([
+      'not_applicable',
+      'normal',
+      'normal',
+      'anomaly',
+    ])
+  })
+
+  it('keeps an action-aware absolute movement ceiling when every step is large', () => {
+    // Catches an entire drifting sequence normalizing its own 100px jumps through the median.
+    const evidence = buildSequenceEvidence(
+      [ready(geometry({ x: 0 })), ready(geometry({ x: 100 })), ready(geometry({ x: 200 }))],
+      'walk',
+    )
+
+    expect(evidence.summary.movementThreshold).toBeLessThan(100)
+    expect(evidence.summary.movementState).toBe('anomaly')
+    expect(evidence.findings.map((finding) => finding.code)).toContain('motion_spike')
+  })
+
+  it('marks jump and crouch height variation as action-allowed attention', () => {
+    const frames = [ready(geometry({ subjectHeight: 20 })), ready(geometry({ subjectHeight: 60 }))]
+
+    for (const actionType of ['jump', 'crouch'] as const) {
+      const evidence = buildSequenceEvidence(frames, actionType)
+      expect(evidence.summary.heightThreshold).toBeNull()
+      expect(evidence.summary.heightState).toBe('attention')
+      expect(evidence.findings.map((finding) => finding.code)).not.toContain('height_drift')
+    }
+  })
+
+  it('flags adjacent outline area changes over 28 percent', () => {
+    // Catches a character silhouette abruptly shrinking without a visible review warning.
+    const evidence = buildSequenceEvidence(
+      [ready(geometry({ opaquePixels: 100 })), ready(geometry({ opaquePixels: 70 }))],
+      'attack',
+    )
+
+    expect(evidence.summary).toMatchObject({
+      maxAreaDeltaPercent: 30,
+      areaState: 'anomaly',
+    })
+    expect(evidence.frames[1]?.areaState).toBe('anomaly')
+  })
+
+  it('marks adjacency-only checks not applicable for one frame', () => {
+    // Catches the first frame displaying fabricated zero deltas as a successful comparison.
+    const evidence = buildSequenceEvidence([ready(geometry())], 'idle')
+
+    expect(evidence.frames[0]).toMatchObject({
+      previousDelta: null,
+      movementState: 'not_applicable',
+      areaState: 'not_applicable',
+    })
+    expect(evidence.summary).toMatchObject({
+      footDrift: null,
+      heightDrift: null,
+      medianStep: null,
+      movementThreshold: null,
+      movementState: 'not_applicable',
+      areaState: 'not_applicable',
+    })
+  })
+
+  it('combines measured image drift with adjacent root-motion increments using an upward y axis', () => {
+    // Catches root motion being subtracted twice or image-space positive-down y being added as positive-up.
+    const evidence = buildSequenceEvidence(
+      [ready(geometry({ x: 0, y: 10 }), null), ready(geometry({ x: 3, y: 14 }), { dx: 10, dy: 6 })],
+      'walk',
+    )
+
+    expect(evidence.frames[0]).toMatchObject({
+      expectedRootDelta: null,
+      composedPreviewDelta: null,
+    })
+    expect(evidence.frames[1]?.expectedRootDelta).toMatchObject({ dx: 10, dy: 6 })
+    expect(evidence.frames[1]?.expectedRootDelta?.distance).toBeCloseTo(Math.sqrt(136))
+    expect(evidence.frames[1]?.composedPreviewDelta).toMatchObject({ dx: 13, dy: 2 })
+    expect(evidence.frames[1]?.composedPreviewDelta?.distance).toBeCloseTo(Math.sqrt(173))
+    expect(evidence.frames[1]?.movementState).toBe('normal')
+  })
+
+  it('treats each frame root motion as an increment instead of subtracting the previous frame', () => {
+    // Catches repeated per-frame dx values collapsing to zero and leaving a walking sprite in place.
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ x: 0, y: 10 }), null),
+        ready(geometry({ x: 1, y: 11 }), { dx: 2, dy: 1 }),
+        ready(geometry({ x: 3, y: 12 }), { dx: 3, dy: 2 }),
+      ],
+      'walk',
+    )
+
+    expect(evidence.frames[2]?.expectedRootDelta).toMatchObject({ dx: 3, dy: 2 })
+    expect(evidence.frames[2]?.composedPreviewDelta).toMatchObject({ dx: 5, dy: 1 })
+  })
+
+  it('does not mislabel merely similar adjacent frames as duplicates', () => {
+    const fingerprint = Array.from({ length: 64 }, () => 0.5)
+    const evidence = buildSequenceEvidence(
+      [
+        ready(geometry({ fingerprint, contentHash: 'frame-a' })),
+        ready(geometry({ fingerprint, contentHash: 'frame-b' })),
+      ],
+      'attack',
+    )
+
+    expect(evidence.findings.map((finding) => finding.code)).not.toContain('duplicate_frame')
+  })
+
+  it('checks a loop boundary against the ordinary adjacent-frame baseline', () => {
+    const evidence = buildSequenceEvidence(
+      [ready(geometry({ x: 0 })), ready(geometry({ x: 20 })), ready(geometry({ x: 40 }))],
+      'walk',
+    )
+
+    expect(evidence.summary.movementThreshold).toBe(24)
+    expect(evidence.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'motion_spike',
+          frameIndex: 0,
+          message: '循环首尾出现异常位移突变',
+        }),
+      ]),
+    )
+  })
+
+  it('uses the project canvas contract instead of accepting a consistently wrong sequence', () => {
+    const evidence = buildSequenceEvidence(
+      [ready(geometry({ width: 256, height: 256 })), ready(geometry({ width: 256, height: 256 }))],
+      'idle',
+      { width: 512, height: 512 },
+    )
+
+    expect(evidence.summary.expectedCanvas).toEqual({ width: 512, height: 512 })
+    expect(
+      evidence.findings.filter((finding) => finding.code === 'canvas_size_mismatch'),
+    ).toHaveLength(2)
+  })
+})

--- a/frontend/src/pages/playtest/workbench/analysis/sequence-evidence.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/sequence-evidence.ts
@@ -1,0 +1,498 @@
+import type { Frame } from '@/entities/character'
+
+import type { PlaytestActionType } from '../model/types'
+import type { FrameGeometry } from './frame-geometry'
+import { deriveLocalQualityPolicy, type CanvasBaseline } from './quality-policy'
+
+export type EvidenceState = 'normal' | 'attention' | 'anomaly' | 'not_applicable'
+
+export type QualityFindingCode =
+  | 'image_unavailable'
+  | 'blank_subject'
+  | 'canvas_size_mismatch'
+  | 'subject_cropped'
+  | 'coverage_too_low'
+  | 'coverage_too_high'
+  | 'duplicate_frame'
+  | 'motion_spike'
+  | 'foot_drift'
+  | 'height_drift'
+  | 'area_spike'
+  | 'root_motion_mismatch'
+
+export interface QualityFinding {
+  code: QualityFindingCode
+  severity: 'warning' | 'error'
+  frameIndex: number | null
+  message: string
+  metrics: Readonly<Record<string, number | string>>
+}
+
+export type FrameGeometryResult =
+  | { status: 'ready'; geometry: FrameGeometry }
+  | { status: 'unavailable'; reason: string }
+
+export interface FrameEvidenceInput {
+  geometry: FrameGeometryResult
+  rootMotion: Frame['rootMotion']
+}
+
+export interface AdjacentFrameDelta {
+  dx: number
+  dy: number
+  distance: number
+  areaDeltaPercent: number
+}
+
+export interface MotionVector {
+  dx: number
+  dy: number
+  distance: number
+}
+
+export interface FrameReviewEvidence {
+  geometry: FrameGeometry | null
+  unavailableReason: string | null
+  previousDelta: AdjacentFrameDelta | null
+  expectedRootDelta: MotionVector | null
+  composedPreviewDelta: MotionVector | null
+  canvasState: EvidenceState
+  coverageState: EvidenceState
+  movementState: EvidenceState
+  areaState: EvidenceState
+}
+
+export interface SequenceReviewEvidence {
+  complete: boolean
+  unavailableFrameCount: number
+  frames: readonly FrameReviewEvidence[]
+  findings: readonly QualityFinding[]
+  summary: {
+    footDrift: number | null
+    heightDrift: number | null
+    medianStep: number | null
+    maxStep: number | null
+    movementThreshold: number | null
+    heightThreshold: number | null
+    footThreshold: number | null
+    areaThresholdPercent: number
+    expectedCanvas: CanvasBaseline | null
+    maxAreaDeltaPercent: number | null
+    canvasState: EvidenceState
+    footState: EvidenceState
+    heightState: EvidenceState
+    movementState: EvidenceState
+    areaState: EvidenceState
+  }
+}
+
+function medianAbsoluteDeviation(values: readonly number[], center: number | null): number | null {
+  if (center === null || values.length === 0) return null
+  return median(values.map((value) => Math.abs(value - center)))
+}
+
+function framesAreIdentical(left: FrameGeometry, right: FrameGeometry): boolean {
+  return left.contentHash !== undefined && left.contentHash === right.contentHash
+}
+
+function isCropped(geometry: FrameGeometry, margin: { x: number; y: number }): boolean {
+  return (
+    geometry.bounds.left < margin.x ||
+    geometry.bounds.top < margin.y ||
+    geometry.bounds.right >= geometry.width - margin.x ||
+    geometry.bounds.bottom >= geometry.height - margin.y
+  )
+}
+
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null
+
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  const upper = sorted[middle]
+  if (upper === undefined) return null
+
+  if (sorted.length % 2 === 1) return upper
+
+  const lower = sorted[middle - 1]
+  return lower === undefined ? upper : (lower + upper) / 2
+}
+
+function spread(values: readonly number[]): number | null {
+  if (values.length < 2) return null
+  return Math.max(...values) - Math.min(...values)
+}
+
+function adjacentDelta(previous: FrameGeometry, current: FrameGeometry): AdjacentFrameDelta {
+  const dx = current.centroid.x - previous.centroid.x
+  const dy = current.centroid.y - previous.centroid.y
+
+  return {
+    dx,
+    dy,
+    distance: Math.hypot(dx, dy),
+    areaDeltaPercent:
+      (Math.abs(current.opaquePixels - previous.opaquePixels) /
+        Math.max(current.opaquePixels, previous.opaquePixels)) *
+      100,
+  }
+}
+
+function motionVector(dx: number, dy: number): MotionVector {
+  return { dx, dy, distance: Math.hypot(dx, dy) }
+}
+
+function rootMotion(frame: FrameEvidenceInput): { dx: number; dy: number } {
+  return frame.rootMotion ?? { dx: 0, dy: 0 }
+}
+
+export function buildSequenceEvidence(
+  inputs: readonly FrameEvidenceInput[],
+  actionType: PlaytestActionType,
+  expectedCanvas: CanvasBaseline | null = null,
+): SequenceReviewEvidence {
+  const results = inputs.map((input) => input.geometry)
+  const readyGeometries = results.flatMap((result) =>
+    result.status === 'ready' ? [result.geometry] : [],
+  )
+  const policy = deriveLocalQualityPolicy(readyGeometries, actionType, expectedCanvas)
+  const isBaselineGeometry = (geometry: FrameGeometry): boolean =>
+    policy.expectedCanvas !== null &&
+    geometry.width === policy.expectedCanvas.width &&
+    geometry.height === policy.expectedCanvas.height
+  const deltas = results.map((result, index): AdjacentFrameDelta | null => {
+    const previous = results[index - 1]
+    if (index === 0 || previous?.status !== 'ready' || result.status !== 'ready') return null
+    if (!isBaselineGeometry(previous.geometry) || !isBaselineGeometry(result.geometry)) return null
+    return adjacentDelta(previous.geometry, result.geometry)
+  })
+  const checksLoopBoundary = actionType === 'idle' || actionType === 'walk'
+  const firstResult = results[0]
+  const lastResult = results.at(-1)
+  const closingDelta =
+    checksLoopBoundary &&
+    results.length > 1 &&
+    results.every((result) => result.status === 'ready') &&
+    firstResult?.status === 'ready' &&
+    lastResult?.status === 'ready' &&
+    isBaselineGeometry(firstResult.geometry) &&
+    isBaselineGeometry(lastResult.geometry)
+      ? adjacentDelta(lastResult.geometry, firstResult.geometry)
+      : null
+  const rootDeltas = inputs.map((input, index): MotionVector | null => {
+    if (index === 0) return null
+
+    const increment = rootMotion(input)
+    return motionVector(increment.dx, increment.dy)
+  })
+  const availableDeltas = deltas.flatMap((delta) => (delta === null ? [] : [delta]))
+  const steps = availableDeltas.map((delta) => delta.distance)
+  const areaDeltas = availableDeltas.map((delta) => delta.areaDeltaPercent)
+  const medianStep = median(steps)
+  const movementMad = medianAbsoluteDeviation(steps, medianStep)
+  const relativeMovementThreshold =
+    medianStep === null
+      ? null
+      : Math.max(
+          medianStep * 2.6 + policy.movementPadding,
+          medianStep + (movementMad ?? 0) * 3 + policy.movementPadding,
+          policy.movementFloor,
+        )
+  const movementThreshold =
+    relativeMovementThreshold === null
+      ? null
+      : Math.min(relativeMovementThreshold, policy.movementCeiling)
+  const maxStep = steps.length === 0 ? null : Math.max(...steps)
+  const maxAreaDeltaPercent = areaDeltas.length === 0 ? null : Math.max(...areaDeltas)
+  const baselineGeometries = readyGeometries.filter(isBaselineGeometry)
+  const footDrift = spread(baselineGeometries.map((geometry) => geometry.footY))
+  const heightDrift = spread(baselineGeometries.map((geometry) => geometry.subjectHeight))
+  const unavailableFrameCount = results.length - readyGeometries.length
+  const findings: QualityFinding[] = []
+  const heightThreshold = policy.heightDriftThreshold
+
+  const frames = results.map((result, index): FrameReviewEvidence => {
+    const expectedRootDelta = rootDeltas[index] ?? null
+    if (result.status === 'unavailable') {
+      return {
+        geometry: null,
+        unavailableReason: result.reason,
+        previousDelta: null,
+        expectedRootDelta,
+        composedPreviewDelta: null,
+        canvasState: 'not_applicable',
+        coverageState: 'not_applicable',
+        movementState: 'not_applicable',
+        areaState: 'not_applicable',
+      }
+    }
+
+    const delta = deltas[index] ?? null
+    const composedPreviewDelta =
+      delta === null || expectedRootDelta === null
+        ? null
+        : motionVector(delta.dx + expectedRootDelta.dx, expectedRootDelta.dy - delta.dy)
+    return {
+      geometry: result.geometry,
+      unavailableReason: null,
+      previousDelta: delta,
+      expectedRootDelta,
+      composedPreviewDelta,
+      canvasState:
+        policy.expectedCanvas !== null &&
+        result.geometry.width === policy.expectedCanvas.width &&
+        result.geometry.height === policy.expectedCanvas.height
+          ? 'normal'
+          : 'anomaly',
+      coverageState:
+        result.geometry.coverageRatio < policy.minimumCoverageRatio ||
+        result.geometry.coverageRatio > policy.maximumCoverageRatio
+          ? 'anomaly'
+          : 'normal',
+      movementState:
+        delta === null || movementThreshold === null
+          ? 'not_applicable'
+          : delta.distance > movementThreshold
+            ? 'anomaly'
+            : 'normal',
+      areaState:
+        delta === null
+          ? 'not_applicable'
+          : delta.areaDeltaPercent > policy.areaDeltaThresholdPercent
+            ? 'anomaly'
+            : 'normal',
+    }
+  })
+
+  results.forEach((result, index) => {
+    if (result.status === 'unavailable') {
+      const blank = result.reason.includes('没有可见主体')
+      findings.push({
+        code: blank ? 'blank_subject' : 'image_unavailable',
+        severity: 'error',
+        frameIndex: index,
+        message: blank ? '当前帧没有可见主体' : result.reason,
+        metrics: {},
+      })
+      return
+    }
+
+    const { geometry } = result
+    if (
+      policy.expectedCanvas !== null &&
+      (geometry.width !== policy.expectedCanvas.width ||
+        geometry.height !== policy.expectedCanvas.height)
+    ) {
+      findings.push({
+        code: 'canvas_size_mismatch',
+        severity: 'error',
+        frameIndex: index,
+        message: '画布尺寸与当前序列基线不一致',
+        metrics: {
+          width: geometry.width,
+          height: geometry.height,
+          expectedWidth: policy.expectedCanvas.width,
+          expectedHeight: policy.expectedCanvas.height,
+        },
+      })
+    }
+    if (isCropped(geometry, policy.edgeMargin)) {
+      findings.push({
+        code: 'subject_cropped',
+        severity: 'error',
+        frameIndex: index,
+        message: '主体接触画布边缘，可能发生裁切',
+        metrics: {
+          left: geometry.bounds.left,
+          top: geometry.bounds.top,
+          right: geometry.bounds.right,
+          bottom: geometry.bounds.bottom,
+        },
+      })
+    }
+    if (geometry.coverageRatio < policy.minimumCoverageRatio) {
+      findings.push({
+        code: 'coverage_too_low',
+        severity: 'warning',
+        frameIndex: index,
+        message: '主体在画布中的占比过小',
+        metrics: { coverageRatio: geometry.coverageRatio },
+      })
+    } else if (geometry.coverageRatio > policy.maximumCoverageRatio) {
+      findings.push({
+        code: 'coverage_too_high',
+        severity: 'error',
+        frameIndex: index,
+        message: '主体在画布中的占比过大',
+        metrics: { coverageRatio: geometry.coverageRatio },
+      })
+    }
+
+    const previous = results[index - 1]
+    if (previous?.status !== 'ready') return
+    if (framesAreIdentical(previous.geometry, geometry)) {
+      findings.push({
+        code: 'duplicate_frame',
+        severity: 'warning',
+        frameIndex: index,
+        message: '当前帧与上一帧完全相同',
+        metrics: {},
+      })
+    }
+
+    const delta = deltas[index]
+    if (delta !== null && movementThreshold !== null && delta.distance > movementThreshold) {
+      findings.push({
+        code: 'motion_spike',
+        severity: 'error',
+        frameIndex: index,
+        message: '相邻帧出现异常位移突变',
+        metrics: { distance: delta.distance, threshold: movementThreshold },
+      })
+    }
+    if (delta !== null && delta.areaDeltaPercent > policy.areaDeltaThresholdPercent) {
+      findings.push({
+        code: 'area_spike',
+        severity: 'warning',
+        frameIndex: index,
+        message: '相邻帧主体轮廓面积变化过大',
+        metrics: { percent: delta.areaDeltaPercent },
+      })
+    }
+
+    const expected = rootDeltas[index]
+    if (
+      delta !== null &&
+      expected !== null &&
+      expected.distance >= policy.rootMotionDirectionMinimum &&
+      delta.distance >= policy.rootMotionDirectionMinimum
+    ) {
+      const dot = delta.dx * expected.dx + -delta.dy * expected.dy
+      if (dot < 0) {
+        findings.push({
+          code: 'root_motion_mismatch',
+          severity: 'warning',
+          frameIndex: index,
+          message: '画面内位移方向与预期根位移矛盾',
+          metrics: { dotProduct: dot },
+        })
+      }
+    }
+  })
+
+  if (closingDelta !== null && firstResult?.status === 'ready' && lastResult?.status === 'ready') {
+    if (framesAreIdentical(lastResult.geometry, firstResult.geometry)) {
+      findings.push({
+        code: 'duplicate_frame',
+        severity: 'warning',
+        frameIndex: 0,
+        message: '循环首帧与尾帧完全相同，可能产生停顿',
+        metrics: {},
+      })
+    }
+    if (movementThreshold !== null && closingDelta.distance > movementThreshold) {
+      findings.push({
+        code: 'motion_spike',
+        severity: 'error',
+        frameIndex: 0,
+        message: '循环首尾出现异常位移突变',
+        metrics: { distance: closingDelta.distance, threshold: movementThreshold },
+      })
+    }
+    if (closingDelta.areaDeltaPercent > policy.areaDeltaThresholdPercent) {
+      findings.push({
+        code: 'area_spike',
+        severity: 'warning',
+        frameIndex: 0,
+        message: '循环首尾轮廓面积变化过大',
+        metrics: { percent: closingDelta.areaDeltaPercent },
+      })
+    }
+  }
+
+  if (
+    footDrift !== null &&
+    policy.footDriftThreshold !== null &&
+    footDrift > policy.footDriftThreshold &&
+    actionType !== 'jump'
+  ) {
+    findings.push({
+      code: 'foot_drift',
+      severity: 'error',
+      frameIndex: null,
+      message: '序列脚底线漂移超过动作允许范围',
+      metrics: { drift: footDrift, threshold: policy.footDriftThreshold },
+    })
+  }
+  if (heightDrift !== null && heightThreshold !== null && heightDrift > heightThreshold) {
+    findings.push({
+      code: 'height_drift',
+      severity: 'warning',
+      frameIndex: null,
+      message: '序列主体高度变化超过动作允许范围',
+      metrics: { drift: heightDrift, threshold: heightThreshold },
+    })
+  }
+
+  return {
+    complete: results.length > 0 && unavailableFrameCount === 0,
+    unavailableFrameCount,
+    frames,
+    findings,
+    summary: {
+      footDrift,
+      heightDrift,
+      medianStep,
+      maxStep,
+      movementThreshold,
+      heightThreshold,
+      footThreshold: policy.footDriftThreshold,
+      areaThresholdPercent: policy.areaDeltaThresholdPercent,
+      expectedCanvas: policy.expectedCanvas,
+      maxAreaDeltaPercent,
+      canvasState:
+        policy.expectedCanvas === null
+          ? 'not_applicable'
+          : readyGeometries.every(
+                (geometry) =>
+                  geometry.width === policy.expectedCanvas?.width &&
+                  geometry.height === policy.expectedCanvas?.height,
+              )
+            ? 'normal'
+            : 'anomaly',
+      footState:
+        footDrift === null
+          ? 'not_applicable'
+          : policy.footDriftThreshold === null
+            ? 'not_applicable'
+            : footDrift <= policy.footDriftThreshold
+              ? 'normal'
+              : actionType === 'jump'
+                ? 'attention'
+                : 'anomaly',
+      heightState:
+        heightDrift === null
+          ? 'not_applicable'
+          : heightThreshold === null
+            ? policy.heightAttentionThreshold !== null &&
+              heightDrift > policy.heightAttentionThreshold
+              ? 'attention'
+              : 'normal'
+            : heightDrift > heightThreshold
+              ? 'anomaly'
+              : 'normal',
+      movementState:
+        maxStep === null || movementThreshold === null
+          ? 'not_applicable'
+          : maxStep > movementThreshold
+            ? 'anomaly'
+            : 'normal',
+      areaState:
+        maxAreaDeltaPercent === null
+          ? 'not_applicable'
+          : maxAreaDeltaPercent > policy.areaDeltaThresholdPercent
+            ? 'anomaly'
+            : 'normal',
+    },
+  }
+}

--- a/frontend/src/pages/playtest/workbench/analysis/use-frame-review-evidence.test.tsx
+++ b/frontend/src/pages/playtest/workbench/analysis/use-frame-review-evidence.test.tsx
@@ -1,0 +1,203 @@
+/** @vitest-environment jsdom */
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { PreviewSequence } from '../model/types'
+import type { FrameGeometry } from './frame-geometry'
+import type { FrameGeometryResult } from './sequence-evidence'
+import { useFrameReviewEvidence, type ImageGeometryReader } from './use-frame-review-evidence'
+
+function sequence(...imageUrls: string[]): PreviewSequence {
+  return {
+    direction: 'south',
+    frames: imageUrls.map((imageUrl) => ({
+      imageUrl,
+      durationMs: 100,
+      rootMotion: null,
+      keyFrame: false,
+    })),
+  }
+}
+
+function geometry(x: number, y = 10): FrameGeometryResult {
+  const value: FrameGeometry = {
+    width: 256,
+    height: 256,
+    bounds: { left: x, top: 0, right: x + 9, bottom: 19, width: 10, height: 20 },
+    centroid: { x, y },
+    footY: 19,
+    subjectHeight: 20,
+    opaquePixels: 100,
+    coverageRatio: 100 / (256 * 256),
+  }
+  return { status: 'ready', geometry: value }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve(value: T): void
+} {
+  let resolvePromise: ((value: T) => void) | null = null
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+
+  return {
+    promise,
+    resolve(value) {
+      if (resolvePromise === null) throw new Error('deferred promise is not initialized')
+      resolvePromise(value)
+    },
+  }
+}
+
+afterEach(cleanup)
+
+describe('useFrameReviewEvidence', () => {
+  it('exposes loading before producing real sequence evidence', async () => {
+    // Catches the Inspector flashing fabricated zeros before image analysis completes.
+    const pending = deferred<FrameGeometryResult>()
+    const reader: ImageGeometryReader = () => pending.promise
+    const { result } = renderHook(() =>
+      useFrameReviewEvidence(sequence('/frame-1.png'), 'walk', reader),
+    )
+
+    expect(result.current).toEqual({ status: 'loading', evidence: null })
+
+    await act(async () => pending.resolve(geometry(4)))
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.evidence?.frames[0]?.geometry?.centroid.x).toBe(4)
+  })
+
+  it('ignores a previous sequence result that resolves after a direction switch', async () => {
+    // Catches a slow old direction replacing the evidence for the currently selected direction.
+    const south = deferred<FrameGeometryResult>()
+    const north = deferred<FrameGeometryResult>()
+    const reader: ImageGeometryReader = (imageUrl) =>
+      imageUrl.includes('south') ? south.promise : north.promise
+    const { result, rerender } = renderHook(
+      ({ current }) => useFrameReviewEvidence(current, 'walk', reader),
+      { initialProps: { current: sequence('/south.png') } },
+    )
+
+    rerender({ current: sequence('/north.png') })
+    await act(async () => north.resolve(geometry(20)))
+    await waitFor(() => expect(result.current.evidence?.frames[0]?.geometry?.centroid.x).toBe(20))
+
+    await act(async () => south.resolve(geometry(2)))
+    expect(result.current.evidence?.frames[0]?.geometry?.centroid.x).toBe(20)
+  })
+
+  it('passes an abort signal to image reads and aborts stale sequence work', () => {
+    const pending = deferred<FrameGeometryResult>()
+    const reader = vi.fn<ImageGeometryReader>(() => pending.promise)
+    const { rerender } = renderHook(
+      ({ current }) => useFrameReviewEvidence(current, 'walk', reader),
+      { initialProps: { current: sequence('/south.png') } },
+    )
+
+    const firstSignal = reader.mock.calls[0]?.[1]
+    expect(firstSignal).toBeInstanceOf(AbortSignal)
+    expect(firstSignal?.aborted).toBe(false)
+
+    rerender({ current: sequence('/north.png') })
+
+    expect(firstSignal?.aborted).toBe(true)
+    expect(reader.mock.calls[1]?.[1]).toBeInstanceOf(AbortSignal)
+  })
+
+  it('rereads revisited image URLs so regenerated content cannot reuse stale geometry', async () => {
+    // Catches frame navigation repeatedly decoding every image in the same review session.
+    const reader = vi.fn<ImageGeometryReader>(async (imageUrl) =>
+      geometry(imageUrl.includes('one') ? 1 : 2),
+    )
+    const first = sequence('/one.png')
+    const second = sequence('/two.png')
+    const { result, rerender } = renderHook(
+      ({ current }) => useFrameReviewEvidence(current, 'walk', reader),
+      { initialProps: { current: first } },
+    )
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    rerender({ current: first })
+    expect(reader).toHaveBeenCalledTimes(1)
+
+    rerender({ current: second })
+    await waitFor(() => expect(result.current.evidence?.frames[0]?.geometry?.centroid.x).toBe(2))
+    rerender({ current: first })
+    await waitFor(() => expect(result.current.evidence?.frames[0]?.geometry?.centroid.x).toBe(1))
+    expect(reader).toHaveBeenCalledTimes(3)
+  })
+
+  it('retries an unavailable image when its sequence is revisited', async () => {
+    // A transient image failure must not become a permanent session-level cache entry.
+    let failedOnce = false
+    const reader = vi.fn<ImageGeometryReader>(async (imageUrl) => {
+      if (imageUrl.includes('retry') && !failedOnce) {
+        failedOnce = true
+        return { status: 'unavailable', reason: 'temporary failure' }
+      }
+      return geometry(imageUrl.includes('retry') ? 9 : 2)
+    })
+    const retrySequence = sequence('/retry.png')
+    const otherSequence = sequence('/other.png')
+    const { result, rerender } = renderHook(
+      ({ current }) => useFrameReviewEvidence(current, 'walk', reader),
+      { initialProps: { current: retrySequence } },
+    )
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.evidence?.complete).toBe(false)
+
+    rerender({ current: otherSequence })
+    await waitFor(() => expect(result.current.evidence?.frames[0]?.geometry?.centroid.x).toBe(2))
+    rerender({ current: retrySequence })
+    await waitFor(() => expect(result.current.evidence?.frames[0]?.geometry?.centroid.x).toBe(9))
+
+    expect(reader).toHaveBeenCalledTimes(3)
+  })
+
+  it('stays idle without a review sequence and does not read an image', () => {
+    // Catches direct-control mode starting hidden Canvas work.
+    const reader = vi.fn<ImageGeometryReader>()
+    const { result } = renderHook(() => useFrameReviewEvidence(null, null, reader))
+
+    expect(result.current).toEqual({ status: 'idle', evidence: null })
+    expect(reader).not.toHaveBeenCalled()
+  })
+
+  it('does not update React state after the consumer unmounts', async () => {
+    // Catches an image completion writing into a removed Playtest workbench.
+    const pending = deferred<FrameGeometryResult>()
+    const reader: ImageGeometryReader = () => pending.promise
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const mounted = renderHook(() => useFrameReviewEvidence(sequence('/slow.png'), 'walk', reader))
+
+    mounted.unmount()
+    await act(async () => pending.resolve(geometry(1)))
+
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('keeps each preview frame root motion beside its measured geometry', async () => {
+    // Catches asynchronous image results losing their matching motion contract before aggregation.
+    const base = sequence('/first.png', '/second.png')
+    const motionSequence: PreviewSequence = {
+      ...base,
+      frames: [
+        { ...base.frames[0]!, rootMotion: null },
+        { ...base.frames[1]!, rootMotion: { dx: 10, dy: 6 } },
+      ],
+    }
+    const reader: ImageGeometryReader = async (imageUrl) =>
+      imageUrl.includes('first') ? geometry(0, 10) : geometry(3, 14)
+    const { result } = renderHook(() => useFrameReviewEvidence(motionSequence, 'walk', reader))
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.evidence?.frames[1]).toMatchObject({
+      expectedRootDelta: { dx: 10, dy: 6 },
+      composedPreviewDelta: { dx: 13, dy: 2 },
+    })
+  })
+})

--- a/frontend/src/pages/playtest/workbench/analysis/use-frame-review-evidence.ts
+++ b/frontend/src/pages/playtest/workbench/analysis/use-frame-review-evidence.ts
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react'
+
+import type { PlaytestActionType, PreviewFrame, PreviewSequence } from '../model/types'
+import { readImageGeometry } from './image-geometry'
+import type { CanvasBaseline } from './quality-policy'
+import {
+  buildSequenceEvidence,
+  type FrameGeometryResult,
+  type SequenceReviewEvidence,
+} from './sequence-evidence'
+
+export type FrameReviewEvidenceState =
+  | { status: 'idle'; evidence: null }
+  | { status: 'loading'; evidence: null }
+  | { status: 'ready'; evidence: SequenceReviewEvidence }
+
+export type ImageGeometryReader = (
+  imageUrl: string,
+  signal?: AbortSignal,
+) => Promise<FrameGeometryResult>
+
+interface ResolvedState {
+  key: string | null
+  value: FrameReviewEvidenceState
+}
+
+const IDLE_STATE: FrameReviewEvidenceState = { status: 'idle', evidence: null }
+const LOADING_STATE: FrameReviewEvidenceState = { status: 'loading', evidence: null }
+
+export function useFrameReviewEvidence(
+  sequence: PreviewSequence | null,
+  actionType: PlaytestActionType | null,
+  reader: ImageGeometryReader = readImageGeometry,
+  expectedCanvas: CanvasBaseline | null = null,
+): FrameReviewEvidenceState {
+  const sequenceKey =
+    sequence === null || actionType === null
+      ? null
+      : JSON.stringify([
+          actionType,
+          expectedCanvas,
+          ...sequence.frames.map((frame) => ({
+            imageUrl: frame.imageUrl,
+            rootMotion: frame.rootMotion,
+          })),
+        ])
+  const [resolved, setResolved] = useState<ResolvedState>({ key: null, value: IDLE_STATE })
+
+  useEffect(() => {
+    if (sequenceKey === null || actionType === null) {
+      setResolved({ key: null, value: IDLE_STATE })
+      return
+    }
+
+    const [, , ...frameDescriptors] = JSON.parse(sequenceKey) as [
+      PlaytestActionType,
+      CanvasBaseline | null,
+      ...Array<{ imageUrl: string; rootMotion: PreviewFrame['rootMotion'] }>,
+    ]
+    const imageUrls = frameDescriptors.map((frame) => frame.imageUrl)
+
+    const controller = new AbortController()
+    let active = true
+    const inFlight = new Map<string, Promise<FrameGeometryResult>>()
+
+    setResolved({ key: sequenceKey, value: LOADING_STATE })
+
+    const results = imageUrls.map((imageUrl) => {
+      const existing = inFlight.get(imageUrl)
+      if (existing !== undefined) return existing
+
+      const pending = reader(imageUrl, controller.signal).catch(
+        (): FrameGeometryResult => ({ status: 'unavailable', reason: '图片分析失败' }),
+      )
+      inFlight.set(imageUrl, pending)
+      return pending
+    })
+
+    void Promise.all(results).then((frameResults) => {
+      if (!active || controller.signal.aborted) return
+
+      setResolved({
+        key: sequenceKey,
+        value: {
+          status: 'ready',
+          evidence: buildSequenceEvidence(
+            frameResults.map((geometry, index) => ({
+              geometry,
+              rootMotion: frameDescriptors[index]?.rootMotion ?? null,
+            })),
+            actionType,
+            expectedCanvas,
+          ),
+        },
+      })
+    })
+
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [actionType, expectedCanvas, reader, sequenceKey])
+
+  if (sequenceKey === null) return IDLE_STATE
+  return resolved.key === sequenceKey ? resolved.value : LOADING_STATE
+}

--- a/frontend/src/pages/playtest/workbench/animation-stage.test.tsx
+++ b/frontend/src/pages/playtest/workbench/animation-stage.test.tsx
@@ -1,0 +1,184 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ActionSelector } from './action-selector'
+import { AnimationStage } from './animation-stage'
+import { FrameTimeline } from './frame-timeline'
+import { PlaybackControls } from './playback-controls'
+import type { PreviewAction, PreviewFrame, PreviewSequence } from './model/types'
+
+const currentFrame: PreviewFrame = {
+  imageUrl: 'https://cdn.example.test/current.png',
+  durationMs: 100,
+  rootMotion: { dx: 12, dy: 5 },
+  keyFrame: true,
+}
+
+const nextFrame: PreviewFrame = {
+  ...currentFrame,
+  imageUrl: 'https://cdn.example.test/next.png',
+  keyFrame: false,
+}
+
+const sequence: PreviewSequence = {
+  direction: 'south',
+  frames: [currentFrame, nextFrame],
+}
+
+const actions: readonly PreviewAction[] = [
+  {
+    id: 'walk',
+    name: '行走',
+    type: 'walk',
+    fps: 12,
+    sequences: [sequence],
+  },
+  {
+    id: 'empty',
+    name: '空动作',
+    type: 'idle',
+    fps: 12,
+    sequences: [],
+  },
+]
+
+afterEach(cleanup)
+
+describe('playtest visual primitives', () => {
+  it('renders prop-supplied action names, FPS and actual frame counts while disabling empty actions', () => {
+    // Catches a selector replacing supplied actions with demo data or permitting a non-playable action.
+    const onSelectAction = vi.fn()
+
+    render(
+      <ActionSelector
+        assets={[
+          {
+            key: 'character-1:outfit-1',
+            characterId: 'character-1',
+            outfitId: 'outfit-1',
+            name: '默认造型',
+            actionCount: actions.length,
+          },
+        ]}
+        selectedAssetKey="character-1:outfit-1"
+        actions={actions}
+        selectedActionId="walk"
+        onSelectAsset={vi.fn()}
+        onSelectAction={onSelectAction}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: /行走/ }).textContent).toContain('12 FPS')
+    expect(screen.getByRole('button', { name: /行走/ }).textContent).toContain('2 帧')
+    expect((screen.getByRole('button', { name: /空动作/ }) as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /行走/ }))
+    expect(onSelectAction).toHaveBeenCalledWith('walk')
+  })
+
+  it('uses the real frame URL and reports image failure with the accumulated mirrored transform', () => {
+    // Catches the stage reading per-frame root motion instead of the accumulated owner state, inverting y incorrectly, or hiding load errors.
+    render(
+      <AnimationStage
+        currentFrame={currentFrame}
+        motionOffset={{ x: 18, y: 7 }}
+        mirrored
+        showGrid
+        showChecker
+      />,
+    )
+
+    const image = screen.getByRole('img', { name: '角色动画预览' })
+    expect(image.getAttribute('src')).toBe(currentFrame.imageUrl)
+    expect(image.getAttribute('style')).toContain('translate(18px, -7px) scaleX(-1)')
+    expect(screen.getAllByRole('img')).toHaveLength(1)
+
+    fireEvent.error(image)
+    expect(screen.getByText('当前帧图片加载失败')).toBeTruthy()
+  })
+
+  it('reports horizontal travel from the measured stage and actor widths', () => {
+    const onHorizontalBoundsChange = vi.fn()
+    const rect = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const width = this.getAttribute('aria-label') === '动画预览舞台' ? 600 : 200
+        return {
+          width,
+          height: 400,
+          x: 0,
+          y: 0,
+          top: 0,
+          right: width,
+          bottom: 400,
+          left: 0,
+          toJSON: () => ({}),
+        }
+      })
+
+    render(
+      <AnimationStage
+        currentFrame={currentFrame}
+        motionOffset={{ x: 0, y: 0 }}
+        mirrored={false}
+        showGrid={false}
+        showChecker={false}
+        onHorizontalBoundsChange={onHorizontalBoundsChange}
+      />,
+    )
+
+    fireEvent.load(screen.getByRole('img', { name: '角色动画预览' }))
+    expect(onHorizontalBoundsChange).toHaveBeenLastCalledWith({ minX: -200, maxX: 200 })
+    rect.mockRestore()
+  })
+
+  it('surfaces key-frame markers and delegates timeline selection without its own playback behavior', () => {
+    // Catches a timeline dropping key-frame annotations or mutating playback rather than using its selection callback.
+    const onSelectFrame = vi.fn()
+
+    render(
+      <FrameTimeline sequence={sequence} currentFrameIndex={0} onSelectFrame={onSelectFrame} />,
+    )
+
+    expect(screen.getByText('关键帧')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: '第 2 帧' }))
+    expect(onSelectFrame).toHaveBeenCalledWith(1)
+  })
+
+  it('only relays playback controller callbacks', () => {
+    // Catches controls owning local play state instead of reporting user intent to the controller.
+    const onTogglePlaying = vi.fn()
+    const onNextFrame = vi.fn()
+
+    render(
+      <PlaybackControls
+        playing={false}
+        loop
+        frameIndex={0}
+        frameCount={2}
+        fps={12}
+        jumpAvailable={false}
+        crouchAvailable
+        onFirstFrame={vi.fn()}
+        onPreviousFrame={vi.fn()}
+        onTogglePlaying={onTogglePlaying}
+        onNextFrame={onNextFrame}
+        onLastFrame={vi.fn()}
+        onToggleLoop={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '播放' }))
+    fireEvent.click(screen.getByRole('button', { name: '下一帧' }))
+    expect(onTogglePlaying).toHaveBeenCalledTimes(1)
+    expect(onNextFrame).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('跳跃不可用，下蹲可用')).toBeTruthy()
+    expect(screen.getByRole('button', { name: '循环播放' }).getAttribute('aria-pressed')).toBe(
+      'true',
+    )
+  })
+})

--- a/frontend/src/pages/playtest/workbench/animation-stage.tsx
+++ b/frontend/src/pages/playtest/workbench/animation-stage.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { PreviewFrame } from './model/types'
+import type { HorizontalStageBounds, StageOffset } from './stage-motion'
+
+const ZOOM_LEVELS = [0.5, 0.75, 1, 1.5, 2, 3, 4, 6, 8] as const
+const DEFAULT_ZOOM = 4 // 64px sprite at 4x = 256px on screen
+/** 高分辨率精灵(>=192px)首次加载时用 1x,避免 256px 素材被默认放大到 1024px。 */
+const HIGH_RES_ZOOM = 1
+const HIGH_RES_THRESHOLD_PX = 192
+
+export interface AnimationStageProps {
+  currentFrame: PreviewFrame | null
+  /** Accumulated playback position in world coordinates (positive y is up). */
+  motionOffset: StageOffset
+  mirrored: boolean
+  showGrid: boolean
+  showChecker: boolean
+  onHorizontalBoundsChange?(bounds: HorizontalStageBounds | null): void
+  onFrameAvailabilityChange?(available: boolean): void
+}
+
+export function AnimationStage({
+  currentFrame,
+  motionOffset,
+  mirrored,
+  showGrid,
+  showChecker,
+  onHorizontalBoundsChange,
+  onFrameAvailabilityChange,
+}: AnimationStageProps) {
+  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null)
+  const [zoomIndex, setZoomIndex] = useState(() => ZOOM_LEVELS.indexOf(DEFAULT_ZOOM))
+  const stageRef = useRef<HTMLElement>(null)
+  const imageRef = useRef<HTMLImageElement>(null)
+
+  const zoom = ZOOM_LEVELS[zoomIndex] ?? DEFAULT_ZOOM
+  const zoomIn = useCallback(() => {
+    setZoomIndex((i) => Math.min(i + 1, ZOOM_LEVELS.length - 1))
+  }, [])
+  const zoomOut = useCallback(() => {
+    setZoomIndex((i) => Math.max(i - 1, 0))
+  }, [])
+  const resetZoom = useCallback(() => {
+    setZoomIndex(ZOOM_LEVELS.indexOf(DEFAULT_ZOOM))
+  }, [])
+
+  const reportHorizontalBounds = useCallback(() => {
+    if (onHorizontalBoundsChange === undefined) return
+    const stage = stageRef.current
+    const image = imageRef.current
+    if (stage === null || image === null) {
+      onHorizontalBoundsChange(null)
+      return
+    }
+
+    const stageWidth = stage.getBoundingClientRect().width
+    const actorWidth = image.getBoundingClientRect().width
+    if (stageWidth <= 0 || actorWidth <= 0) {
+      onHorizontalBoundsChange(null)
+      return
+    }
+    const travel = Math.max(0, (stageWidth - actorWidth) / 2)
+    onHorizontalBoundsChange({ minX: -travel, maxX: travel })
+  }, [onHorizontalBoundsChange])
+
+  useEffect(() => {
+    setFailedImageUrl(null)
+    onFrameAvailabilityChange?.(false)
+  }, [currentFrame?.imageUrl, onFrameAvailabilityChange])
+
+  // Mouse wheel zoom on stage
+  useEffect(() => {
+    const stage = stageRef.current
+    if (stage === null) return
+    const handleWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return
+      e.preventDefault()
+      setZoomIndex((i) => {
+        if (e.deltaY < 0) return Math.min(i + 1, ZOOM_LEVELS.length - 1)
+        if (e.deltaY > 0) return Math.max(i - 1, 0)
+        return i
+      })
+    }
+    stage.addEventListener('wheel', handleWheel, { passive: false })
+    return () => stage.removeEventListener('wheel', handleWheel)
+  }, [])
+
+  useEffect(() => {
+    reportHorizontalBounds()
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', reportHorizontalBounds)
+      return () => window.removeEventListener('resize', reportHorizontalBounds)
+    }
+
+    const observer = new ResizeObserver(reportHorizontalBounds)
+    if (stageRef.current !== null) observer.observe(stageRef.current)
+    if (imageRef.current !== null) observer.observe(imageRef.current)
+    return () => observer.disconnect()
+  }, [currentFrame?.imageUrl, reportHorizontalBounds])
+
+  const imageFailed = currentFrame !== null && failedImageUrl === currentFrame.imageUrl
+
+  return (
+    <section
+      ref={stageRef}
+      aria-label="动画预览舞台"
+      className={`relative grid h-full min-h-[360px] place-items-center overflow-hidden rounded-lg border border-[#c8cec9] ${
+        showChecker
+          ? 'bg-[linear-gradient(45deg,#e5e7eb_25%,transparent_25%),linear-gradient(-45deg,#e5e7eb_25%,transparent_25%),linear-gradient(45deg,transparent_75%,#e5e7eb_75%),linear-gradient(-45deg,transparent_75%,#e5e7eb_75%)] bg-[length:24px_24px] bg-[position:0_0,0_12px,12px_-12px,-12px_0px]'
+          : 'bg-slate-100'
+      }`}
+    >
+      {showGrid ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 bg-[linear-gradient(rgba(15,23,42,0.055)_1px,transparent_1px),linear-gradient(90deg,rgba(15,23,42,0.055)_1px,transparent_1px)] bg-[length:24px_24px]"
+        />
+      ) : null}
+      <span
+        aria-hidden="true"
+        className="absolute bottom-[18%] left-[8%] right-[8%] h-px bg-emerald-900/30"
+      />
+      {currentFrame === null ? (
+        <div className="relative z-10 rounded-xl border border-dashed border-slate-400 bg-white/70 p-6 text-center text-sm text-slate-500">
+          当前动作没有可播放的帧
+        </div>
+      ) : imageFailed ? (
+        <div
+          role="alert"
+          className="relative z-10 rounded-xl border border-rose-200 bg-white/90 p-6 text-sm text-rose-700"
+        >
+          当前帧图片加载失败
+        </div>
+      ) : (
+        <img
+          ref={imageRef}
+          src={currentFrame.imageUrl}
+          alt="角色动画预览"
+          onLoad={(event) => {
+            reportHorizontalBounds()
+            onFrameAvailabilityChange?.(true)
+            if (event.currentTarget.naturalWidth >= HIGH_RES_THRESHOLD_PX) {
+              setZoomIndex(ZOOM_LEVELS.indexOf(HIGH_RES_ZOOM))
+            }
+          }}
+          onError={() => {
+            setFailedImageUrl(currentFrame.imageUrl)
+            onFrameAvailabilityChange?.(false)
+          }}
+          style={{
+            transform: `translate(${motionOffset.x}px, ${-motionOffset.y}px) scaleX(${mirrored ? -1 : 1}) scale(${zoom})`,
+          }}
+          className="relative z-10 max-h-[68%] max-w-[68%] object-contain drop-shadow-[0_18px_12px_rgba(15,23,42,0.12)] [image-rendering:pixelated]"
+        />
+      )}
+
+      {/* Zoom controls */}
+      <div className="absolute bottom-3 right-3 z-20 flex items-center gap-1 rounded-md border border-[#bfc7c0] bg-white/90 px-1.5 py-1 text-xs">
+        <button
+          type="button"
+          onClick={zoomOut}
+          disabled={zoomIndex <= 0}
+          className="grid h-6 w-6 place-items-center rounded font-bold text-slate-600 hover:bg-slate-100 disabled:opacity-30"
+          aria-label="缩小"
+        >
+          −
+        </button>
+        <button
+          type="button"
+          onClick={resetZoom}
+          className="min-w-[3rem] rounded px-1 text-center font-mono text-slate-700 hover:bg-slate-100"
+          aria-label="重置缩放"
+        >
+          {zoom * 100}%
+        </button>
+        <button
+          type="button"
+          onClick={zoomIn}
+          disabled={zoomIndex >= ZOOM_LEVELS.length - 1}
+          className="grid h-6 w-6 place-items-center rounded font-bold text-slate-600 hover:bg-slate-100 disabled:opacity-30"
+          aria-label="放大"
+        >
+          +
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/audit/audit-panel.test.tsx
+++ b/frontend/src/pages/playtest/workbench/audit/audit-panel.test.tsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { PreviewFrame } from '../model/types'
+import { AuditPanel } from './audit-panel'
+
+const frame: PreviewFrame = {
+  imageUrl: '/walk-03.png',
+  durationMs: 100,
+  rootMotion: { dx: 4, dy: 0 },
+  keyFrame: false,
+}
+
+afterEach(cleanup)
+
+describe('AuditPanel', () => {
+  it('marks the current frame and keeps automatic findings read-only', () => {
+    const onAdd = vi.fn()
+    render(
+      <AuditPanel
+        actionId="walk"
+        actionName="行走"
+        direction="south"
+        frameIndex={2}
+        frame={frame}
+        automaticFindings={[
+          {
+            code: 'subject_cropped',
+            severity: 'error',
+            frameIndex: 2,
+            message: '主体接触画布边缘，可能发生裁切',
+            metrics: {},
+          },
+        ]}
+        issues={[]}
+        onAdd={onAdd}
+        onUpdate={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('自动')).toBeTruthy()
+    expect(screen.getByText('主体接触画布边缘，可能发生裁切')).toBeTruthy()
+    fireEvent.change(screen.getByLabelText('问题类型'), {
+      target: { value: 'style_inconsistent' },
+    })
+    fireEvent.change(screen.getByLabelText('问题说明'), {
+      target: { value: '衣服颜色跳变' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '标记当前帧问题' }))
+
+    expect(onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'style_inconsistent',
+        actionId: 'walk',
+        direction: 'south',
+        frameIndex: 2,
+        imageUrl: '/walk-03.png',
+        note: '衣服颜色跳变',
+      }),
+    )
+  })
+
+  it('edits and removes an existing manual issue', () => {
+    const onUpdate = vi.fn()
+    const onRemove = vi.fn()
+    render(
+      <AuditPanel
+        actionId="walk"
+        actionName="行走"
+        direction="south"
+        frameIndex={2}
+        frame={frame}
+        automaticFindings={[]}
+        issues={[
+          {
+            id: 'manual-1',
+            category: 'motion_discontinuity',
+            actionId: 'walk',
+            direction: 'south',
+            frameIndex: 2,
+            imageUrl: '/walk-03.png',
+            note: '步幅突然变化',
+          },
+        ]}
+        onAdd={vi.fn()}
+        onUpdate={onUpdate}
+        onRemove={onRemove}
+      />,
+    )
+
+    expect(screen.getByText('人工')).toBeTruthy()
+    fireEvent.change(screen.getByLabelText('人工问题类型'), {
+      target: { value: 'motion_direction' },
+    })
+    fireEvent.change(screen.getByLabelText('人工问题说明'), {
+      target: { value: '移动方向错误' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '删除人工问题' }))
+
+    expect(onUpdate).toHaveBeenCalledWith('manual-1', 'motion_direction', '步幅突然变化')
+    expect(onUpdate).toHaveBeenCalledWith('manual-1', 'motion_discontinuity', '移动方向错误')
+    expect(onRemove).toHaveBeenCalledWith('manual-1')
+  })
+})

--- a/frontend/src/pages/playtest/workbench/audit/audit-panel.tsx
+++ b/frontend/src/pages/playtest/workbench/audit/audit-panel.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react'
+
+import type { QualityFinding } from '../analysis/sequence-evidence'
+import type { PlaytestDirection, PreviewFrame } from '../model/types'
+import type { ManualAuditIssue, ManualIssueCategory } from './audit-session'
+
+const CATEGORY_LABELS: Readonly<Record<ManualIssueCategory, string>> = {
+  subject_cropped: '主体裁切',
+  transparency: '透明背景异常',
+  image_unavailable: '空白或加载失败',
+  duplicate_frame: '重复帧',
+  motion_discontinuity: '动作抖动或不连续',
+  motion_direction: '位移或方向错误',
+  style_inconsistent: '风格不一致',
+  other: '其他',
+}
+
+let fallbackId = 0
+
+function createIssueId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  fallbackId += 1
+  return `manual-${Date.now()}-${fallbackId}`
+}
+
+export interface AuditPanelProps {
+  actionId: string | null
+  actionName: string | null
+  direction: PlaytestDirection | null
+  frameIndex: number
+  frame: PreviewFrame | null
+  automaticFindings: readonly QualityFinding[]
+  issues: readonly ManualAuditIssue[]
+  onAdd(issue: ManualAuditIssue): void
+  onUpdate(id: string, category: ManualIssueCategory, note: string): void
+  onRemove(id: string): void
+}
+
+export function AuditPanel({
+  actionId,
+  actionName,
+  direction,
+  frameIndex,
+  frame,
+  automaticFindings,
+  issues,
+  onAdd,
+  onUpdate,
+  onRemove,
+}: AuditPanelProps) {
+  const [category, setCategory] = useState<ManualIssueCategory>('subject_cropped')
+  const [note, setNote] = useState('')
+  const canMark = actionId !== null && direction !== null && frame !== null
+
+  return (
+    <section
+      aria-label="问题记录"
+      className="space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+    >
+      <header>
+        <p className="text-[10px] font-semibold tracking-[0.18em] text-slate-400">QUALITY ISSUES</p>
+        <h2 className="mt-1 text-sm font-semibold text-slate-900">问题记录</h2>
+        <p className="mt-1 text-[11px] text-slate-500">仅保留在当前 Playtest 会话</p>
+      </header>
+
+      <div className="space-y-2">
+        <h3 className="text-xs font-semibold text-slate-800">自动发现</h3>
+        {automaticFindings.length === 0 ? (
+          <p className="text-xs text-slate-500">当前序列没有自动问题</p>
+        ) : (
+          <ul className="space-y-2">
+            {automaticFindings.map((finding, index) => (
+              <li
+                key={`${finding.code}-${finding.frameIndex ?? 'sequence'}-${index}`}
+                className="rounded-lg bg-slate-50 p-2 text-xs"
+              >
+                <div className="flex justify-between gap-2">
+                  <span>{finding.message}</span>
+                  <strong className="text-[10px] text-slate-500">自动</strong>
+                </div>
+                <span className="mt-1 block text-[10px] text-slate-500">
+                  {finding.frameIndex === null ? '整段序列' : `第 ${finding.frameIndex + 1} 帧`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="space-y-2 border-t border-slate-100 pt-3">
+        <h3 className="text-xs font-semibold text-slate-800">
+          标记当前帧{actionName === null ? '' : ` · ${actionName} #${frameIndex + 1}`}
+        </h3>
+        <label className="block text-xs text-slate-600">
+          问题类型
+          <select
+            aria-label="问题类型"
+            value={category}
+            onChange={(event) => setCategory(event.target.value as ManualIssueCategory)}
+            className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-2 py-2"
+          >
+            {Object.entries(CATEGORY_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-xs text-slate-600">
+          问题说明
+          <textarea
+            aria-label="问题说明"
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            className="mt-1 min-h-16 w-full rounded-lg border border-slate-200 px-2 py-2"
+          />
+        </label>
+        <button
+          type="button"
+          disabled={!canMark}
+          onClick={() => {
+            if (actionId === null || direction === null || frame === null) return
+            onAdd({
+              id: createIssueId(),
+              category,
+              actionId,
+              direction,
+              frameIndex,
+              imageUrl: frame.imageUrl,
+              note: note.trim(),
+            })
+            setNote('')
+          }}
+          className="w-full rounded-lg bg-slate-900 px-3 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          标记当前帧问题
+        </button>
+      </div>
+
+      <div className="space-y-2 border-t border-slate-100 pt-3">
+        <h3 className="text-xs font-semibold text-slate-800">人工记录</h3>
+        {issues.length === 0 ? (
+          <p className="text-xs text-slate-500">尚未标记人工问题</p>
+        ) : (
+          issues.map((issue) => (
+            <article key={issue.id} className="space-y-2 rounded-lg border border-slate-200 p-2">
+              <div className="flex items-center justify-between gap-2 text-[10px] text-slate-500">
+                <strong>人工</strong>
+                <span>
+                  {issue.actionId} · {issue.direction} · 第 {issue.frameIndex + 1} 帧
+                </span>
+              </div>
+              <select
+                aria-label="人工问题类型"
+                value={issue.category}
+                onChange={(event) =>
+                  onUpdate(issue.id, event.target.value as ManualIssueCategory, issue.note)
+                }
+                className="w-full rounded-lg border border-slate-200 bg-white px-2 py-2 text-xs"
+              >
+                {Object.entries(CATEGORY_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <textarea
+                aria-label="人工问题说明"
+                value={issue.note}
+                onChange={(event) => onUpdate(issue.id, issue.category, event.target.value)}
+                className="min-h-14 w-full rounded-lg border border-slate-200 px-2 py-2 text-xs"
+              />
+              <button
+                type="button"
+                aria-label="删除人工问题"
+                onClick={() => onRemove(issue.id)}
+                className="text-xs font-semibold text-rose-700"
+              >
+                删除
+              </button>
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/audit/audit-session.test.ts
+++ b/frontend/src/pages/playtest/workbench/audit/audit-session.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { reduceAuditSession, type ManualAuditIssue } from './audit-session'
+
+const issue: ManualAuditIssue = {
+  id: 'issue-1',
+  category: 'subject_cropped',
+  actionId: 'walk',
+  direction: 'south',
+  frameIndex: 2,
+  imageUrl: '/walk-03.png',
+  note: '右侧被裁切',
+}
+
+describe('reduceAuditSession', () => {
+  it('adds, updates and removes manual issues without mutating identity fields', () => {
+    const added = reduceAuditSession([], { type: 'add', issue })
+    const updated = reduceAuditSession(added, {
+      type: 'update',
+      id: issue.id,
+      category: 'style_inconsistent',
+      note: '衣服颜色跳变',
+    })
+    const removed = reduceAuditSession(updated, { type: 'remove', id: issue.id })
+
+    expect(added).toEqual([issue])
+    expect(updated[0]).toEqual({
+      ...issue,
+      category: 'style_inconsistent',
+      note: '衣服颜色跳变',
+    })
+    expect(updated[0]).toMatchObject({
+      actionId: 'walk',
+      direction: 'south',
+      frameIndex: 2,
+      imageUrl: '/walk-03.png',
+    })
+    expect(removed).toEqual([])
+    expect(added).not.toBe(updated)
+  })
+
+  it('ignores updates and removals for unknown issue ids', () => {
+    expect(
+      reduceAuditSession([issue], {
+        type: 'update',
+        id: 'missing',
+        category: 'other',
+        note: '无效更新',
+      }),
+    ).toEqual([issue])
+    expect(reduceAuditSession([issue], { type: 'remove', id: 'missing' })).toEqual([issue])
+  })
+})

--- a/frontend/src/pages/playtest/workbench/audit/audit-session.ts
+++ b/frontend/src/pages/playtest/workbench/audit/audit-session.ts
@@ -1,0 +1,41 @@
+import type { PlaytestDirection } from '../model/types'
+
+export type ManualIssueCategory =
+  | 'subject_cropped'
+  | 'transparency'
+  | 'image_unavailable'
+  | 'duplicate_frame'
+  | 'motion_discontinuity'
+  | 'motion_direction'
+  | 'style_inconsistent'
+  | 'other'
+
+export interface ManualAuditIssue {
+  id: string
+  category: ManualIssueCategory
+  actionId: string
+  direction: PlaytestDirection
+  frameIndex: number
+  imageUrl: string
+  note: string
+}
+
+export type AuditSessionAction =
+  | { type: 'add'; issue: ManualAuditIssue }
+  | { type: 'update'; id: string; category: ManualIssueCategory; note: string }
+  | { type: 'remove'; id: string }
+
+export function reduceAuditSession(
+  state: readonly ManualAuditIssue[],
+  action: AuditSessionAction,
+): readonly ManualAuditIssue[] {
+  if (action.type === 'add') return [...state, action.issue]
+  if (action.type === 'remove') {
+    if (!state.some((issue) => issue.id === action.id)) return state
+    return state.filter((issue) => issue.id !== action.id)
+  }
+  if (!state.some((issue) => issue.id === action.id)) return state
+  return state.map((issue) =>
+    issue.id === action.id ? { ...issue, category: action.category, note: action.note } : issue,
+  )
+}

--- a/frontend/src/pages/playtest/workbench/frame-review-evidence.test.tsx
+++ b/frontend/src/pages/playtest/workbench/frame-review-evidence.test.tsx
@@ -1,0 +1,244 @@
+/** @vitest-environment jsdom */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { FrameReviewEvidenceState } from './analysis/use-frame-review-evidence'
+import { FrameReviewEvidencePanel } from './frame-review-evidence'
+
+const readyState: FrameReviewEvidenceState = {
+  status: 'ready',
+  evidence: {
+    complete: true,
+    unavailableFrameCount: 0,
+    findings: [],
+    frames: [
+      {
+        geometry: {
+          width: 256,
+          height: 256,
+          bounds: { left: 80, top: 30, right: 175, bottom: 236, width: 96, height: 207 },
+          centroid: { x: 127, y: 140 },
+          footY: 236,
+          subjectHeight: 207,
+          opaquePixels: 12_000,
+          coverageRatio: 0.1831,
+        },
+        unavailableReason: null,
+        previousDelta: null,
+        expectedRootDelta: null,
+        composedPreviewDelta: null,
+        canvasState: 'normal',
+        coverageState: 'normal',
+        movementState: 'not_applicable',
+        areaState: 'not_applicable',
+      },
+      {
+        geometry: {
+          width: 256,
+          height: 256,
+          bounds: { left: 83, top: 31, right: 174, bottom: 237, width: 92, height: 207 },
+          centroid: { x: 130, y: 144 },
+          footY: 237,
+          subjectHeight: 207,
+          opaquePixels: 9_600,
+          coverageRatio: 0.1465,
+        },
+        unavailableReason: null,
+        previousDelta: { dx: 3, dy: 4, distance: 5, areaDeltaPercent: 20 },
+        expectedRootDelta: { dx: 10, dy: 6, distance: Math.sqrt(136) },
+        composedPreviewDelta: { dx: 13, dy: 2, distance: Math.sqrt(173) },
+        canvasState: 'normal',
+        coverageState: 'normal',
+        movementState: 'normal',
+        areaState: 'normal',
+      },
+    ],
+    summary: {
+      footDrift: 1,
+      heightDrift: 0,
+      medianStep: 5,
+      maxStep: 5,
+      movementThreshold: 15,
+      heightThreshold: 12,
+      footThreshold: 3,
+      areaThresholdPercent: 28,
+      expectedCanvas: { width: 256, height: 256 },
+      maxAreaDeltaPercent: 20,
+      canvasState: 'normal',
+      footState: 'normal',
+      heightState: 'normal',
+      movementState: 'normal',
+      areaState: 'normal',
+    },
+  },
+}
+
+afterEach(cleanup)
+
+describe('FrameReviewEvidencePanel', () => {
+  it('keeps analysis loading distinct from measured zero values', () => {
+    // Catches the right panel presenting fabricated zero evidence before image decoding completes.
+    render(
+      <FrameReviewEvidencePanel
+        state={{ status: 'loading', evidence: null }}
+        frameIndex={0}
+        actionType="walk"
+      />,
+    )
+
+    expect(screen.getByRole('status').textContent).toContain('分析中')
+    expect(screen.queryByText(/0\.0 px/)).toBeNull()
+  })
+
+  it('shows measured drift, expected root increment and composed preview motion separately', () => {
+    // Catches expected motion and in-image drift being merged into one misleading number.
+    render(<FrameReviewEvidencePanel state={readyState} frameIndex={1} actionType="walk" />)
+
+    expect(screen.getByRole('region', { name: '自动审核依据' })).toBeTruthy()
+    expect(screen.getByText('画面内额外漂移')).toBeTruthy()
+    expect(screen.getByText('x +3.0 px，y +4.0 px，距离 5.0 px')).toBeTruthy()
+    expect(screen.getByText('预期根位移增量')).toBeTruthy()
+    expect(screen.getByText('x +10.0 px，y +6.0 px，距离 11.7 px')).toBeTruthy()
+    expect(screen.getByText('合成预览位移')).toBeTruthy()
+    expect(screen.getByText('x +13.0 px，y +2.0 px，距离 13.2 px')).toBeTruthy()
+    expect(screen.getByText('脚底线')).toBeTruthy()
+    expect(screen.getByText('237 px')).toBeTruthy()
+    expect(screen.getByText('主体高度')).toBeTruthy()
+    expect(screen.getByText('207 px')).toBeTruthy()
+    expect(screen.getByText('画布尺寸')).toBeTruthy()
+    expect(screen.getByText('256 × 256 px')).toBeTruthy()
+    expect(screen.getByText('轮廓面积变化')).toBeTruthy()
+    expect(screen.getByText('20.0%')).toBeTruthy()
+    expect(screen.getByText('序列基线')).toBeTruthy()
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  it('shows the inferred canvas baseline and scaled pixel thresholds', () => {
+    const scaledState: FrameReviewEvidenceState = {
+      status: 'ready',
+      evidence: {
+        ...readyState.evidence!,
+        frames: readyState.evidence!.frames.map((frame) => ({
+          ...frame,
+          geometry: frame.geometry === null ? null : { ...frame.geometry, width: 512, height: 512 },
+        })),
+        summary: {
+          ...readyState.evidence!.summary,
+          expectedCanvas: { width: 512, height: 512 },
+          footThreshold: 6,
+          heightThreshold: 24,
+        },
+      },
+    }
+
+    render(<FrameReviewEvidencePanel state={scaledState} frameIndex={1} actionType="walk" />)
+
+    expect(screen.getByText('512 × 512 px')).toBeTruthy()
+    expect(screen.getByText('序列基线 512 × 512')).toBeTruthy()
+    expect(screen.getByText('1.0 px / 阈值 6.0 px')).toBeTruthy()
+    expect(screen.getByText('0.0 px / 阈值 24.0 px')).toBeTruthy()
+  })
+
+  it('does not fabricate an adjacent comparison for the first frame', () => {
+    // Catches first-frame null deltas being displayed as a successful zero movement.
+    render(<FrameReviewEvidencePanel state={readyState} frameIndex={0} actionType="walk" />)
+
+    expect(screen.getAllByText('相邻对比不适用')).toHaveLength(3)
+  })
+
+  it('explains that jump foot drift requires human judgement instead of failing it', () => {
+    // Catches intentional lift being shown as an ordinary foot-anchor anomaly.
+    const jumpState: FrameReviewEvidenceState = {
+      status: 'ready',
+      evidence: {
+        ...readyState.evidence!,
+        summary: {
+          ...readyState.evidence!.summary,
+          footDrift: 42,
+          footState: 'attention',
+        },
+      },
+    }
+
+    render(<FrameReviewEvidencePanel state={jumpState} frameIndex={1} actionType="jump" />)
+
+    expect(screen.getByText('42.0 px / 本序列阈值 3.0 px；允许离地，需人工判断')).toBeTruthy()
+  })
+
+  it('explains action-allowed jump height variation without a false anomaly', () => {
+    const jumpState: FrameReviewEvidenceState = {
+      status: 'ready',
+      evidence: {
+        ...readyState.evidence!,
+        summary: {
+          ...readyState.evidence!.summary,
+          heightDrift: 42,
+          heightThreshold: null,
+          heightState: 'attention',
+        },
+      },
+    }
+
+    render(<FrameReviewEvidencePanel state={jumpState} frameIndex={1} actionType="jump" />)
+
+    expect(screen.getByText('42.0 px / 动作允许高度变化，需人工判断')).toBeTruthy()
+    expect(screen.getAllByText('注意').length).toBeGreaterThan(0)
+  })
+
+  it('shows the exact unavailable reason without disabling the rest of Playtest', () => {
+    // Catches cross-origin failures being converted to a normal geometry result.
+    const unavailableState: FrameReviewEvidenceState = {
+      status: 'ready',
+      evidence: {
+        ...readyState.evidence!,
+        complete: false,
+        unavailableFrameCount: 1,
+        frames: [
+          {
+            geometry: null,
+            unavailableReason: '图片跨域，无法计算像素',
+            previousDelta: null,
+            expectedRootDelta: null,
+            composedPreviewDelta: null,
+            canvasState: 'not_applicable',
+            coverageState: 'not_applicable',
+            movementState: 'not_applicable',
+            areaState: 'not_applicable',
+          },
+        ],
+      },
+    }
+
+    render(<FrameReviewEvidencePanel state={unavailableState} frameIndex={0} actionType="walk" />)
+
+    expect(screen.getByText('无法计算：图片跨域，无法计算像素')).toBeTruthy()
+    expect(screen.getByText('1 帧无法计算，序列结论不完整')).toBeTruthy()
+  })
+
+  it('renders structured findings with severity and frame location', () => {
+    const findingState: FrameReviewEvidenceState = {
+      status: 'ready',
+      evidence: {
+        ...readyState.evidence!,
+        complete: false,
+        unavailableFrameCount: 1,
+        findings: [
+          {
+            code: 'subject_cropped',
+            severity: 'error',
+            frameIndex: 1,
+            message: '主体接触画布边缘，可能发生裁切',
+            metrics: { left: 0 },
+          },
+        ],
+      },
+    }
+
+    render(<FrameReviewEvidencePanel state={findingState} frameIndex={1} actionType="walk" />)
+
+    expect(screen.getByText('分析不完整')).toBeTruthy()
+    expect(screen.getByText('主体接触画布边缘，可能发生裁切')).toBeTruthy()
+    expect(screen.getByText('第 2 帧')).toBeTruthy()
+    expect(screen.getByText('错误')).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/playtest/workbench/frame-review-evidence.tsx
+++ b/frontend/src/pages/playtest/workbench/frame-review-evidence.tsx
@@ -1,0 +1,263 @@
+import type { EvidenceState, MotionVector } from './analysis/sequence-evidence'
+import type { FrameReviewEvidenceState } from './analysis/use-frame-review-evidence'
+import type { PlaytestActionType } from './model/types'
+
+export interface FrameReviewEvidencePanelProps {
+  state: FrameReviewEvidenceState
+  frameIndex: number
+  actionType: PlaytestActionType
+}
+
+const STATE_LABELS: Record<EvidenceState, string> = {
+  normal: '正常',
+  attention: '注意',
+  anomaly: '异常',
+  not_applicable: '不适用',
+}
+
+const STATE_CLASSES: Record<EvidenceState, string> = {
+  normal: 'bg-emerald-50 text-emerald-800',
+  attention: 'bg-amber-50 text-amber-800',
+  anomaly: 'bg-rose-50 text-rose-800',
+  not_applicable: 'bg-slate-100 text-slate-500',
+}
+
+function signed(value: number): string {
+  return `${value >= 0 ? '+' : ''}${value.toFixed(1)}`
+}
+
+function vectorText(vector: MotionVector | null): string {
+  if (vector === null) return '相邻对比不适用'
+  return `x ${signed(vector.dx)} px，y ${signed(vector.dy)} px，距离 ${vector.distance.toFixed(1)} px`
+}
+
+function optionalPixels(value: number | null): string {
+  return value === null ? '不适用' : `${value.toFixed(1)} px`
+}
+
+function StateBadge({ state }: { state: EvidenceState }) {
+  return (
+    <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${STATE_CLASSES[state]}`}>
+      {STATE_LABELS[state]}
+    </span>
+  )
+}
+
+function EvidenceRow({
+  label,
+  value,
+  state,
+}: {
+  label: string
+  value: string
+  state?: EvidenceState
+}) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 border-t border-slate-100 py-2 first:border-t-0">
+      <div className="min-w-0">
+        <dt className="text-[11px] text-slate-500">{label}</dt>
+        <dd className="mt-0.5 break-words text-xs font-medium text-slate-900">{value}</dd>
+      </div>
+      {state === undefined ? null : <StateBadge state={state} />}
+    </div>
+  )
+}
+
+export function FrameReviewEvidencePanel({
+  state,
+  frameIndex,
+  actionType,
+}: FrameReviewEvidencePanelProps) {
+  return (
+    <section
+      role="region"
+      aria-label="自动审核依据"
+      className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+    >
+      <header>
+        <p className="text-[10px] font-semibold tracking-[0.18em] text-slate-400">AUTO REVIEW</p>
+        <h2 className="mt-1 text-sm font-semibold text-slate-900">自动审核依据</h2>
+        <p className="mt-1 text-[11px] leading-5 text-slate-500">检查画面与序列质量，不修改 QC</p>
+      </header>
+
+      {state.status === 'idle' ? (
+        <p className="mt-3 text-xs text-slate-500">未开始分析</p>
+      ) : state.status === 'loading' ? (
+        <p role="status" className="mt-3 text-xs text-slate-500">
+          分析中，请稍候…
+        </p>
+      ) : (
+        <EvidenceContent state={state} frameIndex={frameIndex} actionType={actionType} />
+      )}
+    </section>
+  )
+}
+
+function EvidenceContent({
+  state,
+  frameIndex,
+  actionType,
+}: {
+  state: Extract<FrameReviewEvidenceState, { status: 'ready' }>
+  frameIndex: number
+  actionType: PlaytestActionType
+}) {
+  const { evidence } = state
+  const frame = evidence.frames[frameIndex] ?? null
+  const summary = evidence.summary
+
+  if (frame === null) return <p className="mt-3 text-xs text-slate-500">当前帧没有分析结果</p>
+
+  return (
+    <div className="mt-3 space-y-4">
+      {frame.unavailableReason === null ? null : (
+        <p role="status" className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-900">
+          无法计算：{frame.unavailableReason}
+        </p>
+      )}
+
+      <div>
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-xs font-semibold text-slate-800">质量问题</h3>
+          {!evidence.complete ? (
+            <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-800">
+              分析不完整
+            </span>
+          ) : null}
+        </div>
+        {evidence.findings.length === 0 ? (
+          <p className="mt-2 text-xs text-slate-500">未发现自动质量问题</p>
+        ) : (
+          <ul className="mt-2 space-y-2">
+            {evidence.findings.map((finding, index) => (
+              <li
+                key={`${finding.code}-${finding.frameIndex ?? 'sequence'}-${index}`}
+                className={`rounded-lg border px-3 py-2 text-xs ${
+                  finding.severity === 'error'
+                    ? 'border-rose-200 bg-rose-50 text-rose-900'
+                    : 'border-amber-200 bg-amber-50 text-amber-900'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span>{finding.message}</span>
+                  <strong className="shrink-0 text-[10px]">
+                    {finding.severity === 'error' ? '错误' : '提醒'}
+                  </strong>
+                </div>
+                <span className="mt-1 block text-[10px] opacity-70">
+                  {finding.frameIndex === null ? '整段序列' : `第 ${finding.frameIndex + 1} 帧`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div>
+        <h3 className="text-xs font-semibold text-slate-800">当前帧</h3>
+        <dl className="mt-1">
+          <EvidenceRow
+            label="画面内额外漂移"
+            value={vectorText(frame.previousDelta)}
+            state={frame.movementState}
+          />
+          <EvidenceRow label="预期根位移增量" value={vectorText(frame.expectedRootDelta)} />
+          <EvidenceRow label="合成预览位移" value={vectorText(frame.composedPreviewDelta)} />
+          <EvidenceRow
+            label="画布尺寸"
+            value={
+              frame.geometry === null
+                ? '无法计算'
+                : `${frame.geometry.width} × ${frame.geometry.height} px`
+            }
+            state={frame.canvasState}
+          />
+          <EvidenceRow
+            label="脚底线"
+            value={frame.geometry === null ? '无法计算' : `${frame.geometry.footY} px`}
+          />
+          <EvidenceRow
+            label="主体高度"
+            value={frame.geometry === null ? '无法计算' : `${frame.geometry.subjectHeight} px`}
+          />
+          <EvidenceRow
+            label="主体覆盖率"
+            value={
+              frame.geometry === null
+                ? '无法计算'
+                : `${(frame.geometry.coverageRatio * 100).toFixed(1)}%`
+            }
+            state={frame.coverageState}
+          />
+          <EvidenceRow
+            label="轮廓面积变化"
+            value={
+              frame.previousDelta === null
+                ? '不适用'
+                : `${frame.previousDelta.areaDeltaPercent.toFixed(1)}%`
+            }
+            state={frame.areaState}
+          />
+        </dl>
+      </div>
+
+      <div>
+        <h3 className="text-xs font-semibold text-slate-800">序列基线</h3>
+        {!evidence.complete ? (
+          <p className="mt-2 rounded-lg bg-amber-50 px-3 py-2 text-[11px] text-amber-900">
+            {evidence.unavailableFrameCount} 帧无法计算，序列结论不完整
+          </p>
+        ) : null}
+        <dl className="mt-1">
+          <EvidenceRow
+            label="整段画布规格"
+            value={
+              summary.expectedCanvas === null
+                ? '无法推断序列基线'
+                : `序列基线 ${summary.expectedCanvas.width} × ${summary.expectedCanvas.height}`
+            }
+            state={summary.canvasState}
+          />
+          <EvidenceRow
+            label="最大脚底漂移"
+            value={
+              actionType === 'jump' && summary.footState === 'attention'
+                ? `${optionalPixels(summary.footDrift)} / 本序列阈值 ${optionalPixels(summary.footThreshold)}；允许离地，需人工判断`
+                : `${optionalPixels(summary.footDrift)} / 阈值 ${optionalPixels(summary.footThreshold)}`
+            }
+            state={summary.footState}
+          />
+          <EvidenceRow
+            label="最大高度波动"
+            value={
+              summary.heightThreshold === null && summary.heightDrift !== null
+                ? `${optionalPixels(summary.heightDrift)} / 动作允许高度变化，需人工判断`
+                : `${optionalPixels(summary.heightDrift)} / 阈值 ${summary.heightThreshold?.toFixed(1) ?? '不适用'} px`
+            }
+            state={summary.heightState}
+          />
+          <EvidenceRow
+            label="相邻位移连续性"
+            value={
+              summary.maxStep === null ||
+              summary.medianStep === null ||
+              summary.movementThreshold === null
+                ? '不适用'
+                : `最大 ${summary.maxStep.toFixed(1)} px，中值 ${summary.medianStep.toFixed(1)} px，阈值 ${summary.movementThreshold.toFixed(1)} px`
+            }
+            state={summary.movementState}
+          />
+          <EvidenceRow
+            label="最大轮廓面积变化"
+            value={
+              summary.maxAreaDeltaPercent === null
+                ? '不适用'
+                : `最大 ${summary.maxAreaDeltaPercent.toFixed(1)}% / 阈值 ${summary.areaThresholdPercent.toFixed(1)}%`
+            }
+            state={summary.areaState}
+          />
+        </dl>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/frame-timeline.tsx
+++ b/frontend/src/pages/playtest/workbench/frame-timeline.tsx
@@ -1,0 +1,58 @@
+import type { PreviewSequence } from './model/types'
+
+export interface FrameTimelineProps {
+  sequence: PreviewSequence | null
+  currentFrameIndex: number
+  onSelectFrame(index: number): void
+}
+
+export function FrameTimeline({ sequence, currentFrameIndex, onSelectFrame }: FrameTimelineProps) {
+  const frames = sequence?.frames ?? []
+
+  return (
+    <section aria-label="逐帧时间线" className="rounded-lg border border-[#d2d8d3] bg-white p-2">
+      <header className="mb-2 flex items-center justify-between gap-4 px-1">
+        <strong className="text-[10px] text-[#59635b]">逐帧</strong>
+        <span className="font-mono text-[9px] text-[#7a827c]">{frames.length} FRAMES</span>
+      </header>
+      {frames.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-slate-300 p-4 text-sm text-slate-500">
+          当前方向没有帧
+        </p>
+      ) : (
+        <div className="flex gap-1.5 overflow-x-auto pb-1">
+          {frames.map((frame, index) => (
+            <button
+              key={`${frame.imageUrl}-${index}`}
+              type="button"
+              aria-label={`第 ${index + 1} 帧`}
+              aria-pressed={index === currentFrameIndex}
+              onClick={() => onSelectFrame(index)}
+              className={`w-20 shrink-0 overflow-hidden rounded-md border p-1 text-left transition-colors ${
+                index === currentFrameIndex
+                  ? 'border-emerald-900 bg-emerald-50'
+                  : 'border-slate-200 bg-slate-50 hover:border-slate-400'
+              }`}
+            >
+              <span className="grid aspect-square place-items-center rounded-md bg-white">
+                <img
+                  src={frame.imageUrl}
+                  alt=""
+                  className="h-full w-full object-contain p-1 [image-rendering:pixelated]"
+                />
+              </span>
+              <span className="mt-1.5 block px-1 text-[10px]">
+                <strong className="block">#{String(index + 1).padStart(2, '0')}</strong>
+                <span className="mt-1 flex flex-wrap gap-1 text-[9px] text-slate-500">
+                  {frame.keyFrame ? (
+                    <span className="rounded bg-amber-100 px-1 text-amber-800">关键帧</span>
+                  ) : null}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/index.test.tsx
+++ b/frontend/src/pages/playtest/workbench/index.test.tsx
@@ -1,0 +1,227 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Character } from '@/entities/character'
+import type { PlaytestInspectionApis } from '@/entities/playtest-inspection'
+
+import type { FrameGeometryResult } from './analysis/sequence-evidence'
+import { PlaytestWorkbench } from './index'
+
+const readImageGeometry = vi.hoisted(() => vi.fn())
+vi.mock('./analysis/image-geometry', () => ({ readImageGeometry }))
+
+const character: Character = {
+  id: 'character-1',
+  projectId: 'project-1',
+  createdAt: '2026-07-30T00:00:00.000Z',
+  updatedAt: '2026-07-30T00:00:00.000Z',
+  outfits: [
+    {
+      id: 'outfit-1',
+      characterId: 'character-1',
+      name: 'Explorer',
+      candidateCharacterTemplates: [],
+      characterTemplateUrl: 'https://cdn.example.test/aster.png',
+      baseFrames: [{ imageUrl: 'https://cdn.example.test/base.png' }],
+      actions: [
+        {
+          id: 'walk',
+          outfitId: 'outfit-1',
+          name: 'Walk',
+          kind: 'preset',
+          type: 'walk',
+          fps: 8,
+          keyFrameIndex: 0,
+          frames: [
+            {
+              imageUrl: 'https://cdn.example.test/walk-01.png',
+              durationMs: 125,
+              rootMotion: { dx: 2, dy: 0 },
+            },
+            {
+              imageUrl: 'https://cdn.example.test/walk-02.png',
+              durationMs: 125,
+              rootMotion: { dx: 4, dy: 0 },
+            },
+          ],
+        },
+        {
+          id: 'jump',
+          outfitId: 'outfit-1',
+          name: 'Jump',
+          kind: 'preset',
+          type: 'jump',
+          fps: 8,
+          keyFrameIndex: 0,
+          frames: [
+            {
+              imageUrl: 'https://cdn.example.test/jump-01.png',
+              durationMs: 125,
+              rootMotion: { dx: 0, dy: 3 },
+            },
+          ],
+        },
+        {
+          id: 'crouch',
+          outfitId: 'outfit-1',
+          name: 'Crouch',
+          kind: 'custom',
+          type: 'custom',
+          fps: 8,
+          keyFrameIndex: 0,
+          frames: [
+            {
+              imageUrl: 'https://cdn.example.test/crouch-01.png',
+              durationMs: 125,
+              rootMotion: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+function measuredGeometry(imageUrl: string): FrameGeometryResult {
+  return {
+    status: 'ready',
+    geometry: {
+      width: 256,
+      height: 256,
+      bounds: { left: 80, top: 30, right: 175, bottom: 236, width: 96, height: 207 },
+      centroid: { x: imageUrl.includes('02') ? 129 : 128, y: 130 },
+      footY: 236,
+      subjectHeight: 207,
+      opaquePixels: 13_000,
+      coverageRatio: 0.2,
+    },
+  }
+}
+
+beforeEach(() => {
+  readImageGeometry.mockImplementation(async (imageUrl: string) => measuredGeometry(imageUrl))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('PlaytestWorkbench on the PR #70 character contract', () => {
+  it('renders confirmed asset actions through one synthetic default direction', async () => {
+    render(<PlaytestWorkbench character={character} outfitId="outfit-1" />)
+
+    expect(screen.getByRole('heading', { name: 'character-1 · Explorer' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Walk/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Jump/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Crouch/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'default' })).toBeTruthy()
+    expect(screen.getByText('只读预览，不写入角色、动作或帧')).toBeTruthy()
+    await waitFor(() => expect(readImageGeometry).toHaveBeenCalled())
+  })
+
+  it('keeps playback controls and the shared current frame in sync', () => {
+    render(<PlaytestWorkbench character={character} outfitId="outfit-1" />)
+
+    expect(screen.getByText('01 / 02')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '下一帧' }))
+    expect(screen.getByText('02 / 02')).toBeTruthy()
+
+    const timeline = screen.getByRole('region', { name: '逐帧时间线' })
+    fireEvent.click(within(timeline).getByRole('button', { name: '第 1 帧' }))
+    expect(screen.getByText('01 / 02')).toBeTruthy()
+  })
+
+  it('maps A/D to walk facing, W to jump, and custom Crouch to S', () => {
+    render(<PlaytestWorkbench character={character} outfitId="outfit-1" />)
+
+    fireEvent.keyDown(window, { key: 'd' })
+    expect(screen.getByRole('button', { name: /Walk/ }).getAttribute('aria-pressed')).toBe('true')
+    fireEvent.keyUp(window, { key: 'd' })
+
+    fireEvent.keyDown(window, { key: 'w' })
+    expect(screen.getByRole('button', { name: /Jump/ }).getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.keyDown(window, { key: 's' })
+    expect(screen.getByRole('button', { name: /Crouch/ }).getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('loads and saves the current action inspection through the Playtest API', async () => {
+    const inspections: Pick<PlaytestInspectionApis, 'get' | 'save'> = {
+      get: vi.fn().mockResolvedValue(null),
+      save: vi.fn().mockImplementation(async (input) => ({
+        id: 'inspection-1',
+        ...input,
+        createdAt: '2026-08-03T00:00:00.000Z',
+        updatedAt: '2026-08-03T00:00:00.000Z',
+      })),
+    }
+    render(
+      <PlaytestWorkbench character={character} outfitId="outfit-1" inspectionApis={inspections} />,
+    )
+
+    await waitFor(() =>
+      expect(inspections.get).toHaveBeenCalledWith({
+        characterId: 'character-1',
+        outfitId: 'outfit-1',
+        actionId: 'walk',
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '打开检查工具' }))
+    fireEvent.click(screen.getByRole('button', { name: '发现问题' }))
+    await waitFor(() =>
+      expect(inspections.save).toHaveBeenCalledWith({
+        characterId: 'character-1',
+        outfitId: 'outfit-1',
+        actionId: 'walk',
+        status: 'issues_found',
+      }),
+    )
+    const acceptance = screen.getByRole('region', { name: '核验状态' })
+    expect(within(acceptance).getAllByText('发现问题')).toHaveLength(2)
+    expect(within(acceptance).getByText('已保存到 Playtest 核验记录')).toBeTruthy()
+  })
+
+  it('does not allow a failed image to be recorded as passed', async () => {
+    const inspections: Pick<PlaytestInspectionApis, 'get' | 'save'> = {
+      get: vi.fn().mockResolvedValue(null),
+      save: vi.fn(),
+    }
+    render(
+      <PlaytestWorkbench character={character} outfitId="outfit-1" inspectionApis={inspections} />,
+    )
+
+    fireEvent.error(screen.getByRole('img', { name: '角色动画预览' }))
+    fireEvent.click(screen.getByRole('button', { name: '打开检查工具' }))
+
+    await waitFor(() =>
+      expect((screen.getByRole('button', { name: '发现问题' }) as HTMLButtonElement).disabled).toBe(
+        false,
+      ),
+    )
+    expect((screen.getByRole('button', { name: '核验通过' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    expect((screen.getByRole('button', { name: '发现问题' }) as HTMLButtonElement).disabled).toBe(
+      false,
+    )
+  })
+
+  it('reports a missing outfit instead of falling back to another asset', () => {
+    render(<PlaytestWorkbench character={character} outfitId="missing" />)
+
+    expect(screen.getByText('找不到指定造型，无法构造只读预览。')).toBeTruthy()
+  })
+
+  it('keeps inspection and issue recording in the same workbench', () => {
+    render(<PlaytestWorkbench character={character} outfitId="outfit-1" />)
+
+    expect(screen.queryByRole('tab', { name: '帧检查' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: '打开检查工具' }))
+    expect(screen.getByRole('tab', { name: '帧检查' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('tab', { name: '问题记录' }))
+    expect(screen.getByRole('tabpanel', { name: '问题记录' })).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/playtest/workbench/index.tsx
+++ b/frontend/src/pages/playtest/workbench/index.tsx
@@ -1,0 +1,426 @@
+import { useMemo, useReducer, useState, type KeyboardEvent } from 'react'
+
+import type { Character } from '@/entities/character'
+import type { PlaytestInspectionApis } from '@/entities/playtest-inspection'
+import type { CanvasBaseline } from './analysis/quality-policy'
+
+import { ActionSelector, type PlaytestAssetOption } from './action-selector'
+import { Acceptance } from './acceptance'
+import { useFrameReviewEvidence } from './analysis/use-frame-review-evidence'
+import { AnimationStage } from './animation-stage'
+import { AuditPanel } from './audit/audit-panel'
+import { reduceAuditSession } from './audit/audit-session'
+import { FrameTimeline } from './frame-timeline'
+import { Inspector } from './inspector'
+import { createPreviewModel } from './model/create-preview-model'
+import type { PreviewAction } from './model/types'
+import { PlaybackControls } from './playback-controls'
+import { usePlaybackController } from './playback/use-playback-controller'
+import { useStageMotion } from './stage-motion'
+import { StatusPanel } from './status-panel'
+import { usePlaytestKeyboard } from './use-playtest-keyboard'
+import { usePlaytestInspection } from './use-playtest-inspection'
+
+export interface PlaytestWorkbenchProps {
+  character: Character
+  outfitId: string
+  assetOptions?: readonly PlaytestAssetOption[]
+  expectedCanvas?: CanvasBaseline | null
+  inspectionApis?: Pick<PlaytestInspectionApis, 'get' | 'save'>
+  initialActionId?: string | null
+  onSelectAsset?(asset: PlaytestAssetOption): void
+}
+
+export type { PlaytestAssetOption } from './action-selector'
+
+const EMPTY_PREVIEW_ACTIONS: readonly PreviewAction[] = []
+const RIGHT_PANELS = [
+  ['inspect', '帧检查'],
+  ['audit', '问题记录'],
+] as const
+type RightPanel = (typeof RIGHT_PANELS)[number][0]
+
+export function PlaytestWorkbench({
+  character,
+  outfitId,
+  assetOptions = [],
+  expectedCanvas = null,
+  inspectionApis,
+  initialActionId = null,
+  onSelectAsset = () => undefined,
+}: PlaytestWorkbenchProps) {
+  const [frameAvailable, setFrameAvailable] = useState(false)
+  const previewResult = useMemo(
+    () => createPreviewModel(character, outfitId),
+    [character, outfitId],
+  )
+  const preview = previewResult.ok ? previewResult.model : null
+  const playback = usePlaybackController(preview?.actions ?? EMPTY_PREVIEW_ACTIONS, initialActionId)
+  const {
+    firstFrame,
+    lastFrame,
+    nextFrame,
+    previousFrame,
+    playActionType,
+    toggleLoop,
+    togglePlaying,
+  } = playback
+  const isPlaying = playback.state.playing
+  const stageMotion = useStageMotion({
+    frame: playback.frame,
+    playing: isPlaying,
+    frameTick: playback.frameTick,
+    resetKey: `${character.id}:${outfitId}`,
+  })
+  const { setMirrored } = stageMotion
+  const jumpAvailable =
+    preview?.actions.some(
+      (action) =>
+        action.type === 'jump' && action.sequences.some((sequence) => sequence.frames.length > 0),
+    ) ?? false
+  const crouchAvailable =
+    preview?.actions.some(
+      (action) =>
+        action.type === 'crouch' && action.sequences.some((sequence) => sequence.frames.length > 0),
+    ) ?? false
+  const reviewEvidence = useFrameReviewEvidence(
+    playback.sequence,
+    playback.action?.type ?? null,
+    undefined,
+    expectedCanvas,
+  )
+  const inspectionTarget = useMemo(
+    () =>
+      playback.action === null
+        ? null
+        : {
+            characterId: character.id,
+            outfitId,
+            actionId: playback.action.id,
+          },
+    [character.id, outfitId, playback.action],
+  )
+  const inspection = usePlaytestInspection(inspectionApis, inspectionTarget)
+  const [activeRightPanel, setActiveRightPanel] = useState<RightPanel>('inspect')
+  const [toolsOpen, setToolsOpen] = useState(false)
+  const [manualIssues, dispatchAudit] = useReducer(reduceAuditSession, [])
+
+  const frameCount = playback.sequence?.frames.length ?? 0
+  const automaticFindings =
+    reviewEvidence.status === 'ready' ? reviewEvidence.evidence.findings : []
+  const automaticErrorCount = automaticFindings.filter(
+    (finding) => finding.severity === 'error',
+  ).length
+  const qualityIssueCount = automaticErrorCount + manualIssues.length
+
+  const movePanelFocus = (event: KeyboardEvent<HTMLButtonElement>, current: RightPanel) => {
+    const currentIndex = RIGHT_PANELS.findIndex(([value]) => value === current)
+    let nextIndex: number | null = null
+    if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % RIGHT_PANELS.length
+    else if (event.key === 'ArrowLeft')
+      nextIndex = (currentIndex - 1 + RIGHT_PANELS.length) % RIGHT_PANELS.length
+    else if (event.key === 'Home') nextIndex = 0
+    else if (event.key === 'End') nextIndex = RIGHT_PANELS.length - 1
+    if (nextIndex === null) return
+
+    event.preventDefault()
+    const nextPanel = RIGHT_PANELS[nextIndex]?.[0]
+    if (nextPanel === undefined) return
+    setActiveRightPanel(nextPanel)
+    document.getElementById(`playtest-tool-tab-${nextPanel}`)?.focus()
+  }
+
+  const keyboardCommands = useMemo(
+    () => ({
+      togglePlaying,
+      previousFrame: () => {
+        if (isPlaying) togglePlaying()
+        previousFrame()
+      },
+      nextFrame: () => {
+        if (isPlaying) togglePlaying()
+        nextFrame()
+      },
+      firstFrame,
+      lastFrame,
+      toggleLoop,
+      playLeft: () => {
+        if (isPlaying) togglePlaying()
+        previousFrame()
+      },
+      playRight: () => {
+        if (isPlaying) togglePlaying()
+        nextFrame()
+      },
+      stopHorizontal: () => {
+        // A/D 松开后无需恢复播放，用户通过空格控制播放
+      },
+      playJump: () => {
+        if (!jumpAvailable) return
+        playActionType('jump')
+      },
+      playCrouch: () => {
+        if (!crouchAvailable) return
+        playActionType('crouch')
+      },
+    }),
+    [
+      firstFrame,
+      lastFrame,
+      nextFrame,
+      previousFrame,
+      playActionType,
+      toggleLoop,
+      isPlaying,
+      togglePlaying,
+      jumpAvailable,
+      crouchAvailable,
+    ],
+  )
+  usePlaytestKeyboard(keyboardCommands, preview !== null)
+
+  if (preview === null) {
+    return (
+      <main aria-label="Playtest">
+        <StatusPanel title="无法打开 Playtest" tone="warning">
+          找不到指定造型，无法构造只读预览。
+        </StatusPanel>
+      </main>
+    )
+  }
+
+  const selectedAssetKey = `${character.id}:${outfitId}`
+  const availableAssets =
+    assetOptions.length > 0
+      ? assetOptions
+      : [
+          {
+            key: selectedAssetKey,
+            characterId: character.id,
+            outfitId,
+            name: preview.outfitName,
+            actionCount: preview.actions.length,
+          },
+        ]
+
+  return (
+    <main
+      aria-label="Playtest"
+      className="mx-auto min-h-[calc(100vh-5rem)] w-full max-w-[1920px] space-y-3 bg-[#eef0ed] px-3 pb-4 pt-2 text-[#202722] sm:px-5"
+    >
+      <header className="flex min-h-14 flex-wrap items-center justify-between gap-3 border-b border-[#d3d8d4] pb-3">
+        <div className="min-w-0">
+          <p className="font-mono text-[9px] font-semibold text-[#79817b]">PLAYTEST</p>
+          <h1 className="mt-1 truncate text-lg font-semibold">
+            {preview.characterName} · {preview.outfitName}
+          </h1>
+        </div>
+        <div className="flex items-center gap-3">
+          <p className="hidden text-[10px] text-[#727a74] sm:block">
+            只读预览，不写入角色、动作或帧
+          </p>
+          <button
+            type="button"
+            aria-label={toolsOpen ? '关闭检查工具' : '打开检查工具'}
+            aria-expanded={toolsOpen}
+            aria-controls="playtest-tools"
+            onClick={() => setToolsOpen((open) => !open)}
+            className={`inline-flex min-h-9 items-center gap-2 rounded-md border px-3 text-xs font-semibold transition-colors ${
+              toolsOpen
+                ? 'border-[#35583f] bg-[#35583f] text-white'
+                : 'border-[#aeb7b0] bg-white text-[#35583f] hover:border-[#718278]'
+            }`}
+          >
+            检查
+            {qualityIssueCount > 0 ? (
+              <span className="min-w-5 rounded bg-[#f7e2de] px-1 py-0.5 text-[9px] text-[#8d352d]">
+                {qualityIssueCount}
+              </span>
+            ) : null}
+          </button>
+        </div>
+      </header>
+      <div
+        className={`grid items-stretch gap-3 lg:min-h-[680px] lg:grid-cols-[208px_minmax(0,1fr)] ${
+          toolsOpen ? 'xl:grid-cols-[208px_minmax(0,1fr)_320px]' : ''
+        }`}
+      >
+        <nav
+          aria-label="动作列表"
+          className="min-h-0 min-w-0 overflow-hidden rounded-lg lg:h-[calc(100vh-9.5rem)] lg:min-h-[680px] lg:max-h-[900px]"
+        >
+          <ActionSelector
+            assets={availableAssets}
+            selectedAssetKey={selectedAssetKey}
+            actions={preview.actions}
+            selectedActionId={playback.state.actionId}
+            onSelectAsset={onSelectAsset}
+            onSelectAction={playback.selectAction}
+          />
+        </nav>
+        <section aria-label="预览工作台" className="flex min-h-0 min-w-0 flex-col gap-2">
+          <div className="relative min-h-[360px] flex-1 lg:min-h-[480px]">
+            <AnimationStage
+              currentFrame={playback.frame}
+              motionOffset={stageMotion.offset}
+              mirrored={stageMotion.mirrored}
+              onHorizontalBoundsChange={stageMotion.setBounds}
+              onFrameAvailabilityChange={setFrameAvailable}
+              showGrid
+              showChecker
+            />
+            <div
+              role="group"
+              aria-label="方向选择"
+              className="absolute left-3 top-3 z-20 flex max-w-[calc(100%-1.5rem)] flex-wrap items-center gap-1 rounded-md border border-[#aeb7b0] bg-white/90 p-1 backdrop-blur-sm"
+            >
+              <button
+                type="button"
+                aria-label="翻转方向"
+                aria-pressed={stageMotion.mirrored}
+                onClick={() => setMirrored(!stageMotion.mirrored)}
+                className={`grid h-8 w-8 place-items-center rounded text-base transition-colors ${
+                  stageMotion.mirrored
+                    ? 'bg-[#35583f] text-white'
+                    : 'text-[#59635b] hover:bg-[#e7ebe7]'
+                }`}
+                title="翻转水平方向 (F)"
+              >
+                ⇄
+              </button>
+              {playback.action?.sequences.map((sequence) => (
+                <button
+                  key={sequence.direction}
+                  type="button"
+                  aria-pressed={sequence.direction === playback.state.direction}
+                  disabled={sequence.frames.length === 0}
+                  onClick={() => playback.selectDirection(sequence.direction)}
+                  className={`min-h-8 rounded px-2 text-[10px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                    sequence.direction === playback.state.direction
+                      ? 'bg-[#252a27] text-white'
+                      : 'text-[#59635b] hover:bg-[#e7ebe7]'
+                  }`}
+                >
+                  {sequence.direction}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div role="group" aria-label="播放控制">
+            <PlaybackControls
+              playing={playback.state.playing}
+              loop={playback.state.loop}
+              frameIndex={playback.state.frameIndex}
+              frameCount={frameCount}
+              fps={playback.action?.fps ?? 0}
+              jumpAvailable={jumpAvailable}
+              crouchAvailable={crouchAvailable}
+              onFirstFrame={playback.firstFrame}
+              onPreviousFrame={playback.previousFrame}
+              onTogglePlaying={togglePlaying}
+              onNextFrame={playback.nextFrame}
+              onLastFrame={playback.lastFrame}
+              onToggleLoop={playback.toggleLoop}
+            />
+          </div>
+          <FrameTimeline
+            sequence={playback.sequence}
+            currentFrameIndex={playback.state.frameIndex}
+            onSelectFrame={playback.selectFrame}
+          />
+        </section>
+        {toolsOpen ? (
+          <aside
+            id="playtest-tools"
+            aria-label="Playtest 工具栏"
+            className="flex min-h-0 flex-col gap-3 rounded-lg border border-[#cdd4ce] bg-[#f8f9f7] p-2 lg:col-span-2 xl:col-span-1 xl:h-[calc(100vh-9.5rem)] xl:min-h-[680px] xl:max-h-[900px]"
+          >
+            <header className="flex min-h-9 items-center justify-between border-b border-[#d9ded9] px-1 pb-2">
+              <strong className="text-xs">检查工具</strong>
+              <button
+                type="button"
+                aria-label="关闭检查工具"
+                onClick={() => setToolsOpen(false)}
+                className="grid h-8 w-8 place-items-center rounded text-lg text-[#687069] hover:bg-[#e8ece8]"
+              >
+                ×
+              </button>
+            </header>
+            <div
+              role="tablist"
+              aria-label="Playtest 工具"
+              className="grid grid-cols-2 gap-1 rounded-md bg-[#e7ebe7] p-1"
+            >
+              {RIGHT_PANELS.map(([value, label]) => (
+                <button
+                  key={value}
+                  id={`playtest-tool-tab-${value}`}
+                  type="button"
+                  role="tab"
+                  aria-selected={activeRightPanel === value}
+                  aria-controls={`playtest-tool-panel-${value}`}
+                  tabIndex={activeRightPanel === value ? 0 : -1}
+                  onClick={() => setActiveRightPanel(value)}
+                  onKeyDown={(event) => movePanelFocus(event, value)}
+                  className={`rounded px-2 py-2 text-[10px] font-semibold ${
+                    activeRightPanel === value
+                      ? 'bg-white text-[#26372c] shadow-sm'
+                      : 'text-[#667068] hover:text-[#26372c]'
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <div
+              id="playtest-tool-panel-inspect"
+              role="tabpanel"
+              aria-labelledby="playtest-tool-tab-inspect"
+              hidden={activeRightPanel !== 'inspect'}
+              className="min-h-0 flex-1 overflow-y-auto"
+            >
+              <Inspector
+                action={playback.action}
+                sequence={playback.sequence}
+                frame={playback.frame}
+                frameIndex={playback.state.frameIndex}
+                reviewEvidence={reviewEvidence}
+              />
+            </div>
+            <div
+              id="playtest-tool-panel-audit"
+              role="tabpanel"
+              aria-labelledby="playtest-tool-tab-audit"
+              hidden={activeRightPanel !== 'audit'}
+              className="min-h-0 flex-1 overflow-y-auto"
+            >
+              <AuditPanel
+                actionId={playback.action?.id ?? null}
+                actionName={playback.action?.name ?? null}
+                direction={playback.sequence?.direction ?? null}
+                frameIndex={playback.state.frameIndex}
+                frame={playback.frame}
+                automaticFindings={automaticFindings}
+                issues={manualIssues}
+                onAdd={(issue) => dispatchAudit({ type: 'add', issue })}
+                onUpdate={(id, category, note) =>
+                  dispatchAudit({ type: 'update', id, category, note })
+                }
+                onRemove={(id) => dispatchAudit({ type: 'remove', id })}
+              />
+            </div>
+            <Acceptance
+              inspectionStatus={inspection.status}
+              available={inspection.available}
+              canPass={frameAvailable}
+              loading={inspection.loading}
+              saving={inspection.saving}
+              error={inspection.error}
+              onRecordStatus={inspection.save}
+            />
+          </aside>
+        ) : null}
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/inspector.tsx
+++ b/frontend/src/pages/playtest/workbench/inspector.tsx
@@ -1,0 +1,64 @@
+import type { FrameReviewEvidenceState } from './analysis/use-frame-review-evidence'
+import { FrameReviewEvidencePanel } from './frame-review-evidence'
+import type { PreviewAction, PreviewFrame, PreviewSequence } from './model/types'
+
+export interface InspectorProps {
+  action: PreviewAction | null
+  sequence: PreviewSequence | null
+  frame: PreviewFrame | null
+  frameIndex: number
+  reviewEvidence?: FrameReviewEvidenceState | null
+}
+
+function rootMotionText(frame: PreviewFrame | null): string {
+  if (frame?.rootMotion === null || frame === null) return '无'
+  return `x ${frame.rootMotion.dx}, y ${frame.rootMotion.dy}`
+}
+
+export function Inspector({
+  action,
+  sequence,
+  frame,
+  frameIndex,
+  reviewEvidence = null,
+}: InspectorProps) {
+  const frameCount = sequence?.frames.length ?? 0
+
+  return (
+    <aside aria-label="资产检查器" className="space-y-4">
+      <section className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <header>
+          <p className="text-[10px] font-semibold tracking-[0.18em] text-slate-400">INSPECTOR</p>
+          <h2 className="mt-1 text-sm font-semibold text-slate-900">资产检查器</h2>
+        </header>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-xs">
+          <dt className="text-slate-500">动作</dt>
+          <dd className="font-medium text-slate-900">{action?.name ?? '未选择'}</dd>
+          <dt className="text-slate-500">方向</dt>
+          <dd className="font-medium text-slate-900">{sequence?.direction ?? '—'}</dd>
+          <dt className="text-slate-500">帧序号</dt>
+          <dd className="font-medium text-slate-900">
+            {frameCount === 0 ? '0 / 0' : `${frameIndex + 1} / ${frameCount}`}
+          </dd>
+          <dt className="text-slate-500">时长</dt>
+          <dd className="font-medium text-slate-900">
+            {frame === null ? '—' : `${frame.durationMs} ms`}
+          </dd>
+          <dt className="text-slate-500">FPS</dt>
+          <dd className="font-medium text-slate-900">{action?.fps ?? '—'}</dd>
+          <dt className="text-slate-500">预期根位移</dt>
+          <dd className="font-medium text-slate-900">{rootMotionText(frame)}</dd>
+          <dt className="text-slate-500">关键帧</dt>
+          <dd className="font-medium text-slate-900">{frame?.keyFrame ? '是' : '否'}</dd>
+        </dl>
+      </section>
+      {reviewEvidence !== null && action !== null ? (
+        <FrameReviewEvidencePanel
+          state={reviewEvidence}
+          frameIndex={frameIndex}
+          actionType={action.type}
+        />
+      ) : null}
+    </aside>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/model/create-preview-model.test.ts
+++ b/frontend/src/pages/playtest/workbench/model/create-preview-model.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Character } from '../../../../entities'
+import { createPreviewModel } from './create-preview-model'
+
+const character: Character = {
+  id: 'character-1',
+  projectId: 'project-1',
+  createdAt: '2026-07-30T00:00:00.000Z',
+  updatedAt: '2026-07-30T00:00:00.000Z',
+  outfits: [
+    {
+      id: 'outfit-1',
+      characterId: 'character-1',
+      name: 'Explorer',
+      candidateCharacterTemplates: [],
+      characterTemplateUrl: 'https://cdn.example.test/aster.png',
+      baseFrames: [
+        { imageUrl: 'https://cdn.example.test/base-1.png' },
+        { imageUrl: 'https://cdn.example.test/base-2.png' },
+      ],
+      actions: [
+        {
+          id: 'walk',
+          outfitId: 'outfit-1',
+          name: 'Walk',
+          kind: 'preset',
+          type: 'walk',
+          fps: 5,
+          keyFrameIndex: 1,
+          frames: [
+            {
+              imageUrl: 'https://cdn.example.test/walk-0.png',
+              durationMs: 125,
+              rootMotion: { dx: 2, dy: 0 },
+            },
+            {
+              imageUrl: 'https://cdn.example.test/walk-1.png',
+              durationMs: null,
+              rootMotion: { dx: 5, dy: 1 },
+            },
+            {
+              imageUrl: 'https://cdn.example.test/walk-2.png',
+              durationMs: null,
+              rootMotion: null,
+            },
+          ],
+        },
+        {
+          id: 'idle',
+          outfitId: 'outfit-1',
+          name: 'Idle',
+          kind: 'custom',
+          type: 'idle',
+          fps: 0,
+          keyFrameIndex: 0,
+          frames: [
+            {
+              imageUrl: 'https://cdn.example.test/idle-0.png',
+              durationMs: null,
+              rootMotion: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+describe('createPreviewModel', () => {
+  it('reports a missing outfit without constructing a preview model', () => {
+    expect(createPreviewModel(character, 'missing-outfit')).toEqual({
+      ok: false,
+      reason: 'outfit_not_found',
+    })
+  })
+
+  it('maps the standard skeleton single-frame list to one default preview direction', () => {
+    const result = createPreviewModel(character, 'outfit-1')
+    if (!result.ok) throw new Error('expected preview model')
+
+    expect(result.model.actions.map((action) => action.id)).toEqual(['walk', 'idle'])
+    expect(result.model.actions[0].sequences.map((sequence) => sequence.direction)).toEqual([
+      'default',
+    ])
+    expect(result.model).toMatchObject({
+      characterId: 'character-1',
+      characterName: 'character-1',
+      outfitId: 'outfit-1',
+      outfitName: 'Explorer',
+      characterTemplateUrl: 'https://cdn.example.test/aster.png',
+      baseFrameCount: 2,
+    })
+  })
+
+  it('uses frame duration before fps fallback and maps the action key frame', () => {
+    const result = createPreviewModel(character, 'outfit-1')
+    if (!result.ok) throw new Error('expected preview model')
+
+    const frames = result.model.actions[0].sequences[0].frames
+    expect(frames.map((frame) => frame.durationMs)).toEqual([125, 200, 200])
+    expect(frames.map((frame) => frame.keyFrame)).toEqual([false, true, false])
+  })
+
+  it('converts absolute-from-first root motion into playback increments', () => {
+    const result = createPreviewModel(character, 'outfit-1')
+    if (!result.ok) throw new Error('expected preview model')
+
+    expect(result.model.actions[0].sequences[0].frames.map((frame) => frame.rootMotion)).toEqual([
+      { dx: 2, dy: 0 },
+      { dx: 3, dy: 1 },
+      null,
+    ])
+  })
+
+  it('uses a safe display fallback for invalid fps without mutating the character', () => {
+    const before = JSON.stringify(character)
+    const result = createPreviewModel(character, 'outfit-1')
+    if (!result.ok) throw new Error('expected preview model')
+
+    expect(result.model.actions[1].sequences[0].frames[0].durationMs).toBe(100)
+    expect(JSON.stringify(character)).toBe(before)
+  })
+})

--- a/frontend/src/pages/playtest/workbench/model/create-preview-model.ts
+++ b/frontend/src/pages/playtest/workbench/model/create-preview-model.ts
@@ -1,0 +1,94 @@
+import type { Action, Character, Frame } from '@/entities/character'
+
+import type {
+  PlaytestPreviewModel,
+  PreviewAction,
+  PreviewFrame,
+  PreviewModelResult,
+  PreviewSequence,
+} from './types'
+
+const SAFE_DURATION_MS = 100
+
+function getFallbackDurationMs(fps: Action['fps']): number {
+  if (!Number.isFinite(fps) || fps <= 0) return SAFE_DURATION_MS
+
+  const durationMs = Math.round(1000 / fps)
+  return durationMs > 0 ? durationMs : SAFE_DURATION_MS
+}
+
+function createPreviewFrame(
+  frame: Frame,
+  frameIndex: number,
+  keyFrameIndex: number | null,
+  fallbackDurationMs: number,
+  previousAbsoluteRootMotion: Frame['rootMotion'],
+): PreviewFrame {
+  const rootMotion =
+    frame.rootMotion === null
+      ? null
+      : {
+          dx: frame.rootMotion.dx - (previousAbsoluteRootMotion?.dx ?? 0),
+          dy: frame.rootMotion.dy - (previousAbsoluteRootMotion?.dy ?? 0),
+        }
+
+  return {
+    imageUrl: frame.imageUrl,
+    durationMs:
+      frame.durationMs !== null && frame.durationMs > 0 ? frame.durationMs : fallbackDurationMs,
+    rootMotion,
+    keyFrame: frameIndex === keyFrameIndex,
+  }
+}
+
+function createPreviewAction(action: Action): PreviewAction {
+  const fallbackDurationMs = getFallbackDurationMs(action.fps)
+  let previousAbsoluteRootMotion: Frame['rootMotion'] = null
+  const frames = action.frames.map((frame, frameIndex) => {
+    const previewFrame = createPreviewFrame(
+      frame,
+      frameIndex,
+      action.keyFrameIndex,
+      fallbackDurationMs,
+      previousAbsoluteRootMotion,
+    )
+    if (frame.rootMotion !== null) previousAbsoluteRootMotion = frame.rootMotion
+    return previewFrame
+  })
+  const sequences: readonly PreviewSequence[] = [{ direction: 'default', frames }]
+
+  return {
+    id: action.id,
+    name: action.name,
+    // #70 用 custom 承载尚未进入内置枚举的动作；Playtest 只在本地识别下蹲控制语义。
+    type:
+      action.type === 'custom' && /(?:crouch|下蹲|蹲伏)/iu.test(action.name)
+        ? 'crouch'
+        : action.type,
+    fps: action.fps,
+    sequences,
+  }
+}
+
+function createModel(
+  character: Character,
+  outfit: Character['outfits'][number],
+): PlaytestPreviewModel {
+  return {
+    characterId: character.id,
+    characterName: character.id,
+    outfitId: outfit.id,
+    outfitName: outfit.name,
+    characterTemplateUrl: outfit.characterTemplateUrl,
+    baseFrameCount: outfit.baseFrames.length,
+    actions: outfit.actions.map(createPreviewAction),
+  }
+}
+
+export function createPreviewModel(character: Character, outfitId: string): PreviewModelResult {
+  const outfit = character.outfits.find((candidate) => candidate.id === outfitId)
+
+  if (!outfit) return { ok: false, reason: 'outfit_not_found' }
+
+  return { ok: true, model: createModel(character, outfit) }
+}

--- a/frontend/src/pages/playtest/workbench/model/types.ts
+++ b/frontend/src/pages/playtest/workbench/model/types.ts
@@ -1,0 +1,45 @@
+import type { ActionType, Frame } from '@/entities/character'
+
+/**
+ * Playtest 需要识别的控制动作。
+ *
+ * `crouch` 暂时只属于预览控制语义，不借此修改 Character 的公共数据合同。
+ */
+export type PlaytestActionType = ActionType | 'crouch'
+/** #70 暂未定义多方向存储；正式资产进入预览时统一映射为 default。 */
+export type PlaytestDirection = string
+
+export interface PreviewFrame {
+  imageUrl: string
+  durationMs: number
+  /** 从实体的“相对首帧位移”换算出的逐帧增量，仅供预览运动使用。 */
+  rootMotion: Frame['rootMotion']
+  keyFrame: boolean
+}
+
+export interface PreviewSequence {
+  direction: PlaytestDirection
+  frames: readonly PreviewFrame[]
+}
+
+export interface PreviewAction {
+  id: string
+  name: string
+  type: PlaytestActionType
+  fps: number
+  sequences: readonly PreviewSequence[]
+}
+
+export interface PlaytestPreviewModel {
+  characterId: string
+  characterName: string
+  outfitId: string
+  outfitName: string
+  characterTemplateUrl: string | null
+  baseFrameCount: number
+  actions: readonly PreviewAction[]
+}
+
+export type PreviewModelResult =
+  | { ok: true; model: PlaytestPreviewModel }
+  | { ok: false; reason: 'outfit_not_found' }

--- a/frontend/src/pages/playtest/workbench/playback-controls.tsx
+++ b/frontend/src/pages/playtest/workbench/playback-controls.tsx
@@ -1,0 +1,94 @@
+export interface PlaybackControlsProps {
+  playing: boolean
+  loop: boolean
+  frameIndex: number
+  frameCount: number
+  fps: number
+  jumpAvailable: boolean
+  crouchAvailable: boolean
+  onFirstFrame(): void
+  onPreviousFrame(): void
+  onTogglePlaying(): void
+  onNextFrame(): void
+  onLastFrame(): void
+  onToggleLoop(): void
+}
+
+interface ControlButtonProps {
+  label: string
+  text: string
+  disabled?: boolean
+  onPress(): void
+}
+
+function ControlButton({ label, text, disabled = false, onPress }: ControlButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      disabled={disabled}
+      onClick={onPress}
+      className="grid h-9 w-9 place-items-center rounded-md border border-white/15 bg-white/6 text-sm text-white hover:bg-white/12 disabled:cursor-not-allowed disabled:opacity-35"
+    >
+      {text}
+    </button>
+  )
+}
+
+export function PlaybackControls({
+  playing,
+  loop,
+  frameIndex,
+  frameCount,
+  fps,
+  jumpAvailable,
+  crouchAvailable,
+  onFirstFrame,
+  onPreviousFrame,
+  onTogglePlaying,
+  onNextFrame,
+  onLastFrame,
+  onToggleLoop,
+}: PlaybackControlsProps) {
+  const disabled = frameCount === 0
+  const keyboardStatus = `跳跃${jumpAvailable ? '可用' : '不可用'}，下蹲${crouchAvailable ? '可用' : '不可用'}`
+
+  return (
+    <section
+      aria-label="播放控制"
+      className="flex min-h-12 flex-wrap items-center gap-1.5 rounded-lg bg-[#252a27] px-2 py-1.5 text-white"
+    >
+      <span className="sr-only">{keyboardStatus}</span>
+      <ControlButton label="第一帧" text="|‹" disabled={disabled} onPress={onFirstFrame} />
+      <ControlButton label="上一帧" text="‹" disabled={disabled} onPress={onPreviousFrame} />
+      <button
+        type="button"
+        aria-label={playing ? '暂停' : '播放'}
+        disabled={disabled}
+        onClick={onTogglePlaying}
+        className="grid h-9 w-12 place-items-center rounded-md bg-[#dce9df] text-sm font-semibold text-[#24402d] hover:bg-[#cce0d1] disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <span aria-hidden="true">{playing ? 'Ⅱ' : '▶'}</span>
+      </button>
+      <ControlButton label="下一帧" text="›" disabled={disabled} onPress={onNextFrame} />
+      <ControlButton label="最后一帧" text="›|" disabled={disabled} onPress={onLastFrame} />
+      <span className="ml-1 border-l border-white/15 pl-2 text-[11px] tabular-nums text-white/80">
+        {frameCount === 0
+          ? '00 / 00'
+          : `${String(frameIndex + 1).padStart(2, '0')} / ${String(frameCount).padStart(2, '0')}`}
+      </span>
+      <span className="ml-auto text-[9px] font-semibold text-white/45">{fps || '—'} FPS</span>
+      <button
+        type="button"
+        aria-label="循环播放"
+        aria-pressed={loop}
+        onClick={onToggleLoop}
+        className={`grid h-9 w-9 place-items-center rounded-md border text-base ${
+          loop ? 'border-[#a7c5ae] bg-[#dce9df] text-[#24402d]' : 'border-white/15 text-white/55'
+        }`}
+      >
+        <span aria-hidden="true">↻</span>
+      </button>
+    </section>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/playback/playback-state.test.ts
+++ b/frontend/src/pages/playtest/workbench/playback/playback-state.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PreviewAction } from '../model/types'
+import {
+  createPlaybackState,
+  firstFrame,
+  lastFrame,
+  nextFrame,
+  playActionType,
+  previousFrame,
+  selectAction,
+  selectDirection,
+  selectFrame,
+  toggleLoop,
+} from './playback-state'
+import * as playbackState from './playback-state'
+
+const actions: readonly PreviewAction[] = [
+  {
+    id: 'walk',
+    name: 'Walk',
+    type: 'walk',
+    fps: 12,
+    sequences: [
+      {
+        direction: 'south',
+        frames: [
+          {
+            imageUrl: '/walk-s-0.png',
+            durationMs: 80,
+            rootMotion: null,
+            keyFrame: true,
+          },
+          {
+            imageUrl: '/walk-s-1.png',
+            durationMs: 160,
+            rootMotion: null,
+            keyFrame: false,
+          },
+          {
+            imageUrl: '/walk-s-2.png',
+            durationMs: 120,
+            rootMotion: null,
+            keyFrame: false,
+          },
+        ],
+      },
+      {
+        direction: 'north',
+        frames: [
+          {
+            imageUrl: '/walk-n-0.png',
+            durationMs: 100,
+            rootMotion: null,
+            keyFrame: true,
+          },
+          {
+            imageUrl: '/walk-n-1.png',
+            durationMs: 100,
+            rootMotion: null,
+            keyFrame: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'idle',
+    name: 'Idle',
+    type: 'idle',
+    fps: 10,
+    sequences: [
+      {
+        direction: 'default',
+        frames: [
+          {
+            imageUrl: '/idle-0.png',
+            durationMs: 100,
+            rootMotion: null,
+            keyFrame: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'jump',
+    name: 'Jump',
+    type: 'jump',
+    fps: 10,
+    sequences: [
+      {
+        direction: 'default',
+        frames: [
+          {
+            imageUrl: '/jump-0.png',
+            durationMs: 100,
+            rootMotion: { dx: 0, dy: 12 },
+            keyFrame: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'crouch',
+    name: 'Crouch',
+    type: 'crouch',
+    fps: 10,
+    sequences: [
+      {
+        direction: 'default',
+        frames: [
+          {
+            imageUrl: '/crouch-0.png',
+            durationMs: 100,
+            rootMotion: null,
+            keyFrame: true,
+          },
+        ],
+      },
+    ],
+  },
+]
+
+describe('playback state', () => {
+  it('initializes the requested action at its first direction and frame', () => {
+    // Catches a regression where initial selection uses a later action, direction, or frame.
+    expect(createPlaybackState(actions, 'walk')).toEqual({
+      actionId: 'walk',
+      direction: 'south',
+      frameIndex: 0,
+      playing: false,
+      loop: true,
+    })
+  })
+
+  it('switches action or direction by pausing and returning to frame zero', () => {
+    // Catches selection preserving stale playback position or playing state.
+    const playingWalk = { ...createPlaybackState(actions, 'walk'), frameIndex: 2, playing: true }
+    const selectedAction = selectAction(playingWalk, actions, 'idle')
+    const selectedDirection = selectDirection({ ...playingWalk, playing: true }, actions, 'north')
+
+    expect(selectedAction).toMatchObject({
+      actionId: 'idle',
+      direction: 'default',
+      frameIndex: 0,
+      playing: false,
+    })
+    expect(selectedDirection).toMatchObject({
+      actionId: 'walk',
+      direction: 'north',
+      frameIndex: 0,
+      playing: false,
+    })
+  })
+
+  it('pauses when a frame is selected manually', () => {
+    // Catches a manual scrub continuing the old timer-driven animation.
+    const state = selectFrame(
+      { ...createPlaybackState(actions, 'walk'), playing: true },
+      actions,
+      2,
+    )
+
+    expect(state).toMatchObject({ frameIndex: 2, playing: false })
+  })
+
+  it('clamps at non-looping frame boundaries', () => {
+    // Catches non-loop playback wrapping around instead of stopping at the selected edge.
+    const start = { ...createPlaybackState(actions, 'walk'), loop: false }
+    const end = { ...start, frameIndex: 2, playing: true }
+
+    expect(previousFrame(start, actions)).toMatchObject({ frameIndex: 0, playing: false })
+    expect(nextFrame(end, actions)).toMatchObject({ frameIndex: 2, playing: false })
+    expect(firstFrame(end, actions)).toMatchObject({ frameIndex: 0, playing: false })
+    expect(lastFrame(start, actions)).toMatchObject({ frameIndex: 2, playing: false })
+  })
+
+  it('wraps at looping frame boundaries', () => {
+    // Catches looping playback sticking on the first or last frame.
+    const looped = toggleLoop({ ...createPlaybackState(actions, 'walk'), loop: false })
+
+    expect(previousFrame(looped, actions)).toMatchObject({ frameIndex: 2, playing: false })
+    expect(nextFrame({ ...looped, frameIndex: 2 }, actions)).toMatchObject({
+      frameIndex: 0,
+      playing: false,
+    })
+  })
+
+  it('returns a safe inactive state for an empty action collection', () => {
+    // Catches empty preview data dereferencing a missing action or sequence.
+    const state = createPlaybackState([], 'walk')
+
+    expect(state).toEqual({
+      actionId: null,
+      direction: null,
+      frameIndex: 0,
+      playing: false,
+      loop: true,
+    })
+    expect(nextFrame(state, [])).toEqual(state)
+    expect(selectAction(state, [], 'walk')).toEqual(state)
+  })
+
+  it('starts a playable action type at frame zero without changing the loop setting', () => {
+    // Catches W/S preserving a stale frame, pausing the target action, or silently changing loop.
+    const walk = { ...createPlaybackState(actions, 'walk'), frameIndex: 2, loop: false }
+    const jumping = playActionType(walk, actions, 'jump')
+    const crouching = playActionType(jumping, actions, 'crouch')
+
+    expect(jumping).toMatchObject({
+      actionId: 'jump',
+      direction: 'default',
+      frameIndex: 0,
+      playing: true,
+      loop: false,
+    })
+    expect(crouching).toMatchObject({
+      actionId: 'crouch',
+      direction: 'default',
+      frameIndex: 0,
+      playing: true,
+      loop: false,
+    })
+  })
+
+  it('continues a playable current walk without resetting its direction, frame, or loop', () => {
+    // Catches A/D restarting an already selected walk instead of only resuming its playback.
+    const current = {
+      ...createPlaybackState(actions, 'walk'),
+      direction: 'north' as const,
+      frameIndex: 1,
+      playing: false,
+      loop: false,
+    }
+    const continueActionType = (
+      playbackState as typeof playbackState & {
+        continueActionType?: typeof playActionType
+      }
+    ).continueActionType
+
+    expect(continueActionType).toBeTypeOf('function')
+    expect(continueActionType?.(current, actions, 'walk')).toEqual({ ...current, playing: true })
+  })
+
+  it('starts the first playable walk from its first frame when the current action is not walk', () => {
+    // Catches A/D trying to resume a non-walk action or selecting a walk sequence with no frames.
+    const current = { ...createPlaybackState(actions, 'idle'), frameIndex: 0, loop: false }
+    const continueActionType = (
+      playbackState as typeof playbackState & {
+        continueActionType?: typeof playActionType
+      }
+    ).continueActionType
+
+    expect(continueActionType?.(current, actions, 'walk')).toMatchObject({
+      actionId: 'walk',
+      direction: 'south',
+      frameIndex: 0,
+      playing: true,
+      loop: false,
+    })
+  })
+
+  it('starts the first non-empty sequence of the first playable walk', () => {
+    // Catches A/D selecting an empty first direction even though the chosen walk has playable frames.
+    const actionsWithEmptyFirstWalkSequence: readonly PreviewAction[] = [
+      {
+        ...actions[0],
+        sequences: [{ direction: 'south', frames: [] }, actions[0].sequences[1]],
+      },
+      ...actions.slice(1),
+    ]
+    const continueActionType = (
+      playbackState as typeof playbackState & {
+        continueActionType?: typeof playActionType
+      }
+    ).continueActionType
+
+    expect(
+      continueActionType?.(
+        createPlaybackState(actionsWithEmptyFirstWalkSequence, 'idle'),
+        actionsWithEmptyFirstWalkSequence,
+        'walk',
+      ),
+    ).toMatchObject({ actionId: 'walk', direction: 'north', frameIndex: 0, playing: true })
+  })
+
+  it('keeps the exact playback state when an action type has no playable frames', () => {
+    // Catches a missing W/S target clearing or replacing the action currently under inspection.
+    const current = { ...createPlaybackState(actions, 'walk'), frameIndex: 1 }
+
+    expect(playActionType(current, actions, 'attack')).toBe(current)
+  })
+
+  it('keeps the exact playback state when a matching action has only empty sequences', () => {
+    // Catches type lookup selecting an action that exists but cannot show any frame.
+    const current = { ...createPlaybackState(actions, 'walk'), frameIndex: 1, playing: true }
+    const actionsWithEmptyAttack: readonly PreviewAction[] = [
+      ...actions,
+      {
+        id: 'attack-empty',
+        name: 'Attack',
+        type: 'attack',
+        fps: 10,
+        sequences: [{ direction: 'default', frames: [] }],
+      },
+    ]
+
+    expect(playActionType(current, actionsWithEmptyAttack, 'attack')).toBe(current)
+  })
+
+  it('chooses the first playable action when several actions share a type', () => {
+    // Catches type lookup choosing a later matching action instead of the source-order first match.
+    const actionsWithSecondJump: readonly PreviewAction[] = [
+      ...actions,
+      {
+        id: 'jump-second',
+        name: 'Second jump',
+        type: 'jump',
+        fps: 10,
+        sequences: [
+          {
+            direction: 'default',
+            frames: [
+              {
+                imageUrl: '/jump-second-0.png',
+                durationMs: 100,
+                rootMotion: null,
+                keyFrame: true,
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    expect(
+      playActionType(createPlaybackState(actions, 'walk'), actionsWithSecondJump, 'jump'),
+    ).toMatchObject({ actionId: 'jump', direction: 'default', frameIndex: 0, playing: true })
+  })
+})

--- a/frontend/src/pages/playtest/workbench/playback/playback-state.ts
+++ b/frontend/src/pages/playtest/workbench/playback/playback-state.ts
@@ -1,0 +1,155 @@
+import type {
+  PlaytestActionType,
+  PlaytestDirection,
+  PreviewAction,
+  PreviewSequence,
+} from '../model/types'
+
+export interface PlaybackState {
+  actionId: string | null
+  direction: PlaytestDirection | null
+  frameIndex: number
+  playing: boolean
+  loop: boolean
+}
+
+export function selectedAction(
+  actions: readonly PreviewAction[],
+  actionId: string | null,
+): PreviewAction | null {
+  return actions.find((action) => action.id === actionId) ?? null
+}
+
+export function selectedSequence(
+  actions: readonly PreviewAction[],
+  state: PlaybackState,
+): PreviewSequence | null {
+  const action = selectedAction(actions, state.actionId)
+  return action?.sequences.find((sequence) => sequence.direction === state.direction) ?? null
+}
+
+function initialStateFor(action: PreviewAction | null, loop: boolean): PlaybackState {
+  return {
+    actionId: action?.id ?? null,
+    direction: action?.sequences[0]?.direction ?? null,
+    frameIndex: 0,
+    playing: false,
+    loop,
+  }
+}
+
+function initialPlayableStateFor(action: PreviewAction, loop: boolean): PlaybackState {
+  const sequence = action.sequences.find((candidate) => candidate.frames.length > 0)
+  return {
+    actionId: action.id,
+    direction: sequence?.direction ?? null,
+    frameIndex: 0,
+    playing: true,
+    loop,
+  }
+}
+
+function frameCount(actions: readonly PreviewAction[], state: PlaybackState): number {
+  return selectedSequence(actions, state)?.frames.length ?? 0
+}
+
+export function createPlaybackState(
+  actions: readonly PreviewAction[],
+  initialActionId: string | null,
+): PlaybackState {
+  return initialStateFor(selectedAction(actions, initialActionId) ?? actions[0] ?? null, true)
+}
+
+export function selectAction(
+  state: PlaybackState,
+  actions: readonly PreviewAction[],
+  actionId: string,
+): PlaybackState {
+  const action = selectedAction(actions, actionId)
+  return action === null ? state : initialStateFor(action, state.loop)
+}
+
+export function playActionType(
+  state: PlaybackState,
+  actions: readonly PreviewAction[],
+  type: PlaytestActionType,
+): PlaybackState {
+  const action = actions.find(
+    (candidate) =>
+      candidate.type === type && candidate.sequences.some((sequence) => sequence.frames.length > 0),
+  )
+  return action === undefined ? state : initialPlayableStateFor(action, state.loop)
+}
+
+export function continueActionType(
+  state: PlaybackState,
+  actions: readonly PreviewAction[],
+  type: PlaytestActionType,
+): PlaybackState {
+  const action = selectedAction(actions, state.actionId)
+  if (action?.type === type && frameCount(actions, state) > 0) {
+    return { ...state, playing: true }
+  }
+
+  return playActionType(state, actions, type)
+}
+
+export function selectDirection(
+  state: PlaybackState,
+  actions: readonly PreviewAction[],
+  direction: PlaytestDirection,
+): PlaybackState {
+  const action = selectedAction(actions, state.actionId)
+  if (action?.sequences.some((sequence) => sequence.direction === direction) !== true) return state
+
+  return { ...state, direction, frameIndex: 0, playing: false }
+}
+
+export function selectFrame(
+  state: PlaybackState,
+  actions: readonly PreviewAction[],
+  index: number,
+): PlaybackState {
+  const count = frameCount(actions, state)
+  if (count === 0) return { ...state, frameIndex: 0, playing: false }
+
+  return { ...state, frameIndex: Math.min(Math.max(index, 0), count - 1), playing: false }
+}
+
+export function previousFrame(
+  state: PlaybackState,
+  actions: readonly PreviewAction[],
+): PlaybackState {
+  const count = frameCount(actions, state)
+  if (count === 0) return { ...state, frameIndex: 0, playing: false }
+  if (state.frameIndex > 0) return { ...state, frameIndex: state.frameIndex - 1, playing: false }
+  return { ...state, frameIndex: state.loop ? count - 1 : 0, playing: false }
+}
+
+export function nextFrame(state: PlaybackState, actions: readonly PreviewAction[]): PlaybackState {
+  const count = frameCount(actions, state)
+  if (count === 0) return { ...state, frameIndex: 0, playing: false }
+  if (state.frameIndex < count - 1)
+    return { ...state, frameIndex: state.frameIndex + 1, playing: false }
+  return { ...state, frameIndex: state.loop ? 0 : count - 1, playing: false }
+}
+
+export function firstFrame(state: PlaybackState, actions: readonly PreviewAction[]): PlaybackState {
+  return selectFrame(state, actions, 0)
+}
+
+export function lastFrame(state: PlaybackState, actions: readonly PreviewAction[]): PlaybackState {
+  return selectFrame(state, actions, frameCount(actions, state) - 1)
+}
+
+export function togglePlaying(
+  state: PlaybackState,
+  actions: readonly PreviewAction[],
+): PlaybackState {
+  if (frameCount(actions, state) === 0) return { ...state, playing: false }
+  return { ...state, playing: !state.playing }
+}
+
+export function toggleLoop(state: PlaybackState): PlaybackState {
+  return { ...state, loop: !state.loop }
+}

--- a/frontend/src/pages/playtest/workbench/playback/use-playback-controller.test.tsx
+++ b/frontend/src/pages/playtest/workbench/playback/use-playback-controller.test.tsx
@@ -1,0 +1,300 @@
+/** @vitest-environment jsdom */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { PreviewAction } from '../model/types'
+import { type PlaybackController, usePlaybackController } from './use-playback-controller'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const actions: readonly PreviewAction[] = [
+  {
+    id: 'walk',
+    name: 'Walk',
+    type: 'walk',
+    fps: 12,
+    sequences: [
+      {
+        direction: 'south',
+        frames: [
+          {
+            imageUrl: '/walk-0.png',
+            durationMs: 80,
+            rootMotion: null,
+            keyFrame: true,
+          },
+          {
+            imageUrl: '/walk-1.png',
+            durationMs: 160,
+            rootMotion: null,
+            keyFrame: false,
+          },
+          {
+            imageUrl: '/walk-2.png',
+            durationMs: 120,
+            rootMotion: null,
+            keyFrame: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'idle',
+    name: 'Idle',
+    type: 'idle',
+    fps: 10,
+    sequences: [
+      {
+        direction: 'default',
+        frames: [
+          {
+            imageUrl: '/idle-0.png',
+            durationMs: 100,
+            rootMotion: null,
+            keyFrame: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'jump',
+    name: 'Jump',
+    type: 'jump',
+    fps: 10,
+    sequences: [
+      {
+        direction: 'default',
+        frames: [
+          {
+            imageUrl: '/jump-0.png',
+            durationMs: 100,
+            rootMotion: { dx: 0, dy: 12 },
+            keyFrame: true,
+          },
+        ],
+      },
+    ],
+  },
+]
+
+interface MountedController {
+  readonly controller: PlaybackController
+  unmount(): void
+}
+
+function mountController(initialActionId = 'walk'): MountedController {
+  const host = document.createElement('div')
+  const root: Root = createRoot(host)
+  let controller: PlaybackController | null = null
+
+  function Probe() {
+    controller = usePlaybackController(actions, initialActionId)
+    return null
+  }
+
+  act(() => {
+    root.render(<Probe />)
+  })
+
+  return {
+    get controller() {
+      if (controller === null) throw new Error('controller was not rendered')
+      return controller
+    },
+    unmount() {
+      act(() => {
+        root.unmount()
+      })
+    },
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('usePlaybackController', () => {
+  it('plays the first playable action of a requested type without changing loop mode', () => {
+    // Catches typed shortcuts preserving stale position, pausing the target, or changing loop mode.
+    const mounted = mountController()
+
+    act(() => {
+      mounted.controller.toggleLoop()
+      mounted.controller.selectFrame(2)
+      mounted.controller.playActionType('jump')
+    })
+
+    expect(mounted.controller.state).toMatchObject({
+      actionId: 'jump',
+      direction: 'default',
+      frameIndex: 0,
+      playing: true,
+      loop: false,
+    })
+
+    const current = mounted.controller.state
+    act(() => {
+      mounted.controller.playActionType('attack')
+    })
+    expect(mounted.controller.state).toBe(current)
+    mounted.unmount()
+  })
+
+  it('exposes walk continuation that resumes the current walk without resetting playback position', () => {
+    // Catches keyboard direction controls being forced through the restart-only action command.
+    const mounted = mountController()
+
+    act(() => {
+      mounted.controller.selectFrame(2)
+      mounted.controller.toggleLoop()
+    })
+
+    const controller = mounted.controller as PlaybackController & {
+      continueActionType?: (type: 'walk') => void
+    }
+    expect(controller.continueActionType).toBeTypeOf('function')
+    act(() => {
+      controller.continueActionType?.('walk')
+    })
+
+    expect(mounted.controller.state).toMatchObject({
+      actionId: 'walk',
+      direction: 'south',
+      frameIndex: 2,
+      playing: true,
+      loop: false,
+    })
+    mounted.unmount()
+  })
+
+  it('increments frameTick for every timed advance, including a single-frame loop', () => {
+    // Catches stage motion missing a loop iteration because its visible frame index remains zero.
+    vi.useFakeTimers()
+    const mounted = mountController()
+    const controller = mounted.controller as PlaybackController & { frameTick?: number }
+
+    expect(controller.frameTick).toBe(0)
+    act(() => {
+      mounted.controller.selectAction('idle')
+      mounted.controller.togglePlaying()
+    })
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+
+    expect(mounted.controller.state).toMatchObject({
+      actionId: 'idle',
+      frameIndex: 0,
+      playing: true,
+    })
+    expect((mounted.controller as PlaybackController & { frameTick?: number }).frameTick).toBe(1)
+    mounted.unmount()
+  })
+
+  it('waits for each current-frame duration before advancing', () => {
+    // Catches fixed-interval scheduling that skips the current frame's actual duration.
+    vi.useFakeTimers()
+    const mounted = mountController()
+
+    act(() => {
+      mounted.controller.togglePlaying()
+    })
+    act(() => {
+      vi.advanceTimersByTime(79)
+    })
+    expect(mounted.controller.state.frameIndex).toBe(0)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(mounted.controller.state.frameIndex).toBe(1)
+
+    act(() => {
+      vi.advanceTimersByTime(159)
+    })
+    expect(mounted.controller.state.frameIndex).toBe(1)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(mounted.controller.state.frameIndex).toBe(2)
+    mounted.unmount()
+  })
+
+  it('clears playback when paused or when its action changes', () => {
+    // Catches old timers advancing a manually paused or newly selected action.
+    vi.useFakeTimers()
+    const mounted = mountController()
+
+    act(() => {
+      mounted.controller.togglePlaying()
+      mounted.controller.togglePlaying()
+      vi.advanceTimersByTime(500)
+    })
+    expect(mounted.controller.state).toMatchObject({
+      actionId: 'walk',
+      frameIndex: 0,
+      playing: false,
+    })
+
+    act(() => {
+      mounted.controller.togglePlaying()
+      mounted.controller.selectAction('idle')
+      vi.advanceTimersByTime(500)
+    })
+    expect(mounted.controller.state).toMatchObject({
+      actionId: 'idle',
+      frameIndex: 0,
+      playing: false,
+    })
+    mounted.unmount()
+  })
+
+  it('restarts the current-frame timeout when loop changes', () => {
+    // Catches a pending timeout surviving a loop-mode change near the frame boundary.
+    vi.useFakeTimers()
+    const mounted = mountController()
+
+    act(() => {
+      mounted.controller.togglePlaying()
+    })
+    act(() => {
+      vi.advanceTimersByTime(80)
+    })
+    act(() => {
+      vi.advanceTimersByTime(159)
+    })
+    expect(mounted.controller.state.frameIndex).toBe(1)
+
+    act(() => {
+      mounted.controller.toggleLoop()
+    })
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(mounted.controller.state.frameIndex).toBe(1)
+
+    act(() => {
+      vi.advanceTimersByTime(159)
+    })
+    expect(mounted.controller.state.frameIndex).toBe(2)
+    mounted.unmount()
+  })
+
+  it('cleans up a scheduled timeout when unmounted', () => {
+    // Catches a timeout retaining the controller after its React tree is gone.
+    vi.useFakeTimers()
+    const mounted = mountController()
+
+    act(() => {
+      mounted.controller.togglePlaying()
+    })
+    expect(vi.getTimerCount()).toBe(1)
+
+    mounted.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/frontend/src/pages/playtest/workbench/playback/use-playback-controller.ts
+++ b/frontend/src/pages/playtest/workbench/playback/use-playback-controller.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type {
+  PlaytestActionType,
+  PlaytestDirection,
+  PreviewAction,
+  PreviewFrame,
+  PreviewSequence,
+} from '../model/types'
+import {
+  createPlaybackState,
+  continueActionType,
+  firstFrame,
+  lastFrame,
+  nextFrame,
+  playActionType,
+  previousFrame,
+  selectAction,
+  selectDirection,
+  selectFrame,
+  selectedAction,
+  selectedSequence,
+  toggleLoop,
+  togglePlaying,
+  type PlaybackState,
+} from './playback-state'
+
+export interface PlaybackController {
+  state: PlaybackState
+  frameTick: number
+  action: PreviewAction | null
+  sequence: PreviewSequence | null
+  frame: PreviewFrame | null
+  playActionType(type: PlaytestActionType): void
+  continueActionType(type: PlaytestActionType): void
+  selectAction(actionId: string): void
+  selectDirection(direction: PlaytestDirection): void
+  selectFrame(index: number): void
+  previousFrame(): void
+  nextFrame(): void
+  firstFrame(): void
+  lastFrame(): void
+  togglePlaying(): void
+  toggleLoop(): void
+}
+
+export function usePlaybackController(
+  actions: readonly PreviewAction[],
+  initialActionId: string | null,
+): PlaybackController {
+  const [state, setState] = useState(() => createPlaybackState(actions, initialActionId))
+  const [frameTick, setFrameTick] = useState(0)
+  const action = selectedAction(actions, state.actionId)
+  const sequence = selectedSequence(actions, state)
+  const frame = sequence?.frames[state.frameIndex] ?? null
+
+  useEffect(() => {
+    if (!state.playing || frame === null) return
+
+    const timeoutId = window.setTimeout(() => {
+      const finalFrameIndex = (sequence?.frames.length ?? 1) - 1
+      if (state.loop || state.frameIndex < finalFrameIndex) {
+        setFrameTick((tick) => tick + 1)
+      }
+      setState((current) => {
+        const currentSequence = selectedSequence(actions, current)
+        const currentFinalFrameIndex = (currentSequence?.frames.length ?? 1) - 1
+        const advanced = nextFrame(current, actions)
+
+        if (!current.loop && current.frameIndex >= currentFinalFrameIndex) return advanced
+        return { ...advanced, playing: true }
+      })
+    }, frame.durationMs)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [actions, frame, sequence, state.frameIndex, state.loop, state.playing])
+
+  const chooseAction = useCallback(
+    (actionId: string) => {
+      setState((current) => selectAction(current, actions, actionId))
+    },
+    [actions],
+  )
+
+  const chooseActionType = useCallback(
+    (type: PlaytestActionType) => {
+      setState((current) => playActionType(current, actions, type))
+    },
+    [actions],
+  )
+
+  const continueAction = useCallback(
+    (type: PlaytestActionType) => {
+      setState((current) => continueActionType(current, actions, type))
+    },
+    [actions],
+  )
+
+  const chooseDirection = useCallback(
+    (direction: PlaytestDirection) => {
+      setState((current) => selectDirection(current, actions, direction))
+    },
+    [actions],
+  )
+
+  const chooseFrame = useCallback(
+    (index: number) => {
+      setState((current) => selectFrame(current, actions, index))
+    },
+    [actions],
+  )
+
+  const choosePreviousFrame = useCallback(() => {
+    setState((current) => previousFrame(current, actions))
+  }, [actions])
+
+  const chooseNextFrame = useCallback(() => {
+    setState((current) => nextFrame(current, actions))
+  }, [actions])
+
+  const chooseFirstFrame = useCallback(() => {
+    setState((current) => firstFrame(current, actions))
+  }, [actions])
+
+  const chooseLastFrame = useCallback(() => {
+    setState((current) => lastFrame(current, actions))
+  }, [actions])
+
+  const choosePlaying = useCallback(() => {
+    setState((current) => togglePlaying(current, actions))
+  }, [actions])
+
+  const chooseLoop = useCallback(() => {
+    setState((current) => toggleLoop(current))
+  }, [])
+
+  return {
+    state,
+    frameTick,
+    action,
+    sequence,
+    frame,
+    playActionType: chooseActionType,
+    continueActionType: continueAction,
+    selectAction: chooseAction,
+    selectDirection: chooseDirection,
+    selectFrame: chooseFrame,
+    previousFrame: choosePreviousFrame,
+    nextFrame: chooseNextFrame,
+    firstFrame: chooseFirstFrame,
+    lastFrame: chooseLastFrame,
+    togglePlaying: choosePlaying,
+    toggleLoop: chooseLoop,
+  }
+}

--- a/frontend/src/pages/playtest/workbench/stage-motion.test.tsx
+++ b/frontend/src/pages/playtest/workbench/stage-motion.test.tsx
@@ -1,0 +1,250 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { PreviewFrame } from './model/types'
+import { createStageMotionState, reduceStageMotion, useStageMotion } from './stage-motion'
+
+const movingFrame: PreviewFrame = {
+  imageUrl: 'https://cdn.example.test/walk.png',
+  durationMs: 100,
+  rootMotion: { dx: 4, dy: 3 },
+  keyFrame: false,
+}
+
+afterEach(cleanup)
+
+function MotionProbe({
+  frame,
+  playing,
+  frameTick,
+  resetKey,
+}: {
+  frame: PreviewFrame | null
+  playing: boolean
+  frameTick: number
+  resetKey: string
+}) {
+  const motion = useStageMotion({ frame, playing, frameTick, resetKey })
+
+  return (
+    <>
+      <output>{`${motion.offset.x},${motion.offset.y}`}</output>
+      <button type="button" onClick={() => motion.setMirrored(true)}>
+        向左
+      </button>
+      <button type="button" onClick={() => motion.setMirrored(false)}>
+        向右
+      </button>
+    </>
+  )
+}
+
+describe('stage motion', () => {
+  it('clamps at the right edge, turns left, and keeps moving inward', () => {
+    const bounded = reduceStageMotion(createStageMotionState(0), {
+      type: 'set-bounds',
+      bounds: { minX: -10, maxX: 10 },
+    })
+    const nearEdge = reduceStageMotion(bounded, {
+      type: 'consume-frame',
+      tick: 1,
+      rootMotion: { dx: 8, dy: 0 },
+    })
+    const hitEdge = reduceStageMotion(nearEdge, {
+      type: 'consume-frame',
+      tick: 2,
+      rootMotion: { dx: 4, dy: 0 },
+    })
+    const movedInward = reduceStageMotion(hitEdge, {
+      type: 'consume-frame',
+      tick: 3,
+      rootMotion: { dx: 3, dy: 0 },
+    })
+
+    expect(hitEdge).toMatchObject({ offset: { x: 10, y: 0 }, mirrored: true })
+    expect(movedInward).toMatchObject({ offset: { x: 7, y: 0 }, mirrored: true })
+  })
+
+  it('clamps at the left edge, turns right, and keeps moving inward', () => {
+    const bounded = reduceStageMotion(createStageMotionState(0), {
+      type: 'set-bounds',
+      bounds: { minX: -10, maxX: 10 },
+    })
+    const facingLeft = reduceStageMotion(bounded, { type: 'set-mirrored', mirrored: true })
+    const nearEdge = reduceStageMotion(facingLeft, {
+      type: 'consume-frame',
+      tick: 1,
+      rootMotion: { dx: 8, dy: 0 },
+    })
+    const hitEdge = reduceStageMotion(nearEdge, {
+      type: 'consume-frame',
+      tick: 2,
+      rootMotion: { dx: 4, dy: 0 },
+    })
+    const movedInward = reduceStageMotion(hitEdge, {
+      type: 'consume-frame',
+      tick: 3,
+      rootMotion: { dx: 3, dy: 0 },
+    })
+
+    expect(hitEdge).toMatchObject({ offset: { x: -10, y: 0 }, mirrored: false })
+    expect(movedInward).toMatchObject({ offset: { x: -7, y: 0 }, mirrored: false })
+  })
+
+  it('reclamps an existing position when the measured stage becomes narrower', () => {
+    const wide = reduceStageMotion(createStageMotionState(0), {
+      type: 'set-bounds',
+      bounds: { minX: -20, maxX: 20 },
+    })
+    const moved = reduceStageMotion(wide, {
+      type: 'consume-frame',
+      tick: 1,
+      rootMotion: { dx: 16, dy: 0 },
+    })
+    const narrowed = reduceStageMotion(moved, {
+      type: 'set-bounds',
+      bounds: { minX: -5, maxX: 5 },
+    })
+
+    expect(narrowed).toMatchObject({ offset: { x: 5, y: 0 }, mirrored: true })
+  })
+
+  it('adds each newly advanced playback tick once', () => {
+    // Catches a rerender applying a frame's incremental root motion more than once.
+    const first = reduceStageMotion(createStageMotionState(0), {
+      type: 'consume-frame',
+      tick: 1,
+      rootMotion: { dx: 4, dy: 3 },
+    })
+    const duplicate = reduceStageMotion(first, {
+      type: 'consume-frame',
+      tick: 1,
+      rootMotion: { dx: 4, dy: 3 },
+    })
+    const second = reduceStageMotion(duplicate, {
+      type: 'consume-frame',
+      tick: 2,
+      rootMotion: { dx: -1, dy: 2 },
+    })
+
+    expect(second.offset).toEqual({ x: 3, y: 5 })
+    expect(second.consumedTick).toBe(2)
+  })
+
+  it('uses a fresh loop tick to continue accumulating when playback returns to the first frame', () => {
+    // Catches loop wraps being mistaken for a duplicate frame and dropping their root-motion increment.
+    const afterFirstPass = reduceStageMotion(createStageMotionState(0), {
+      type: 'consume-frame',
+      tick: 1,
+      rootMotion: { dx: 2, dy: 0 },
+    })
+    const afterLoop = reduceStageMotion(afterFirstPass, {
+      type: 'consume-frame',
+      tick: 2,
+      rootMotion: { dx: 2, dy: 0 },
+    })
+
+    expect(afterLoop.offset).toEqual({ x: 4, y: 0 })
+  })
+
+  it('sets mirrored direction idempotently without resetting position and reverses future horizontal increments', () => {
+    // Catches repeated A/D presses flipping back to the opposite direction, resetting placement, or leaving mirrored locomotion moving right.
+    const movedRight = reduceStageMotion(createStageMotionState(0), {
+      type: 'consume-frame',
+      tick: 1,
+      rootMotion: { dx: 5, dy: 1 },
+    })
+    const mirrored = reduceStageMotion(movedRight, { type: 'set-mirrored', mirrored: true })
+    const mirroredAgain = reduceStageMotion(mirrored, { type: 'set-mirrored', mirrored: true })
+    const movedLeft = reduceStageMotion(mirroredAgain, {
+      type: 'consume-frame',
+      tick: 2,
+      rootMotion: { dx: 2, dy: 0 },
+    })
+    const restored = reduceStageMotion(movedLeft, { type: 'set-mirrored', mirrored: false })
+
+    expect(mirrored).toMatchObject({ offset: { x: 5, y: 1 }, mirrored: true })
+    expect(mirroredAgain).toMatchObject({ offset: { x: 5, y: 1 }, mirrored: true })
+    expect(movedLeft.offset).toEqual({ x: 3, y: 1 })
+    expect(restored).toMatchObject({ offset: { x: 3, y: 1 }, mirrored: false })
+  })
+
+  it('treats absent root motion as stationary', () => {
+    // Catches missing rootMotion producing a non-zero offset or erasing the accumulated position.
+    const moved = reduceStageMotion(createStageMotionState(0), {
+      type: 'consume-frame',
+      tick: 1,
+      rootMotion: movingFrame.rootMotion,
+    })
+    const stationary = reduceStageMotion(moved, {
+      type: 'consume-frame',
+      tick: 2,
+      rootMotion: null,
+    })
+
+    expect(stationary.offset).toEqual({ x: 4, y: 3 })
+  })
+
+  it('does not consume on start, resume, direction change, or same-tick rerenders', () => {
+    // Catches playback state changes applying the current frame before an automatic tick reaches its target frame.
+    const { rerender } = render(
+      <MotionProbe
+        frame={movingFrame}
+        playing={false}
+        frameTick={0}
+        resetKey="character-a:outfit-a"
+      />,
+    )
+
+    expect(screen.getByRole('status').textContent).toBe('0,0')
+
+    rerender(
+      <MotionProbe frame={movingFrame} playing frameTick={0} resetKey="character-a:outfit-a" />,
+    )
+    expect(screen.getByRole('status').textContent).toBe('0,0')
+
+    fireEvent.click(screen.getByRole('button', { name: '向左' }))
+    expect(screen.getByRole('status').textContent).toBe('0,0')
+
+    rerender(
+      <MotionProbe frame={movingFrame} playing frameTick={1} resetKey="character-a:outfit-a" />,
+    )
+    expect(screen.getByRole('status').textContent).toBe('-4,3')
+
+    rerender(
+      <MotionProbe
+        frame={{ ...movingFrame, rootMotion: { dx: 100, dy: 100 } }}
+        playing={false}
+        frameTick={1}
+        resetKey="character-a:outfit-a"
+      />,
+    )
+    rerender(
+      <MotionProbe
+        frame={{ ...movingFrame, rootMotion: { dx: 100, dy: 100 } }}
+        playing
+        frameTick={1}
+        resetKey="character-a:outfit-a"
+      />,
+    )
+    expect(screen.getByRole('status').textContent).toBe('-4,3')
+  })
+
+  it('uses the current tick as a reset baseline for a new character or outfit', () => {
+    // Catches a reset immediately consuming the new preview's current frame or retaining the old preview position.
+    const { rerender } = render(
+      <MotionProbe frame={movingFrame} playing frameTick={4} resetKey="character-a:outfit-a" />,
+    )
+
+    rerender(
+      <MotionProbe frame={movingFrame} playing frameTick={5} resetKey="character-a:outfit-a" />,
+    )
+    expect(screen.getByRole('status').textContent).toBe('4,3')
+
+    rerender(
+      <MotionProbe frame={movingFrame} playing frameTick={5} resetKey="character-b:outfit-a" />,
+    )
+    expect(screen.getByRole('status').textContent).toBe('0,0')
+  })
+})

--- a/frontend/src/pages/playtest/workbench/stage-motion.ts
+++ b/frontend/src/pages/playtest/workbench/stage-motion.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useReducer } from 'react'
+
+import type { FrameRootMotion } from '@/entities/character'
+
+import type { PreviewFrame } from './model/types'
+
+export interface StageOffset {
+  x: number
+  /** Positive values move the character upward in world coordinates. */
+  y: number
+}
+
+export interface HorizontalStageBounds {
+  minX: number
+  maxX: number
+}
+
+export interface StageMotionState {
+  offset: StageOffset
+  /** The latest automatic playback tick already reflected in offset. */
+  consumedTick: number
+  mirrored: boolean
+  bounds: HorizontalStageBounds | null
+}
+
+export type StageMotionAction =
+  | { type: 'consume-frame'; tick: number; rootMotion: FrameRootMotion | null }
+  | { type: 'set-mirrored'; mirrored: boolean }
+  | { type: 'set-bounds'; bounds: HorizontalStageBounds | null }
+  | { type: 'reset'; baselineTick: number }
+
+export function createStageMotionState(baselineTick = 0): StageMotionState {
+  return {
+    offset: { x: 0, y: 0 },
+    consumedTick: baselineTick,
+    mirrored: false,
+    bounds: null,
+  }
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum)
+}
+
+export function reduceStageMotion(
+  state: StageMotionState,
+  action: StageMotionAction,
+): StageMotionState {
+  if (action.type === 'reset') {
+    return { ...createStageMotionState(action.baselineTick), bounds: state.bounds }
+  }
+  if (action.type === 'set-mirrored') return { ...state, mirrored: action.mirrored }
+  if (action.type === 'set-bounds') {
+    if (action.bounds === null) return { ...state, bounds: null }
+
+    const minX = Math.min(action.bounds.minX, action.bounds.maxX)
+    const maxX = Math.max(action.bounds.minX, action.bounds.maxX)
+    const x = clamp(state.offset.x, minX, maxX)
+    const mirrored = state.offset.x > maxX ? true : state.offset.x < minX ? false : state.mirrored
+    return { ...state, offset: { ...state.offset, x }, mirrored, bounds: { minX, maxX } }
+  }
+  if (action.tick <= state.consumedTick) return state
+
+  const rootMotion = action.rootMotion ?? { dx: 0, dy: 0 }
+  const horizontalIncrement = state.mirrored ? -rootMotion.dx : rootMotion.dx
+  const candidateX = state.offset.x + horizontalIncrement
+  const nextX =
+    state.bounds === null ? candidateX : clamp(candidateX, state.bounds.minX, state.bounds.maxX)
+  const mirrored =
+    state.bounds === null || horizontalIncrement === 0
+      ? state.mirrored
+      : horizontalIncrement > 0 && candidateX >= state.bounds.maxX
+        ? true
+        : horizontalIncrement < 0 && candidateX <= state.bounds.minX
+          ? false
+          : state.mirrored
+  return {
+    ...state,
+    offset: {
+      x: nextX,
+      y: state.offset.y + rootMotion.dy,
+    },
+    mirrored,
+    consumedTick: action.tick,
+  }
+}
+
+export interface UseStageMotionInput {
+  frame: PreviewFrame | null
+  /** Only timed playback contributes root-motion increments. */
+  playing: boolean
+  /** Monotonically increases only when timed playback advances to a frame. */
+  frameTick: number
+  /** A character/outfit identity supplied by the owner of the preview. */
+  resetKey: string
+}
+
+export interface StageMotion {
+  offset: StageOffset
+  mirrored: boolean
+  setMirrored(mirrored: boolean): void
+  setBounds(bounds: HorizontalStageBounds | null): void
+}
+
+export function useStageMotion({
+  frame,
+  playing,
+  frameTick,
+  resetKey,
+}: UseStageMotionInput): StageMotion {
+  const [state, dispatch] = useReducer(reduceStageMotion, frameTick, createStageMotionState)
+
+  useEffect(() => {
+    dispatch({ type: 'reset', baselineTick: frameTick })
+    // resetKey deliberately captures the tick at the identity transition only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetKey])
+
+  useEffect(() => {
+    if (!playing || frame === null) return
+    dispatch({ type: 'consume-frame', tick: frameTick, rootMotion: frame.rootMotion })
+  }, [frame, frameTick, playing])
+
+  return {
+    offset: state.offset,
+    mirrored: state.mirrored,
+    setMirrored: useCallback(
+      (mirrored: boolean) => dispatch({ type: 'set-mirrored', mirrored }),
+      [],
+    ),
+    setBounds: useCallback(
+      (bounds: HorizontalStageBounds | null) => dispatch({ type: 'set-bounds', bounds }),
+      [],
+    ),
+  }
+}

--- a/frontend/src/pages/playtest/workbench/status-panel.tsx
+++ b/frontend/src/pages/playtest/workbench/status-panel.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react'
+
+export interface StatusPanelProps {
+  title: string
+  tone?: 'neutral' | 'success' | 'warning' | 'danger'
+  children: ReactNode
+}
+
+const toneClassNames = {
+  neutral: 'border-slate-200 bg-slate-50 text-slate-700',
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+  warning: 'border-amber-200 bg-amber-50 text-amber-900',
+  danger: 'border-rose-200 bg-rose-50 text-rose-900',
+} as const
+
+/**
+ * Playtest 内部状态提示，不作为 shared 公共组件向其他模块扩散。
+ */
+export function StatusPanel({ title, tone = 'neutral', children }: StatusPanelProps) {
+  return (
+    <section className={`rounded-xl border p-3 text-sm ${toneClassNames[tone]}`}>
+      <strong className="block text-xs">{title}</strong>
+      <div className="mt-1">{children}</div>
+    </section>
+  )
+}

--- a/frontend/src/pages/playtest/workbench/use-playtest-inspection.ts
+++ b/frontend/src/pages/playtest/workbench/use-playtest-inspection.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type {
+  PlaytestInspectionApis,
+  PlaytestInspectionStatus,
+  PlaytestInspectionTarget,
+} from '@/entities/playtest-inspection'
+
+interface PlaytestInspectionState {
+  status: PlaytestInspectionStatus | null
+  loading: boolean
+  saving: boolean
+  error: string | null
+}
+
+const EMPTY_STATE: PlaytestInspectionState = {
+  status: null,
+  loading: false,
+  saving: false,
+  error: null,
+}
+
+function errorMessage(cause: unknown, fallback: string): string {
+  return cause instanceof Error && cause.message.trim() ? cause.message : fallback
+}
+
+export function usePlaytestInspection(
+  apis: Pick<PlaytestInspectionApis, 'get' | 'save'> | undefined,
+  target: PlaytestInspectionTarget | null,
+) {
+  const [state, setState] = useState<PlaytestInspectionState>(EMPTY_STATE)
+  const operationId = useRef(0)
+
+  useEffect(() => {
+    const currentOperation = ++operationId.current
+    if (apis === undefined || target === null) {
+      setState(EMPTY_STATE)
+      return
+    }
+
+    let active = true
+    setState({ ...EMPTY_STATE, loading: true })
+    void apis.get(target).then(
+      (inspection) => {
+        if (active && operationId.current === currentOperation) {
+          setState({ ...EMPTY_STATE, status: inspection?.status ?? null })
+        }
+      },
+      (cause: unknown) => {
+        if (active && operationId.current === currentOperation) {
+          setState({
+            ...EMPTY_STATE,
+            error: errorMessage(cause, '核验记录读取失败'),
+          })
+        }
+      },
+    )
+
+    return () => {
+      active = false
+    }
+  }, [apis, target])
+
+  const save = useCallback(
+    async (status: PlaytestInspectionStatus) => {
+      if (apis === undefined || target === null) return
+
+      const currentOperation = ++operationId.current
+      setState((current) => ({ ...current, saving: true, error: null }))
+      try {
+        const inspection = await apis.save({ ...target, status })
+        if (operationId.current === currentOperation) {
+          setState({ ...EMPTY_STATE, status: inspection.status })
+        }
+      } catch (cause) {
+        if (operationId.current === currentOperation) {
+          setState((current) => ({
+            ...current,
+            saving: false,
+            error: errorMessage(cause, '核验记录保存失败'),
+          }))
+        }
+      }
+    },
+    [apis, target],
+  )
+
+  return { ...state, save, available: apis !== undefined && target !== null }
+}

--- a/frontend/src/pages/playtest/workbench/use-playtest-keyboard.test.tsx
+++ b/frontend/src/pages/playtest/workbench/use-playtest-keyboard.test.tsx
@@ -1,0 +1,265 @@
+/** @vitest-environment jsdom */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { type PlaytestKeyboardCommands, usePlaytestKeyboard } from './use-playtest-keyboard'
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+const mountedRoots = new Set<Root>()
+
+function createCommands(): PlaytestKeyboardCommands {
+  return {
+    togglePlaying: vi.fn(),
+    previousFrame: vi.fn(),
+    nextFrame: vi.fn(),
+    firstFrame: vi.fn(),
+    lastFrame: vi.fn(),
+    toggleLoop: vi.fn(),
+    playLeft: vi.fn(),
+    playRight: vi.fn(),
+    stopHorizontal: vi.fn(),
+    playJump: vi.fn(),
+    playCrouch: vi.fn(),
+  }
+}
+
+const shortcutKeys = [' ', 'ArrowLeft', 'ArrowRight', 'Home', 'End', 'L'] as const
+const interactiveShortcutKeys = [...shortcutKeys, 'a', 'D', 'w', 'S'] as const
+
+function dispatchKey(
+  key: string,
+  target: EventTarget = window,
+  options: KeyboardEventInit = {},
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key,
+    ...options,
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+function mountKeyboard(commands: PlaytestKeyboardCommands, enabled = true): () => void {
+  const host = document.createElement('div')
+  const root: Root = createRoot(host)
+
+  function Probe() {
+    usePlaytestKeyboard(commands, enabled)
+    return null
+  }
+
+  act(() => {
+    root.render(<Probe />)
+  })
+  mountedRoots.add(root)
+
+  return () => {
+    if (!mountedRoots.delete(root)) return
+
+    act(() => {
+      root.unmount()
+    })
+  }
+}
+
+afterEach(() => {
+  for (const root of mountedRoots) {
+    act(() => {
+      root.unmount()
+    })
+  }
+  mountedRoots.clear()
+  document.body.replaceChildren()
+})
+
+describe('usePlaytestKeyboard', () => {
+  it('maps the playback shortcuts to their commands', () => {
+    // Catches an incomplete or swapped shortcut map while the workbench is focused.
+    const commands = createCommands()
+    const unmount = mountKeyboard(commands)
+
+    const events = shortcutKeys.map((key) => dispatchKey(key))
+
+    expect(events.every((event) => event.defaultPrevented)).toBe(true)
+
+    expect(commands.togglePlaying).toHaveBeenCalledOnce()
+    expect(commands.previousFrame).toHaveBeenCalledOnce()
+    expect(commands.nextFrame).toHaveBeenCalledOnce()
+    expect(commands.firstFrame).toHaveBeenCalledOnce()
+    expect(commands.lastFrame).toHaveBeenCalledOnce()
+    expect(commands.toggleLoop).toHaveBeenCalledOnce()
+    unmount()
+  })
+
+  it('maps A/D to directional walk commands and W/S to action commands', () => {
+    // Catches A/D retaining their old frame-navigation semantics instead of selecting a walk direction.
+    const commands = createCommands()
+    const unmount = mountKeyboard(commands)
+
+    dispatchKey('a')
+    dispatchKey('D')
+    dispatchKey('w')
+    dispatchKey('S')
+
+    expect(commands.playLeft).toHaveBeenCalledOnce()
+    expect(commands.playRight).toHaveBeenCalledOnce()
+    expect(commands.playJump).toHaveBeenCalledOnce()
+    expect(commands.playCrouch).toHaveBeenCalledOnce()
+    unmount()
+  })
+
+  it('handles shortcuts dispatched from the body and ordinary elements', () => {
+    // Catches a missing editable ancestor being mistaken for an interactive editing surface.
+    const commands = createCommands()
+    const target = document.createElement('div')
+    document.body.append(target)
+    const unmount = mountKeyboard(commands)
+
+    const arrowEvent = dispatchKey('ArrowRight', document.body)
+    const spaceEvent = dispatchKey(' ', target)
+
+    expect(arrowEvent.defaultPrevented).toBe(true)
+    expect(spaceEvent.defaultPrevented).toBe(true)
+    expect(commands.nextFrame).toHaveBeenCalledOnce()
+    expect(commands.togglePlaying).toHaveBeenCalledOnce()
+    unmount()
+  })
+
+  it.each([
+    ['input', () => document.createElement('input')],
+    ['textarea', () => document.createElement('textarea')],
+    ['select', () => document.createElement('select')],
+    [
+      'contenteditable',
+      () => {
+        const element = document.createElement('div')
+        element.setAttribute('contenteditable', 'true')
+        return element
+      },
+    ],
+  ])('does not intercept any shortcut when focus is in %s', (_label, createElement) => {
+    // Catches global shortcuts stealing native control or text-editing input.
+    const commands = createCommands()
+    const target = createElement()
+    document.body.append(target)
+    const unmount = mountKeyboard(commands)
+
+    const events = interactiveShortcutKeys.map((key) => dispatchKey(key, target))
+
+    expect(events.every((event) => !event.defaultPrevented)).toBe(true)
+    expect(Object.values(commands).every((command) => !vi.mocked(command).mock.calls.length)).toBe(
+      true,
+    )
+    unmount()
+  })
+
+  it('keeps A/D/W/S active when a workbench button still owns focus', () => {
+    // Catches clicking Play/Pause leaving focus on its button and disabling the movement controls.
+    const commands = createCommands()
+    const button = document.createElement('button')
+    document.body.append(button)
+    const unmount = mountKeyboard(commands)
+
+    const actionEvents = ['a', 'D', 'w', 'S'].map((key) => dispatchKey(key, button))
+    const spaceEvent = dispatchKey(' ', button)
+
+    expect(actionEvents.every((event) => event.defaultPrevented)).toBe(true)
+    expect(spaceEvent.defaultPrevented).toBe(false)
+    expect(commands.playLeft).toHaveBeenCalledOnce()
+    expect(commands.playRight).toHaveBeenCalledOnce()
+    expect(commands.playJump).toHaveBeenCalledOnce()
+    expect(commands.playCrouch).toHaveBeenCalledOnce()
+    expect(commands.togglePlaying).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('ignores repeated toggle shortcuts while keeping frame navigation repeatable', () => {
+    // Catches a held Space or L key repeatedly flipping state while arrow/home/end retain key repeat.
+    const commands = createCommands()
+    const unmount = mountKeyboard(commands)
+
+    expect(dispatchKey(' ', window, { repeat: true }).defaultPrevented).toBe(true)
+    expect(dispatchKey('L', window, { repeat: true }).defaultPrevented).toBe(true)
+    dispatchKey('ArrowLeft', window, { repeat: true })
+    dispatchKey('ArrowRight', window, { repeat: true })
+    dispatchKey('Home', window, { repeat: true })
+    dispatchKey('End', window, { repeat: true })
+
+    expect(commands.togglePlaying).not.toHaveBeenCalled()
+    expect(commands.toggleLoop).not.toHaveBeenCalled()
+    expect(commands.previousFrame).toHaveBeenCalledOnce()
+    expect(commands.nextFrame).toHaveBeenCalledOnce()
+    expect(commands.firstFrame).toHaveBeenCalledOnce()
+    expect(commands.lastFrame).toHaveBeenCalledOnce()
+    unmount()
+  })
+
+  it('keeps A/D repeatable while ignoring repeated W/S action shortcuts', () => {
+    // Catches held action keys replaying while held navigation keys remain repeatable.
+    const commands = createCommands()
+    const unmount = mountKeyboard(commands)
+
+    dispatchKey('a', window, { repeat: true })
+    dispatchKey('D', window, { repeat: true })
+    expect(dispatchKey('w', window, { repeat: true }).defaultPrevented).toBe(true)
+    expect(dispatchKey('S', window, { repeat: true }).defaultPrevented).toBe(true)
+
+    expect(commands.playLeft).toHaveBeenCalledOnce()
+    expect(commands.playRight).toHaveBeenCalledOnce()
+    expect(commands.playJump).not.toHaveBeenCalled()
+    expect(commands.playCrouch).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('ends transient horizontal playback after the last held A/D key is released', () => {
+    // Catches held movement starting Walk without restoring the previous paused state on keyup.
+    const commands = createCommands()
+    const unmount = mountKeyboard(commands)
+
+    dispatchKey('d')
+    window.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, key: 'd' }))
+
+    expect(commands.playRight).toHaveBeenCalledOnce()
+    expect(commands.stopHorizontal).toHaveBeenCalledOnce()
+    unmount()
+  })
+
+  it('handles shortcuts when contenteditable is explicitly false', () => {
+    // Catches the attribute selector treating a non-editable element as an editor.
+    const commands = createCommands()
+    const target = document.createElement('div')
+    target.setAttribute('contenteditable', 'false')
+    document.body.append(target)
+    const unmount = mountKeyboard(commands)
+
+    const events = shortcutKeys.map((key) => dispatchKey(key, target))
+
+    expect(events.every((event) => event.defaultPrevented)).toBe(true)
+    expect(commands.togglePlaying).toHaveBeenCalledOnce()
+    expect(commands.previousFrame).toHaveBeenCalledOnce()
+    expect(commands.nextFrame).toHaveBeenCalledOnce()
+    expect(commands.firstFrame).toHaveBeenCalledOnce()
+    expect(commands.lastFrame).toHaveBeenCalledOnce()
+    expect(commands.toggleLoop).toHaveBeenCalledOnce()
+    unmount()
+  })
+
+  it('does not listen while disabled and removes its listener when unmounted', () => {
+    // Catches shortcuts escaping a disabled workbench or a detached React tree.
+    const commands = createCommands()
+    const disabledUnmount = mountKeyboard(commands, false)
+
+    expect(dispatchKey('ArrowRight').defaultPrevented).toBe(false)
+    expect(commands.nextFrame).not.toHaveBeenCalled()
+    disabledUnmount()
+
+    const unmount = mountKeyboard(commands)
+    unmount()
+    expect(dispatchKey('ArrowRight').defaultPrevented).toBe(false)
+    expect(commands.nextFrame).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/playtest/workbench/use-playtest-keyboard.ts
+++ b/frontend/src/pages/playtest/workbench/use-playtest-keyboard.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from 'react'
+
+export interface PlaytestKeyboardCommands {
+  togglePlaying(): void
+  previousFrame(): void
+  nextFrame(): void
+  firstFrame(): void
+  lastFrame(): void
+  toggleLoop(): void
+  playLeft(): void
+  playRight(): void
+  stopHorizontal(): void
+  playJump(): void
+  playCrouch(): void
+}
+
+function isTextEditingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+
+  if (target.closest('input, textarea, select') !== null) return true
+
+  const editableAncestor = target.closest('[contenteditable]')
+  return (
+    editableAncestor !== null &&
+    editableAncestor.getAttribute('contenteditable')?.toLowerCase() !== 'false'
+  )
+}
+
+function isButtonTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && target.closest('button') !== null
+}
+
+export function usePlaytestKeyboard(commands: PlaytestKeyboardCommands, enabled: boolean): void {
+  const heldHorizontalKeys = useRef(new Set<'a' | 'd'>())
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key
+      if (isTextEditingTarget(event.target)) return
+      if (isButtonTarget(event.target) && key !== 'a' && key !== 'd' && key !== 'w' && key !== 's')
+        return
+
+      const command = {
+        ' ': commands.togglePlaying,
+        ArrowLeft: commands.previousFrame,
+        ArrowRight: commands.nextFrame,
+        Home: commands.firstFrame,
+        End: commands.lastFrame,
+        l: commands.toggleLoop,
+        a: commands.playLeft,
+        d: commands.playRight,
+        w: commands.playJump,
+        s: commands.playCrouch,
+      }[key]
+
+      if (command === undefined) return
+
+      event.preventDefault()
+      if (event.repeat && (key === ' ' || key === 'l' || key === 'w' || key === 's')) {
+        return
+      }
+      if (key === 'a' || key === 'd') heldHorizontalKeys.current.add(key)
+      command()
+    }
+
+    const stopHorizontal = () => {
+      if (heldHorizontalKeys.current.size === 0) return
+      heldHorizontalKeys.current.clear()
+      commands.stopHorizontal()
+    }
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key
+      if (key !== 'a' && key !== 'd') return
+      if (!heldHorizontalKeys.current.delete(key)) return
+      event.preventDefault()
+      if (heldHorizontalKeys.current.size === 0) commands.stopHorizontal()
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    window.addEventListener('blur', stopHorizontal)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+      window.removeEventListener('blur', stopHorizontal)
+    }
+  }, [commands, enabled])
+}

--- a/frontend/src/shared/api/http-client.test.ts
+++ b/frontend/src/shared/api/http-client.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { del, get, post } from './http-client'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('http client request headers', () => {
+  it('does not force a CORS preflight for a bodyless GET request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await get('/projects')
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(new Headers(init.headers).has('Content-Type')).toBe(false)
+  })
+
+  it('marks a JSON request body with the correct content type', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await post('/projects', { name: 'Windup' })
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(new Headers(init.headers).get('Content-Type')).toBe('application/json')
+  })
+
+  it('accepts a successful delete with no response body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 204 })))
+
+    await expect(del('/characters/25')).resolves.toBeUndefined()
+  })
+
+  it('accepts a successful delete envelope whose data is null', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(null)))
+
+    await expect(del('/projects/3')).resolves.toBeUndefined()
+  })
+})
+
+function jsonResponse(data: unknown) {
+  return new Response(JSON.stringify({ code: 200, message: 'success', data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/frontend/src/shared/api/http-client.ts
+++ b/frontend/src/shared/api/http-client.ts
@@ -1,0 +1,101 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:8000'
+
+interface ApiEnvelope<T> {
+  code: number
+  message: string
+  data: T
+}
+
+export class ApiError extends Error {
+  /** HTTP 状态码。 */
+  readonly status: number
+  /** 业务码（与 HTTP 状态码分离）。 */
+  readonly code: number
+
+  constructor(status: number, code: number, message: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.code = code
+  }
+}
+
+async function executeRequest<T>(path: string, init: RequestInit | undefined, allowEmpty: boolean) {
+  const url = `${BASE_URL}${path}`
+  const headers = new Headers(init?.headers)
+
+  if (
+    init?.body !== undefined &&
+    init.body !== null &&
+    !headers.has('Content-Type') &&
+    !(init.body instanceof FormData)
+  ) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  const response = await fetch(url, { ...init, headers })
+
+  if (!response.ok) {
+    let code = response.status
+    let message = response.statusText
+    try {
+      const body = (await response.json()) as Partial<ApiEnvelope<unknown>>
+      if (body.code !== undefined) code = body.code
+      if (body.message) message = body.message
+    } catch {
+      // 响应体不是 JSON，保留默认错误信息
+    }
+    throw new ApiError(response.status, code, message)
+  }
+
+  if (allowEmpty && response.status === 204) return undefined as T
+
+  let envelope: ApiEnvelope<T>
+  try {
+    envelope = (await response.json()) as ApiEnvelope<T>
+  } catch {
+    throw new ApiError(response.status, response.status, '响应格式错误，无法解析 JSON')
+  }
+  if (envelope.data === null || envelope.data === undefined) {
+    if (allowEmpty) return undefined as T
+    throw new ApiError(
+      response.status,
+      envelope.code ?? response.status,
+      envelope.message || '服务端未返回数据',
+    )
+  }
+  return envelope.data
+}
+
+export function request<T>(path: string, init?: RequestInit): Promise<T> {
+  return executeRequest<T>(path, init, false)
+}
+
+export function get<T>(path: string): Promise<T> {
+  return request<T>(path)
+}
+
+export function post<T>(path: string, body: unknown): Promise<T> {
+  return request<T>(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+export function patch<T>(path: string, body: unknown): Promise<T> {
+  return request<T>(path, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  })
+}
+
+export function del(path: string): Promise<void> {
+  return executeRequest<void>(path, { method: 'DELETE' }, true)
+}
+
+export function upload<T>(path: string, formData: FormData): Promise<T> {
+  return request<T>(path, {
+    method: 'POST',
+    body: formData,
+  })
+}

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -1,0 +1,2 @@
+/** 通用 HTTP 能力。这里只处理传输协议，不包含项目、角色等业务映射。 */
+export { ApiError, del, get, patch, post, request, upload } from './http-client'


### PR DESCRIPTION
## 基线与范围

- 目标分支仅为 `main`
- 单提交，来源为个人 Fork，不依赖上游功能分支
- 仅修改 `frontend/`
- 不包含 Quick Start、Generation、WorkflowRun、WorkflowController、发布、导出、后端、历史记录或资产库
- 不包含 `dist`、`node_modules`、数据库、日志、截图等产物

## 改动内容

- 新增独立 `/playtest` 目录，按项目浏览已有角色造型和动作
- 支持同项目资产切换、同一造型多动作切换和逐帧播放
- 支持 Playtest 目录内的资产移动、改名和删除
- 增加帧尺寸、透明边界、序列位移、关键帧和人工问题记录检查
- 保存每个动作当前的 Playtest 核验结论，不形成历史版本
- 仅补充 Playtest 直接需要的 Project、Character、Inspection API 适配器和共享 HTTP 客户端
- 路径生成留在 Playtest 页面内部，不再依赖发布模块

## 提交前修正

- 角色整树更新会原样保留动作 `loop` 标记
- DELETE 支持 `204` 和成功信封中的 `data: null`
- 当前帧未成功加载时禁止标记“核验通过”，仍允许记录“发现问题”
- 移除 Playtest 空状态中的 Quick Start 入口

## 验证

- `npm run typecheck`：通过
- `npm run test`：21 个测试文件、134 项测试通过
- `npm run lint`：通过
- `npm run build`：通过
- 57 个改动文件的 `oxfmt --check`：通过
- `git diff --check upstream/main`：通过
- 构建产物与依赖目录均被 Git 忽略