### PR TITLE
feat(auth): guard protected routes and handle session expiry

### DIFF
--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { MemoryRouter, useLocation } from 'react-router'
 
@@ -119,6 +119,45 @@ describe('AppRoutes authentication boundary', () => {
     expect((await screen.findByRole('alert')).textContent).toContain('登录状态已过期，请重新登录。')
     expect(screen.getByRole('link', { name: '重新登录' }).getAttribute('href')).toBe(
       '/?account=login&returnTo=%2F',
+    )
+  })
+
+  it('reuses the protected return path after the expired-session panel is closed and reopened', async () => {
+    const expiredApis: UserApis = {
+      sendCode: async () => undefined,
+      register: async () => Promise.reject(new Error('not used')),
+      login: async () => Promise.reject(new Error('not used')),
+      loginByCode: async () => Promise.reject(new Error('not used')),
+      refresh: async () => Promise.reject(new Error('refresh token expired')),
+      logout: async () => undefined,
+      me: async () => Promise.reject(new Error('not used')),
+      changePassword: async () => Promise.reject(new Error('not used')),
+    }
+    window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, 'expired-refresh-token')
+
+    render(
+      <AuthSessionProvider apis={expiredApis}>
+        <MemoryRouter initialEntries={['/quick-start?draft=1#setup']}>
+          <AppRoutes />
+          <LocationProbe />
+        </MemoryRouter>
+      </AuthSessionProvider>,
+    )
+
+    expect(await screen.findByRole('dialog', { name: '登录 Windup' })).toBeTruthy()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/?returnTo=%2Fquick-start%3Fdraft%3D1%23setup',
+      ),
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: '重新登录' }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/?account=login&returnTo=%2Fquick-start%3Fdraft%3D1%23setup',
+      ),
     )
   })
 })

--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { MemoryRouter, useLocation } from 'react-router'
+
+import type { AuthTokens, UserApis } from '@/entities'
+import { AuthSessionProvider } from '@/features/auth-session'
+import { REFRESH_TOKEN_STORAGE_KEY } from '@/features/auth-session/session-storage'
+import {
+  AuthenticatedAuthSession,
+  createAuthenticatedTestApis,
+  GuestAuthSession,
+} from '@/test/auth-session'
+import { AppRoutes } from './app'
+
+function LocationProbe() {
+  const location = useLocation()
+  return (
+    <output data-testid="location">{`${location.pathname}${location.search}${location.hash}`}</output>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+})
+
+describe('AppRoutes authentication boundary', () => {
+  it('keeps the home page available to guests', async () => {
+    render(
+      <GuestAuthSession>
+        <MemoryRouter initialEntries={['/']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </GuestAuthSession>,
+    )
+
+    expect(await screen.findByRole('heading', { name: /让你的角色/ })).toBeTruthy()
+  })
+
+  it('redirects a guest before rendering a protected product page and preserves its return path', async () => {
+    render(
+      <GuestAuthSession>
+        <MemoryRouter initialEntries={['/quick-start?draft=1#setup']}>
+          <AppRoutes />
+          <LocationProbe />
+        </MemoryRouter>
+      </GuestAuthSession>,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/?account=login&returnTo=%2Fquick-start%3Fdraft%3D1%23setup',
+      ),
+    )
+    expect(screen.queryByRole('heading', { name: '快速开始' })).toBeNull()
+  })
+
+  it('waits for session restoration before mounting a protected page', async () => {
+    let resolveRefresh!: (tokens: AuthTokens) => void
+    const refresh = new Promise<AuthTokens>((resolve) => {
+      resolveRefresh = resolve
+    })
+    const baseApis = createAuthenticatedTestApis()
+    const restoringApis: UserApis = { ...baseApis, refresh: async () => refresh }
+    window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, 'stored-refresh-token')
+
+    render(
+      <AuthSessionProvider apis={restoringApis}>
+        <MemoryRouter initialEntries={['/quick-start']}>
+          <AppRoutes />
+          <LocationProbe />
+        </MemoryRouter>
+      </AuthSessionProvider>,
+    )
+
+    expect(screen.queryByRole('heading', { name: '快速开始' })).toBeNull()
+    expect(screen.getByTestId('location').textContent).toBe('/quick-start')
+
+    const restoredTokens = await baseApis.refresh('stored-refresh-token')
+    await act(async () => resolveRefresh(restoredTokens))
+
+    expect(await screen.findByRole('heading', { name: '快速开始' })).toBeTruthy()
+  })
+
+  it('renders protected product pages for an authenticated session', async () => {
+    render(
+      <AuthenticatedAuthSession>
+        <MemoryRouter initialEntries={['/quick-start']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </AuthenticatedAuthSession>,
+    )
+
+    expect(await screen.findByRole('heading', { name: '快速开始' })).toBeTruthy()
+  })
+
+  it('tells the user when restoring the session fails instead of becoming a silent guest', async () => {
+    const expiredApis: UserApis = {
+      sendCode: async () => undefined,
+      register: async () => Promise.reject(new Error('not used')),
+      login: async () => Promise.reject(new Error('not used')),
+      loginByCode: async () => Promise.reject(new Error('not used')),
+      refresh: async () => Promise.reject(new Error('refresh token expired')),
+      logout: async () => undefined,
+      me: async () => Promise.reject(new Error('not used')),
+      changePassword: async () => Promise.reject(new Error('not used')),
+    }
+    window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, 'expired-refresh-token')
+
+    render(
+      <AuthSessionProvider apis={expiredApis}>
+        <MemoryRouter initialEntries={['/']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </AuthSessionProvider>,
+    )
+
+    expect((await screen.findByRole('alert')).textContent).toContain('登录状态已过期，请重新登录。')
+    expect(screen.getByRole('link', { name: '重新登录' }).getAttribute('href')).toBe(
+      '/?account=login&returnTo=%2F',
+    )
+  })
+})

--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -10,6 +10,7 @@ import { ProjectCreatePage } from '@/pages/project-create'
 import { ProjectsPage } from '@/pages/projects'
 import { QuickStartPage } from '@/pages/quick-start'
 import { WorkflowEditorPage } from '@/pages/workflow-editor'
+import { ProtectedRoute } from '@/features/auth-guard'
 import { AppShellRoute } from './layout'
 
 /**
@@ -32,19 +33,23 @@ export function AppRoutes() {
     <Routes>
       <Route element={<AppShellRoute />}>
         <Route path="/" element={<HomePage />} />
-        <Route path="/quick-start" element={<QuickStartPage />} />
-        <Route path="/quick-start/:runId" element={<QuickStartPage />} />
-        <Route path="/projects" element={<ProjectsPage />} />
-        <Route path="/projects/new" element={<ProjectCreatePage />} />
-        <Route path="/workflow-editor/:runId" element={<WorkflowEditorPage />} />
-        <Route path="/workflow-editor/:runId/:stage" element={<WorkflowEditorPage />} />
-        <Route path="/playtest/:characterId/:outfitId" element={<PlaytestPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/quick-start" element={<QuickStartPage />} />
+          <Route path="/quick-start/:runId" element={<QuickStartPage />} />
+          <Route path="/projects" element={<ProjectsPage />} />
+          <Route path="/projects/new" element={<ProjectCreatePage />} />
+          <Route path="/workflow-editor/:runId" element={<WorkflowEditorPage />} />
+          <Route path="/workflow-editor/:runId/:stage" element={<WorkflowEditorPage />} />
+          <Route path="/playtest/:characterId/:outfitId" element={<PlaytestPage />} />
+        </Route>
         <Route path="*" element={<NotFoundPage />} />
       </Route>
-      <Route path="/projects/:projectId" element={<ProjectDetailPage />}>
-        <Route index element={<Navigate replace to="assets" />} />
-        <Route path="assets" element={<AssetLibraryPage />} />
-        <Route path="assets/:characterId" element={<CharacterDetailPage />} />
+      <Route element={<ProtectedRoute />}>
+        <Route path="/projects/:projectId" element={<ProjectDetailPage />}>
+          <Route index element={<Navigate replace to="assets" />} />
+          <Route path="assets" element={<AssetLibraryPage />} />
+          <Route path="assets/:characterId" element={<CharacterDetailPage />} />
+        </Route>
       </Route>
     </Routes>
   )

--- a/frontend/src/app/layout/index.tsx
+++ b/frontend/src/app/layout/index.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { Outlet } from 'react-router'
 
 import { AccountPanel } from '@/features/account-panel'
+import { SessionExpiredNotice } from '@/features/auth-guard'
 import { AppHeader } from './app-header'
 
 /** 跨页面常驻导航属于应用外壳，由 app 层统一承载。 */
@@ -23,6 +24,7 @@ export function AppShell({ children }: AppShellProps) {
       */}
       <main className="w-full">{children}</main>
       <AccountPanel />
+      <SessionExpiredNotice />
     </div>
   )
 }

--- a/frontend/src/features/account-panel/index.test.tsx
+++ b/frontend/src/features/account-panel/index.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { type ReactNode } from 'react'
+import { StrictMode, type ReactNode } from 'react'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
@@ -174,6 +174,29 @@ describe('AccountPanel', () => {
 
     await act(async () => vi.advanceTimersByTimeAsync(900))
     expect(screen.getByTestId('location').textContent).toBe('/projects?view=recent')
+  })
+
+  it('completes safe return navigation under the production StrictMode lifecycle', async () => {
+    vi.useFakeTimers()
+    const apis = createApis()
+    render(
+      <StrictMode>
+        <AuthSessionProvider apis={apis}>
+          <MemoryRouter initialEntries={['/?account=login&returnTo=%2Fprojects']}>
+            <AccountPanel />
+            <LocationProbe />
+          </MemoryRouter>
+        </AuthSessionProvider>
+      </StrictMode>,
+    )
+    fillCodeLogin()
+
+    fireEvent.submit(screen.getByRole('button', { name: '登录' }).closest('form')!)
+    await act(async () => Promise.resolve())
+
+    expect(screen.getByText(/登录成功/)).toBeTruthy()
+    await act(async () => vi.advanceTimersByTimeAsync(900))
+    expect(screen.getByTestId('location').textContent).toBe('/projects')
   })
 
   it('does not navigate after the panel closes while a submission is pending', async () => {

--- a/frontend/src/features/account-panel/index.tsx
+++ b/frontend/src/features/account-panel/index.tsx
@@ -123,13 +123,14 @@ function AccountPanelDialog() {
     }
   }, [])
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // StrictMode 会用一次 setup → cleanup → setup 检查副作用；第二次 setup 代表组件仍然存活。
+    dismissedRef.current = false
+    return () => {
       dismissedRef.current = true
       if (navigationTimerRef.current) window.clearTimeout(navigationTimerRef.current)
-    },
-    [],
-  )
+    }
+  }, [])
 
   function close() {
     dismissedRef.current = true

--- a/frontend/src/features/auth-guard/index.tsx
+++ b/frontend/src/features/auth-guard/index.tsx
@@ -1,0 +1,53 @@
+import { Link, Navigate, Outlet, useLocation } from 'react-router'
+
+import { useAuthSession } from '@/features/auth-session'
+
+/**
+ * 受保护路由只消费会话三态，不读取 token，也不触发业务请求。
+ * 启动恢复完成前不挂载页面；访客统一去已有账号面板，原地址交给登录成功后的安全回跳处理。
+ */
+export function ProtectedRoute() {
+  const session = useAuthSession()
+  const { pathname, search, hash } = useLocation()
+
+  if (session.state.status === 'booting') return null
+  if (session.state.status === 'authenticated') return <Outlet />
+
+  const accountSearch = new URLSearchParams({
+    account: 'login',
+    returnTo: `${pathname}${search}${hash}`,
+  })
+  return <Navigate replace to={`/?${accountSearch}`} />
+}
+
+/** 会话最终恢复失败时给出一次明确的人类可见说明；登录成功后随会话状态自动消失。 */
+export function SessionExpiredNotice() {
+  const session = useAuthSession()
+  const { pathname, search, hash } = useLocation()
+
+  if (session.state.status !== 'guest' || session.state.reason !== 'session-expired') return null
+
+  const currentSearch = new URLSearchParams(search)
+  const accountPanelOpen = currentSearch.get('account') === 'login'
+  const accountSearch = new URLSearchParams({
+    account: 'login',
+    returnTo: `${pathname}${search}${hash}`,
+  })
+
+  return (
+    <aside
+      role="alert"
+      className="fixed right-4 bottom-4 z-[80] flex max-w-[min(24rem,calc(100vw-2rem))] items-center gap-3 rounded-xl border border-[#8a5a4d]/25 bg-[#fff8f4] px-4 py-3 text-sm text-[#6f352b] shadow-[0_14px_36px_rgba(46,30,24,0.18)]"
+    >
+      <span className="leading-5">登录状态已过期，请重新登录。</span>
+      {!accountPanelOpen && (
+        <Link
+          to={`/?${accountSearch}`}
+          className="inline-flex min-h-11 shrink-0 items-center rounded-lg px-2 font-semibold text-[#284331] underline decoration-[#78927e] underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331]"
+        >
+          重新登录
+        </Link>
+      )}
+    </aside>
+  )
+}

--- a/frontend/src/features/auth-guard/index.tsx
+++ b/frontend/src/features/auth-guard/index.tsx
@@ -1,6 +1,7 @@
 import { Link, Navigate, Outlet, useLocation } from 'react-router'
 
 import { useAuthSession } from '@/features/auth-session'
+import { sanitizeInternalPath } from '@/shared/navigation'
 
 /**
  * 受保护路由只消费会话三态，不读取 token，也不触发业务请求。
@@ -12,6 +13,7 @@ export function ProtectedRoute() {
 
   if (session.state.status === 'booting') return null
   if (session.state.status === 'authenticated') return <Outlet />
+  if (session.state.reason === 'logged-out') return <Navigate replace to="/" />
 
   const accountSearch = new URLSearchParams({
     account: 'login',
@@ -29,9 +31,11 @@ export function SessionExpiredNotice() {
 
   const currentSearch = new URLSearchParams(search)
   const accountPanelOpen = currentSearch.get('account') === 'login'
+  const returnTarget =
+    sanitizeInternalPath(currentSearch.get('returnTo')) ?? `${pathname}${search}${hash}`
   const accountSearch = new URLSearchParams({
     account: 'login',
-    returnTo: `${pathname}${search}${hash}`,
+    returnTo: returnTarget,
   })
 
   return (

--- a/frontend/src/features/auth-session/index.test.tsx
+++ b/frontend/src/features/auth-session/index.test.tsx
@@ -168,7 +168,7 @@ describe('AuthSessionProvider', () => {
     act(() => {
       logoutPromise = session().logout()
     })
-    await expectState('guest::')
+    await expectState('guest:logged-out:')
     expect(getApiAccessToken()).toBeNull()
     expect(window.localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY)).toBeNull()
     expect(apis.logout).toHaveBeenCalledWith('refresh-token')
@@ -176,7 +176,7 @@ describe('AuthSessionProvider', () => {
     const rejectedLogout = expect(logoutPromise).rejects.toThrow('network unavailable')
     await act(async () => logout.reject(new Error('network unavailable')))
     await rejectedLogout
-    await expectState('guest::')
+    await expectState('guest:logged-out:')
   })
 
   it('clears the session with a password-changed reason after changing the password', async () => {

--- a/frontend/src/features/auth-session/index.tsx
+++ b/frontend/src/features/auth-session/index.tsx
@@ -19,7 +19,7 @@ import {
   saveRefreshToken,
 } from './session-storage'
 
-export type AuthGuestReason = null | 'session-expired' | 'password-changed'
+export type AuthGuestReason = null | 'logged-out' | 'session-expired' | 'password-changed'
 
 export type AuthSessionState =
   | { status: 'booting'; user: null }
@@ -324,7 +324,7 @@ export function AuthSessionProvider({ apis, children }: AuthSessionProviderProps
   )
   const logout = useCallback(async () => {
     const refreshToken = refreshTokenRef.current
-    clearSession(null)
+    clearSession('logged-out')
     if (refreshToken) await apis.logout(refreshToken)
   }, [apis, clearSession])
 

--- a/frontend/src/pages/asset-library/index.test.tsx
+++ b/frontend/src/pages/asset-library/index.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router'
 
 import { AppRoutes } from '@/app'
+import { AuthenticatedAuthSession } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 afterEach(() => {
@@ -17,9 +18,11 @@ function renderRoute(route: string) {
   vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
   vi.stubGlobal('fetch', backend.fetch)
   return render(
-    <MemoryRouter initialEntries={[route]}>
-      <AppRoutes />
-    </MemoryRouter>,
+    <AuthenticatedAuthSession>
+      <MemoryRouter initialEntries={[route]}>
+        <AppRoutes />
+      </MemoryRouter>
+    </AuthenticatedAuthSession>,
   )
 }
 
@@ -52,9 +55,11 @@ describe('AssetLibraryPage', () => {
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
     vi.stubGlobal('fetch', backend.fetch)
     render(
-      <MemoryRouter initialEntries={['/projects/42/assets']}>
-        <AppRoutes />
-      </MemoryRouter>,
+      <AuthenticatedAuthSession>
+        <MemoryRouter initialEntries={['/projects/42/assets']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </AuthenticatedAuthSession>,
     )
 
     expect(await screen.findAllByRole('link', { name: /查看角色/ })).toHaveLength(24)

--- a/frontend/src/pages/character-detail/index.test.tsx
+++ b/frontend/src/pages/character-detail/index.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router'
 
 import { AppRoutes } from '@/app'
+import { AuthenticatedAuthSession } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 afterEach(() => {
@@ -17,9 +18,11 @@ function renderCharacter(characterId: string) {
   vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
   vi.stubGlobal('fetch', backend.fetch)
   return render(
-    <MemoryRouter initialEntries={[`/projects/42/assets/${characterId}`]}>
-      <AppRoutes />
-    </MemoryRouter>,
+    <AuthenticatedAuthSession>
+      <MemoryRouter initialEntries={[`/projects/42/assets/${characterId}`]}>
+        <AppRoutes />
+      </MemoryRouter>
+    </AuthenticatedAuthSession>,
   )
 }
 

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AppRoutes } from '@/app'
-import { GuestAuthSession } from '@/test/auth-session'
+import { AuthenticatedAuthSession } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 afterEach(() => {
@@ -27,11 +27,11 @@ function renderPlaytest(path: string, fetchFn?: typeof globalThis.fetch) {
   vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
   vi.stubGlobal('fetch', fetchFn ?? createProjectAssetsBackend().fetch)
   return render(
-    <GuestAuthSession>
+    <AuthenticatedAuthSession>
       <MemoryRouter initialEntries={[path]}>
         <AppRoutes />
       </MemoryRouter>
-    </GuestAuthSession>,
+    </AuthenticatedAuthSession>,
   )
 }
 
@@ -43,7 +43,6 @@ describe('PlaytestPage', () => {
   it('loads the routed character through the Character API', async () => {
     renderPlaytest('/playtest/51/outfit-default')
 
-    expect(screen.getByText('加载 Playtest 数据中')).toBeTruthy()
     expect(await screen.findByRole('heading', { name: '51 · 常态造型' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '绑定动作：呼吸待机' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '绑定动作：行走' })).toBeTruthy()

--- a/frontend/src/pages/project-create/index.test.tsx
+++ b/frontend/src/pages/project-create/index.test.tsx
@@ -68,15 +68,12 @@ describe('ProjectCreatePage', () => {
     expect(Object.hasOwn(body, 'user_id')).toBe(false)
   })
 
-  it('没有登录凭证时禁用创建并说明原因', async () => {
+  it('没有登录凭证时先进入登录面板，不挂载创建页面', async () => {
     const backend = installBackend()
     await renderProjectCreate(false)
 
-    const submit = await screen.findByRole('button', { name: '创建项目' })
-    expect(submit.hasAttribute('disabled')).toBe(true)
-    expect(
-      screen.getByText('创建项目需要先登录。登录模块尚未接入，创建入口暂时保持关闭。'),
-    ).toBeTruthy()
+    expect(await screen.findByRole('dialog', { name: '登录 Windup' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: '创建项目' })).toBeNull()
     expect(creationRequests(backend)).toHaveLength(0)
   })
 

--- a/frontend/src/pages/project-detail/index.test.tsx
+++ b/frontend/src/pages/project-detail/index.test.tsx
@@ -4,13 +4,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, useLocation } from 'react-router'
 
 import { AppRoutes } from '@/app'
-import { AuthenticatedAuthSession } from '@/test/auth-session'
+import { AuthSessionProvider } from '@/features/auth-session'
+import { REFRESH_TOKEN_STORAGE_KEY } from '@/features/auth-session/session-storage'
+import { AuthenticatedAuthSession, createAuthenticatedTestApis } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 afterEach(() => {
   cleanup()
   vi.unstubAllEnvs()
   vi.unstubAllGlobals()
+  window.localStorage.clear()
 })
 
 describe('ProjectDetailPage', () => {
@@ -68,14 +71,16 @@ describe('ProjectDetailPage', () => {
 
   it('shows the current account in the workspace and returns home after logout', async () => {
     const backend = createProjectAssetsBackend()
+    const apis = createAuthenticatedTestApis()
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
     vi.stubGlobal('fetch', backend.fetch)
+    window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, 'stored-refresh-token')
 
     render(
       <MemoryRouter initialEntries={['/projects/42/assets']}>
-        <AuthenticatedAuthSession>
+        <AuthSessionProvider apis={apis}>
           <AppRoutes />
-        </AuthenticatedAuthSession>
+        </AuthSessionProvider>
         <LocationProbe />
       </MemoryRouter>,
     )
@@ -89,9 +94,36 @@ describe('ProjectDetailPage', () => {
 
     await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'))
   })
+
+  it('returns home without waiting for the remote logout request', async () => {
+    const backend = createProjectAssetsBackend()
+    const apis = createAuthenticatedTestApis()
+    const pendingLogout = new Promise<void>(() => undefined)
+    apis.logout = async () => pendingLogout
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+    vi.stubGlobal('fetch', backend.fetch)
+    window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, 'stored-refresh-token')
+
+    render(
+      <MemoryRouter initialEntries={['/projects/42/assets']}>
+        <AuthSessionProvider apis={apis}>
+          <AppRoutes />
+        </AuthSessionProvider>
+        <LocationProbe />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('heading', { name: '点灯人 · MVP' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '退出登录' }))
+
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'))
+    expect(screen.queryByRole('dialog', { name: '登录 Windup' })).toBeNull()
+  })
 })
 
 function LocationProbe() {
   const location = useLocation()
-  return <output data-testid="location">{location.pathname}</output>
+  return (
+    <output data-testid="location">{`${location.pathname}${location.search}${location.hash}`}</output>
+  )
 }

--- a/frontend/src/pages/project-detail/index.test.tsx
+++ b/frontend/src/pages/project-detail/index.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter, useLocation } from 'react-router'
 
 import { AppRoutes } from '@/app'
+import { AuthenticatedAuthSession } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 afterEach(() => {
@@ -19,9 +20,11 @@ describe('ProjectDetailPage', () => {
     vi.stubGlobal('fetch', backend.fetch)
 
     const { container } = render(
-      <MemoryRouter initialEntries={['/projects/42/assets/51']}>
-        <AppRoutes />
-      </MemoryRouter>,
+      <AuthenticatedAuthSession>
+        <MemoryRouter initialEntries={['/projects/42/assets/51']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </AuthenticatedAuthSession>,
     )
 
     expect(await screen.findByRole('heading', { name: '点灯人 · MVP' })).toBeTruthy()
@@ -51,13 +54,44 @@ describe('ProjectDetailPage', () => {
     })
 
     render(
-      <MemoryRouter initialEntries={['/projects/42/assets/51']}>
-        <AppRoutes />
-      </MemoryRouter>,
+      <AuthenticatedAuthSession>
+        <MemoryRouter initialEntries={['/projects/42/assets/51']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </AuthenticatedAuthSession>,
     )
 
     expect(await screen.findByRole('heading', { name: '点灯人 · MVP' })).toBeTruthy()
     expect(screen.queryByRole('alert')).toBeNull()
     expect(await screen.findByRole('heading', { name: '轻装信使' })).toBeTruthy()
   })
+
+  it('shows the current account in the workspace and returns home after logout', async () => {
+    const backend = createProjectAssetsBackend()
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+    vi.stubGlobal('fetch', backend.fetch)
+
+    render(
+      <MemoryRouter initialEntries={['/projects/42/assets']}>
+        <AuthenticatedAuthSession>
+          <AppRoutes />
+        </AuthenticatedAuthSession>
+        <LocationProbe />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('heading', { name: '点灯人 · MVP' })).toBeTruthy()
+    const account = screen.getByLabelText('当前账号')
+    expect(account.textContent).toContain('Reader')
+    expect(account.textContent).toContain('reader@example.com')
+
+    fireEvent.click(screen.getByRole('button', { name: '退出登录' }))
+
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'))
+  })
 })
+
+function LocationProbe() {
+  const location = useLocation()
+  return <output data-testid="location">{location.pathname}</output>
+}

--- a/frontend/src/pages/project-detail/index.tsx
+++ b/frontend/src/pages/project-detail/index.tsx
@@ -77,7 +77,7 @@ export function ProjectDetailPage() {
   }
 
   return (
-    <div className="grid h-screen gap-3 overflow-hidden bg-[#f7f8f5] p-3 md:grid-cols-[13rem_minmax(0,1fr)] xl:grid-cols-[14rem_minmax(0,1fr)]">
+    <div className="grid min-h-screen gap-3 bg-[#f7f8f5] p-3 md:h-screen md:grid-cols-[13rem_minmax(0,1fr)] md:overflow-hidden xl:grid-cols-[14rem_minmax(0,1fr)]">
       <aside className="flex min-h-0 flex-col overflow-hidden rounded-[1.35rem] border border-[#d9ddd6] bg-[#fbfbf8] text-[#222520]">
         <div className="border-b border-[#dfe2dc] px-4 py-4">
           <Link

--- a/frontend/src/pages/project-detail/index.tsx
+++ b/frontend/src/pages/project-detail/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, Outlet, useLocation, useNavigate, useParams } from 'react-router'
+import { Link, Outlet, useLocation, useParams } from 'react-router'
 
 import {
   CHARACTER_PERSPECTIVE,
@@ -14,7 +14,6 @@ import { useAuthSession } from '@/features/auth-session'
 export function ProjectDetailPage() {
   const { projectId } = useParams()
   const location = useLocation()
-  const navigate = useNavigate()
   const session = useAuthSession()
   const [project, setProject] = useState<Project | null>(null)
   const [characterCount, setCharacterCount] = useState(0)
@@ -72,8 +71,7 @@ export function ProjectDetailPage() {
   ]
 
   function signOut() {
-    const returnHome = () => navigate('/', { replace: true })
-    void session.logout().then(returnHome, returnHome)
+    void session.logout().catch(() => undefined)
   }
 
   return (

--- a/frontend/src/pages/project-detail/index.tsx
+++ b/frontend/src/pages/project-detail/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, Outlet, useLocation, useParams } from 'react-router'
+import { Link, Outlet, useLocation, useNavigate, useParams } from 'react-router'
 
 import {
   CHARACTER_PERSPECTIVE,
@@ -8,11 +8,14 @@ import {
   projectApis,
   type Project,
 } from '@/entities'
+import { useAuthSession } from '@/features/auth-session'
 
 /** 项目常驻工作区；子路由负责具体资产内容。 */
 export function ProjectDetailPage() {
   const { projectId } = useParams()
   const location = useLocation()
+  const navigate = useNavigate()
+  const session = useAuthSession()
   const [project, setProject] = useState<Project | null>(null)
   const [characterCount, setCharacterCount] = useState(0)
   const [error, setError] = useState<string | null>(null)
@@ -67,6 +70,11 @@ export function ProjectDetailPage() {
     ['尺寸', `${project.spriteSize.width} × ${project.spriteSize.height}`],
     ['画风', project.gameStyle ?? '尚未设定'],
   ]
+
+  function signOut() {
+    const returnHome = () => navigate('/', { replace: true })
+    void session.logout().then(returnHome, returnHome)
+  }
 
   return (
     <div className="grid h-screen gap-3 overflow-hidden bg-[#f7f8f5] p-3 md:grid-cols-[13rem_minmax(0,1fr)] xl:grid-cols-[14rem_minmax(0,1fr)]">
@@ -124,6 +132,26 @@ export function ProjectDetailPage() {
             ))}
           </dl>
         </div>
+
+        {session.state.status === 'authenticated' ? (
+          <div aria-label="当前账号" className="mt-auto border-t border-[#e3e6e0] p-3">
+            <div className="min-w-0 px-2 py-1">
+              <p className="truncate text-xs font-semibold text-[#343a34]">
+                {session.state.user.nickname || session.state.user.email}
+              </p>
+              <p className="mt-0.5 truncate text-[0.68rem] text-[#7a8279]">
+                {session.state.user.email}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={signOut}
+              className="mt-2 inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-[#cfd5cc] px-3 text-xs font-semibold text-[#59635a] transition-colors hover:bg-[#edf1eb] hover:text-[#26372c] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331]"
+            >
+              退出登录
+            </button>
+          </div>
+        ) : null}
       </aside>
 
       <div className="min-w-0 overflow-y-auto">

--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router'
 
 import { AppRoutes } from '@/app'
-import { GuestAuthSession } from '@/test/auth-session'
+import { AuthenticatedAuthSession } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 afterEach(() => {
@@ -24,11 +24,11 @@ describe('ProjectsPage', () => {
   it('renders backend Projects as the first browsing level', async () => {
     installBackend()
     const { container } = render(
-      <GuestAuthSession>
+      <AuthenticatedAuthSession>
         <MemoryRouter initialEntries={['/projects']}>
           <AppRoutes />
         </MemoryRouter>
-      </GuestAuthSession>,
+      </AuthenticatedAuthSession>,
     )
 
     expect(await screen.findByRole('heading', { name: '项目中心' })).toBeTruthy()
@@ -44,11 +44,11 @@ describe('ProjectsPage', () => {
   it('sends creation to the project create page and deletes through the Project API', async () => {
     const backend = installBackend()
     render(
-      <GuestAuthSession>
+      <AuthenticatedAuthSession>
         <MemoryRouter initialEntries={['/projects']}>
           <AppRoutes />
         </MemoryRouter>
-      </GuestAuthSession>,
+      </AuthenticatedAuthSession>,
     )
 
     expect(await screen.findAllByRole('link', { name: /打开项目/ })).toHaveLength(2)
@@ -75,11 +75,11 @@ describe('ProjectsPage', () => {
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
     vi.stubGlobal('fetch', backend.fetch)
     render(
-      <GuestAuthSession>
+      <AuthenticatedAuthSession>
         <MemoryRouter initialEntries={['/projects']}>
           <AppRoutes />
         </MemoryRouter>
-      </GuestAuthSession>,
+      </AuthenticatedAuthSession>,
     )
 
     expect(await screen.findAllByRole('link', { name: /打开项目/ })).toHaveLength(12)


### PR DESCRIPTION
本 PR 落地 #160 的前端登录边界：保留首页匿名访问，其余产品页面在挂载前检查会话状态；访客进入现有账号面板并在登录后安全回到原路径。同时补充会话过期提示，以及项目工作区内的账号信息和登出入口。

## Why

认证会话层和账号面板已经落地，但产品页面此前仍会在未登录或会话恢复期间直接挂载，进而发出必然失败的业务请求。会话失效后，用户也无法判断失败原因。

#157 已确认首页允许匿名访问，其余产品页面需要登录。本 PR 将这一产品边界落实到现有前端路由，并补齐会话过期和工作区登出的用户反馈。

## Changes

- 首页继续允许匿名访问，为快速开始、项目中心、项目创建、工作流编辑器、Playtest 和项目资产工作区增加登录态守卫。
- 会话启动恢复期间不挂载受保护页面；访客进入账号面板，并保留原路径、查询参数和 hash。
- 登录成功后安全回到原路径；非法站外 `returnTo` 继续回落到首页。
- 会话过期时展示明确提示，避免用户静默停留在失效状态。
- 在项目工作区侧栏显示当前用户的昵称、邮箱和登出入口，登出完成后回到首页。
- 修复 React StrictMode 生命周期下登录成功回跳可能被错误取消的问题。
- 调整项目工作区的移动端高度策略，避免账号区域被固定视口布局裁切。

## Implementation

- 新增 `ProtectedRoute`，只消费既有会话三态，通过嵌套路由控制业务页面是否挂载，不读取 token，也不直接触发业务请求。
- 复用账号面板现有的 `returnTo` 站内路径清洗和登录回跳逻辑，不新增另一套导航状态。
- 在应用外壳中挂载会话过期提示，根据会话层提供的失败原因决定是否显示。
- 项目工作区通过会话层公开接口读取用户信息并执行登出，不修改认证接口或后端数据结构。

## Verification

- [x] `npm run format:check`：通过，共检查 90 个文件。
- [x] `npm run lint`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run test`：通过，共 27 个测试文件、189 个测试。
- [x] `npm run build`：通过。
- [x] `git diff --check upstream/main...HEAD`：通过。
- [x] 真实浏览器验证：桌面端与 375×812 移动端均通过。

回归测试覆盖访客路由拦截、启动恢复等待、完整 `returnTo` 保留、会话过期提示、StrictMode 登录回跳和工作区登出。

## Screenshots


以下均为改动后截图；对应状态在修改前不存在，因此不提供 Before 图。

### Unauthenticated Route Guard

| Desktop | Mobile |
| --- | --- |
| <img width="1440" height="900" alt="Unauthenticated route guard on desktop" src="https://github.com/user-attachments/assets/85ae1f9a-57ec-4e3b-8574-f39afae2b551" /> | <img width="375" height="812" alt="Unauthenticated route guard on mobile" src="https://github.com/user-attachments/assets/b189aefe-9e2c-4076-9187-8e30b93cb0e0" /> |

### Session Expiry Notice

| Desktop | Mobile |
| --- | --- |
| <img width="1440" height="900" alt="Session expiry notice on desktop" src="https://github.com/user-attachments/assets/167ed028-13ec-4ca4-b282-05442bbb42c9" /> | <img width="375" height="812" alt="Session expiry notice on mobile" src="https://github.com/user-attachments/assets/8633b167-10f4-4582-ac1c-fd595878d6d0" /> |

### Workspace Account Controls

| Desktop | Mobile |
| --- | --- |
| <img width="1440" height="900" alt="Workspace account controls on desktop" src="https://github.com/user-attachments/assets/e20d8723-d267-4f8f-a4a6-1e59113fa2a8" /> | <img width="375" height="812" alt="Workspace account controls on mobile" src="https://github.com/user-attachments/assets/efc981f2-675b-4fc4-a101-d5db2552d3a9" /> |

## Scope

- 本 PR 不包含后端接口、数据结构或权限分级调整。
- 本 PR 不重复修改由 #164 独立负责的全局 Header 账号入口。
- 本 PR 不新增 `/account` 页面，不包含资料查看、修改密码等 #161 账号中心能力。

## Related Issues

Closes #160
Refs #157
Refs #164
