### PR TITLE
feat(workflow): persist character names

### DIFF
--- a/frontend/src/entities/workflow-run/api.test.ts
+++ b/frontend/src/entities/workflow-run/api.test.ts
@@ -238,6 +238,24 @@ describe('workflowRunApis', () => {
     })
   })
 
+  it('拒绝超过 20 个字符的角色名称', async () => {
+    const apis = await loadWorkflowRunApis(async () =>
+      jsonResponse({
+        ...workflowRunDto,
+        nodes: nodes.map((node) =>
+          node.type === 'character-setup'
+            ? { ...node, input: { ...node.input, name: 'x'.repeat(21) } }
+            : node,
+        ),
+      }),
+    )
+
+    await expect(apis.get('17')).rejects.toMatchObject({
+      name: 'ApiError',
+      kind: 'invalid-response',
+    })
+  })
+
   it('rejects an empty deletion marker instead of treating it as archived history', async () => {
     const apis = await loadWorkflowRunApis(async () =>
       jsonResponse({

--- a/frontend/src/entities/workflow-run/api.ts
+++ b/frontend/src/entities/workflow-run/api.ts
@@ -88,6 +88,11 @@ function hasOnlyGenerationRole(value: Record<string, unknown>, role: string | nu
 function hasValidCharacterInput(value: unknown): boolean {
   if (!isRecord(value)) return false
   return (
+    (value.name === undefined ||
+      value.name === null ||
+      (typeof value.name === 'string' &&
+        value.name.trim().length > 0 &&
+        value.name.length <= 20)) &&
     typeof value.prompt === 'string' &&
     Array.isArray(value.referenceMedia) &&
     value.referenceMedia.every((item) => typeof item === 'string')

--- a/frontend/src/entities/workflow-run/index.ts
+++ b/frontend/src/entities/workflow-run/index.ts
@@ -44,6 +44,8 @@ interface WorkflowNodeBase {
 }
 
 export interface WorkflowCharacterInput {
+  /** 用户填写或后端提取的最终角色名称；旧数据可以没有该字段。 */
+  name?: string | null
   prompt: string
   referenceMedia: readonly MediaReference[]
 }

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -312,6 +312,40 @@ describe('WorkflowController', () => {
     ).rejects.toThrow('已经绑定')
   })
 
+  it('保存归一化后的角色名称且不修改角色提示词', async () => {
+    const { controller, workflow } = createController()
+
+    await controller.setCharacterName('setup-1', '  雾港旅人  ')
+
+    expect(workflow.getSaved().nodes[0]).toMatchObject({
+      type: 'character-setup',
+      input: {
+        name: '雾港旅人',
+        prompt: '像素骑士',
+        referenceMedia: [],
+      },
+    })
+  })
+
+  it('纯空白角色名称按未填写保存', async () => {
+    const { controller } = createController()
+
+    await controller.setCharacterName('setup-1', '   ')
+
+    expect(controller.getWorkflow().nodes[0]).toMatchObject({
+      type: 'character-setup',
+      input: { name: null },
+    })
+  })
+
+  it('拒绝超过 20 个字符的角色名称', async () => {
+    const { controller } = createController()
+
+    await expect(controller.setCharacterName('setup-1', 'x'.repeat(21))).rejects.toThrow(
+      '角色名称不能超过 20 个字符',
+    )
+  })
+
   it('adds a complete first-frame, method, full-frame, and review chain for one Action', async () => {
     const { controller } = createController(createRun(completedCharacterNodes()))
 

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -72,6 +72,7 @@ export interface WorkflowController {
   getWorkflow(): WorkflowRun
   subscribe(listener: (workflow: WorkflowRun) => void): () => void
 
+  setCharacterName(nodeId: CharacterSetupWorkflowNode['id'], name: string | null): Promise<void>
   addAction(input: AddActionInput): Promise<void>
   generateCharacterTemplate(
     nodeId: CharacterSetupWorkflowNode['id'],
@@ -213,6 +214,27 @@ export function createWorkflowController({
 
   function getWorkflow() {
     return snapshot()
+  }
+
+  function setCharacterName(
+    nodeId: CharacterSetupWorkflowNode['id'],
+    name: string | null,
+  ): Promise<WorkflowRun> {
+    ensureRunning()
+    const normalizedName = name?.trim() || null
+    if (normalizedName && normalizedName.length > 20) {
+      throw new Error('角色名称不能超过 20 个字符')
+    }
+    return persist((run) =>
+      updateNode(run, nodeId, (node) => {
+        if (node.type !== 'character-setup') throw new Error('目标节点不是角色设定')
+        if (node.input.name === normalizedName) return run
+        return replaceNode(run, {
+          ...node,
+          input: { ...node.input, name: normalizedName },
+        })
+      }),
+    )
   }
 
   function addAction({ nodeId = createId(), dependsOnNodeIds, input }: AddActionInput) {
@@ -830,6 +852,7 @@ export function createWorkflowController({
     create: asCommand(create),
     getWorkflow,
     subscribe,
+    setCharacterName: asCommand(setCharacterName),
     addAction: asCommand(addAction),
     generateCharacterTemplate: asCommand(generateCharacterTemplate),
     confirmCharacterTemplate: asCommand(confirmCharacterTemplate),


### PR DESCRIPTION
为 WorkflowRun 增加可选角色名称，并由 WorkflowController 统一完成归一化与持久化，为用户填写和后续后端自动提取名称提供同一接入点。

## Why

WorkflowRun 的角色设定输入缺少名称字段，Controller 也没有与名称来源无关的保存能力，无法稳定承接用户填写或后端返回的最终名称。

## Changes

- 为 `WorkflowCharacterInput` 增加向后兼容的可选 `name`。
- 增加 `setCharacterName`，trim 名称、将纯空白转为 `null`，并限制最多 20 个字符。
- 名称通过 WorkflowController 写回 WorkflowRun，不修改已有 prompt。
- 补充 Controller 持久化和 WorkflowRun 响应校验测试。

## Verification

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 28 files / 211 tests passed
- [x] `npm run build`

## Scope

- 本 PR 不包含：Workflow Editor、Quick Start、Character API、后端自动名称提取或任何 UI 改动。
- 后续事项：后端名称提取接口与 UI 接入继续在 #188 跟进。

## Related Issues

Refs #188
