### PR TITLE
fix(account-panel): drop the email code from password login

### DIFF
--- a/frontend/src/entities/user/api.test.ts
+++ b/frontend/src/entities/user/api.test.ts
@@ -55,7 +55,6 @@ describe('createUserApis', () => {
     await apis.login({
       email: 'reader@example.com',
       password: 'password-123',
-      code: '123456',
     })
     await apis.loginByCode({ email: 'reader@example.com', code: '123456' })
     await apis.refresh('refresh-token')
@@ -89,7 +88,6 @@ describe('createUserApis', () => {
           json: {
             email: 'reader@example.com',
             password: 'password-123',
-            code: '123456',
           },
         },
       ],

--- a/frontend/src/entities/user/index.ts
+++ b/frontend/src/entities/user/index.ts
@@ -25,7 +25,8 @@ export interface UserApis {
     code: string
     nickname?: string
   }): Promise<AuthTokens>
-  login(input: { email: string; password: string; code: string }): Promise<AuthTokens>
+  /** 密码登录不带验证码；验证码只用于注册、免密登录与重设密码。 */
+  login(input: { email: string; password: string }): Promise<AuthTokens>
   loginByCode(input: { email: string; code: string }): Promise<AuthTokens>
   refresh(refreshToken: string): Promise<AuthTokens>
   logout(refreshToken: string): Promise<void>

--- a/frontend/src/features/account-panel/index.test.tsx
+++ b/frontend/src/features/account-panel/index.test.tsx
@@ -207,31 +207,26 @@ describe('AccountPanel', () => {
     expect(screen.getByTestId('location').textContent).toBe('/')
   })
 
-  it('submits password login with a login-purpose code and keeps recovery visibly unavailable', async () => {
+  it('submits password login without an email code and keeps recovery visibly unavailable', async () => {
     const { apis } = renderPanel()
     fireEvent.click(screen.getByRole('tab', { name: '密码登录' }))
     expect(screen.getByText('忘记密码')).toBeTruthy()
     expect(screen.getByText('暂未开放')).toBeTruthy()
+    expect(screen.queryByLabelText('验证码')).toBeNull()
+    expect(screen.queryByRole('button', { name: '发送验证码' })).toBeNull()
+    expect(screen.getByText('用邮箱和密码直接登录。')).toBeTruthy()
 
     fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'reader@example.com' } })
     fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'password-123' } })
-    fireEvent.change(screen.getByLabelText('验证码'), { target: { value: '123456' } })
-    fireEvent.click(screen.getByRole('button', { name: '发送验证码' }))
-    await waitFor(() =>
-      expect(apis.sendCode).toHaveBeenCalledWith({
-        email: 'reader@example.com',
-        purpose: 'login',
-      }),
-    )
 
     fireEvent.submit(screen.getByRole('button', { name: '登录' }).closest('form')!)
     await waitFor(() =>
       expect(apis.login).toHaveBeenCalledWith({
         email: 'reader@example.com',
         password: 'password-123',
-        code: '123456',
       }),
     )
+    expect(apis.sendCode).not.toHaveBeenCalled()
   })
 
   it('validates registration fields and sends register-purpose codes', async () => {

--- a/frontend/src/features/account-panel/index.tsx
+++ b/frontend/src/features/account-panel/index.tsx
@@ -32,7 +32,7 @@ const modeCopy: Record<
   password: {
     tab: '密码登录',
     title: '登录 Windup',
-    description: '使用密码和邮箱验证码确认身份。',
+    description: '用邮箱和密码直接登录。',
     submit: '登录',
   },
   register: {
@@ -177,7 +177,7 @@ function AccountPanelDialog() {
     if (mode !== 'code' && (password.length < 8 || password.length > 128)) {
       return '密码需为 8–128 位'
     }
-    if (!CODE_PATTERN.test(code)) return '验证码需为 6 位数字'
+    if (mode !== 'password' && !CODE_PATTERN.test(code)) return '验证码需为 6 位数字'
     if (mode === 'register' && nickname.length > 50) return '昵称不能超过 50 个字符'
     return null
   }
@@ -200,7 +200,7 @@ function AccountPanelDialog() {
         await session.loginByCode({ email: normalizedEmail, code })
         successMessage = '登录成功。如果这是你首次使用该邮箱，我们已为你创建账号。'
       } else if (mode === 'password') {
-        await session.login({ email: normalizedEmail, password, code })
+        await session.login({ email: normalizedEmail, password })
         successMessage = '登录成功，正在继续。'
       } else {
         await session.register({
@@ -379,35 +379,37 @@ function AccountPanelDialog() {
             </div>
           )}
 
-          <div className="grid gap-1.5 text-sm font-semibold text-[#344039]">
-            <label htmlFor={codeId}>验证码</label>
-            <span className="flex items-stretch gap-2">
-              <input
-                id={codeId}
-                type="text"
-                inputMode="numeric"
-                autoComplete="one-time-code"
-                maxLength={6}
-                value={code}
-                onChange={(event) => setCode(event.target.value)}
-                disabled={isSubmitting}
-                className={fieldClass}
-                placeholder="6 位数字"
-              />
-              <button
-                type="button"
-                onClick={() => void sendCode()}
-                disabled={isSendingCode || isSubmitting || cooldownSeconds > 0}
-                className="min-h-11 min-w-[7.25rem] rounded-xl border border-[#607067] bg-[#eef2ef] px-3 text-sm font-semibold text-[#34483a] transition-colors hover:bg-[#e1e8e3] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] disabled:cursor-not-allowed disabled:border-[#bbc2bc] disabled:text-[#858d87]"
-              >
-                {isSendingCode
-                  ? '正在发送…'
-                  : cooldownSeconds > 0
-                    ? `${cooldownSeconds} 秒后重发`
-                    : '发送验证码'}
-              </button>
-            </span>
-          </div>
+          {mode !== 'password' && (
+            <div className="grid gap-1.5 text-sm font-semibold text-[#344039]">
+              <label htmlFor={codeId}>验证码</label>
+              <span className="flex items-stretch gap-2">
+                <input
+                  id={codeId}
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  maxLength={6}
+                  value={code}
+                  onChange={(event) => setCode(event.target.value)}
+                  disabled={isSubmitting}
+                  className={fieldClass}
+                  placeholder="6 位数字"
+                />
+                <button
+                  type="button"
+                  onClick={() => void sendCode()}
+                  disabled={isSendingCode || isSubmitting || cooldownSeconds > 0}
+                  className="min-h-11 min-w-[7.25rem] rounded-xl border border-[#607067] bg-[#eef2ef] px-3 text-sm font-semibold text-[#34483a] transition-colors hover:bg-[#e1e8e3] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] disabled:cursor-not-allowed disabled:border-[#bbc2bc] disabled:text-[#858d87]"
+                >
+                  {isSendingCode
+                    ? '正在发送…'
+                    : cooldownSeconds > 0
+                      ? `${cooldownSeconds} 秒后重发`
+                      : '发送验证码'}
+                </button>
+              </span>
+            </div>
+          )}
 
           {mode === 'code' && (
             <p className="rounded-xl border border-[#97a99b]/45 bg-[#edf3ee] px-3.5 py-3 text-sm leading-6 text-[#46564b]">

--- a/frontend/src/features/auth-session/index.test.tsx
+++ b/frontend/src/features/auth-session/index.test.tsx
@@ -144,7 +144,6 @@ describe('AuthSessionProvider', () => {
           await session().login({
             email: 'reader@example.com',
             password: 'password-123',
-            code: '123456',
           })
         } else {
           await session().loginByCode({ email: 'reader@example.com', code: '123456' })


### PR DESCRIPTION
前端密码登录路径去掉邮箱验证码，与 #149 已合入的后端 `/auth/login` 对齐。

Closes #169

## Why

#156 讨论定下的口径是密码登录不再需要验证码，验证码只保留给注册、免密登录与重设密码。后端已在 #149 落地，`LoginRequest` 现在只有 `email` 与 `password`。

前端没跟上，而且症状不是"多发一个字段被后端忽略"这么轻。`validate()` 里的验证码格式校验对三种模式一视同仁，所以在密码登录页签填对邮箱和密码也提交不了，用户必须先走一次邮件往返，去拿一个后端根本不会校验的验证码。按 #156 的描述，换设备或清理浏览器数据之后重新登录就会撞上这条路径。

## Change Description

5 个文件，+41 −46。

- `entities/user/index.ts`：`login()` 入参类型去掉 `code`
- `features/account-panel/index.tsx`：密码模式跳过验证码校验、不再渲染验证码输入框与发送按钮、提交载荷去掉 `code`、模式说明文案改写
- 三个测试文件跟随调整

免密登录与注册两条路径的验证码行为完全不动。

## Implementation Approach

- 门控条件统一用 `mode !== 'password'`，一处管校验、一处管渲染，不引入新的 state
- 先收窄类型再改实现。`UserApis['login']` 去掉 `code` 之后 `tsc` 会把所有还在传 `code` 的调用点报出来，其中 `features/auth-session/index.test.tsx` 不在 issue 声明的范围里——它不是夹带，是类型收窄的编译强制连带，不改则 typecheck 与 build 都不过
- `code` state 与 60 秒冷却逻辑原样保留，免密登录和注册仍在用

## Screenshots

密码登录页签，改动前后：

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/huyanxius/Windup/assets/169-password-login/pr-169/before-password-login.jpg" width="440"> | <img src="https://raw.githubusercontent.com/huyanxius/Windup/assets/169-password-login/pr-169/after-password-login.jpg" width="440"> |

改动前多出「验证码」输入框与「发送验证码」按钮，说明文案是「使用密码和邮箱验证码确认身份。」；改动后只剩邮箱与密码两项，文案改为「用邮箱和密码直接登录。」

## Testing

本地跑了 `frontend-ci.yml` 的全部五步：

- `npm run format:check` — 通过，85 个文件
- `npm run lint` — 通过
- `npm run typecheck` — 通过
- `npm run test` — 通过，24 个文件 146 个用例
- `npm run build` — 通过

另外用一个干净上下文的子代理做了独立验收。它自己重跑了这五步，并做了变异测试：把 `code` 加回提交载荷、把验证码 UI 改成无条件渲染、把 `validate()` 的 mode 条件去掉、把 `login()` 类型改回要求 `code`，四处都能让对应检查变红，确认这些测试挡得住回归。文案那条验收标准最初没有测试守护，是它指出来的，已补上断言并验证过能红。

## Follow-ups

- #154 找回密码接口仍未实现，面板上「忘记密码 · 暂未开放」维持原状
- `SendCodePurpose` 的 `reset_password` 目前面板不产生，等 #154 落地后接入

## Related

- Refs #156，口径讨论
- 依赖 #149，后端已合入 main
