### PR TITLE
feat(header): add account access

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -1,19 +1,75 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
-import { MemoryRouter } from 'react-router'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 
+import type { AuthTokens, UserApis } from '@/entities'
+import { AuthSessionProvider } from '@/features/auth-session'
 import { AppHeader } from './app-header'
 
-afterEach(cleanup)
+const user = {
+  id: '7',
+  email: 'reader@example.com',
+  nickname: 'Reader',
+  emailVerifiedAt: '2026-08-07T01:02:03Z',
+  statusCode: 0,
+}
+
+function tokens(): AuthTokens {
+  return { accessToken: 'access-token', refreshToken: 'rotated-refresh-token', user }
+}
+
+function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn>> {
+  return {
+    sendCode: vi.fn(async () => undefined),
+    register: vi.fn(async () => tokens()),
+    login: vi.fn(async () => tokens()),
+    loginByCode: vi.fn(async () => tokens()),
+    refresh: vi.fn(async () => tokens()),
+    logout: vi.fn(async () => undefined),
+    me: vi.fn(async () => user),
+    changePassword: vi.fn(async () => undefined),
+  }
+}
+
+function LocationProbe() {
+  const location = useLocation()
+  return (
+    <output data-testid="location">{`${location.pathname}${location.search}${location.hash}`}</output>
+  )
+}
+
+function renderHeader(entry = '/', apis = createApis()) {
+  return {
+    apis,
+    ...render(
+      <AuthSessionProvider apis={apis}>
+        <MemoryRouter initialEntries={[entry]}>
+          <Routes>
+            <Route
+              path="*"
+              element={
+                <>
+                  <AppHeader />
+                  <LocationProbe />
+                </>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </AuthSessionProvider>,
+    ),
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+})
 
 describe('AppHeader', () => {
   it('保留三个产品入口，并将工作流路由归入创作', () => {
-    render(
-      <MemoryRouter initialEntries={['/workflow-editor/run-1']}>
-        <AppHeader />
-      </MemoryRouter>,
-    )
+    renderHeader('/workflow-editor/run-1')
 
     expect(screen.getByRole('link', { name: '返回 Windup 首页' }).getAttribute('href')).toBe('/')
     expect(screen.getByRole('link', { name: '项目资产' }).getAttribute('href')).toBe('/projects')
@@ -22,14 +78,31 @@ describe('AppHeader', () => {
   })
 
   it('在首页只高亮首页一项', () => {
-    render(
-      <MemoryRouter initialEntries={['/']}>
-        <AppHeader />
-      </MemoryRouter>,
-    )
+    renderHeader()
 
     expect(screen.getByRole('link', { name: '首页' }).getAttribute('aria-current')).toBe('page')
     expect(screen.getByRole('link', { name: '项目资产' }).getAttribute('aria-current')).toBeNull()
     expect(screen.getByRole('link', { name: '创作' }).getAttribute('aria-current')).toBeNull()
+  })
+
+  it('为访客提供可发现的登录入口并保留完整站内回跳地址', async () => {
+    renderHeader('/quick-start?mode=fast#brief')
+
+    const entry = await screen.findByRole('link', { name: '登录 / 注册' })
+    expect(entry.getAttribute('href')).toBe(
+      '/?account=login&returnTo=%2Fquick-start%3Fmode%3Dfast%23brief',
+    )
+  })
+
+  it('显示登录用户并在登出后回到首页访客态', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    const { apis } = renderHeader('/projects')
+
+    expect(await screen.findByText('Reader')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '退出登录' }))
+
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'))
+    expect(await screen.findByRole('link', { name: '登录 / 注册' })).toBeTruthy()
+    expect(apis.logout).toHaveBeenCalledWith('rotated-refresh-token')
   })
 })

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -132,16 +132,16 @@ export function AppHeader() {
             <Link
               to={accountEntry}
               aria-label="登录 / 注册"
-              className="inline-flex min-h-11 items-center rounded-[0.5625rem] bg-[#284331] px-2.5 text-[13px] font-semibold whitespace-nowrap text-white transition-colors hover:bg-[#1f3627] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331]"
+              className="inline-flex min-h-11 items-center rounded-[0.5625rem] border border-[#2d3b31]/14 bg-white/35 px-3 text-[13px] font-semibold whitespace-nowrap text-[#34483a] transition-colors hover:border-[#2d3b31]/22 hover:bg-[#edf2ed] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331]"
             >
               <span className="hidden sm:inline">登录 / 注册</span>
               <span className="sm:hidden">登录</span>
             </Link>
           ) : (
-            <>
+            <div className="flex min-w-0 items-center overflow-hidden rounded-[0.5625rem] border border-[#2d3b31]/14 bg-white/35">
               <span
                 title={session.state.user.email}
-                className="max-w-14 truncate px-1 text-xs font-semibold text-[#34483a] sm:max-w-28"
+                className="inline-flex min-h-11 max-w-16 items-center truncate px-3 text-xs font-semibold text-[#34483a] sm:max-w-28"
               >
                 {session.state.user.nickname || session.state.user.email}
               </span>
@@ -149,11 +149,11 @@ export function AppHeader() {
                 type="button"
                 onClick={signOut}
                 aria-label="退出登录"
-                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-[0.5625rem] px-2 text-xs font-semibold text-[#68736a] transition-colors hover:bg-[#e7eee8] hover:text-[#26372c] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331]"
+                className="inline-flex min-h-11 min-w-11 items-center justify-center border-l border-[#2d3b31]/12 px-2.5 text-xs font-semibold text-[#68736a] transition-colors hover:bg-[#dce9df] hover:text-[#26372c] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#284331]"
               >
                 退出
               </button>
-            </>
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -1,4 +1,6 @@
-import { Link, useLocation } from 'react-router'
+import { Link, useLocation, useNavigate } from 'react-router'
+
+import { useAuthSession } from '@/features/auth-session'
 
 interface ProductNavigationItem {
   to: string
@@ -53,8 +55,19 @@ function getWorkspaceLabel(pathname: string): { title: string; detail: string } 
  * 悬浮不占布局高度，页面顶部留白由页面或 PageContainer 自己让出。
  */
 export function AppHeader() {
-  const { pathname } = useLocation()
+  const { pathname, search, hash } = useLocation()
+  const navigate = useNavigate()
+  const session = useAuthSession()
   const workspace = getWorkspaceLabel(pathname)
+  const accountEntry = `/?${new URLSearchParams({
+    account: 'login',
+    returnTo: `${pathname}${search}${hash}`,
+  })}`
+
+  function signOut() {
+    const returnHome = () => navigate('/', { replace: true })
+    void session.logout().then(returnHome, returnHome)
+  }
 
   return (
     <header className="pointer-events-none fixed inset-x-0 top-3.5 z-50 flex items-start justify-between gap-2 px-3 text-[#1c231e] sm:gap-4 sm:px-[18px]">
@@ -62,10 +75,10 @@ export function AppHeader() {
         <Link
           to="/"
           aria-label="返回 Windup 首页"
-          className="flex shrink-0 items-center gap-2 text-[#1c231e] focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] md:border-r md:border-[#2d3b31]/12 md:pr-3"
+          className="flex min-h-11 min-w-11 shrink-0 items-center justify-center gap-2 text-[#1c231e] focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] sm:min-w-0 sm:justify-start md:border-r md:border-[#2d3b31]/12 md:pr-3"
         >
           <img src="/windup-mark.svg" alt="" className="h-[1.6875rem] w-[1.6875rem]" />
-          <strong className="font-serif text-base leading-none">Windup</strong>
+          <strong className="hidden font-serif text-base leading-none sm:inline">Windup</strong>
         </Link>
 
         <span className="hidden min-w-0 gap-0.5 md:grid">
@@ -74,38 +87,76 @@ export function AppHeader() {
         </span>
       </div>
 
-      <nav
-        aria-label="产品导航"
-        className="pointer-events-auto flex min-h-[3.625rem] items-center gap-[3px] rounded-xl border border-[#171817]/14 bg-[#dfe3df] p-[7px_9px]"
-      >
-        {productNavigation.map((item) => {
-          const active = item.isActive(pathname)
+      <div className="pointer-events-auto flex min-h-[3.625rem] min-w-0 items-center gap-1 rounded-xl border border-[#171817]/14 bg-[#dfe3df] p-[7px]">
+        <nav aria-label="产品导航" className="flex min-w-0 items-center gap-[3px]">
+          {productNavigation.map((item) => {
+            const active = item.isActive(pathname)
 
-          return (
-            <Link
-              key={item.to}
-              to={item.to}
-              aria-label={item.label}
-              aria-current={active ? 'page' : undefined}
-              style={{ fontSize: '13px', fontWeight: 600 }}
-              className={`inline-flex min-h-[2.125rem] items-center rounded-[0.5625rem] px-2.5 whitespace-nowrap transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331] ${
-                active
-                  ? 'bg-[#dce9df] text-[#284331]'
-                  : 'text-[#5b655d] hover:bg-[#e7eee8] hover:text-[#26372c]'
-              }`}
+            return (
+              <Link
+                key={item.to}
+                to={item.to}
+                aria-label={item.label}
+                aria-current={active ? 'page' : undefined}
+                style={{ fontSize: '13px', fontWeight: 600 }}
+                className={`inline-flex min-h-11 items-center rounded-[0.5625rem] px-2.5 whitespace-nowrap transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331] ${
+                  active
+                    ? 'bg-[#dce9df] text-[#284331]'
+                    : 'text-[#5b655d] hover:bg-[#e7eee8] hover:text-[#26372c]'
+                }`}
+              >
+                {item.compactLabel ? (
+                  <>
+                    <span className="hidden sm:inline">{item.label}</span>
+                    <span className="sm:hidden">{item.compactLabel}</span>
+                  </>
+                ) : (
+                  item.label
+                )}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <span aria-hidden="true" className="mx-0.5 h-7 w-px shrink-0 bg-[#2d3b31]/14" />
+
+        <div aria-label="账号" className="flex min-w-0 items-center gap-1">
+          {session.state.status === 'booting' ? (
+            <span
+              aria-label="正在恢复登录状态"
+              className="inline-grid min-h-11 min-w-11 place-items-center text-sm text-[#778078] sm:min-w-20"
             >
-              {item.compactLabel ? (
-                <>
-                  <span className="hidden sm:inline">{item.label}</span>
-                  <span className="sm:hidden">{item.compactLabel}</span>
-                </>
-              ) : (
-                item.label
-              )}
+              …
+            </span>
+          ) : session.state.status === 'guest' ? (
+            <Link
+              to={accountEntry}
+              aria-label="登录 / 注册"
+              className="inline-flex min-h-11 items-center rounded-[0.5625rem] bg-[#284331] px-2.5 text-[13px] font-semibold whitespace-nowrap text-white transition-colors hover:bg-[#1f3627] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331]"
+            >
+              <span className="hidden sm:inline">登录 / 注册</span>
+              <span className="sm:hidden">登录</span>
             </Link>
-          )
-        })}
-      </nav>
+          ) : (
+            <>
+              <span
+                title={session.state.user.email}
+                className="max-w-14 truncate px-1 text-xs font-semibold text-[#34483a] sm:max-w-28"
+              >
+                {session.state.user.nickname || session.state.user.email}
+              </span>
+              <button
+                type="button"
+                onClick={signOut}
+                aria-label="退出登录"
+                className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-[0.5625rem] px-2 text-xs font-semibold text-[#68736a] transition-colors hover:bg-[#e7eee8] hover:text-[#26372c] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331]"
+              >
+                退出
+              </button>
+            </>
+          )}
+        </div>
+      </div>
     </header>
   )
 }

--- a/frontend/src/features/account-panel/index.test.tsx
+++ b/frontend/src/features/account-panel/index.test.tsx
@@ -275,13 +275,10 @@ describe('AppShell account panel host', () => {
   it('does not require an auth context while the panel is closed', () => {
     render(
       <MemoryRouter initialEntries={['/']}>
-        <AppShell>
-          <p>当前页面</p>
-        </AppShell>
+        <AccountPanel />
       </MemoryRouter>,
     )
 
-    expect(screen.getByText('当前页面')).toBeTruthy()
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AppRoutes } from '@/app'
+import { GuestAuthSession } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 afterEach(() => {
@@ -26,9 +27,11 @@ function renderPlaytest(path: string, fetchFn?: typeof globalThis.fetch) {
   vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
   vi.stubGlobal('fetch', fetchFn ?? createProjectAssetsBackend().fetch)
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <AppRoutes />
-    </MemoryRouter>,
+    <GuestAuthSession>
+      <MemoryRouter initialEntries={[path]}>
+        <AppRoutes />
+      </MemoryRouter>
+    </GuestAuthSession>,
   )
 }
 

--- a/frontend/src/pages/project-create/index.test.tsx
+++ b/frontend/src/pages/project-create/index.test.tsx
@@ -4,14 +4,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router'
 
 import { AppRoutes } from '@/app'
-import { registerApiAccessTokenProvider } from '@/shared/api'
+import { AuthenticatedAuthSession, GuestAuthSession } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
-
-const revokeProviders: Array<() => void> = []
 
 afterEach(() => {
   cleanup()
-  while (revokeProviders.length) revokeProviders.pop()?.()
+  window.localStorage.clear()
   vi.unstubAllEnvs()
   vi.unstubAllGlobals()
 })
@@ -23,17 +21,17 @@ function installBackend() {
   return backend
 }
 
-/** 登录模块尚未落地，测试里用同一个 provider 边界冒充已签发的 access token。 */
-function signIn(accessToken = 'access-token-for-test') {
-  revokeProviders.push(registerApiAccessTokenProvider(() => accessToken))
-}
-
-function renderProjectCreate() {
-  return render(
-    <MemoryRouter initialEntries={['/projects/new']}>
-      <AppRoutes />
-    </MemoryRouter>,
+async function renderProjectCreate(authenticated = true) {
+  const Session = authenticated ? AuthenticatedAuthSession : GuestAuthSession
+  const result = render(
+    <Session>
+      <MemoryRouter initialEntries={['/projects/new']}>
+        <AppRoutes />
+      </MemoryRouter>
+    </Session>,
   )
+  if (authenticated) await screen.findByText('Reader')
+  return result
 }
 
 function creationRequests(backend: ReturnType<typeof createProjectAssetsBackend>) {
@@ -45,8 +43,7 @@ function creationRequests(backend: ReturnType<typeof createProjectAssetsBackend>
 describe('ProjectCreatePage', () => {
   it('按项目契约提交表单并进入创建出的项目', async () => {
     const backend = installBackend()
-    signIn()
-    renderProjectCreate()
+    await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
     fireEvent.change(screen.getByLabelText('游戏视角'), { target: { value: 'top-down' } })
@@ -73,18 +70,19 @@ describe('ProjectCreatePage', () => {
 
   it('没有登录凭证时禁用创建并说明原因', async () => {
     const backend = installBackend()
-    renderProjectCreate()
+    await renderProjectCreate(false)
 
     const submit = await screen.findByRole('button', { name: '创建项目' })
     expect(submit.hasAttribute('disabled')).toBe(true)
-    expect(screen.getByText(/登录/)).toBeTruthy()
+    expect(
+      screen.getByText('创建项目需要先登录。登录模块尚未接入，创建入口暂时保持关闭。'),
+    ).toBeTruthy()
     expect(creationRequests(backend)).toHaveLength(0)
   })
 
   it('名称超过 20 字时在提交前拦下', async () => {
     const backend = installBackend()
-    signIn()
-    renderProjectCreate()
+    await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾'.repeat(21) } })
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
@@ -95,8 +93,7 @@ describe('ProjectCreatePage', () => {
 
   it('名称重复时保留已填内容并显示后端给出的原因', async () => {
     installBackend()
-    signIn()
-    renderProjectCreate()
+    await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '点灯人 · MVP' } })
     fireEvent.change(screen.getByLabelText('画风约束'), { target: { value: '低饱和像素绘本' } })
@@ -108,8 +105,7 @@ describe('ProjectCreatePage', () => {
 
   it('连续点击创建只发出一次请求', async () => {
     const backend = installBackend()
-    signIn()
-    renderProjectCreate()
+    await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
     const submit = screen.getByRole('button', { name: '创建项目' })
@@ -121,8 +117,7 @@ describe('ProjectCreatePage', () => {
   })
   it('名称留空时在提交前拦下', async () => {
     const backend = installBackend()
-    signIn()
-    renderProjectCreate()
+    await renderProjectCreate()
 
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
 
@@ -132,8 +127,7 @@ describe('ProjectCreatePage', () => {
 
   it('精灵宽高越界时在提交前拦下', async () => {
     const backend = installBackend()
-    signIn()
-    renderProjectCreate()
+    await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
     fireEvent.change(screen.getByLabelText('宽度（像素）'), { target: { value: '16' } })
@@ -148,8 +142,7 @@ describe('ProjectCreatePage', () => {
   it('传输失败时收敛成一句统一文案', async () => {
     installBackend()
     vi.stubGlobal('fetch', () => Promise.reject(new TypeError('offline')))
-    signIn()
-    renderProjectCreate()
+    await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
@@ -159,8 +152,7 @@ describe('ProjectCreatePage', () => {
 
   it('改动任一字段后撤掉上一次的错误', async () => {
     installBackend()
-    signIn()
-    renderProjectCreate()
+    await renderProjectCreate()
 
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
     expect(await screen.findByRole('alert')).toBeTruthy()
@@ -171,8 +163,7 @@ describe('ProjectCreatePage', () => {
   })
   it('点尺寸预设后撤掉上一次的错误', async () => {
     installBackend()
-    signIn()
-    renderProjectCreate()
+    await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
     fireEvent.change(screen.getByLabelText('宽度（像素）'), { target: { value: '16' } })

--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router'
 
 import { AppRoutes } from '@/app'
+import { GuestAuthSession } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 afterEach(() => {
@@ -23,9 +24,11 @@ describe('ProjectsPage', () => {
   it('renders backend Projects as the first browsing level', async () => {
     installBackend()
     const { container } = render(
-      <MemoryRouter initialEntries={['/projects']}>
-        <AppRoutes />
-      </MemoryRouter>,
+      <GuestAuthSession>
+        <MemoryRouter initialEntries={['/projects']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </GuestAuthSession>,
     )
 
     expect(await screen.findByRole('heading', { name: '项目中心' })).toBeTruthy()
@@ -41,9 +44,11 @@ describe('ProjectsPage', () => {
   it('sends creation to the project create page and deletes through the Project API', async () => {
     const backend = installBackend()
     render(
-      <MemoryRouter initialEntries={['/projects']}>
-        <AppRoutes />
-      </MemoryRouter>,
+      <GuestAuthSession>
+        <MemoryRouter initialEntries={['/projects']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </GuestAuthSession>,
     )
 
     expect(await screen.findAllByRole('link', { name: /打开项目/ })).toHaveLength(2)
@@ -70,9 +75,11 @@ describe('ProjectsPage', () => {
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
     vi.stubGlobal('fetch', backend.fetch)
     render(
-      <MemoryRouter initialEntries={['/projects']}>
-        <AppRoutes />
-      </MemoryRouter>,
+      <GuestAuthSession>
+        <MemoryRouter initialEntries={['/projects']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </GuestAuthSession>,
     )
 
     expect(await screen.findAllByRole('link', { name: /打开项目/ })).toHaveLength(12)

--- a/frontend/src/test/auth-session.tsx
+++ b/frontend/src/test/auth-session.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react'
+
+import type { UserApis } from '@/entities'
+import { AuthSessionProvider } from '@/features/auth-session'
+
+const guestApis: UserApis = {
+  sendCode: async () => undefined,
+  register: async () => Promise.reject(new Error('guest test session does not register')),
+  login: async () => Promise.reject(new Error('guest test session does not log in')),
+  loginByCode: async () => Promise.reject(new Error('guest test session does not log in')),
+  refresh: async () => Promise.reject(new Error('guest test session has no refresh token')),
+  logout: async () => undefined,
+  me: async () => Promise.reject(new Error('guest test session has no current user')),
+  changePassword: async () =>
+    Promise.reject(new Error('guest test session cannot change password')),
+}
+
+/** 为直接渲染 AppRoutes 的页面测试补齐生产组合根中的访客会话。 */
+export function GuestAuthSession({ children }: { children: ReactNode }) {
+  return <AuthSessionProvider apis={guestApis}>{children}</AuthSessionProvider>
+}

--- a/frontend/src/test/auth-session.tsx
+++ b/frontend/src/test/auth-session.tsx
@@ -1,7 +1,37 @@
+/* oxlint-disable react/only-export-components -- 测试会话组件与配套 fixture 共用一个入口。 */
 import type { ReactNode } from 'react'
 
-import type { UserApis } from '@/entities'
-import { AuthSessionProvider } from '@/features/auth-session'
+import type { AuthTokens, User, UserApis } from '@/entities'
+import { AuthSessionProvider, useAuthSession } from '@/features/auth-session'
+
+export const testUser: User = {
+  id: '7',
+  email: 'reader@example.com',
+  nickname: 'Reader',
+  emailVerifiedAt: '2026-08-07T01:02:03Z',
+  statusCode: 0,
+}
+
+function tokens(): AuthTokens {
+  return {
+    accessToken: 'access-token-for-test',
+    refreshToken: 'rotated-refresh-token',
+    user: testUser,
+  }
+}
+
+export function createAuthenticatedTestApis(): UserApis {
+  return {
+    sendCode: async () => undefined,
+    register: async () => tokens(),
+    login: async () => tokens(),
+    loginByCode: async () => tokens(),
+    refresh: async () => tokens(),
+    logout: async () => undefined,
+    me: async () => testUser,
+    changePassword: async () => undefined,
+  }
+}
 
 const guestApis: UserApis = {
   sendCode: async () => undefined,
@@ -18,4 +48,19 @@ const guestApis: UserApis = {
 /** 为直接渲染 AppRoutes 的页面测试补齐生产组合根中的访客会话。 */
 export function GuestAuthSession({ children }: { children: ReactNode }) {
   return <AuthSessionProvider apis={guestApis}>{children}</AuthSessionProvider>
+}
+
+export function AuthenticatedAuthSession({ children }: { children: ReactNode }) {
+  window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+  return (
+    <AuthSessionProvider apis={createAuthenticatedTestApis()}>
+      <AuthenticatedChildren>{children}</AuthenticatedChildren>
+    </AuthSessionProvider>
+  )
+}
+
+/** 业务页面只在 access token 已恢复后挂载，避免把启动中的空 token 固化进首次 render。 */
+function AuthenticatedChildren({ children }: { children: ReactNode }) {
+  const session = useAuthSession()
+  return session.state.status === 'authenticated' ? children : null
 }


### PR DESCRIPTION
## Feature Description

- 为全局 Header 增加稳定的账号区域，覆盖启动、访客和已登录三态。
- 访客可从 Header 打开 #159 的登录/注册面板，并保留当前站内路径作为安全回跳地址。
- 已登录用户显示昵称，缺失时回退到邮箱，并可直接退出登录回到首页。
- 桌面与窄屏均保持导航可用、无横向滚动，交互区域不小于 44px。

## Implementation Approach

- Header 只消费认证会话公开状态、用户昵称/邮箱与 `logout()`，不读取 token、DTO 或持久化实现。
- 为直接渲染路由的页面测试补充访客会话包装；项目工作区继续使用自身外壳，不增加全局 Header。
- 本 PR 仅包含 #164 的三个原子提交，不重复携带 #158、#159 的提交；按 #158 → #159 → #164 顺序合并。

## Screenshots

以下截图统一为 1280 × 720 横屏完整页面。

### 访客态

![Header 访客态横屏完整页面](https://github.com/user-attachments/assets/ad37db55-f618-433a-b3fe-8cf20c0fb18d)

### 登录态

![Header 登录态横屏完整页面](https://github.com/user-attachments/assets/9bdd18a6-7e80-4a0c-bbba-3d97213f0f3c)

## Testing

- `git diff --check upstream/main...HEAD`：通过。
- 在完整用户模块集成分支执行 4 个聚焦文件：26/26 通过。
- 全量测试：22 个文件、124 项通过。
- `npm run format:check`、`npm run lint`、`npm run typecheck`、`npm run build`：通过。
- 干净上下文独立验收：通过，无阻断项；另复跑项目工作区 2/2 与 `typecheck`。

## Scope Boundary

- #160 不再重复修改全局 Header，只处理路由守卫、会话过期提示和项目工作区账号入口。
- `/account`、资料查看和修改密码仍归 #161。
- 本地认证桩只验证前端交互，不代表真实后端联调。

Closes #164

## Related

- #157
- #158
- #159
- #160
- #161
- PR #75
