### PR TITLE
docs(workflow-run): align persisted run contract with main

### DIFF
--- a/frontend/src/entities/workflow-run/README.md
+++ b/frontend/src/entities/workflow-run/README.md
@@ -13,16 +13,18 @@
   `character-template`，角色母版通过后即可并行，不互相阻塞。
 - 资产生成方式当前可选 `video-cropping` 与 `3d-to-2d`。3D 转 2D 后端接口未提供前只保存选择并明确阻止提交，不伪装成视频路线。
 - Quick Start 与 Workflow Editor 是两种独立界面，但推进同一张节点图，核心数据不区分 `ai/manual driver`。
+- 角色设定节点在 `input.characterId` 中保存所属角色。前端按项目列出 Run 后用该字段定位角色的唯一 Run；旧数据允许暂未绑定。
 - 后端不提供 Revision 历史。重做时覆盖旧结果，并用 `nodeId + taskId` 防止旧请求串线。
 - 已发布 Action 被删除后，对应四节点分支以 `deletedAt` 标记并继续留在图中，生成输入、任务引用和审核历史不会被擦除；角色母版及其他并行动作不受影响。
 
 ## 前后端边界
 
 前端负责节点结构、依赖边、推进规则和状态变化；后端只把 `WorkflowRun.nodes` JSON 原样保存。
-HTTP 接口严格对应 `POST /workflow-runs`、`GET/PATCH/DELETE /workflow-runs/{id}`。
+HTTP 接口严格对应 `POST /workflow-runs`、`GET /workflow-runs?project_id=...` 与
+`GET/PATCH/DELETE /workflow-runs/{id}`。项目内列表使用后端统一的分页响应，并只返回未软删除记录。
 
-当前后端没有列表、按 Character 查询或订阅接口，因此前端也不虚构这些方法。所有持久化调用
-都是异步的。后端 CRUD service 尚未实现时，本模块只提供真实接口适配器，不宣称已经联通。
+当前后端没有按 Character 查询或订阅接口，因此前端也不虚构这些方法。所有持久化调用都是异步的。
+`version` 当前只是后端随 PATCH 递增的更新序号，不宣称具备后端尚未实现的并发冲突检测。
 
 ## 文件
 

--- a/frontend/src/entities/workflow-run/index.ts
+++ b/frontend/src/entities/workflow-run/index.ts
@@ -121,7 +121,7 @@ export type WorkflowNode =
 export interface WorkflowRun {
   id: string
   projectId: string
-  /** 后端乐观版本号，每次 PATCH 后使用响应中的新值。 */
+  /** 后端更新序号；当前仅随 PATCH 递增，不承担并发冲突检测。 */
   version: number
   /** 后端资源状态，仅表示正常或软删除。 */
   storageStatus: WorkflowRunStorageStatus


### PR DESCRIPTION
## 当前改动

- 已 rebase 到最新 `main`（`40cf126`），冲突已解决。
- `listByProject` 的真实实现、分页映射、角色绑定和测试均已由后续 main 改动覆盖，不在本 PR 重复提交。
- 保留 main 的兼容策略：公共 `WorkflowRunApis.listByProject` 继续可选，真实 `workflowRunApis` 导出保证该方法存在，避免破坏旧测试夹具与注入实现。
- 更新 WorkflowRun 契约说明，记录项目内分页列表、`input.characterId` 绑定与旧 Run 未绑定兼容。
- 修正 `version` 注释：当前只是 PATCH 后递增的更新序号，不宣称后端尚未实现的并发冲突检测。

## 最终范围

仅 2 个文件，`+6/-4`：

- `frontend/src/entities/workflow-run/README.md`
- `frontend/src/entities/workflow-run/index.ts`

## 验证

- 改动文件格式检查通过
- oxlint 通过
- TypeScript 类型检查通过
- 前端全量测试：41 个测试文件、378 项测试通过
- 生产构建通过
