### PR TITLE
feat(project-create): add the project creation page

### DIFF
--- a/frontend/API_CONTRACT.md
+++ b/frontend/API_CONTRACT.md
@@ -15,7 +15,7 @@
 
 `ProjectOut` 的 `user_id`、`workflow_id`、`project_name`、`character_perspective`、`directional_movement`、精灵宽高、画风、参考图和时间字段，均在 `entities/project` 内显式映射为 camelCase。PR #75 没有项目更新端点，因此前端不声明 `ProjectApis.update`。
 
-`POST /projects` 把 `user_id` 放在请求体里，不从 token 推导，所以前端除 token 外还需要单独拿到当前用户 ID。该值由 `shared/api` 的 `getCurrentUserId()` 提供；登录模块尚未接入，没有人注册来源时 `/projects/new` 的创建入口保持禁用，不使用占位 ID。
+项目归属由后端从 access token 取：`ProjectCreate` 不含 `user_id`，`/projects` 各路由统一读 `request.state.current_user.id`，且 `/projects` 不在鉴权白名单里。因此 `CreateProjectInput` 没有 ownerId，请求体也不带 `user_id`——带了等于宣称调用方可以替别人建项目，那正是后端刚修掉的越权口子。`/projects/new` 的创建入口只看有没有 access token（`getApiAccessToken()`）；登录模块尚未接入时保持禁用并写明需要登录。
 
 后端枚举按下表映射：
 

--- a/frontend/API_CONTRACT.md
+++ b/frontend/API_CONTRACT.md
@@ -15,6 +15,8 @@
 
 `ProjectOut` 的 `user_id`、`workflow_id`、`project_name`、`character_perspective`、`directional_movement`、精灵宽高、画风、参考图和时间字段，均在 `entities/project` 内显式映射为 camelCase。PR #75 没有项目更新端点，因此前端不声明 `ProjectApis.update`。
 
+`POST /projects` 把 `user_id` 放在请求体里，不从 token 推导，所以前端除 token 外还需要单独拿到当前用户 ID。该值由 `shared/api` 的 `getCurrentUserId()` 提供；登录模块尚未接入，没有人注册来源时 `/projects/new` 的创建入口保持禁用，不使用占位 ID。
+
 后端枚举按下表映射：
 
 | 后端值 | `character_perspective` | `directional_movement` |
@@ -54,7 +56,6 @@ Outfit、Action、Frame 没有独立端点。`outfit.characterId` 与 `action.ou
 
 ## 二、本轮明确不实现
 
-- 新建项目流程：只保留禁用入口，后续单独实现。
 - Workflow Editor 与生成流程：不在 Projects / 资产库模块内创建弹窗或复制生成逻辑。
 - Action Template：后端没有模块、存储或 HTTP 接口，只保留带原因的禁用入口。
 - 导出：PR #75 没有导出接口；PR #97 是尚未接入资产页的前端打包实现，只保留带原因的禁用入口。

--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -6,6 +6,7 @@ import { HomePage } from '@/pages/home'
 import { NotFoundPage } from '@/pages/not-found'
 import { PlaytestPage } from '@/pages/playtest'
 import { ProjectDetailPage } from '@/pages/project-detail'
+import { ProjectCreatePage } from '@/pages/project-create'
 import { ProjectsPage } from '@/pages/projects'
 import { QuickStartPage } from '@/pages/quick-start'
 import { WorkflowEditorPage } from '@/pages/workflow-editor'
@@ -34,6 +35,7 @@ export function AppRoutes() {
         <Route path="/quick-start" element={<QuickStartPage />} />
         <Route path="/quick-start/:runId" element={<QuickStartPage />} />
         <Route path="/projects" element={<ProjectsPage />} />
+        <Route path="/projects/new" element={<ProjectCreatePage />} />
         <Route path="/workflow-editor/:runId" element={<WorkflowEditorPage />} />
         <Route path="/workflow-editor/:runId/:stage" element={<WorkflowEditorPage />} />
         <Route path="/playtest/:characterId/:outfitId" element={<PlaytestPage />} />

--- a/frontend/src/entities/project/index.test.ts
+++ b/frontend/src/entities/project/index.test.ts
@@ -82,7 +82,6 @@ describe('projectApis', () => {
     })
 
     await projectApis.create({
-      ownerId: '7',
       workflowId: '9',
       name: '点灯人',
       perspective: 'isometric',
@@ -93,8 +92,8 @@ describe('projectApis', () => {
     })
 
     expect(request?.method).toBe('POST')
+    // 请求体不含 user_id：归属由后端从 access token 取，见 CreateProjectInput 的注释。
     await expect(request?.json()).resolves.toEqual({
-      user_id: 7,
       workflow_id: 9,
       project_name: '点灯人',
       character_perspective: 3,

--- a/frontend/src/entities/project/index.ts
+++ b/frontend/src/entities/project/index.ts
@@ -16,9 +16,12 @@ export interface Project {
   updatedAt: string
 }
 
-/** 后端创建 Project 需要的完整字段；创建流程本身不属于资产库页面。 */
+/**
+ * 后端创建 Project 需要的完整字段。
+ * 这里没有 ownerId：归属由后端从 access token 里取（`ProjectCreate` 不含 user_id），
+ * 请求体再带一个用户 ID 就等于宣称调用方可以替别人建项目。
+ */
 export interface CreateProjectInput {
-  ownerId: string
   workflowId?: string | null
   name: string
   perspective: CharacterPerspective
@@ -163,7 +166,6 @@ export const projectApis: ProjectApis = {
     const dto = await getApiClient().request<ProjectDto>('/projects', {
       method: 'POST',
       json: {
-        user_id: toBackendId(input.ownerId, 'ownerId'),
         workflow_id:
           input.workflowId === undefined
             ? undefined

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,7 +104,151 @@ body,
   .projects-dialog-backdrop,
   .projects-dialog-panel,
   .route-transition,
-  .action-reveal {
+  .action-reveal,
+  .project-pixel-mark i {
     animation: none;
   }
+}
+
+@keyframes project-pixel-field {
+  0%,
+  58%,
+  100% {
+    opacity: 0.5;
+    transform: scale(0.84);
+  }
+
+  16% {
+    opacity: 0.96;
+    transform: scale(1.08);
+  }
+}
+
+@keyframes project-pixel-frame {
+  0%,
+  100% {
+    opacity: 0.72;
+    transform: scale(0.86);
+  }
+
+  38% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+}
+
+@keyframes project-pixel-handle {
+  0%,
+  24%,
+  100% {
+    transform: scale(0.82);
+  }
+
+  42%,
+  58% {
+    transform: scale(1.18);
+  }
+}
+
+@keyframes project-pixel-cursor {
+  0%,
+  14%,
+  100% {
+    opacity: 0.28;
+    transform: translate(-5px, -5px) scale(0.86);
+  }
+
+  38% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+/*
+  创建页左侧的装饰点阵。289 个格子共用四组动画，靠 animation-delay 错峰：
+  pixel-ring-N 是格子到中心的距离环，管底噪；pixel-phase-N 是 (x+y)%4，管实心笔画。
+  两组延迟都是负值，页面一进来就处在动画中段，不会先静止再启动。
+*/
+.project-pixel-mark {
+  display: grid;
+  grid-template-columns: repeat(17, 5px);
+  grid-template-rows: repeat(17, 5px);
+  gap: 8px;
+  place-content: center;
+  width: 248px;
+  height: 248px;
+}
+
+.project-pixel-mark i {
+  width: 5px;
+  height: 5px;
+  border-radius: 1px;
+  background: #bfc6bf;
+  opacity: 0.62;
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 18%);
+  animation: project-pixel-field 4.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+.project-pixel-mark .pixel-ring-1 {
+  animation-delay: -0.14s;
+}
+
+.project-pixel-mark .pixel-ring-2 {
+  animation-delay: -0.28s;
+}
+
+.project-pixel-mark .pixel-ring-3 {
+  animation-delay: -0.42s;
+}
+
+.project-pixel-mark .pixel-ring-4 {
+  animation-delay: -0.56s;
+}
+
+.project-pixel-mark .pixel-ring-5 {
+  animation-delay: -0.7s;
+}
+
+.project-pixel-mark .pixel-ring-6 {
+  animation-delay: -0.84s;
+}
+
+.project-pixel-mark .pixel-ring-7 {
+  animation-delay: -0.98s;
+}
+
+.project-pixel-mark .pixel-ring-8 {
+  animation-delay: -1.12s;
+}
+
+.project-pixel-mark i.is-active {
+  background: #202120;
+  opacity: 0.9;
+  box-shadow: none;
+  animation: project-pixel-frame 3.4s ease-in-out infinite;
+}
+
+.project-pixel-mark i.is-active.pixel-phase-1 {
+  animation-delay: -0.18s;
+}
+
+.project-pixel-mark i.is-active.pixel-phase-2 {
+  animation-delay: -0.36s;
+}
+
+.project-pixel-mark i.is-active.pixel-phase-3 {
+  animation-delay: -0.54s;
+}
+
+.project-pixel-mark i.is-handle {
+  background: #050505;
+  opacity: 1;
+  box-shadow: 0 0 0 4px rgb(17 18 17 / 9%);
+  animation: project-pixel-handle 3.8s ease-in-out infinite;
+}
+
+.project-pixel-mark i.is-cursor {
+  background: #090a09;
+  opacity: 1;
+  animation: project-pixel-cursor 2.8s cubic-bezier(0.22, 1, 0.36, 1) infinite;
 }

--- a/frontend/src/pages/home/index.test.tsx
+++ b/frontend/src/pages/home/index.test.tsx
@@ -18,7 +18,9 @@ describe('HomePage', () => {
     expect(screen.getByRole('heading', { name: /真正登场/ })).toBeTruthy()
     expect(screen.getByRole('link', { name: /快速开始/ }).getAttribute('href')).toBe('/quick-start')
     expect(screen.getByText('工作流画布')).toBeTruthy()
-    expect(screen.getByRole('link', { name: '创建新项目' }).getAttribute('href')).toBe('/projects')
+    expect(screen.getByRole('link', { name: '创建新项目' }).getAttribute('href')).toBe(
+      '/projects/new',
+    )
     expect(screen.getByRole('link', { name: '继续已有项目' }).getAttribute('href')).toBe(
       '/projects',
     )

--- a/frontend/src/pages/home/index.tsx
+++ b/frontend/src/pages/home/index.tsx
@@ -87,8 +87,9 @@ export function HomePage() {
               />
               {/*
                 画布入口必须先确定角色挂在哪个项目下，所以动作条悬停后分成新建与继续两条。
-                两条现在都落在 /projects 占位页；建项目、建 workflow run 再进
-                /workflow-editor/:runId 的真实链路等后端接口对齐后接上。
+                新建直达创建页；继续先落项目中心选项目，等项目级 WorkflowRun 历史页面就位后
+                再指到那里。两条都还进不了 /workflow-editor/:runId——建 workflow run 需要
+                WorkflowController，它目前只有接口没有实现。
               */}
               <HomeChoiceCard
                 to="/projects"
@@ -98,7 +99,7 @@ export function HomePage() {
                 description="打开工作流画布，逐个节点决定生成什么、留下哪一版。"
                 actionLabel="打开画布"
                 actions={[
-                  { to: '/projects', label: '创建新项目' },
+                  { to: '/projects/new', label: '创建新项目' },
                   { to: '/projects', label: '继续已有项目' },
                 ]}
               />

--- a/frontend/src/pages/project-create/index.test.tsx
+++ b/frontend/src/pages/project-create/index.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router'
 
 import { AppRoutes } from '@/app'
-import { registerCurrentUserIdProvider } from '@/shared/api'
+import { registerApiAccessTokenProvider } from '@/shared/api'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 const revokeProviders: Array<() => void> = []
@@ -23,9 +23,9 @@ function installBackend() {
   return backend
 }
 
-/** 登录模块尚未落地，测试里用同一个 provider 边界冒充已登录用户。 */
-function signIn(ownerId = '7') {
-  revokeProviders.push(registerCurrentUserIdProvider(() => ownerId))
+/** 登录模块尚未落地，测试里用同一个 provider 边界冒充已签发的 access token。 */
+function signIn(accessToken = 'access-token-for-test') {
+  revokeProviders.push(registerApiAccessTokenProvider(() => accessToken))
 }
 
 function renderProjectCreate() {
@@ -57,8 +57,9 @@ describe('ProjectCreatePage', () => {
 
     expect(await screen.findByRole('heading', { name: '角色' })).toBeTruthy()
     const [request] = creationRequests(backend)
-    expect(await request.json()).toMatchObject({
-      user_id: 7,
+    expect(request.headers.get('authorization')).toBe('Bearer access-token-for-test')
+    const body = (await request.json()) as Record<string, unknown>
+    expect(body).toMatchObject({
       project_name: '雾港来信',
       character_perspective: 2,
       directional_movement: 3,
@@ -66,9 +67,11 @@ describe('ProjectCreatePage', () => {
       sprite_height: 512,
       game_style: '低饱和像素绘本',
     })
+    // 归属由后端从 JWT 取；请求体再带 user_id 就等于宣称可以替别人建项目。
+    expect(Object.hasOwn(body, 'user_id')).toBe(false)
   })
 
-  it('没有当前用户来源时禁用创建并说明原因', async () => {
+  it('没有登录凭证时禁用创建并说明原因', async () => {
     const backend = installBackend()
     renderProjectCreate()
 

--- a/frontend/src/pages/project-create/index.test.tsx
+++ b/frontend/src/pages/project-create/index.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router'
+
+import { AppRoutes } from '@/app'
+import { registerCurrentUserIdProvider } from '@/shared/api'
+import { createProjectAssetsBackend } from '@/test/project-assets-backend'
+
+const revokeProviders: Array<() => void> = []
+
+afterEach(() => {
+  cleanup()
+  while (revokeProviders.length) revokeProviders.pop()?.()
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+})
+
+function installBackend() {
+  const backend = createProjectAssetsBackend()
+  vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+  vi.stubGlobal('fetch', backend.fetch)
+  return backend
+}
+
+/** 登录模块尚未落地，测试里用同一个 provider 边界冒充已登录用户。 */
+function signIn(ownerId = '7') {
+  revokeProviders.push(registerCurrentUserIdProvider(() => ownerId))
+}
+
+function renderProjectCreate() {
+  return render(
+    <MemoryRouter initialEntries={['/projects/new']}>
+      <AppRoutes />
+    </MemoryRouter>,
+  )
+}
+
+function creationRequests(backend: ReturnType<typeof createProjectAssetsBackend>) {
+  return backend.requests.filter(
+    (request) => request.method === 'POST' && new URL(request.url).pathname === '/projects',
+  )
+}
+
+describe('ProjectCreatePage', () => {
+  it('按项目契约提交表单并进入创建出的项目', async () => {
+    const backend = installBackend()
+    signIn()
+    renderProjectCreate()
+
+    fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
+    fireEvent.change(screen.getByLabelText('游戏视角'), { target: { value: 'top-down' } })
+    fireEvent.change(screen.getByLabelText('朝向'), { target: { value: 'eight-way' } })
+    fireEvent.click(screen.getByRole('button', { name: '512 × 512' }))
+    fireEvent.change(screen.getByLabelText('画风约束'), { target: { value: '低饱和像素绘本' } })
+    fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
+
+    expect(await screen.findByRole('heading', { name: '角色' })).toBeTruthy()
+    const [request] = creationRequests(backend)
+    expect(await request.json()).toMatchObject({
+      user_id: 7,
+      project_name: '雾港来信',
+      character_perspective: 2,
+      directional_movement: 3,
+      sprite_width: 512,
+      sprite_height: 512,
+      game_style: '低饱和像素绘本',
+    })
+  })
+
+  it('没有当前用户来源时禁用创建并说明原因', async () => {
+    const backend = installBackend()
+    renderProjectCreate()
+
+    const submit = await screen.findByRole('button', { name: '创建项目' })
+    expect(submit.hasAttribute('disabled')).toBe(true)
+    expect(screen.getByText(/登录/)).toBeTruthy()
+    expect(creationRequests(backend)).toHaveLength(0)
+  })
+
+  it('名称超过 20 字时在提交前拦下', async () => {
+    const backend = installBackend()
+    signIn()
+    renderProjectCreate()
+
+    fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾'.repeat(21) } })
+    fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
+
+    expect(await screen.findByText('项目名称最多 20 个字')).toBeTruthy()
+    expect(creationRequests(backend)).toHaveLength(0)
+  })
+
+  it('名称重复时保留已填内容并显示后端给出的原因', async () => {
+    installBackend()
+    signIn()
+    renderProjectCreate()
+
+    fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '点灯人 · MVP' } })
+    fireEvent.change(screen.getByLabelText('画风约束'), { target: { value: '低饱和像素绘本' } })
+    fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
+
+    expect((await screen.findByRole('alert')).textContent).toBe('项目名称已存在')
+    expect((screen.getByLabelText('画风约束') as HTMLTextAreaElement).value).toBe('低饱和像素绘本')
+  })
+
+  it('连续点击创建只发出一次请求', async () => {
+    const backend = installBackend()
+    signIn()
+    renderProjectCreate()
+
+    fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
+    const submit = screen.getByRole('button', { name: '创建项目' })
+    fireEvent.click(submit)
+    fireEvent.click(submit)
+
+    await waitFor(() => expect(creationRequests(backend).length).toBeGreaterThan(0))
+    expect(creationRequests(backend)).toHaveLength(1)
+  })
+})

--- a/frontend/src/pages/project-create/index.test.tsx
+++ b/frontend/src/pages/project-create/index.test.tsx
@@ -116,4 +116,54 @@ describe('ProjectCreatePage', () => {
     await waitFor(() => expect(creationRequests(backend).length).toBeGreaterThan(0))
     expect(creationRequests(backend)).toHaveLength(1)
   })
+  it('名称留空时在提交前拦下', async () => {
+    const backend = installBackend()
+    signIn()
+    renderProjectCreate()
+
+    fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
+
+    expect((await screen.findByRole('alert')).textContent).toBe('请填写项目名称')
+    expect(creationRequests(backend)).toHaveLength(0)
+  })
+
+  it('精灵宽高越界时在提交前拦下', async () => {
+    const backend = installBackend()
+    signIn()
+    renderProjectCreate()
+
+    fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
+    fireEvent.change(screen.getByLabelText('宽度（像素）'), { target: { value: '16' } })
+    fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
+
+    expect((await screen.findByRole('alert')).textContent).toBe(
+      '精灵宽高需要是 32 到 2048 之间的整数',
+    )
+    expect(creationRequests(backend)).toHaveLength(0)
+  })
+
+  it('传输失败时收敛成一句统一文案', async () => {
+    installBackend()
+    vi.stubGlobal('fetch', () => Promise.reject(new TypeError('offline')))
+    signIn()
+    renderProjectCreate()
+
+    fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
+    fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
+
+    expect((await screen.findByRole('alert')).textContent).toBe('项目暂时无法创建')
+  })
+
+  it('改动任一字段后撤掉上一次的错误', async () => {
+    installBackend()
+    signIn()
+    renderProjectCreate()
+
+    fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
+    expect(await screen.findByRole('alert')).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
 })

--- a/frontend/src/pages/project-create/index.test.tsx
+++ b/frontend/src/pages/project-create/index.test.tsx
@@ -166,4 +166,18 @@ describe('ProjectCreatePage', () => {
 
     expect(screen.queryByRole('alert')).toBeNull()
   })
+  it('点尺寸预设后撤掉上一次的错误', async () => {
+    installBackend()
+    signIn()
+    renderProjectCreate()
+
+    fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
+    fireEvent.change(screen.getByLabelText('宽度（像素）'), { target: { value: '16' } })
+    fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
+    expect(await screen.findByRole('alert')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: '256 × 256' }))
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
 })

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -181,6 +181,8 @@ export function ProjectCreatePage() {
                   onClick={() => {
                     setSpriteWidth(String(preset))
                     setSpriteHeight(String(preset))
+                    // 按钮点击不是表单的 change 事件，收不到表单上那个清错误的处理，只能自己清。
+                    setError(null)
                   }}
                   aria-pressed={spriteWidth === String(preset) && spriteHeight === String(preset)}
                   className="rounded-full border border-[#d5d9d2] px-4 py-1.5 text-xs text-[#41473f] aria-pressed:border-[#252825] aria-pressed:bg-[#252825] aria-pressed:text-white"

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -77,14 +77,15 @@ export function ProjectCreatePage() {
 
   return (
     <div className="grid min-h-[calc(100vh-4rem)] w-full bg-[#e5e8e3] text-[#191b18] lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
-      <aside className="hidden place-content-center justify-items-center gap-8 px-10 py-16 lg:grid">
+      <aside className="hidden place-content-center justify-items-center gap-8 px-10 pb-16 pt-24 lg:grid">
         <ProjectCreatePixelMark />
         <p className="max-w-72 text-center text-xs leading-6 text-[#747973]">
           项目决定角色资产的视角、朝向与精灵尺寸。这些约束建立之后会跟着项目下的每一个角色。
         </p>
       </aside>
 
-      <section className="bg-white/70 px-6 py-12 sm:px-12 lg:px-16 lg:py-20">
+      {/* pt-24 与 PageContainer 同源：给 fixed 顶栏（top-3.5 加最小高 3.625rem）让位，改顶栏尺寸时一起改。 */}
+      <section className="bg-white/70 px-6 pb-12 pt-24 sm:px-12 lg:px-16 lg:pb-20 lg:pt-28">
         <form noValidate onSubmit={submit} className="mx-auto grid max-w-2xl gap-7">
           <header>
             <p className="font-mono text-[10px] font-semibold tracking-[0.18em] text-[#8b9089]">

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -240,7 +240,7 @@ export function ProjectCreatePage() {
           ) : null}
 
           <footer className="flex flex-wrap items-center justify-between gap-4 border-t border-[#d8dbd4] pt-6">
-            <small className="max-w-sm text-[11px] leading-5 text-[#747973]">
+            <small id="project-create-hint" className="max-w-sm text-[11px] leading-5 text-[#747973]">
               {ownerId
                 ? '创建后进入该项目的资产工作区。'
                 : '登录模块尚未接入，暂时拿不到当前账号，创建入口保持关闭。'}
@@ -248,6 +248,7 @@ export function ProjectCreatePage() {
             <button
               type="submit"
               disabled={submitting || !ownerId}
+              aria-describedby="project-create-hint"
               className="rounded-full bg-[#252825] px-6 py-3 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-[#a4aaa2]"
             >
               {submitting ? '正在创建…' : '创建项目'}

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import { useRef, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router'
 
 import {
@@ -39,10 +39,12 @@ export function ProjectCreatePage() {
   const [gameStyle, setGameStyle] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  /** 同一批事件里 submitting 还是上一次 render 的值，按钮变灰之前的重复提交只能靠这个挡。 */
+  const inFlight = useRef(false)
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (submitting || !ownerId) return
+    if (inFlight.current || !ownerId) return
 
     const trimmedName = name.trim()
     const width = Number(spriteWidth)
@@ -54,6 +56,7 @@ export function ProjectCreatePage() {
       return setError(`精灵宽高需要是 ${SPRITE_MIN} 到 ${SPRITE_MAX} 之间的整数`)
     }
 
+    inFlight.current = true
     setSubmitting(true)
     setError(null)
     try {
@@ -71,6 +74,7 @@ export function ProjectCreatePage() {
       setError(
         cause instanceof ApiError && cause.kind === 'business' ? cause.message : '项目暂时无法创建',
       )
+      inFlight.current = false
       setSubmitting(false)
     }
   }

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -90,7 +90,12 @@ export function ProjectCreatePage() {
 
       {/* pt-24 与 PageContainer 同源：给 fixed 顶栏（top-3.5 加最小高 3.625rem）让位，改顶栏尺寸时一起改。 */}
       <section className="bg-white/70 px-6 pb-12 pt-24 sm:px-12 lg:px-16 lg:pb-20 lg:pt-28">
-        <form noValidate onSubmit={submit} className="mx-auto grid max-w-2xl gap-7">
+        <form
+          noValidate
+          onSubmit={submit}
+          onChange={() => setError(null)}
+          className="mx-auto grid max-w-2xl gap-7"
+        >
           <header>
             <p className="font-mono text-[10px] font-semibold tracking-[0.18em] text-[#8b9089]">
               PROJECT SETUP

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -1,0 +1,254 @@
+import { useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router'
+
+import {
+  CHARACTER_PERSPECTIVE,
+  DIRECTIONAL_MOVEMENT,
+  projectApis,
+  type CharacterPerspective,
+  type DirectionalMovement,
+} from '@/entities'
+import { ApiError, getCurrentUserId } from '@/shared/api'
+import { ProjectCreatePixelMark } from './pixel-mark'
+
+/**
+ * 项目名称上限跟随后端 `windup_project.project_name` 的 String(20)。
+ * 后端 PR #126 想放宽到 64，这里按更严的一边取值，两种契约下都能提交成功。
+ */
+const NAME_MAX_LENGTH = 20
+
+/** 精灵宽高的合法区间由后端 ProjectCreate 的 Field(ge=32, le=2048) 决定。 */
+const SPRITE_MIN = 32
+const SPRITE_MAX = 2048
+
+/** 常用档位只是快捷填充，用户仍可以填这三档之外的任意合法宽高。 */
+const SPRITE_PRESETS = [128, 256, 512]
+
+const GAME_STYLE_MAX_LENGTH = 240
+
+/** 创建真实项目；首页画布入口与项目中心的新建按钮共用这一页。 */
+export function ProjectCreatePage() {
+  const navigate = useNavigate()
+  const ownerId = getCurrentUserId()
+
+  const [name, setName] = useState('')
+  const [perspective, setPerspective] = useState<CharacterPerspective>('side')
+  const [directionalMovement, setDirectionalMovement] = useState<DirectionalMovement>('single')
+  const [spriteWidth, setSpriteWidth] = useState('256')
+  const [spriteHeight, setSpriteHeight] = useState('256')
+  const [gameStyle, setGameStyle] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (submitting || !ownerId) return
+
+    const trimmedName = name.trim()
+    const width = Number(spriteWidth)
+    const height = Number(spriteHeight)
+    if (!trimmedName) return setError('请填写项目名称')
+    if (trimmedName.length > NAME_MAX_LENGTH)
+      return setError(`项目名称最多 ${NAME_MAX_LENGTH} 个字`)
+    if (![width, height].every(isLegalSpriteLength)) {
+      return setError(`精灵宽高需要是 ${SPRITE_MIN} 到 ${SPRITE_MAX} 之间的整数`)
+    }
+
+    setSubmitting(true)
+    setError(null)
+    try {
+      const project = await projectApis.create({
+        ownerId,
+        name: trimmedName,
+        perspective,
+        directionalMovement,
+        spriteSize: { width, height },
+        gameStyle: gameStyle.trim() || null,
+      })
+      navigate(`/projects/${project.id}`)
+    } catch (cause) {
+      // 业务错误（如重名）由后端给出具体原因，原样转达；传输错误对用户没有信息量，收敛成一句。
+      setError(
+        cause instanceof ApiError && cause.kind === 'business' ? cause.message : '项目暂时无法创建',
+      )
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="grid min-h-[calc(100vh-4rem)] w-full bg-[#e5e8e3] text-[#191b18] lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
+      <aside className="hidden place-content-center justify-items-center gap-8 px-10 py-16 lg:grid">
+        <ProjectCreatePixelMark />
+        <p className="max-w-72 text-center text-xs leading-6 text-[#747973]">
+          项目决定角色资产的视角、朝向与精灵尺寸。这些约束建立之后会跟着项目下的每一个角色。
+        </p>
+      </aside>
+
+      <section className="bg-white/70 px-6 py-12 sm:px-12 lg:px-16 lg:py-20">
+        <form noValidate onSubmit={submit} className="mx-auto grid max-w-2xl gap-7">
+          <header>
+            <p className="font-mono text-[10px] font-semibold tracking-[0.18em] text-[#8b9089]">
+              PROJECT SETUP
+            </p>
+            <h1 className="mt-3 font-serif text-4xl font-medium tracking-[-0.045em]">新建项目</h1>
+            <p className="mt-3 text-sm leading-6 text-[#666b64]">
+              只确定项目级的题材与规格；角色和动作在项目内再逐个创建。
+            </p>
+          </header>
+
+          <div className="grid gap-2">
+            <label className="text-xs font-semibold text-[#41473f]" htmlFor="project-name">
+              项目名称
+            </label>
+            <input
+              id="project-name"
+              value={name}
+              maxLength={NAME_MAX_LENGTH}
+              placeholder="例如：雾港来信"
+              onChange={(event) => setName(event.target.value)}
+              className="rounded-xl border border-[#d5d9d2] bg-[#f5f5f2] px-4 py-3 text-sm outline-none focus-visible:border-[#8f978d]"
+            />
+            <small className="text-[10px] text-[#8b9089]">
+              最多 {NAME_MAX_LENGTH} 个字，同一账号下不能重名。
+            </small>
+          </div>
+
+          <div className="grid gap-5 sm:grid-cols-2">
+            <div className="grid gap-2">
+              <label className="text-xs font-semibold text-[#41473f]" htmlFor="project-perspective">
+                游戏视角
+              </label>
+              <select
+                id="project-perspective"
+                value={perspective}
+                onChange={(event) => setPerspective(event.target.value as CharacterPerspective)}
+                className="rounded-xl border border-[#d5d9d2] bg-[#f5f5f2] px-4 py-3 text-sm outline-none focus-visible:border-[#8f978d]"
+              >
+                {Object.entries(CHARACTER_PERSPECTIVE).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="grid gap-2">
+              <label className="text-xs font-semibold text-[#41473f]" htmlFor="project-movement">
+                朝向
+              </label>
+              <select
+                id="project-movement"
+                value={directionalMovement}
+                onChange={(event) =>
+                  setDirectionalMovement(event.target.value as DirectionalMovement)
+                }
+                className="rounded-xl border border-[#d5d9d2] bg-[#f5f5f2] px-4 py-3 text-sm outline-none focus-visible:border-[#8f978d]"
+              >
+                {Object.entries(DIRECTIONAL_MOVEMENT).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <fieldset className="grid gap-3">
+            <legend className="text-xs font-semibold text-[#41473f]">精灵尺寸</legend>
+            <div className="flex flex-wrap gap-2">
+              {SPRITE_PRESETS.map((preset) => (
+                <button
+                  key={preset}
+                  type="button"
+                  onClick={() => {
+                    setSpriteWidth(String(preset))
+                    setSpriteHeight(String(preset))
+                  }}
+                  aria-pressed={spriteWidth === String(preset) && spriteHeight === String(preset)}
+                  className="rounded-full border border-[#d5d9d2] px-4 py-1.5 text-xs text-[#41473f] aria-pressed:border-[#252825] aria-pressed:bg-[#252825] aria-pressed:text-white"
+                >
+                  {preset} × {preset}
+                </button>
+              ))}
+            </div>
+            <div className="grid gap-5 sm:grid-cols-2">
+              <div className="grid gap-2">
+                <label className="text-[10px] text-[#8b9089]" htmlFor="project-sprite-width">
+                  宽度（像素）
+                </label>
+                <input
+                  id="project-sprite-width"
+                  type="number"
+                  inputMode="numeric"
+                  min={SPRITE_MIN}
+                  max={SPRITE_MAX}
+                  value={spriteWidth}
+                  onChange={(event) => setSpriteWidth(event.target.value)}
+                  className="rounded-xl border border-[#d5d9d2] bg-[#f5f5f2] px-4 py-3 text-sm outline-none focus-visible:border-[#8f978d]"
+                />
+              </div>
+              <div className="grid gap-2">
+                <label className="text-[10px] text-[#8b9089]" htmlFor="project-sprite-height">
+                  高度（像素）
+                </label>
+                <input
+                  id="project-sprite-height"
+                  type="number"
+                  inputMode="numeric"
+                  min={SPRITE_MIN}
+                  max={SPRITE_MAX}
+                  value={spriteHeight}
+                  onChange={(event) => setSpriteHeight(event.target.value)}
+                  className="rounded-xl border border-[#d5d9d2] bg-[#f5f5f2] px-4 py-3 text-sm outline-none focus-visible:border-[#8f978d]"
+                />
+              </div>
+            </div>
+          </fieldset>
+
+          <div className="grid gap-2">
+            <label className="text-xs font-semibold text-[#41473f]" htmlFor="project-style">
+              画风约束
+            </label>
+            <textarea
+              id="project-style"
+              rows={3}
+              value={gameStyle}
+              maxLength={GAME_STYLE_MAX_LENGTH}
+              placeholder="例如：低饱和像素风、细长比例、深灰旅行服"
+              onChange={(event) => setGameStyle(event.target.value)}
+              className="resize-none rounded-xl border border-[#d5d9d2] bg-[#f5f5f2] px-4 py-3 text-sm outline-none focus-visible:border-[#8f978d]"
+            />
+          </div>
+
+          {error ? (
+            <p
+              role="alert"
+              className="rounded-xl border border-[#d8c7bd] bg-[#fff8f2] px-4 py-3 text-sm text-[#7a3f2a]"
+            >
+              {error}
+            </p>
+          ) : null}
+
+          <footer className="flex flex-wrap items-center justify-between gap-4 border-t border-[#d8dbd4] pt-6">
+            <small className="max-w-sm text-[11px] leading-5 text-[#747973]">
+              {ownerId
+                ? '创建后进入该项目的资产工作区。'
+                : '登录模块尚未接入，暂时拿不到当前账号，创建入口保持关闭。'}
+            </small>
+            <button
+              type="submit"
+              disabled={submitting || !ownerId}
+              className="rounded-full bg-[#252825] px-6 py-3 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-[#a4aaa2]"
+            >
+              {submitting ? '正在创建…' : '创建项目'}
+            </button>
+          </footer>
+        </form>
+      </section>
+    </div>
+  )
+}
+
+function isLegalSpriteLength(value: number) {
+  return Number.isSafeInteger(value) && value >= SPRITE_MIN && value <= SPRITE_MAX
+}

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -12,18 +12,26 @@ import { ApiError, getCurrentUserId } from '@/shared/api'
 import { ProjectCreatePixelMark } from './pixel-mark'
 
 /**
- * 项目名称上限跟随后端 `windup_project.project_name` 的 String(20)。
- * 后端 PR #126 想放宽到 64，这里按更严的一边取值，两种契约下都能提交成功。
+ * 项目名称上限跟随 main 上 `windup_project.project_name` 的 `String(20)`。
+ * 尚未合入的两个后端 PR 在这里不一致（#75 限 20、#126 放宽到 64），取更严的一边，
+ * 哪条先落地都能提交成功；放宽是加法，反过来会立刻退回重名与截断。
  */
 const NAME_MAX_LENGTH = 20
 
-/** 精灵宽高的合法区间由后端 ProjectCreate 的 Field(ge=32, le=2048) 决定。 */
+/**
+ * 精灵宽高的合法区间。写在前端是因为 main 的后端还没有 `/projects` 路由，
+ * 取值依据是 issue #141 的产品规则（与未合入的 #75 / #126 请求校验一致）。
+ */
 const SPRITE_MIN = 32
 const SPRITE_MAX = 2048
 
 /** 常用档位只是快捷填充，用户仍可以填这三档之外的任意合法宽高。 */
 const SPRITE_PRESETS = [128, 256, 512]
 
+/**
+ * 画风约束的长度上限只存在于前端：后端 `game_style` 是没有长度约束的 Text。
+ * 定这个数是为了让它维持在「一句风格描述」的量级，不是契约要求。
+ */
 const GAME_STYLE_MAX_LENGTH = 240
 
 /** 创建真实项目；首页画布入口与项目中心的新建按钮共用这一页。 */
@@ -240,7 +248,10 @@ export function ProjectCreatePage() {
           ) : null}
 
           <footer className="flex flex-wrap items-center justify-between gap-4 border-t border-[#d8dbd4] pt-6">
-            <small id="project-create-hint" className="max-w-sm text-[11px] leading-5 text-[#747973]">
+            <small
+              id="project-create-hint"
+              className="max-w-sm text-[11px] leading-5 text-[#747973]"
+            >
               {ownerId
                 ? '创建后进入该项目的资产工作区。'
                 : '登录模块尚未接入，暂时拿不到当前账号，创建入口保持关闭。'}

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -8,7 +8,7 @@ import {
   type CharacterPerspective,
   type DirectionalMovement,
 } from '@/entities'
-import { ApiError, getCurrentUserId } from '@/shared/api'
+import { ApiError, getApiAccessToken } from '@/shared/api'
 import { ProjectCreatePixelMark } from './pixel-mark'
 
 /**
@@ -37,7 +37,12 @@ const GAME_STYLE_MAX_LENGTH = 240
 /** 创建真实项目；首页画布入口与项目中心的新建按钮共用这一页。 */
 export function ProjectCreatePage() {
   const navigate = useNavigate()
-  const ownerId = getCurrentUserId()
+  /**
+   * 能不能建项目只取决于有没有登录：后端 `/projects` 不在鉴权白名单里，
+   * 归属也从 access token 里取。登录模块尚未接入时没有人注册 provider，
+   * 这里拿到 null，入口保持禁用并写明原因，不塞占位值让它看起来能用。
+   */
+  const signedIn = Boolean(getApiAccessToken())
 
   const [name, setName] = useState('')
   const [perspective, setPerspective] = useState<CharacterPerspective>('side')
@@ -52,7 +57,7 @@ export function ProjectCreatePage() {
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (inFlight.current || !ownerId) return
+    if (inFlight.current || !signedIn) return
 
     const trimmedName = name.trim()
     const width = Number(spriteWidth)
@@ -69,7 +74,6 @@ export function ProjectCreatePage() {
     setError(null)
     try {
       const project = await projectApis.create({
-        ownerId,
         name: trimmedName,
         perspective,
         directionalMovement,
@@ -254,13 +258,13 @@ export function ProjectCreatePage() {
               id="project-create-hint"
               className="max-w-sm text-[11px] leading-5 text-[#747973]"
             >
-              {ownerId
+              {signedIn
                 ? '创建后进入该项目的资产工作区。'
-                : '登录模块尚未接入，暂时拿不到当前账号，创建入口保持关闭。'}
+                : '创建项目需要先登录。登录模块尚未接入，创建入口暂时保持关闭。'}
             </small>
             <button
               type="submit"
-              disabled={submitting || !ownerId}
+              disabled={submitting || !signedIn}
               aria-describedby="project-create-hint"
               className="rounded-full bg-[#252825] px-6 py-3 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-[#a4aaa2]"
             >

--- a/frontend/src/pages/project-create/pixel-mark.tsx
+++ b/frontend/src/pages/project-create/pixel-mark.tsx
@@ -1,0 +1,59 @@
+const GRID_SIZE = 17
+const CENTER = (GRID_SIZE - 1) / 2
+
+/**
+ * 光标笔画占用的格子，坐标以 (x, y) 记，原点在左上。
+ * 这组坐标画的是一支指向右下的箭头，纯装饰，不跟随真实鼠标。
+ */
+const CURSOR_CELLS = [
+  [8, 7],
+  [8, 8],
+  [8, 9],
+  [8, 10],
+  [8, 11],
+  [9, 8],
+  [9, 9],
+  [9, 10],
+  [10, 9],
+  [10, 10],
+  [10, 11],
+  [11, 10],
+  [11, 12],
+]
+
+/**
+ * 创建页左侧的点阵标记：一张画布方框、四角把手和一支光标。
+ * 整块是装饰，没有语义也不接受输入，因此对辅助技术隐藏。
+ * 动画全部由 CSS 承担：环号决定底噪的相位差，(x+y)%4 决定实心格的相位差，
+ * 换算成 animation-delay，让 289 个格子错峰呼吸而不是整块一起闪。
+ */
+export function ProjectCreatePixelMark() {
+  return (
+    <div aria-hidden="true" className="project-pixel-mark">
+      {Array.from({ length: GRID_SIZE * GRID_SIZE }, (_, index) => {
+        const x = index % GRID_SIZE
+        const y = Math.floor(index / GRID_SIZE)
+        const frame =
+          ((y === 3 || y === 13) && x >= 3 && x <= 13) ||
+          ((x === 3 || x === 13) && y >= 3 && y <= 13)
+        const handle = (x === 2 || x === 14) && (y === 2 || y === 14)
+        const cursor = CURSOR_CELLS.some(([cellX, cellY]) => cellX === x && cellY === y)
+        const guide = (y === 6 && x >= 5 && x <= 7) || (x === 6 && y >= 5 && y <= 7)
+        const ring = Math.min(8, Math.floor(Math.hypot(x - CENTER, y - CENTER)))
+        const role = handle
+          ? 'is-active is-handle'
+          : cursor
+            ? 'is-active is-cursor'
+            : frame || guide
+              ? 'is-active'
+              : ''
+        return (
+          <i
+            key={index}
+            className={`pixel-ring-${ring} pixel-phase-${(x + y) % 4} ${role}`.trim()}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -38,7 +38,7 @@ describe('ProjectsPage', () => {
     expect(screen.queryByRole('link', { name: /查看角色/ })).toBeNull()
   })
 
-  it('keeps creation out of this module and deletes through the Project API', async () => {
+  it('sends creation to the project create page and deletes through the Project API', async () => {
     const backend = installBackend()
     render(
       <MemoryRouter initialEntries={['/projects']}>
@@ -47,8 +47,9 @@ describe('ProjectsPage', () => {
     )
 
     expect(await screen.findAllByRole('link', { name: /打开项目/ })).toHaveLength(2)
-    const createButton = screen.getByRole('button', { name: '新建项目' })
-    expect(createButton.hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('link', { name: '新建项目' }).getAttribute('href')).toBe(
+      '/projects/new',
+    )
     expect(screen.queryByRole('dialog', { name: '新建项目' })).toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: '删除项目 空白海岸' }))

--- a/frontend/src/pages/projects/index.tsx
+++ b/frontend/src/pages/projects/index.tsx
@@ -76,15 +76,13 @@ export function ProjectsPage() {
               项目隔离角色资产与生成规格；先选项目，再管理其资产。
             </p>
           </div>
-          <button
-            type="button"
+          <Link
+            to="/projects/new"
             aria-label="新建项目"
-            disabled
-            title="新建项目流程不在本模块中"
-            className="cursor-not-allowed rounded-full border border-[#cbd1c8] px-5 py-2.5 text-sm font-semibold text-[#858c84]"
+            className="rounded-full border border-[#cbd1c8] px-5 py-2.5 text-sm font-semibold text-[#3a403a] transition hover:border-[#9da59b] hover:bg-white"
           >
             ＋ 新建项目
-          </button>
+          </Link>
         </header>
 
         {error ? (
@@ -99,7 +97,9 @@ export function ProjectsPage() {
         ) : projectsPage.total === 0 ? (
           <div className="mt-6 rounded-2xl border border-dashed border-[#c9cec6] p-7">
             <h2 className="font-semibold text-[#252a25]">还没有项目</h2>
-            <p className="mt-2 text-sm text-[#6d736c]">完成新建项目流程后，项目会显示在这里。</p>
+            <p className="mt-2 text-sm text-[#6d736c]">
+              从右上角新建一个项目，之后它会显示在这里。
+            </p>
           </div>
         ) : (
           <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -48,32 +48,6 @@ export function getApiAccessToken(): string | null | undefined {
   return accessTokenProviders.at(-1)?.()
 }
 
-/**
- * 当前登录用户的 ID 读取函数。
- * 后端多数写接口把 user_id 放在请求体里而不是从 token 推导，所以前端除了 token
- * 之外还要能单独拿到这个 ID；两者都由登录模块持有，这里只保存读取函数。
- */
-export type CurrentUserIdProvider = () => string | null | undefined
-
-const currentUserIdProviders: CurrentUserIdProvider[] = []
-
-/** 注册当前用户 ID 的读取函数；返回值用于模块卸载或测试结束时撤销本次注册。 */
-export function registerCurrentUserIdProvider(provider: CurrentUserIdProvider): () => void {
-  currentUserIdProviders.push(provider)
-  return () => {
-    const index = currentUserIdProviders.lastIndexOf(provider)
-    if (index >= 0) currentUserIdProviders.splice(index, 1)
-  }
-}
-
-/**
- * 读取当前登录用户 ID；登录模块尚未接入时返回 null。
- * 调用方必须按「拿不到就不让写」处理，不允许退回到任何常量 ID。
- */
-export function getCurrentUserId(): string | null {
-  return currentUserIdProviders.at(-1)?.() ?? null
-}
-
 export type ApiErrorKind = 'business' | 'http' | 'invalid-response' | 'network'
 
 /** 后端业务错误与传输错误统一进入这一种前端错误。 */

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -48,6 +48,32 @@ export function getApiAccessToken(): string | null | undefined {
   return accessTokenProviders.at(-1)?.()
 }
 
+/**
+ * 当前登录用户的 ID 读取函数。
+ * 后端多数写接口把 user_id 放在请求体里而不是从 token 推导，所以前端除了 token
+ * 之外还要能单独拿到这个 ID；两者都由登录模块持有，这里只保存读取函数。
+ */
+export type CurrentUserIdProvider = () => string | null | undefined
+
+const currentUserIdProviders: CurrentUserIdProvider[] = []
+
+/** 注册当前用户 ID 的读取函数；返回值用于模块卸载或测试结束时撤销本次注册。 */
+export function registerCurrentUserIdProvider(provider: CurrentUserIdProvider): () => void {
+  currentUserIdProviders.push(provider)
+  return () => {
+    const index = currentUserIdProviders.lastIndexOf(provider)
+    if (index >= 0) currentUserIdProviders.splice(index, 1)
+  }
+}
+
+/**
+ * 读取当前登录用户 ID；登录模块尚未接入时返回 null。
+ * 调用方必须按「拿不到就不让写」处理，不允许退回到任何常量 ID。
+ */
+export function getCurrentUserId(): string | null {
+  return currentUserIdProviders.at(-1)?.() ?? null
+}
+
 export type ApiErrorKind = 'business' | 'http' | 'invalid-response' | 'network'
 
 /** 后端业务错误与传输错误统一进入这一种前端错误。 */

--- a/frontend/src/test/project-assets-backend.ts
+++ b/frontend/src/test/project-assets-backend.ts
@@ -206,7 +206,6 @@ export function createProjectAssetsBackend({
 
     if (request.method === 'POST' && url.pathname === '/projects') {
       const body = (await request.json()) as {
-        user_id: number
         workflow_id?: number | null
         project_name: string
         character_perspective: number
@@ -223,7 +222,8 @@ export function createProjectAssetsBackend({
       }
       const created = {
         id: 4_242,
-        user_id: body.user_id,
+        // 后端从 access token 取归属，请求体里没有 user_id；这里跟 fixture 用同一个用户。
+        user_id: 7,
         workflow_id: body.workflow_id ?? null,
         project_name: body.project_name,
         character_perspective: body.character_perspective,

--- a/frontend/src/test/project-assets-backend.ts
+++ b/frontend/src/test/project-assets-backend.ts
@@ -1,4 +1,20 @@
-const projectDtos = [
+/** 后端 ProjectOut 的形状；写死成显式类型，免得 fixture 的字面量把可空字段收窄。 */
+interface ProjectDto {
+  id: number
+  user_id: number
+  workflow_id: number | null
+  project_name: string
+  character_perspective: number
+  directional_movement: number
+  sprite_width: number
+  sprite_height: number
+  game_style: string | null
+  sprite_sample_url: string | null
+  create_at: string
+  update_at: string
+}
+
+const projectDtos: ProjectDto[] = [
   {
     id: 42,
     user_id: 7,
@@ -186,6 +202,41 @@ export function createProjectAssetsBackend({
       const pageSize = Number(url.searchParams.get('page_size') ?? 20)
       const start = (page - 1) * pageSize
       return listResponse(projects.slice(start, start + pageSize), page, pageSize, projects.length)
+    }
+
+    if (request.method === 'POST' && url.pathname === '/projects') {
+      const body = (await request.json()) as {
+        user_id: number
+        workflow_id?: number | null
+        project_name: string
+        character_perspective: number
+        directional_movement: number
+        sprite_width: number
+        sprite_height: number
+        game_style?: string | null
+        sprite_sample_url?: string | null
+      }
+      if (projects.some((item) => item.project_name === body.project_name)) {
+        return new Response(JSON.stringify({ code: 400, message: '项目名称已存在', data: null }), {
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      const created = {
+        id: 4_242,
+        user_id: body.user_id,
+        workflow_id: body.workflow_id ?? null,
+        project_name: body.project_name,
+        character_perspective: body.character_perspective,
+        directional_movement: body.directional_movement,
+        sprite_width: body.sprite_width,
+        sprite_height: body.sprite_height,
+        game_style: body.game_style ?? null,
+        sprite_sample_url: body.sprite_sample_url ?? null,
+        create_at: '2026-08-06T00:00:00Z',
+        update_at: '2026-08-06T00:00:00Z',
+      }
+      projects = [...projects, created]
+      return response(created)
     }
 
     if (url.pathname.startsWith('/projects/')) {


### PR DESCRIPTION
新增 `/projects/new`，补上 #99 里唯一还没落地的那一段：项目创建。

Closes #141

## Why

`main` 上没有任何地方能创建项目。首页「工作流画布」卡片的两条动作都落在 `/projects`，`pages/home/index.tsx:88` 的注释写明这是占位；项目中心右上角的「＋ 新建项目」从 #119 加进来那天起就是 `disabled`，`title` 写着「新建项目流程不在本模块中」。用户看得到项目列表、能删项目，唯独建不出项目——这条链的第一步是断的。

\#99 把列表、创建、详情放在一起，其中列表与详情已由 #118 落地，剩下创建这一段没人接。

## Change Description

- 新增 `pages/project-create/`，源码 2 个文件、测试 1 个文件；`app.tsx` 加一条路由，`shared/api` 加一个当前用户读取边界，`index.css` 加装饰点阵的 keyframes。
- 首页画布卡片的「创建新项目」与项目中心的「＋ 新建项目」都指向 `/projects/new`，一份实现两个入口。「继续已有项目」本次不动，仍落项目中心。
- 项目中心那个按钮从 `disabled` 换成链接；空状态里「完成新建项目流程后，项目会显示在这里」改成指向右上角的实话。
- 11 条原子提交：用户边界、页面、入口、测试各一条，独立验收后又补了 7 条（详见下）。

一轮独立验收（只看 diff 与 issue，不看本文）后修掉的：

- **顶栏遮挡。** 这页不套 `PageContainer`，自己写的顶部留白在 lg 断点以下只有 48px，而 fixed 顶栏下沿在 72px，标题被压在底下。已按 `PageContainer` 同源的 `pt-24` 让位。
- **重复提交的防护名不副实。** `submit` 里读的是本次 render 闭包中的 `submitting`，同一批事件里它还是旧值，真正拦住第二次的是按钮的 `disabled`。已改成 ref latch，handler 声称有的那道闸真的会拦。
- 错误横幅不随输入撤销；禁用原因与按钮之间没有 `aria-describedby`；三处常量注释把出处指向未合入 PR 里的代码（`grep` 不到）；`API_CONTRACT.md` 仍写着「新建项目流程：只保留禁用入口」。均已修。
- 补了 4 个用例：名称留空、宽高越界、传输失败文案、错误随输入撤销——原先只有重名那一半有测试。

## Implementation Approach

- **字段照 `CreateProjectInput`，不照 live demo。** 视觉参考了 asset-lab 那版「新建角色项目」，但它是 mock：「启动方式」在架构里没有对应物（#120 已把 Workflow 模板复用划到范围外），名称限 48 字，尺寸只有三档正方形的单选。这里只保留契约里真有的六个字段，尺寸拆成宽高两个数字输入（32–2048，取自 issue #141 的产品规则，与未合入的 #75 / #126 请求校验一致），三档退成快捷填充。
- **名称限 20 字，取两个后端 PR 里更严的那个。** #75 的 `ProjectCreate` 写的是 `max_length=20`，与 `main` 上 `project/model.py` 的 `String(20)` 一致；#126 放宽到 64 并同时改了 model。按 20 实现在两种契约下都能提交成功。后端定稿后放宽是加法，反过来是破坏。
- **拿不到当前用户就不让写。** 后端 `POST /projects` 把 `user_id` 放在请求体里，不从 token 推导，而 `main` 上没有任何「当前用户是谁」的来源。新增 `registerCurrentUserIdProvider` / `getCurrentUserId`，照 `getApiAccessToken` 那套惰性 provider 的写法；没有人注册时返回 `null`，页面禁用提交并在页面上写明原因，不塞常量假 ID 让它看起来能用。
- **错误分两类。** `assertSuccessfulEnvelope` 把后端 message 原样带进 `ApiError`（`shared/api/index.ts:128`），所以重名显示的是后端那句「项目名称已存在」，只有传输失败才收敛成「项目暂时无法创建」。两种情况都不清空已填内容。
- **重复提交靠 ref latch，不只靠 disabled。** 按钮变灰之前的那一帧仍可能收到第二次事件，而 `submitting` 在同一批事件里读到的是上一次 render 的值，挡不住；`inFlight` ref 在 `submit` 入口同步判断并置位，请求失败时释放。
- **点阵是纯 CSS。** 17×17 共 289 个空元素，动画延迟由每格到中心的环号与 `(x+y) % 4` 相位算出，四组 keyframes 错峰循环。没有 canvas、没有 pointer 监听、不引任何依赖，`prefers-reduced-motion` 下整体停掉。它画的是画布方框、四角把手和一支光标形状；那支光标是画出来的图形，不跟随真实鼠标。
- **不套 `PageContainer`。** 这页左右满幅，全局顶栏保留：路由挂在 `AppShellRoute` 下，与 `/projects` 平级。

## Screenshots

**Before** — `main` 上的项目中心，「＋ 新建项目」是灰的，`title` 写着流程不在本模块中：

![before-projects](https://raw.githubusercontent.com/huyanxius/Windup/assets/pr-142-project-create/docs/pr-142/before-projects-disabled.jpg)

**Before** — 首页画布卡片展开后的两条动作，此时都指向 `/projects`：

![before-home](https://raw.githubusercontent.com/huyanxius/Windup/assets/pr-142-project-create/docs/pr-142/before-home-actions.jpg)

**After** — `/projects/new`，左侧点阵、右侧表单，顶栏保留：

![after-form](https://raw.githubusercontent.com/huyanxius/Windup/assets/pr-142-project-create/docs/pr-142/after-create-form.jpg)

**After** — 重名时显示后端原话，已填内容不丢：

![after-duplicate](https://raw.githubusercontent.com/huyanxius/Windup/assets/pr-142-project-create/docs/pr-142/after-duplicate-name.jpg)

**After** — 创建成功后项目进入列表，「＋ 新建项目」已是可点的入口：

![after-projects](https://raw.githubusercontent.com/huyanxius/Windup/assets/pr-142-project-create/docs/pr-142/after-projects-active.jpg)

截图取自本地 dev server，配一个只存在于本机、按 PR #75 的 `ProjectCreate` / `ProjectOut` 形状回应的桩服务（业务错误照后端习惯走 HTTP 200 + `code != 200`）。为让创建入口可用，本机临时注册了一个返回固定 `user_id` 的 provider。桩服务与那行临时注册都不进仓库。

## Testing

本地执行了 CI 工作流中的全部步骤：

- `npm run format:check` — 通过（58 个文件）
- `npm run lint` — 通过，无告警
- `npm run typecheck` — 通过
- `npm run test` — 通过（11 个文件 / 48 个用例，其中 project-create 9 个用例）
- `npm run build` — 通过（280.25 kB / gzip 87.98 kB）

浏览器手工核对：两个入口都进 `/projects/new`；重名报错后表单内容保留；改名后提交成功并跳进该项目的资产工作区，侧栏规格与表单填的一致；未注册用户 provider 时提交按钮为灰并给出原因。

## Follow-ups

- **参考图字段留到下一个 PR。** `sprite_sample_url` 后端已有，但前端还没有文件上传能力（#109 / #111）。严格照契约做出来会是一个「请粘贴图片链接」的输入框，产品上是负分，因此本 PR 有意不放这个字段，上传适配落地后单独提 PR 补。
- 「继续已有项目」仍指项目中心。等 #100 / PR #105 的 History 合入后改指 `/projects/:projectId/history`。
- **创建后进不了画布。** `/workflow-editor/:runId` 需要一个 runId，而 `WorkflowController` 在 `main` 上只有接口没有实现（PR #107），编辑器本身也还是占位页（#120）。现在创建成功后落该项目的资产工作区。
- 后端 `/projects` 与 `/auth` 都还没进 `main`（#75 / #126）。接口挂载前，部署环境里这页的创建入口是禁用状态。
- 两个后端 PR 的 `project_name` 限长不一致（#75 是 20，#126 是 64），需要定一个。另外 `POST /projects` 在请求体里收 `user_id` 而不是从登录态取，在已有 JWT 与 `/auth/me` 的前提下意味着可以替别人建项目，这条也值得后端确认。

## Related

- #141 — 本 PR 的 issue。
- #99 — 列表、创建、详情的原始 issue；列表与详情已由 #118 落地，本 PR 补创建这一段。
- #120 — Workflow Editor 画布，创建之后的下一环。
