### PR TITLE
feat(account): add account center

### DIFF
--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -56,6 +56,24 @@ describe('AppRoutes authentication boundary', () => {
     expect(screen.queryByRole('heading', { name: '快速开始' })).toBeNull()
   })
 
+  it('protects direct account-center visits and returns there after login', async () => {
+    render(
+      <GuestAuthSession>
+        <MemoryRouter initialEntries={['/account']}>
+          <AppRoutes />
+          <LocationProbe />
+        </MemoryRouter>
+      </GuestAuthSession>,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/?account=login&returnTo=%2Faccount',
+      ),
+    )
+    expect(screen.queryByRole('heading', { name: '账号中心' })).toBeNull()
+  })
+
   it('waits for session restoration before mounting a protected page', async () => {
     let resolveRefresh!: (tokens: AuthTokens) => void
     const refresh = new Promise<AuthTokens>((resolve) => {
@@ -104,6 +122,7 @@ describe('AppRoutes authentication boundary', () => {
       refresh: async () => Promise.reject(new Error('refresh token expired')),
       logout: async () => undefined,
       me: async () => Promise.reject(new Error('not used')),
+      updateNickname: async () => Promise.reject(new Error('not used')),
       changePassword: async () => Promise.reject(new Error('not used')),
     }
     window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, 'expired-refresh-token')
@@ -131,6 +150,7 @@ describe('AppRoutes authentication boundary', () => {
       refresh: async () => Promise.reject(new Error('refresh token expired')),
       logout: async () => undefined,
       me: async () => Promise.reject(new Error('not used')),
+      updateNickname: async () => Promise.reject(new Error('not used')),
       changePassword: async () => Promise.reject(new Error('not used')),
     }
     window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, 'expired-refresh-token')

--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router'
 
 import { AssetLibraryPage } from '@/pages/asset-library'
+import { AccountPage } from '@/pages/account'
 import { CharacterDetailPage } from '@/pages/character-detail'
 import { HomePage } from '@/pages/home'
 import { NotFoundPage } from '@/pages/not-found'
@@ -34,6 +35,7 @@ export function AppRoutes() {
       <Route element={<AppShellRoute />}>
         <Route path="/" element={<HomePage />} />
         <Route element={<ProtectedRoute />}>
+          <Route path="/account" element={<AccountPage />} />
           <Route path="/quick-start" element={<QuickStartPage />} />
           <Route path="/quick-start/:runId" element={<QuickStartPage />} />
           <Route path="/projects" element={<ProjectsPage />} />

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -28,6 +28,7 @@ function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn
     refresh: vi.fn(async () => tokens()),
     logout: vi.fn(async () => undefined),
     me: vi.fn(async () => user),
+    updateNickname: vi.fn(async () => user),
     changePassword: vi.fn(async () => undefined),
   }
 }
@@ -104,5 +105,16 @@ describe('AppHeader', () => {
     await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'))
     expect(await screen.findByRole('link', { name: '登录 / 注册' })).toBeTruthy()
     expect(apis.logout).toHaveBeenCalledWith('rotated-refresh-token')
+  })
+
+  it('让登录用户从 Header 的账号信息进入账号中心', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    renderHeader('/account')
+
+    const account = await screen.findByRole('link', { name: '打开账号中心' })
+    expect(account.getAttribute('href')).toBe('/account')
+    expect(account.getAttribute('aria-current')).toBe('page')
+    expect(account.textContent).toContain('Reader')
+    expect(screen.getByText('资料与登录安全')).toBeTruthy()
   })
 })

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -37,6 +37,10 @@ const productNavigation: ProductNavigationItem[] = [
 
 /** 左侧标牌上的第二行，随所在区域变化，让用户知道自己在哪一片。 */
 function getWorkspaceLabel(pathname: string): { title: string; detail: string } {
+  if (pathname.startsWith('/account')) {
+    return { title: '账号中心', detail: '资料与登录安全' }
+  }
+
   if (pathname.startsWith('/projects') || pathname.startsWith('/playtest')) {
     return { title: '项目资产', detail: '角色、造型与动作' }
   }
@@ -139,12 +143,15 @@ export function AppHeader() {
             </Link>
           ) : (
             <div className="flex min-w-0 items-center overflow-hidden rounded-[0.5625rem] border border-[#2d3b31]/14 bg-white/35">
-              <span
+              <Link
+                to="/account"
+                aria-label="打开账号中心"
+                aria-current={pathname.startsWith('/account') ? 'page' : undefined}
                 title={session.state.user.email}
-                className="inline-flex min-h-11 max-w-16 items-center truncate px-3 text-xs font-semibold text-[#34483a] sm:max-w-28"
+                className="inline-flex min-h-11 max-w-16 items-center truncate px-3 text-xs font-semibold text-[#34483a] transition-colors hover:bg-[#dce9df] hover:text-[#26372c] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#284331] sm:max-w-28"
               >
                 {session.state.user.nickname || session.state.user.email}
-              </span>
+              </Link>
               <button
                 type="button"
                 onClick={signOut}

--- a/frontend/src/entities/user/api.test.ts
+++ b/frontend/src/entities/user/api.test.ts
@@ -212,4 +212,44 @@ describe('createUserApis', () => {
     expect(recover).not.toHaveBeenCalled()
     unregister()
   })
+
+  it.each([
+    ['current-user', (apis: ReturnType<typeof createUserApis>) => apis.me(), tokenResponse.user],
+    [
+      'nickname-update',
+      (apis: ReturnType<typeof createUserApis>) => apis.updateNickname('New Reader'),
+      tokenResponse.user,
+    ],
+    [
+      'password-change',
+      (apis: ReturnType<typeof createUserApis>) =>
+        apis.changePassword({
+          oldPassword: 'password-123',
+          newPassword: 'new-password-123',
+        }),
+      null,
+    ],
+  ])('recovers and replays protected %s requests', async (_label, invoke, data) => {
+    const recover = vi.fn(async () => true)
+    const unregister = registerApiUnauthorizedRecovery(recover)
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 401, message: 'access token expired', data: null }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 200, message: 'ok', data }), { status: 200 }),
+      )
+    const apis = createUserApis({ baseUrl: 'https://api.windup.test', fetchFn })
+
+    try {
+      await invoke(apis)
+      expect(recover).toHaveBeenCalledTimes(1)
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+    } finally {
+      unregister()
+    }
+  })
 })

--- a/frontend/src/entities/user/api.test.ts
+++ b/frontend/src/entities/user/api.test.ts
@@ -41,6 +41,7 @@ describe('createUserApis', () => {
       .mockResolvedValueOnce(tokenResponse)
       .mockResolvedValueOnce(tokenResponse)
       .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(tokenResponse.user)
       .mockResolvedValueOnce(null)
 
     const apis = createUserApis({ client })
@@ -59,6 +60,7 @@ describe('createUserApis', () => {
     await apis.loginByCode({ email: 'reader@example.com', code: '123456' })
     await apis.refresh('refresh-token')
     await apis.logout('refresh-token')
+    await apis.updateNickname('New Reader')
     await apis.changePassword({ oldPassword: 'password-123', newPassword: 'new-password-123' })
 
     expect(request.mock.calls).toEqual([
@@ -100,6 +102,7 @@ describe('createUserApis', () => {
       ],
       ['/auth/refresh', { method: 'POST', json: { refresh_token: 'refresh-token' } }],
       ['/auth/logout', { method: 'POST', json: { refresh_token: 'refresh-token' } }],
+      ['/auth/profile', { method: 'PATCH', json: { nickname: 'New Reader' } }],
       [
         '/auth/change-password',
         {
@@ -108,6 +111,22 @@ describe('createUserApis', () => {
         },
       ],
     ])
+  })
+
+  it('maps the updated profile response back to the user model', async () => {
+    request.mockResolvedValue({
+      ...tokenResponse.user,
+      nickname: 'New Reader',
+    })
+    const apis = createUserApis({ client })
+
+    await expect(apis.updateNickname('New Reader')).resolves.toEqual({
+      id: '7',
+      email: 'reader@example.com',
+      nickname: 'New Reader',
+      emailVerifiedAt: '2026-08-07T01:02:03Z',
+      statusCode: 37,
+    })
   })
 
   it('maps token and current-user payloads while preserving an unknown numeric status', async () => {

--- a/frontend/src/entities/user/api.ts
+++ b/frontend/src/entities/user/api.ts
@@ -74,17 +74,21 @@ function toAuthTokens(value: unknown): AuthTokens {
 
 export function createUserApis(options: CreateUserApisOptions = {}): UserApis {
   const { client, ...clientOptions } = options
-  const apiClient =
+  const sharedClientOptions = {
+    ...clientOptions,
+    getAccessToken: clientOptions.getAccessToken ?? getApiAccessToken,
+  }
+  const authClient =
     client ??
     createApiClient({
-      ...clientOptions,
-      getAccessToken: clientOptions.getAccessToken ?? getApiAccessToken,
+      ...sharedClientOptions,
       recoverUnauthorized: false,
     })
+  const protectedClient = client ?? createApiClient(sharedClientOptions)
 
   return {
     async sendCode(input) {
-      await apiClient.request<null>('/auth/send-code', { method: 'POST', json: input })
+      await authClient.request<null>('/auth/send-code', { method: 'POST', json: input })
     },
 
     async register(input) {
@@ -95,19 +99,19 @@ export function createUserApis(options: CreateUserApisOptions = {}): UserApis {
         ...(input.nickname ? { nickname: input.nickname } : {}),
       }
       return toAuthTokens(
-        await apiClient.request<AuthTokensDto>('/auth/register', { method: 'POST', json }),
+        await authClient.request<AuthTokensDto>('/auth/register', { method: 'POST', json }),
       )
     },
 
     async login(input) {
       return toAuthTokens(
-        await apiClient.request<AuthTokensDto>('/auth/login', { method: 'POST', json: input }),
+        await authClient.request<AuthTokensDto>('/auth/login', { method: 'POST', json: input }),
       )
     },
 
     async loginByCode(input) {
       return toAuthTokens(
-        await apiClient.request<AuthTokensDto>('/auth/login-by-code', {
+        await authClient.request<AuthTokensDto>('/auth/login-by-code', {
           method: 'POST',
           json: input,
         }),
@@ -116,7 +120,7 @@ export function createUserApis(options: CreateUserApisOptions = {}): UserApis {
 
     async refresh(refreshToken) {
       return toAuthTokens(
-        await apiClient.request<AuthTokensDto>('/auth/refresh', {
+        await authClient.request<AuthTokensDto>('/auth/refresh', {
           method: 'POST',
           json: { refresh_token: refreshToken },
         }),
@@ -124,19 +128,19 @@ export function createUserApis(options: CreateUserApisOptions = {}): UserApis {
     },
 
     async logout(refreshToken) {
-      await apiClient.request<null>('/auth/logout', {
+      await authClient.request<null>('/auth/logout', {
         method: 'POST',
         json: { refresh_token: refreshToken },
       })
     },
 
     async me() {
-      return toUser(await apiClient.request<UserDto>('/auth/me'))
+      return toUser(await protectedClient.request<UserDto>('/auth/me'))
     },
 
     async updateNickname(nickname) {
       return toUser(
-        await apiClient.request<UserDto>('/auth/profile', {
+        await protectedClient.request<UserDto>('/auth/profile', {
           method: 'PATCH',
           json: { nickname },
         }),
@@ -144,7 +148,7 @@ export function createUserApis(options: CreateUserApisOptions = {}): UserApis {
     },
 
     async changePassword(input) {
-      await apiClient.request<null>('/auth/change-password', {
+      await protectedClient.request<null>('/auth/change-password', {
         method: 'POST',
         json: { old_password: input.oldPassword, new_password: input.newPassword },
       })

--- a/frontend/src/entities/user/api.ts
+++ b/frontend/src/entities/user/api.ts
@@ -134,6 +134,15 @@ export function createUserApis(options: CreateUserApisOptions = {}): UserApis {
       return toUser(await apiClient.request<UserDto>('/auth/me'))
     },
 
+    async updateNickname(nickname) {
+      return toUser(
+        await apiClient.request<UserDto>('/auth/profile', {
+          method: 'PATCH',
+          json: { nickname },
+        }),
+      )
+    },
+
     async changePassword(input) {
       await apiClient.request<null>('/auth/change-password', {
         method: 'POST',
@@ -159,5 +168,6 @@ export const userApis: UserApis = {
   refresh: (refreshToken) => getDefaultApis().refresh(refreshToken),
   logout: (refreshToken) => getDefaultApis().logout(refreshToken),
   me: () => getDefaultApis().me(),
+  updateNickname: (nickname) => getDefaultApis().updateNickname(nickname),
   changePassword: (input) => getDefaultApis().changePassword(input),
 }

--- a/frontend/src/entities/user/index.ts
+++ b/frontend/src/entities/user/index.ts
@@ -31,6 +31,7 @@ export interface UserApis {
   refresh(refreshToken: string): Promise<AuthTokens>
   logout(refreshToken: string): Promise<void>
   me(): Promise<User>
+  updateNickname(nickname: string): Promise<User>
   changePassword(input: { oldPassword: string; newPassword: string }): Promise<void>
 }
 

--- a/frontend/src/features/account-panel/index.test.tsx
+++ b/frontend/src/features/account-panel/index.test.tsx
@@ -40,6 +40,7 @@ function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn
     refresh: vi.fn(async () => tokens()),
     logout: vi.fn(async () => undefined),
     me: vi.fn(async () => user),
+    updateNickname: vi.fn(async () => user),
     changePassword: vi.fn(async () => undefined),
   }
 }

--- a/frontend/src/features/account-panel/index.tsx
+++ b/frontend/src/features/account-panel/index.tsx
@@ -86,6 +86,8 @@ function AccountPanelDialog() {
   const passwordId = useId()
   const codeId = useId()
   const copy = modeCopy[mode]
+  const passwordChanged =
+    session.state.status === 'guest' && session.state.reason === 'password-changed'
   const normalizedEmail = email.trim()
   const cooldownSeconds = Math.max(
     0,
@@ -322,7 +324,20 @@ function AccountPanelDialog() {
           ))}
         </div>
 
-        <form className="mt-5 grid gap-4" onSubmit={submit} noValidate>
+        {passwordChanged && (
+          <p
+            role="status"
+            className="mt-5 rounded-xl border border-[#78927e]/40 bg-[#eef5ef] px-3.5 py-3 text-sm leading-6 text-[#34533c]"
+          >
+            密码修改成功，请重新登录
+          </p>
+        )}
+
+        <form
+          className={`${passwordChanged ? 'mt-4' : 'mt-5'} grid gap-4`}
+          onSubmit={submit}
+          noValidate
+        >
           <label htmlFor={emailId} className="grid gap-1.5 text-sm font-semibold text-[#344039]">
             邮箱
             <input

--- a/frontend/src/features/auth-session/index.test.tsx
+++ b/frontend/src/features/auth-session/index.test.tsx
@@ -47,6 +47,7 @@ function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn
     refresh: vi.fn(async () => tokens()),
     logout: vi.fn(async () => undefined),
     me: vi.fn(async () => user),
+    updateNickname: vi.fn(async () => user),
     changePassword: vi.fn(async () => undefined),
   }
 }
@@ -56,11 +57,16 @@ let currentSession: AuthSessionValue | null = null
 function SessionProbe() {
   currentSession = useAuthSession()
   return (
-    <output data-testid="session">
-      {currentSession.state.status}:
-      {currentSession.state.status === 'guest' ? currentSession.state.reason : ''}:
-      {currentSession.state.status === 'authenticated' ? currentSession.state.user.email : ''}
-    </output>
+    <>
+      <output data-testid="session">
+        {currentSession.state.status}:
+        {currentSession.state.status === 'guest' ? currentSession.state.reason : ''}:
+        {currentSession.state.status === 'authenticated' ? currentSession.state.user.email : ''}
+      </output>
+      <span data-testid="session-nickname">
+        {currentSession.state.status === 'authenticated' ? currentSession.state.user.nickname : ''}
+      </span>
+    </>
   )
 }
 
@@ -192,6 +198,56 @@ describe('AuthSessionProvider', () => {
     await expectState('guest:password-changed:')
     expect(getApiAccessToken()).toBeNull()
     expect(window.localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY)).toBeNull()
+  })
+
+  it('refreshes the current user from the backend and synchronizes session consumers', async () => {
+    const apis = createApis()
+    apis.me.mockResolvedValue({ ...user, nickname: 'Fresh Reader' })
+    renderSession(apis)
+    await expectState('guest::')
+    await act(async () => session().loginByCode({ email: 'reader@example.com', code: '123456' }))
+
+    await act(async () => session().refreshCurrentUser())
+
+    expect(apis.me).toHaveBeenCalledTimes(1)
+    expect(document.querySelector('[data-testid="session-nickname"]')?.textContent).toBe(
+      'Fresh Reader',
+    )
+  })
+
+  it('updates the nickname and synchronizes the returned user into the session', async () => {
+    const apis = createApis()
+    apis.updateNickname.mockResolvedValue({ ...user, nickname: 'New Reader' })
+    renderSession(apis)
+    await expectState('guest::')
+    await act(async () => session().loginByCode({ email: 'reader@example.com', code: '123456' }))
+
+    await act(async () => session().updateNickname('New Reader'))
+
+    expect(apis.updateNickname).toHaveBeenCalledWith('New Reader')
+    expect(document.querySelector('[data-testid="session-nickname"]')?.textContent).toBe(
+      'New Reader',
+    )
+  })
+
+  it('does not restore profile state when a pending profile request loses to logout', async () => {
+    const profile = deferred<typeof user>()
+    const apis = createApis()
+    apis.me.mockReturnValue(profile.promise)
+    renderSession(apis)
+    await expectState('guest::')
+    await act(async () => session().loginByCode({ email: 'reader@example.com', code: '123456' }))
+
+    let refreshPromise!: ReturnType<UserApis['me']>
+    act(() => {
+      refreshPromise = session().refreshCurrentUser()
+    })
+    const rejectedRefresh = expect(refreshPromise).rejects.toThrow('登录状态已变更')
+    await act(async () => session().logout())
+    await act(async () => profile.resolve({ ...user, nickname: 'Stale Reader' }))
+
+    await rejectedRefresh
+    await expectState('guest:logged-out:')
   })
 
   it('deduplicates concurrent 401 recovery and lets both requests replay with the rotated token', async () => {

--- a/frontend/src/features/auth-session/index.tsx
+++ b/frontend/src/features/auth-session/index.tsx
@@ -32,6 +32,8 @@ export interface AuthSessionValue {
   register(input: Parameters<UserApis['register']>[0]): Promise<AuthTokens>
   login(input: Parameters<UserApis['login']>[0]): Promise<AuthTokens>
   loginByCode(input: Parameters<UserApis['loginByCode']>[0]): Promise<AuthTokens>
+  refreshCurrentUser(): Promise<User>
+  updateNickname(nickname: string): Promise<User>
   changePassword(input: Parameters<UserApis['changePassword']>[0]): Promise<void>
   logout(): Promise<void>
 }
@@ -315,6 +317,35 @@ export function AuthSessionProvider({ apis, children }: AuthSessionProviderProps
     },
     [apis, startSession],
   )
+  const commitCurrentUser = useCallback(
+    (user: User, expectedGeneration: number): User => {
+      if (
+        !mountedRef.current ||
+        generationRef.current !== expectedGeneration ||
+        stateRef.current.status !== 'authenticated'
+      ) {
+        throw new Error('登录状态已变更')
+      }
+      updateState({ status: 'authenticated', user })
+      return user
+    },
+    [updateState],
+  )
+  const refreshCurrentUser = useCallback(async () => {
+    if (stateRef.current.status !== 'authenticated') throw new Error('请先登录')
+    const generation = generationRef.current
+    const user = await apis.me()
+    return commitCurrentUser(user, generation)
+  }, [apis, commitCurrentUser])
+  const updateNickname = useCallback(
+    async (nickname: string) => {
+      if (stateRef.current.status !== 'authenticated') throw new Error('请先登录')
+      const generation = generationRef.current
+      const user = await apis.updateNickname(nickname)
+      return commitCurrentUser(user, generation)
+    },
+    [apis, commitCurrentUser],
+  )
   const changePassword = useCallback(
     async (input: Parameters<UserApis['changePassword']>[0]) => {
       await apis.changePassword(input)
@@ -329,8 +360,28 @@ export function AuthSessionProvider({ apis, children }: AuthSessionProviderProps
   }, [apis, clearSession])
 
   const value = useMemo<AuthSessionValue>(
-    () => ({ state, sendCode, register, login, loginByCode, changePassword, logout }),
-    [changePassword, login, loginByCode, logout, register, sendCode, state],
+    () => ({
+      state,
+      sendCode,
+      register,
+      login,
+      loginByCode,
+      refreshCurrentUser,
+      updateNickname,
+      changePassword,
+      logout,
+    }),
+    [
+      changePassword,
+      login,
+      loginByCode,
+      logout,
+      refreshCurrentUser,
+      register,
+      sendCode,
+      state,
+      updateNickname,
+    ],
   )
 
   return <AuthSessionContext.Provider value={value}>{children}</AuthSessionContext.Provider>

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter, useLocation } from 'react-router'
+
+import type { AuthTokens, User, UserApis } from '@/entities'
+import { AuthSessionProvider } from '@/features/auth-session'
+import { AppRoutes } from '@/app/app'
+
+const user: User = {
+  id: '7',
+  email: 'reader@example.com',
+  nickname: 'Reader',
+  emailVerifiedAt: '2026-08-07T01:02:03Z',
+  statusCode: 0,
+}
+
+function tokens(): AuthTokens {
+  return { accessToken: 'access-token', refreshToken: 'rotated-refresh-token', user }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn>> {
+  return {
+    sendCode: vi.fn(async () => undefined),
+    register: vi.fn(async () => tokens()),
+    login: vi.fn(async () => tokens()),
+    loginByCode: vi.fn(async () => tokens()),
+    refresh: vi.fn(async () => tokens()),
+    logout: vi.fn(async () => undefined),
+    me: vi.fn(async () => user),
+    updateNickname: vi.fn(async (nickname: string) => ({ ...user, nickname })),
+    changePassword: vi.fn(async () => undefined),
+  }
+}
+
+function LocationProbe() {
+  const location = useLocation()
+  return (
+    <output data-testid="location">{`${location.pathname}${location.search}${location.hash}`}</output>
+  )
+}
+
+function renderAccount(apis = createApis()) {
+  window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+  return {
+    apis,
+    ...render(
+      <AuthSessionProvider apis={apis}>
+        <MemoryRouter initialEntries={['/account']}>
+          <AppRoutes />
+          <LocationProbe />
+        </MemoryRouter>
+      </AuthSessionProvider>,
+    ),
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+})
+
+describe('AccountPage', () => {
+  it('loads a fresh profile on entry and renders account facts', async () => {
+    const apis = createApis()
+    apis.me.mockResolvedValue({
+      ...user,
+      nickname: 'Fresh Reader',
+      emailVerifiedAt: '2026-08-09T08:30:00Z',
+    })
+
+    renderAccount(apis)
+
+    expect(await screen.findByRole('heading', { name: '账号中心' })).toBeTruthy()
+    await waitFor(() => expect(apis.me).toHaveBeenCalledTimes(1))
+    expect(screen.getByDisplayValue('Fresh Reader')).toBeTruthy()
+    expect(screen.getByText('reader@example.com')).toBeTruthy()
+    expect(document.querySelector('time')?.getAttribute('datetime')).toBe('2026-08-09T08:30:00Z')
+    expect(screen.getByRole('link', { name: '打开账号中心' }).textContent).toContain('Fresh Reader')
+  })
+
+  it('reports a profile refresh failure without claiming the data is synchronized', async () => {
+    const apis = createApis()
+    apis.me.mockRejectedValue(new Error('资料读取失败'))
+
+    renderAccount(apis)
+
+    expect(await screen.findByText('资料读取失败')).toBeTruthy()
+    expect(screen.getByText('资料同步失败')).toBeTruthy()
+    expect(screen.queryByText('资料已同步')).toBeNull()
+  })
+
+  it('updates the nickname and synchronizes the Header immediately', async () => {
+    const { apis } = renderAccount()
+    const nickname = await screen.findByLabelText('昵称')
+
+    fireEvent.change(nickname, { target: { value: 'New Reader' } })
+    fireEvent.click(screen.getByRole('button', { name: '保存昵称' }))
+
+    await waitFor(() => expect(apis.updateNickname).toHaveBeenCalledWith('New Reader'))
+    expect(await screen.findByText('昵称已更新。')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '打开账号中心' }).textContent).toContain('New Reader')
+  })
+
+  it('preserves the edited nickname when the backend rejects it', async () => {
+    const apis = createApis()
+    apis.updateNickname.mockRejectedValue(new Error('昵称已存在'))
+    renderAccount(apis)
+    const nickname = await screen.findByLabelText('昵称')
+
+    fireEvent.change(nickname, { target: { value: 'Taken Name' } })
+    fireEvent.click(screen.getByRole('button', { name: '保存昵称' }))
+
+    expect(await screen.findByText('昵称已存在')).toBeTruthy()
+    expect((nickname as HTMLInputElement).value).toBe('Taken Name')
+  })
+
+  it('validates the new password locally and preserves both fields on backend error', async () => {
+    const apis = createApis()
+    apis.changePassword.mockRejectedValue(new Error('当前密码错误'))
+    renderAccount(apis)
+    const oldPassword = await screen.findByLabelText('当前密码')
+    const newPassword = screen.getByLabelText('新密码')
+
+    fireEvent.change(oldPassword, { target: { value: 'old-password' } })
+    fireEvent.change(newPassword, { target: { value: 'short' } })
+    fireEvent.click(screen.getByRole('button', { name: '修改密码' }))
+
+    expect(await screen.findByText('新密码需为 8–128 位')).toBeTruthy()
+    expect(apis.changePassword).not.toHaveBeenCalled()
+
+    fireEvent.change(newPassword, { target: { value: 'new-password-123' } })
+    fireEvent.click(screen.getByRole('button', { name: '修改密码' }))
+
+    expect(await screen.findByText('当前密码错误')).toBeTruthy()
+    expect((oldPassword as HTMLInputElement).value).toBe('old-password')
+    expect((newPassword as HTMLInputElement).value).toBe('new-password-123')
+  })
+
+  it('clears the session after changing the password and asks for login before returning', async () => {
+    renderAccount()
+    fireEvent.change(await screen.findByLabelText('当前密码'), {
+      target: { value: 'old-password' },
+    })
+    fireEvent.change(screen.getByLabelText('新密码'), {
+      target: { value: 'new-password-123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '修改密码' }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/?account=login&returnTo=%2Faccount',
+      ),
+    )
+    expect(await screen.findByRole('dialog', { name: '登录 Windup' })).toBeTruthy()
+    expect(screen.getByText('密码修改成功，请重新登录')).toBeTruthy()
+  })
+
+  it('returns home immediately on logout without waiting for the remote request', async () => {
+    const logout = deferred<void>()
+    const apis = createApis()
+    apis.logout.mockReturnValue(logout.promise)
+    renderAccount(apis)
+
+    fireEvent.click(await screen.findByRole('button', { name: '退出当前账号' }))
+
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'))
+    expect(apis.logout).toHaveBeenCalledWith('rotated-refresh-token')
+  })
+})

--- a/frontend/src/pages/account/index.tsx
+++ b/frontend/src/pages/account/index.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useId, useRef, useState, type FormEvent } from 'react'
+
+import type { User } from '@/entities'
+import { useAuthSession } from '@/features/auth-session'
+import { PageContainer } from '@/shared/ui'
+
+const fieldClass =
+  'min-h-11 w-full rounded-xl border border-[#98a39b] bg-white px-3.5 text-base text-[#1c231e] outline-none transition-[border-color,box-shadow] placeholder:text-[#8a948c] focus:border-[#284331] focus:ring-2 focus:ring-[#284331]/18 disabled:cursor-not-allowed disabled:bg-[#f1f3f1]'
+const primaryButtonClass =
+  'inline-flex min-h-11 items-center justify-center rounded-xl bg-[#284331] px-4 text-sm font-semibold text-white shadow-[0_8px_20px_rgba(40,67,49,0.14)] transition-[background-color,transform] hover:bg-[#1f3627] active:translate-y-px focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] disabled:cursor-not-allowed disabled:bg-[#77857b] disabled:shadow-none'
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : '操作失败，请稍后重试'
+}
+
+function formatVerificationTime(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '验证时间未知'
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+/** 账号页以 /auth/me 为事实来源；会话层负责把刷新和编辑结果同步给 Header。 */
+export function AccountPage() {
+  const session = useAuthSession()
+  const {
+    changePassword: changeSessionPassword,
+    logout,
+    refreshCurrentUser,
+    updateNickname,
+  } = session
+  const currentUser = session.state.status === 'authenticated' ? session.state.user : null
+  const profileRequestRef = useRef<Promise<User> | null>(null)
+  const [nickname, setNickname] = useState(currentUser?.nickname ?? '')
+  const [isProfileLoading, setIsProfileLoading] = useState(true)
+  const [isProfileFresh, setIsProfileFresh] = useState(false)
+  const [isSavingNickname, setIsSavingNickname] = useState(false)
+  const [profileError, setProfileError] = useState<string | null>(null)
+  const [profileSuccess, setProfileSuccess] = useState<string | null>(null)
+  const [oldPassword, setOldPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [isChangingPassword, setIsChangingPassword] = useState(false)
+  const [passwordError, setPasswordError] = useState<string | null>(null)
+  const nicknameId = useId()
+  const oldPasswordId = useId()
+  const newPasswordId = useId()
+
+  useEffect(() => {
+    let active = true
+    profileRequestRef.current ??= refreshCurrentUser()
+    void profileRequestRef.current.then(
+      (user) => {
+        if (!active) return
+        setNickname(user.nickname ?? '')
+        setIsProfileFresh(true)
+        setProfileError(null)
+        setIsProfileLoading(false)
+      },
+      (error) => {
+        if (!active) return
+        setIsProfileFresh(false)
+        setProfileError(errorMessage(error))
+        setIsProfileLoading(false)
+      },
+    )
+    return () => {
+      active = false
+    }
+  }, [refreshCurrentUser])
+
+  async function saveNickname(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (isSavingNickname) return
+    const normalizedNickname = nickname.trim()
+    if (!normalizedNickname) {
+      setProfileSuccess(null)
+      setProfileError('昵称不能为空')
+      return
+    }
+    if (normalizedNickname.length > 50) {
+      setProfileSuccess(null)
+      setProfileError('昵称不能超过 50 个字符')
+      return
+    }
+
+    setProfileError(null)
+    setProfileSuccess(null)
+    setIsSavingNickname(true)
+    try {
+      const user = await updateNickname(normalizedNickname)
+      setNickname(user.nickname ?? '')
+      setIsProfileFresh(true)
+      setProfileSuccess('昵称已更新。')
+    } catch (error) {
+      setProfileError(errorMessage(error))
+    } finally {
+      setIsSavingNickname(false)
+    }
+  }
+
+  async function changePassword(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (isChangingPassword) return
+    if (!oldPassword) {
+      setPasswordError('请输入当前密码')
+      return
+    }
+    if (newPassword.length < 8 || newPassword.length > 128) {
+      setPasswordError('新密码需为 8–128 位')
+      return
+    }
+
+    setPasswordError(null)
+    setIsChangingPassword(true)
+    try {
+      await changeSessionPassword({ oldPassword, newPassword })
+    } catch (error) {
+      setPasswordError(errorMessage(error))
+      setIsChangingPassword(false)
+    }
+  }
+
+  function signOut() {
+    void logout().catch(() => undefined)
+  }
+
+  if (!currentUser) return null
+
+  return (
+    <PageContainer>
+      <section className="mx-auto max-w-5xl text-[#1c231e]">
+        <header className="border-b border-[#284331]/14 pb-7">
+          <p className="text-[11px] font-bold tracking-[0.16em] text-[#617064] uppercase">
+            Windup account
+          </p>
+          <h1 className="mt-2 font-serif text-3xl leading-tight font-semibold sm:text-4xl">
+            账号中心
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-[#68736a]">
+            查看账号资料，更新 Windup 中显示的称呼，或管理登录密码。
+          </p>
+        </header>
+
+        <div className="mt-7 grid items-start gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]">
+          <section className="overflow-hidden rounded-2xl border border-[#284331]/16 bg-[#f8faf8] shadow-[0_14px_38px_rgba(24,40,29,0.07)]">
+            <div className="grid gap-5 border-b border-[#284331]/12 bg-[#e9efea] px-5 py-5 sm:grid-cols-[1fr_auto] sm:items-center sm:px-6">
+              <div>
+                <p className="text-xs font-semibold text-[#617064]">当前账号</p>
+                <p className="mt-1 break-all font-mono text-sm font-semibold text-[#284331]">
+                  {currentUser.email}
+                </p>
+              </div>
+              <div className="justify-self-start rounded-full border border-[#56725d]/25 bg-[#f5faf6] px-3 py-1.5 text-xs font-semibold text-[#3d6047] sm:justify-self-end">
+                {currentUser.emailVerifiedAt ? '邮箱已验证' : '邮箱未验证'}
+              </div>
+            </div>
+
+            <div className="grid gap-6 px-5 py-6 sm:px-6">
+              <dl className="grid gap-2 rounded-xl border border-[#284331]/10 bg-white/70 p-4 text-sm sm:grid-cols-[8rem_1fr] sm:items-center">
+                <dt className="font-semibold text-[#617064]">邮箱验证时间</dt>
+                <dd className="text-[#344039]">
+                  {currentUser.emailVerifiedAt ? (
+                    <time dateTime={currentUser.emailVerifiedAt}>
+                      {formatVerificationTime(currentUser.emailVerifiedAt)}
+                    </time>
+                  ) : (
+                    '尚未验证'
+                  )}
+                </dd>
+              </dl>
+
+              <form className="grid gap-4" onSubmit={saveNickname} noValidate>
+                <div className="grid gap-1.5">
+                  <label htmlFor={nicknameId} className="text-sm font-semibold text-[#344039]">
+                    昵称
+                  </label>
+                  <input
+                    id={nicknameId}
+                    type="text"
+                    autoComplete="nickname"
+                    value={nickname}
+                    maxLength={51}
+                    disabled={isProfileLoading || isSavingNickname}
+                    onChange={(event) => setNickname(event.target.value)}
+                    className={fieldClass}
+                    aria-describedby={`${nicknameId}-hint`}
+                  />
+                  <span id={`${nicknameId}-hint`} className="text-xs text-[#778078]">
+                    1–50 个字符；保存后会同步显示在页面顶栏。
+                  </span>
+                </div>
+
+                {profileError && (
+                  <p
+                    role="alert"
+                    className="rounded-xl bg-[#fff5f3] px-3.5 py-3 text-sm text-[#8a3932]"
+                  >
+                    {profileError}
+                  </p>
+                )}
+                {profileSuccess && (
+                  <p
+                    role="status"
+                    className="rounded-xl bg-[#eef5ef] px-3.5 py-3 text-sm text-[#34533c]"
+                  >
+                    {profileSuccess}
+                  </p>
+                )}
+
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <span className="text-xs text-[#778078]">
+                    {isProfileLoading
+                      ? '正在同步最新资料…'
+                      : isProfileFresh
+                        ? '资料已同步'
+                        : '资料同步失败'}
+                  </span>
+                  <button
+                    type="submit"
+                    disabled={isProfileLoading || isSavingNickname}
+                    className={primaryButtonClass}
+                  >
+                    {isSavingNickname ? '正在保存…' : '保存昵称'}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </section>
+
+          <div className="grid gap-6">
+            <section className="rounded-2xl border border-[#284331]/16 bg-[#f8faf8] p-5 shadow-[0_14px_38px_rgba(24,40,29,0.07)] sm:p-6">
+              <h2 className="font-serif text-xl font-semibold">登录安全</h2>
+              <p className="mt-2 text-sm leading-6 text-[#68736a]">
+                修改后当前会话会立即退出，需要使用新密码重新登录。
+              </p>
+
+              <form className="mt-5 grid gap-4" onSubmit={changePassword} noValidate>
+                <label
+                  htmlFor={oldPasswordId}
+                  className="grid gap-1.5 text-sm font-semibold text-[#344039]"
+                >
+                  当前密码
+                  <input
+                    id={oldPasswordId}
+                    type="password"
+                    autoComplete="current-password"
+                    value={oldPassword}
+                    disabled={isChangingPassword}
+                    onChange={(event) => setOldPassword(event.target.value)}
+                    className={fieldClass}
+                  />
+                </label>
+                <div className="grid gap-1.5 text-sm font-semibold text-[#344039]">
+                  <label htmlFor={newPasswordId}>新密码</label>
+                  <input
+                    id={newPasswordId}
+                    type="password"
+                    autoComplete="new-password"
+                    value={newPassword}
+                    disabled={isChangingPassword}
+                    onChange={(event) => setNewPassword(event.target.value)}
+                    className={fieldClass}
+                    aria-describedby={`${newPasswordId}-hint`}
+                  />
+                  <span id={`${newPasswordId}-hint`} className="text-xs font-normal text-[#778078]">
+                    8–128 位
+                  </span>
+                </div>
+
+                {passwordError && (
+                  <p
+                    role="alert"
+                    className="rounded-xl bg-[#fff5f3] px-3.5 py-3 text-sm text-[#8a3932]"
+                  >
+                    {passwordError}
+                  </p>
+                )}
+
+                <button type="submit" disabled={isChangingPassword} className={primaryButtonClass}>
+                  {isChangingPassword ? '正在修改…' : '修改密码'}
+                </button>
+              </form>
+            </section>
+
+            <section className="rounded-2xl border border-[#8a5a4d]/20 bg-[#fff9f6] p-5 sm:p-6">
+              <h2 className="text-sm font-semibold text-[#613e35]">退出登录</h2>
+              <p className="mt-2 text-sm leading-6 text-[#7a5b53]">
+                退出只影响当前浏览器中的 Windup 会话。
+              </p>
+              <button
+                type="button"
+                onClick={signOut}
+                className="mt-4 inline-flex min-h-11 items-center justify-center rounded-xl border border-[#8a5a4d]/35 px-4 text-sm font-semibold text-[#7b4035] transition-colors hover:bg-[#f5e8e3] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7b4035]"
+              >
+                退出当前账号
+              </button>
+            </section>
+          </div>
+        </div>
+      </section>
+    </PageContainer>
+  )
+}

--- a/frontend/src/test/auth-session.tsx
+++ b/frontend/src/test/auth-session.tsx
@@ -29,6 +29,7 @@ export function createAuthenticatedTestApis(): UserApis {
     refresh: async () => tokens(),
     logout: async () => undefined,
     me: async () => testUser,
+    updateNickname: async () => testUser,
     changePassword: async () => undefined,
   }
 }
@@ -41,6 +42,7 @@ const guestApis: UserApis = {
   refresh: async () => Promise.reject(new Error('guest test session has no refresh token')),
   logout: async () => undefined,
   me: async () => Promise.reject(new Error('guest test session has no current user')),
+  updateNickname: async () => Promise.reject(new Error('guest test session cannot update profile')),
   changePassword: async () =>
     Promise.reject(new Error('guest test session cannot change password')),
 }


### PR DESCRIPTION
本 PR 落地 #161 的账号中心：已登录用户可从 Header 进入受保护的 `/account`，查看并维护账号资料、修改密码或退出登录，资料变化会同步到全局会话与 Header。

## Why

#160 / PR #178 已补齐受保护路由和登录回跳，但登录用户仍没有稳定入口查看服务端最新资料或维护账号安全。原 Issue 创建时后端只提供资料读取与修改密码；#155 现已提供 `PATCH /auth/profile`，因此本 PR 同步纳入昵称修改，避免账号页一落地就与当前接口能力脱节。

## Changes

- 已登录用户点击 Header 中的账号名称进入 `/account`；访客直达时复用 #160 的守卫，登录后返回账号中心。
- 每次进入页面通过 `GET /auth/me` 读取邮箱、昵称和邮箱验证时间；邮箱与验证状态保持只读。
- 通过 `PATCH /auth/profile` 修改 1–50 字符的昵称，成功后账号页与 Header 同步更新；失败时保留输入。
- 通过 `POST /auth/change-password` 修改密码，校验 8–128 位约束；失败时保留表单，成功后清除会话并显示“密码修改成功，请重新登录”。
- 退出登录立即清理本地会话并返回首页，不等待远端请求完成。
- 桌面端与窄屏均保留明确标签、可见焦点和至少 44px 的操作区域。

## Implementation

- `UserApis` 继续作为 HTTP 边界，新增昵称更新方法并复用现有真实 API Client，不在页面中读取 token 或处理 DTO。
- `AuthSession` 负责刷新当前用户、提交昵称结果和清理会话；通过 session generation 拒绝登出后晚到的资料响应，避免旧请求恢复用户状态。
- `AccountPage` 只管理资料与表单交互；路由守卫、登录回跳、改密后的账号面板提示均复用已有能力。
- Header 只消费会话公开状态，将当前昵称或邮箱作为账号中心入口，不新增第二套账号状态。

## Verification

- [x] `npm run format:check`：通过，共检查 92 个文件。
- [x] `npm run lint`：通过。
- [x] `npm run typecheck`：通过，app 与 node 配置均无错误。
- [x] `npm run test`：通过，共 28 个测试文件、204 个测试，0 个未处理错误。
- [x] `npm run build`：通过，共构建 113 个模块。
- [x] `git diff --check upstream/main...HEAD`：通过。
- [x] 干净上下文独立验收：通过，无阻断项。
- [x] 本地浏览器联调：连接项目真实 FastAPI 认证路由与临时 SQLite 测试库，验证密码登录、`GET /auth/me`、`PATCH /auth/profile`、Header 昵称同步、`POST /auth/change-password`、会话清理和登录回跳；桌面端与 375px 窄屏均已检查。
- [ ] 部署环境真实后端 E2E：未执行；当前没有可用的部署端 `VITE_API_BASE_URL`。

## Screenshots

以下均为改动后截图；账号中心此前不存在，因此不提供 Before 图。

### Account Center

| Desktop | Mobile |
| --- | --- |
| <img src="https://raw.githubusercontent.com/huyanxius/Windup/assets/161-account-center/pr-161/account-center-desktop.png" width="720" alt="Account center desktop"> | <img src="https://raw.githubusercontent.com/huyanxius/Windup/assets/161-account-center/pr-161/account-center-mobile-profile.png" width="280" alt="Account center mobile profile"><br><img src="https://raw.githubusercontent.com/huyanxius/Windup/assets/161-account-center/pr-161/account-center-mobile-security.png" width="280" alt="Account center mobile security"> |

### Password Changed

| Desktop | Mobile |
| --- | --- |
| <img src="https://raw.githubusercontent.com/huyanxius/Windup/assets/161-account-center/pr-161/password-changed-desktop.png" width="720" alt="Password changed login notice desktop"> | <img src="https://raw.githubusercontent.com/huyanxius/Windup/assets/161-account-center/pr-161/password-changed-mobile.png" width="280" alt="Password changed login notice mobile"> |

## Risks

- 当前后端 `AuthMiddleware` 会在 CORS 中间件之前拦截受保护接口的 `OPTIONS` 请求；真实浏览器对 `/auth/me` 的跨域预检会返回未登录。本地截图运行只在临时装配层增加了标准 CORS 外层包装，没有修改本 PR 的生产代码。
- 因此部署环境跨域联调仍需要后端单独修复预检放行或中间件顺序，完成前不能把本 PR 视为生产端到端已联通。

## Scope

- 本 PR 不包含后端接口、数据库结构、CORS 或鉴权中间件调整。
- 本 PR 不包含修改邮箱、头像、个性签名、注销账号或找回密码界面。
- 生产代码不包含 runtime mock；测试中的 API doubles 保留用于回归测试。
- 后续需单独跟踪受保护接口的 CORS 预检问题，并在获得部署端 API 地址后补真实环境 E2E。

## Related Issues

Closes #161
Refs #157
Refs #155
Refs #160
Refs #164
