### PR TITLE
feat(playtest): add asset selection entry

### DIFF
--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -56,6 +56,24 @@ describe('AppRoutes authentication boundary', () => {
     expect(screen.queryByRole('heading', { name: '快速开始' })).toBeNull()
   })
 
+  it('redirects a guest from the PlayTest entry and preserves that return path', async () => {
+    render(
+      <GuestAuthSession>
+        <MemoryRouter initialEntries={['/playtest']}>
+          <AppRoutes />
+          <LocationProbe />
+        </MemoryRouter>
+      </GuestAuthSession>,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/?account=login&returnTo=%2Fplaytest',
+      ),
+    )
+    expect(screen.queryByRole('heading', { name: '选择可试玩资产' })).toBeNull()
+  })
+
   it('protects direct account-center visits and returns there after login', async () => {
     render(
       <GuestAuthSession>

--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -6,7 +6,7 @@ import { AccountPage } from '@/pages/account'
 import { CharacterDetailPage } from '@/pages/character-detail'
 import { HomePage } from '@/pages/home'
 import { NotFoundPage } from '@/pages/not-found'
-import { PlaytestPage } from '@/pages/playtest'
+import { PlaytestEntryPage, PlaytestPage } from '@/pages/playtest'
 import { ProjectDetailPage } from '@/pages/project-detail'
 import { ProjectCreatePage } from '@/pages/project-create'
 import { ProjectsPage } from '@/pages/projects'
@@ -54,6 +54,7 @@ export function AppRoutes() {
           <Route path="/projects/new" element={<ProjectCreatePage />} />
           <Route path="/workflow-editor/:runId" element={<LazyWorkflowEditorPage />} />
           <Route path="/workflow-editor/:runId/:stage" element={<LazyWorkflowEditorPage />} />
+          <Route path="/playtest" element={<PlaytestEntryPage />} />
           <Route path="/playtest/:characterId/:outfitId" element={<PlaytestPage />} />
         </Route>
         <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -69,13 +69,13 @@ afterEach(() => {
 })
 
 describe('AppHeader', () => {
-  it('保留三个产品入口，并将工作流路由归入创作', () => {
+  it('提供 PlayTest 入口，并将工作流路由归入创作', () => {
     renderHeader('/workflow-editor/run-1')
 
     expect(screen.getByRole('link', { name: '返回 Windup 首页' }).getAttribute('href')).toBe('/')
     expect(screen.getByRole('link', { name: '项目资产' }).getAttribute('href')).toBe('/projects')
     expect(screen.getByRole('link', { name: '创作' }).getAttribute('aria-current')).toBe('page')
-    expect(screen.queryByRole('link', { name: 'Playtest' })).toBeNull()
+    expect(screen.getByRole('link', { name: 'PlayTest' }).getAttribute('href')).toBe('/playtest')
   })
 
   it('在首页只高亮首页一项', () => {
@@ -84,6 +84,17 @@ describe('AppHeader', () => {
     expect(screen.getByRole('link', { name: '首页' }).getAttribute('aria-current')).toBe('page')
     expect(screen.getByRole('link', { name: '项目资产' }).getAttribute('aria-current')).toBeNull()
     expect(screen.getByRole('link', { name: '创作' }).getAttribute('aria-current')).toBeNull()
+    expect(screen.getByRole('link', { name: 'PlayTest' }).getAttribute('aria-current')).toBeNull()
+  })
+
+  it('在资产选择页和具体试玩台高亮 PlayTest 入口', () => {
+    const { unmount } = renderHeader('/playtest')
+
+    expect(screen.getByRole('link', { name: 'PlayTest' }).getAttribute('aria-current')).toBe('page')
+
+    unmount()
+    renderHeader('/playtest/51/outfit-default')
+    expect(screen.getByRole('link', { name: 'PlayTest' }).getAttribute('aria-current')).toBe('page')
   })
 
   it('为访客提供可发现的登录入口并保留完整站内回跳地址', async () => {

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -9,12 +9,7 @@ interface ProductNavigationItem {
   isActive: (pathname: string) => boolean
 }
 
-/**
- * 三个入口对应三种去处：回首页、看已有资产、做新东西。
- * 07-31 定稿版还有一个 Playtest 项，这里没有搬——本仓库的预览路由是
- * /playtest/:characterId/:outfitId，没有角色和造型就构造不出可用地址，
- * 顶栏给不出一个恒定的链接。等预览有了落地入口再加回来。
- */
+/** 四个入口对应四种去处：回首页、看资产、做新东西、核验已完成的造型。 */
 const productNavigation: ProductNavigationItem[] = [
   {
     to: '/',
@@ -32,6 +27,11 @@ const productNavigation: ProductNavigationItem[] = [
     label: '创作',
     isActive: (pathname) =>
       pathname.startsWith('/quick-start') || pathname.startsWith('/workflow-editor'),
+  },
+  {
+    to: '/playtest',
+    label: 'PlayTest',
+    isActive: (pathname) => pathname.startsWith('/playtest'),
   },
 ]
 
@@ -111,8 +111,8 @@ export function AppHeader() {
               >
                 {item.compactLabel ? (
                   <>
-                    <span className="hidden sm:inline">{item.label}</span>
-                    <span className="sm:hidden">{item.compactLabel}</span>
+                    <span className="hidden md:inline">{item.label}</span>
+                    <span className="md:hidden">{item.compactLabel}</span>
                   </>
                 ) : (
                   item.label

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,6 +140,30 @@ body,
   }
 }
 
+.playtest-pixel-canvas {
+  position: relative;
+  height: 168px;
+  margin-top: 14px;
+  overflow: hidden;
+  mask-image: linear-gradient(90deg, transparent 0%, #000 10%, #000 94%, transparent 100%);
+}
+
+.playtest-pixel-canvas canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+@media (min-width: 768px) {
+  .playtest-pixel-canvas {
+    position: absolute;
+    inset: 0 -10px 0 42%;
+    height: auto;
+    margin-top: 0;
+    mask-image: linear-gradient(90deg, transparent 0%, #000 22%, #000 96%, transparent 100%);
+  }
+}
+
 @keyframes project-pixel-field {
   0%,
   58%,

--- a/frontend/src/pages/character-detail/index.test.tsx
+++ b/frontend/src/pages/character-detail/index.test.tsx
@@ -42,6 +42,9 @@ describe('CharacterDetailPage', () => {
     expect(screen.queryByText('GIF')).toBeNull()
     expect(screen.getByRole('button', { name: '增加动作' }).hasAttribute('disabled')).toBe(true)
     expect(screen.getByRole('button', { name: '导出资产包' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('link', { name: '试玩当前造型' }).getAttribute('href')).toBe(
+      '/playtest/51/outfit-default',
+    )
   })
 
   it('expands an Action into backend Frames sorted by index', async () => {
@@ -69,5 +72,6 @@ describe('CharacterDetailPage', () => {
     expect(await screen.findByRole('heading', { name: '待定角色' })).toBeTruthy()
     expect(screen.getByRole('combobox', { name: '选择造型' })).toBeTruthy()
     expect(screen.getByText('这个造型还没有动作')).toBeTruthy()
+    expect(screen.queryByRole('link', { name: '试玩当前造型' })).toBeNull()
   })
 })

--- a/frontend/src/pages/character-detail/index.tsx
+++ b/frontend/src/pages/character-detail/index.tsx
@@ -77,6 +77,7 @@ export function CharacterDetailPage() {
     character.outfits.find((outfit) => outfit.id === selectedOutfitId) ??
     character.outfits[0] ??
     null
+  const canPlaytest = selectedOutfit?.actions.some((action) => action.frames.length > 0) ?? false
 
   return (
     <section aria-labelledby="character-title" className="p-4 lg:px-6 lg:py-5">
@@ -114,7 +115,16 @@ export function CharacterDetailPage() {
               </select>
             </label>
           ) : null}
-          <div className="text-right">
+          <div className="flex flex-wrap justify-end gap-2">
+            {selectedOutfit && canPlaytest ? (
+              <Link
+                to={`/playtest/${character.id}/${selectedOutfit.id}`}
+                aria-label="试玩当前造型"
+                className="inline-flex min-h-9 items-center rounded-full bg-[#294433] px-4 text-xs font-semibold text-white transition-colors hover:bg-[#1f3828] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#294433]"
+              >
+                试玩当前造型
+              </Link>
+            ) : null}
             <button
               type="button"
               disabled
@@ -123,10 +133,10 @@ export function CharacterDetailPage() {
             >
               导出资产包
             </button>
-            <p className="mt-1 max-w-xs text-[0.62rem] text-[#858c84]">
-              导出能力待 PR #97 合并并完成资产字段接线
-            </p>
           </div>
+          <p className="max-w-xs text-right text-[0.62rem] text-[#858c84]">
+            导出能力待 PR #97 合并并完成资产字段接线
+          </p>
         </div>
       </div>
 

--- a/frontend/src/pages/playtest/entry.test.tsx
+++ b/frontend/src/pages/playtest/entry.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AppRoutes } from '@/app'
+import { AuthenticatedAuthSession } from '@/test/auth-session'
+import { createProjectAssetsBackend } from '@/test/project-assets-backend'
+
+beforeEach(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+})
+
+function renderEntryWith(fetchFn: typeof globalThis.fetch) {
+  vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+  vi.stubGlobal('fetch', fetchFn)
+
+  return render(
+    <AuthenticatedAuthSession>
+      <MemoryRouter initialEntries={['/playtest']}>
+        <AppRoutes />
+      </MemoryRouter>
+    </AuthenticatedAuthSession>,
+  )
+}
+
+function renderEntry(characterCount = 2) {
+  return renderEntryWith(createProjectAssetsBackend({ characterCount }).fetch)
+}
+
+describe('PlaytestEntryPage', () => {
+  it('links playable outfits to their concrete Playtest route', async () => {
+    renderEntry()
+
+    expect(await screen.findByRole('heading', { name: '选择可试玩资产' })).toBeTruthy()
+    expect(screen.getByTestId('playtest-pixel-stage').getAttribute('aria-hidden')).toBe('true')
+    expect(
+      (await screen.findByRole('link', { name: '试玩 轻装信使 · 常态造型' })).getAttribute('href'),
+    ).toBe('/playtest/51/outfit-default')
+    expect(screen.getByText('2 个动作 · 5 帧')).toBeTruthy()
+    expect(screen.getByText('尚无可播放帧')).toBeTruthy()
+  })
+
+  it('directs an empty account back to character creation', async () => {
+    renderEntry(0)
+
+    expect(await screen.findByText('还没有可试玩的角色')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '开始创作' }).getAttribute('href')).toBe('/quick-start')
+    expect(screen.getByRole('link', { name: '查看项目资产' }).getAttribute('href')).toBe(
+      '/projects',
+    )
+  })
+
+  it('keeps a failed asset request distinct from an empty account', async () => {
+    renderEntryWith(() => Promise.reject(new TypeError('network unavailable')))
+
+    expect(await screen.findByText('可试玩资产暂时无法读取')).toBeTruthy()
+    expect(screen.queryByText('还没有可试玩的角色')).toBeNull()
+  })
+})

--- a/frontend/src/pages/playtest/entry.tsx
+++ b/frontend/src/pages/playtest/entry.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router'
+
+import { characterApis, projectApis, type Character, type Outfit, type Project } from '@/entities'
+import { PageContainer } from '@/shared/ui'
+
+import { PlaytestPixelStage } from './pixel-stage'
+
+interface ProjectCharacters {
+  project: Project
+  characters: Character[]
+}
+
+interface EntryState {
+  groups: ProjectCharacters[] | null
+  error: string | null
+}
+
+const initialState: EntryState = { groups: null, error: null }
+
+function characterName(character: Character) {
+  return character.name ?? '未命名角色'
+}
+
+function outfitPlayback(outfit: Outfit) {
+  const frameCount = outfit.actions.reduce((sum, action) => sum + action.frames.length, 0)
+  return { frameCount, playable: frameCount > 0 }
+}
+
+/**
+ * Playtest 的全局入口只负责定位已落入 Character 资产树的 Outfit。
+ * 它不生成测试数据；具体操控仍交给带 characterId 与 outfitId 的试玩台。
+ */
+export function PlaytestEntryPage() {
+  const [state, setState] = useState<EntryState>(initialState)
+
+  useEffect(() => {
+    let active = true
+    setState(initialState)
+
+    void projectApis
+      .list({ page: 1, pageSize: 100 })
+      .then(async (projectsPage) =>
+        Promise.all(
+          projectsPage.items.map(async (project) => ({
+            project,
+            characters: (await characterApis.listByProject(project.id, { page: 1, pageSize: 100 }))
+              .items,
+          })),
+        ),
+      )
+      .then(
+        (groups) => {
+          if (active) setState({ groups, error: null })
+        },
+        () => {
+          if (active) setState({ groups: [], error: '可试玩资产暂时无法读取' })
+        },
+      )
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const outfitCount =
+    state.groups?.reduce(
+      (total, group) =>
+        total + group.characters.reduce((sum, character) => sum + character.outfits.length, 0),
+      0,
+    ) ?? 0
+
+  return (
+    <PageContainer>
+      <section aria-labelledby="playtest-entry-title">
+        <header className="relative overflow-hidden border-b border-[#d8dbd4] bg-[linear-gradient(105deg,#fff_0%,#fff_54%,#f1f4ef_100%)] pb-7 md:min-h-64 md:px-2 md:py-7">
+          <div className="relative z-10 max-w-xl">
+            <p className="font-mono text-[0.68rem] font-semibold tracking-[0.2em] text-[#778078] uppercase">
+              Character field test
+            </p>
+            <div className="mt-3">
+              <h1
+                id="playtest-entry-title"
+                className="font-serif text-4xl font-medium tracking-[-0.045em] text-[#1f211e]"
+              >
+                选择可试玩资产
+              </h1>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-[#696e67]">
+                选择一套已有造型，检查动作衔接、移动反馈和实际播放效果。
+              </p>
+            </div>
+            <div className="mt-5 flex items-center gap-3 font-mono text-[0.68rem] text-[#747c74]">
+              <span className="inline-block h-1.5 w-1.5 bg-[#294433]" />
+              <span>{state.groups !== null ? `${outfitCount} 套造型已接入` : '正在接入资产'}</span>
+            </div>
+          </div>
+
+          <PlaytestPixelStage />
+        </header>
+
+        {state.error ? (
+          <ErrorState />
+        ) : state.groups === null ? (
+          <p className="mt-8 text-sm text-[#70766f]">正在整理可试玩资产…</p>
+        ) : outfitCount === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="mt-7 space-y-8">
+            {state.groups.map((group) => {
+              const charactersWithOutfits = group.characters.filter(
+                (character) => character.outfits.length > 0,
+              )
+              if (charactersWithOutfits.length === 0) return null
+
+              return (
+                <section key={group.project.id} aria-labelledby={`project-${group.project.id}`}>
+                  <div className="flex items-center justify-between gap-4">
+                    <h2
+                      id={`project-${group.project.id}`}
+                      className="text-sm font-semibold text-[#343a34]"
+                    >
+                      {group.project.name}
+                    </h2>
+                    <Link
+                      to={`/projects/${group.project.id}/assets`}
+                      className="text-xs font-medium text-[#687268] underline decoration-[#b8c0b8] underline-offset-4 hover:text-[#294433]"
+                    >
+                      查看项目资产
+                    </Link>
+                  </div>
+                  <div className="mt-3 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                    {charactersWithOutfits.flatMap((character) =>
+                      character.outfits.map((outfit) => (
+                        <OutfitCard
+                          key={`${character.id}:${outfit.id}`}
+                          character={character}
+                          outfit={outfit}
+                        />
+                      )),
+                    )}
+                  </div>
+                </section>
+              )
+            })}
+          </div>
+        )}
+      </section>
+    </PageContainer>
+  )
+}
+
+function OutfitCard({ character, outfit }: { character: Character; outfit: Outfit }) {
+  const { frameCount, playable } = outfitPlayback(outfit)
+  const name = characterName(character)
+  const content = (
+    <article
+      className={`group overflow-hidden rounded-[1.4rem] border bg-[#f4f5f1] ${
+        playable
+          ? 'border-[#d3d8d1] transition duration-300 hover:-translate-y-0.5 hover:border-[#88988b] hover:bg-white'
+          : 'border-[#dfe2dc] text-[#7b827b]'
+      }`}
+    >
+      <div className="relative aspect-[16/9] overflow-hidden border-b border-[#dde1da] bg-[#e8ece7]">
+        {outfit.previewUrl ? (
+          <img
+            src={outfit.previewUrl}
+            alt={`${name}的${outfit.name}预览`}
+            className={`h-full w-full object-contain p-5 [image-rendering:pixelated] ${
+              playable
+                ? 'transition duration-300 group-hover:scale-[1.025]'
+                : 'opacity-55 grayscale'
+            }`}
+          />
+        ) : (
+          <div className="grid h-full place-items-center bg-[linear-gradient(135deg,#e3e7e1_25%,#f1f2ee_25%,#f1f2ee_50%,#e3e7e1_50%,#e3e7e1_75%,#f1f2ee_75%)] bg-[length:24px_24px]">
+            <span className="rounded-full border border-[#c9cec7] bg-[#f8f9f6]/90 px-3 py-1 text-xs font-medium text-[#707870]">
+              暂无造型预览
+            </span>
+          </div>
+        )}
+        <span
+          className={`absolute right-3 top-3 rounded-full border px-2.5 py-1 text-[0.65rem] font-semibold ${
+            playable
+              ? 'border-[#9eafa1] bg-[#edf3ed]/95 text-[#294433]'
+              : 'border-[#cdd2cc] bg-[#f4f5f1]/95 text-[#7a817a]'
+          }`}
+        >
+          {playable ? '可试玩' : '待补帧'}
+        </span>
+      </div>
+      <div className="p-4">
+        <p className="text-xs text-[#747b73]">{name}</p>
+        <div className="mt-1 flex items-start justify-between gap-3">
+          <h3 className="font-serif text-xl font-medium tracking-[-0.03em] text-[#252925]">
+            {outfit.name}
+          </h3>
+          <span aria-hidden="true" className="text-[#7a877d]">
+            {playable ? '↗' : '—'}
+          </span>
+        </div>
+        <p className="mt-4 border-t border-[#dfe2dc] pt-3 text-xs text-[#687168]">
+          {playable ? `${outfit.actions.length} 个动作 · ${frameCount} 帧` : '尚无可播放帧'}
+        </p>
+      </div>
+    </article>
+  )
+
+  if (!playable) return content
+
+  return (
+    <Link
+      to={`/playtest/${character.id}/${outfit.id}`}
+      aria-label={`试玩 ${name} · ${outfit.name}`}
+      className="block rounded-[1.4rem] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#294433]"
+    >
+      {content}
+    </Link>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="mt-7 rounded-[1.5rem] border border-dashed border-[#c9cec6] bg-[#f7f8f4] p-7 sm:p-9">
+      <h2 className="font-serif text-2xl font-medium tracking-[-0.03em] text-[#252a25]">
+        还没有可试玩的角色
+      </h2>
+      <p className="mt-2 max-w-xl text-sm leading-6 text-[#6d736c]">
+        完成角色与动作制作后，可以在这里检查移动和动画效果。
+      </p>
+      <div className="mt-6 flex flex-wrap gap-3">
+        <Link
+          to="/quick-start"
+          className="inline-flex min-h-10 items-center rounded-full bg-[#294433] px-5 text-sm font-semibold text-white hover:bg-[#1f3828] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#294433]"
+        >
+          开始创作
+        </Link>
+        <Link
+          to="/projects"
+          className="inline-flex min-h-10 items-center rounded-full border border-[#c7cec6] px-5 text-sm font-semibold text-[#465047] hover:border-[#939f95] hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#294433]"
+        >
+          查看项目资产
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+function ErrorState() {
+  return (
+    <div className="mt-7 rounded-[1.5rem] border border-[#d8c7bd] bg-[#fff8f2] p-7">
+      <h2 className="font-semibold text-[#6f3928]">可试玩资产暂时无法读取</h2>
+      <p className="mt-2 text-sm text-[#7a5548]">稍后刷新页面，或先回项目资产检查角色数据。</p>
+      <Link
+        to="/projects"
+        className="mt-5 inline-flex min-h-10 items-center rounded-full border border-[#c9a99b] px-5 text-sm font-semibold text-[#6f3928]"
+      >
+        查看项目资产
+      </Link>
+    </div>
+  )
+}

--- a/frontend/src/pages/playtest/index.tsx
+++ b/frontend/src/pages/playtest/index.tsx
@@ -6,6 +6,8 @@ import { ApiError } from '@/shared/api'
 
 import { PlaytestWorkbench } from './workbench'
 
+export { PlaytestEntryPage } from './entry'
+
 interface PageData {
   character: Character | null
   error: string | null

--- a/frontend/src/pages/playtest/pixel-stage-model.ts
+++ b/frontend/src/pages/playtest/pixel-stage-model.ts
@@ -1,0 +1,26 @@
+const PLAYTEST_CYCLE_DURATION = 3600
+
+export function modulo(value: number, size: number) {
+  return ((value % size) + size) % size
+}
+
+export function getPlaytestSceneState(time: number) {
+  const cycle = modulo(time, PLAYTEST_CYCLE_DURATION) / PLAYTEST_CYCLE_DURATION
+  const jumpProgress = cycle >= 0.46 && cycle <= 0.8 ? (cycle - 0.46) / 0.34 : 0
+  const jump = jumpProgress > 0 ? -Math.sin(jumpProgress * Math.PI) * 10 : 0
+  const runWave = Math.sin(cycle * Math.PI * 16)
+  const bob = jumpProgress > 0 ? 0 : runWave > 0 ? -1 : 0
+  const runner = {
+    cycle,
+    jump,
+    jumpProgress,
+    runWave,
+    originX: 38,
+    originY: 33 + jump + bob,
+  }
+
+  return {
+    runner,
+    obstacleX: 154 - runner.cycle * 180,
+  }
+}

--- a/frontend/src/pages/playtest/pixel-stage.test.tsx
+++ b/frontend/src/pages/playtest/pixel-stage.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getPlaytestSceneState } from './pixel-stage-model'
+import { PlaytestPixelStage } from './pixel-stage'
+
+beforeEach(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('PlaytestPixelStage', () => {
+  it('renders the moving scene as one persistent dot-matrix canvas', () => {
+    render(<PlaytestPixelStage />)
+
+    const stage = screen.getByTestId('playtest-pixel-stage')
+    const canvas = screen.getByTestId('playtest-dot-canvas')
+    expect(stage.getAttribute('aria-hidden')).toBe('true')
+    expect(canvas.tagName).toBe('CANVAS')
+    expect(stage.querySelector('svg')).toBeNull()
+  })
+
+  it('aligns the obstacle crossing with the jump and closes the runner loop without a seam', () => {
+    const crossingTime = 3600 * ((154 - 43) / 180)
+    const crossing = getPlaytestSceneState(crossingTime)
+    expect(Math.abs(crossing.obstacleX - (crossing.runner.originX + 5))).toBeLessThan(1)
+    expect(crossing.runner.originY).toBeLessThan(28)
+
+    expect(getPlaytestSceneState(3600)).toEqual(getPlaytestSceneState(0))
+  })
+})

--- a/frontend/src/pages/playtest/pixel-stage.test.tsx
+++ b/frontend/src/pages/playtest/pixel-stage.test.tsx
@@ -12,17 +12,56 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe('PlaytestPixelStage', () => {
   it('renders the moving scene as one persistent dot-matrix canvas', () => {
-    render(<PlaytestPixelStage />)
+    const context = {
+      globalAlpha: 1,
+      fillStyle: '',
+      beginPath: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      fillRect: vi.fn(),
+      save: vi.fn(),
+      translate: vi.fn(),
+      scale: vi.fn(),
+      restore: vi.fn(),
+      setTransform: vi.fn(),
+    }
+    vi.mocked(HTMLCanvasElement.prototype.getContext).mockReturnValue(
+      context as unknown as CanvasRenderingContext2D,
+    )
+    vi.stubGlobal('matchMedia', () => ({ matches: false }))
+
+    const frames: FrameRequestCallback[] = []
+    let nextFrameId = 0
+    const requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      frames.push(callback)
+      nextFrameId += 1
+      return nextFrameId
+    })
+    const cancelAnimationFrame = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrame)
+
+    const { unmount } = render(<PlaytestPixelStage />)
+
+    frames.shift()?.(360)
+    frames.shift()?.(2916)
 
     const stage = screen.getByTestId('playtest-pixel-stage')
     const canvas = screen.getByTestId('playtest-dot-canvas')
     expect(stage.getAttribute('aria-hidden')).toBe('true')
     expect(canvas.tagName).toBe('CANVAS')
     expect(stage.querySelector('svg')).toBeNull()
+    expect(context.fillRect).toHaveBeenCalledTimes(3)
+    expect(context.arc.mock.calls.length).toBeGreaterThan(500)
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(3)
+
+    unmount()
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(3)
   })
 
   it('aligns the obstacle crossing with the jump and closes the runner loop without a seam', () => {

--- a/frontend/src/pages/playtest/pixel-stage.tsx
+++ b/frontend/src/pages/playtest/pixel-stage.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useRef } from 'react'
+
+import { getPlaytestSceneState, modulo } from './pixel-stage-model'
+
+const WORLD_WIDTH = 144
+const WORLD_HEIGHT = 56
+
+const palette = {
+  sky: '#f6f7f2',
+  far: '#d4e6f4',
+  mid: '#719fc4',
+  slate: '#647c82',
+  green: '#294433',
+  dark: '#203628',
+  gold: '#c4a66a',
+  ground: '#294433',
+}
+
+function drawDot(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  color: string,
+  alpha = 1,
+) {
+  context.globalAlpha = alpha
+  context.fillStyle = color
+  context.beginPath()
+  context.arc(x, y, radius, 0, Math.PI * 2)
+  context.fill()
+  context.globalAlpha = 1
+}
+
+function drawDotRect(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  color: string,
+  radius = 0.42,
+) {
+  for (let row = 0; row < height; row += 1) {
+    for (let column = 0; column < width; column += 1) {
+      drawDot(context, x + column, y + row, radius, color)
+    }
+  }
+}
+
+function drawCloud(context: CanvasRenderingContext2D, x: number, y: number, size: number) {
+  const dots = [
+    [0, 1],
+    [1, 1],
+    [2, 0],
+    [2, 1],
+    [3, 0],
+    [3, 1],
+    [4, 0],
+    [4, 1],
+    [5, 1],
+    [6, 1],
+  ]
+
+  for (const [dotX, dotY] of dots) {
+    const centerX = x + dotX * size
+    const centerY = y + dotY * size
+    drawDot(context, centerX, centerY, size * 0.46, palette.far, 0.96)
+    drawDot(context, centerX, centerY, size * 0.24, '#ffffff', 0.9)
+  }
+}
+
+function drawObstacle(context: CanvasRenderingContext2D, x: number, time: number) {
+  const stoneDots = [
+    [1, 43],
+    [3, 43],
+    [5, 43],
+    [7, 43],
+    [9, 43],
+    [2, 41],
+    [4, 41],
+    [6, 41],
+    [8, 41],
+    [3, 39],
+    [5, 39],
+    [7, 39],
+    [4, 37],
+    [6, 37],
+    [5, 35],
+  ]
+
+  for (const [dotX, dotY] of stoneDots) {
+    const isEdge = dotY === 43 || dotX === 1 || dotX === 9
+    drawDot(context, x + dotX, dotY, 0.55, isEdge ? palette.green : palette.slate, 0.96)
+  }
+
+  const pulse = 0.72 + Math.sin(time * 0.006) * 0.2
+  drawDot(context, x + 5, 38, 0.42, palette.gold, pulse)
+  drawDot(context, x + 6, 40, 0.34, palette.gold, pulse * 0.76)
+}
+
+function drawScenery(context: CanvasRenderingContext2D, time: number) {
+  const farScroll = time * 0.0024
+  const midScroll = time * 0.0068
+  const { runner, obstacleX } = getPlaytestSceneState(time)
+
+  const overlapsRunner = (x: number, y: number) => {
+    const horizontal = (x - (runner.originX + 6)) / 13
+    const vertical = (y - (runner.originY + 6)) / 12
+    return y < 43 && horizontal * horizontal + vertical * vertical < 1
+  }
+
+  for (let x = 0; x <= WORLD_WIDTH; x += 3) {
+    const farSample = x + farScroll
+    const farTop = 23 + Math.sin(farSample * 0.12) * 4 + Math.sin(farSample * 0.31) * 2
+    for (let layer = 0; layer < 4; layer += 1) {
+      const y = Math.round(farTop) + layer * 3
+      if (!overlapsRunner(x, y)) {
+        drawDot(context, x, y, 0.5 - layer * 0.035, palette.far, 0.7 - layer * 0.12)
+      }
+    }
+
+    const midSample = x + midScroll
+    const midTop = 34 + Math.sin(midSample * 0.15) * 2 + Math.sin(midSample * 0.43)
+    for (let layer = 0; layer < 3; layer += 1) {
+      const y = Math.round(midTop) + layer * 3
+      if (!overlapsRunner(x, y)) {
+        drawDot(context, x, y, 0.56 - layer * 0.04, palette.mid, 0.78 - layer * 0.14)
+      }
+    }
+  }
+
+  const cloudScroll = time * 0.0016
+  for (const [cloudX, cloudY, size] of [
+    [18, 8, 2.1],
+    [82, 5, 1.8],
+    [139, 11, 1.5],
+  ] as const) {
+    drawCloud(context, modulo(cloudX - cloudScroll + 18, 180) - 18, cloudY, size)
+  }
+
+  for (const [speckX, speckY, speed] of [
+    [62, 17, 0.001],
+    [103, 12, 0.0014],
+    [132, 21, 0.0008],
+  ] as const) {
+    drawDot(context, modulo(speckX - time * speed + 4, 152) - 4, speckY, 0.36, palette.gold, 0.58)
+  }
+
+  for (let x = -2; x <= WORLD_WIDTH + 2; x += 1.5) {
+    drawDot(context, x, 44, 0.56, palette.ground, 0.98)
+  }
+
+  for (let x = -2; x <= WORLD_WIDTH + 2; x += 1.8) {
+    drawDot(context, x + 0.7, 46, 0.5, palette.ground, 0.82)
+  }
+
+  for (let x = -2; x <= WORLD_WIDTH + 2; x += 2) {
+    drawDot(context, x, 48, 0.43, palette.slate, 0.64)
+  }
+
+  for (let x = -2; x <= WORLD_WIDTH + 2; x += 2.3) {
+    drawDot(context, x + 0.9, 50, 0.36, palette.ground, 0.5)
+  }
+
+  for (let x = -2; x <= WORLD_WIDTH + 2; x += 2.8) {
+    drawDot(context, x, 52, 0.3, palette.slate, 0.3)
+  }
+
+  drawObstacle(context, obstacleX, time)
+}
+
+function drawRunner(context: CanvasRenderingContext2D, time: number) {
+  const {
+    runner: { cycle, jump, runWave, originX, originY },
+  } = getPlaytestSceneState(time)
+
+  const shadowWidth = 5 + Math.abs(jump) * 0.32
+  const shadowAlpha = 0.42 - Math.abs(jump) * 0.025
+  for (let x = -shadowWidth; x <= shadowWidth; x += 2) {
+    drawDot(context, originX + 5 + x, 44, 0.55, palette.green, Math.max(0.12, shadowAlpha))
+  }
+
+  drawDotRect(context, originX + 3, originY, 4, 1, palette.dark)
+  drawDotRect(context, originX + 2, originY + 1, 6, 4, palette.green)
+  drawDotRect(context, originX + 3, originY + 5, 5, 4, palette.slate)
+  drawDotRect(context, originX + 1, originY + 5, 2, 3, palette.green)
+
+  const scarfWave = Math.round(Math.sin(time * 0.018))
+  drawDot(context, originX + 2, originY + 4, 0.44, palette.gold)
+  drawDot(context, originX + 1, originY + 4, 0.44, palette.gold)
+  for (let index = 0; index < 5; index += 1) {
+    const tailLift = index > 1 ? scarfWave : 0
+    drawDot(context, originX - index, originY + 4 + tailLift, 0.43, palette.gold)
+  }
+  drawDot(context, originX - 4, originY + 5 + scarfWave, 0.4, palette.gold)
+
+  if (runWave >= 0) {
+    drawDotRect(context, originX + 1, originY + 9, 3, 2, palette.dark)
+    drawDotRect(context, originX + 6, originY + 9, 3, 2, palette.dark)
+  } else {
+    drawDotRect(context, originX + 2, originY + 9, 3, 2, palette.dark)
+    drawDotRect(context, originX + 5, originY + 9, 3, 2, palette.dark)
+  }
+
+  if (cycle >= 0.76 && cycle <= 0.86) {
+    const burst = 1 - Math.abs((cycle - 0.81) / 0.05)
+    for (const direction of [-1, 1]) {
+      drawDot(
+        context,
+        originX + 5 + direction * (5 + burst * 4),
+        43 - burst * 2,
+        0.45,
+        palette.green,
+        burst,
+      )
+    }
+  }
+}
+
+function drawFrame(context: CanvasRenderingContext2D, width: number, height: number, time: number) {
+  context.fillStyle = palette.sky
+  context.fillRect(0, 0, width, height)
+
+  const scale = Math.max(width / WORLD_WIDTH, height / WORLD_HEIGHT)
+  const offsetX = (width - WORLD_WIDTH * scale) / 2
+  const offsetY = (height - WORLD_HEIGHT * scale) / 2
+
+  context.save()
+  context.translate(offsetX, offsetY)
+  context.scale(scale, scale)
+  drawScenery(context, time)
+  drawRunner(context, time)
+  context.restore()
+}
+
+export function PlaytestPixelStage() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const context = canvas?.getContext('2d')
+    if (!canvas || !context) return
+
+    let frame = 0
+    let width = 1
+    let height = 1
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    const resize = () => {
+      const bounds = canvas.getBoundingClientRect()
+      const pixelRatio = Math.min(window.devicePixelRatio || 1, 2)
+      width = Math.max(1, bounds.width)
+      height = Math.max(1, bounds.height)
+      canvas.width = Math.round(width * pixelRatio)
+      canvas.height = Math.round(height * pixelRatio)
+      context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0)
+    }
+
+    const render = (time: number) => {
+      const pixelRatio = Math.min(window.devicePixelRatio || 1, 2)
+      context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0)
+      drawFrame(context, width, height, time)
+      if (!reducedMotion) frame = window.requestAnimationFrame(render)
+    }
+
+    resize()
+    render(0)
+
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(resize)
+    observer?.observe(canvas)
+    if (!observer) window.addEventListener('resize', resize)
+
+    return () => {
+      window.cancelAnimationFrame(frame)
+      observer?.disconnect()
+      if (!observer) window.removeEventListener('resize', resize)
+    }
+  }, [])
+
+  return (
+    <div data-testid="playtest-pixel-stage" aria-hidden="true" className="playtest-pixel-canvas">
+      <canvas ref={canvasRef} data-testid="playtest-dot-canvas" />
+    </div>
+  )
+}


### PR DESCRIPTION
补齐 PlayTest 的稳定入口与资产选择前置页，让用户在进入试玩台前先选择具备可播放帧的角色造型，并可从角色详情直接进入试玩。

## Why

原有 PlayTest 只能通过带有角色与造型 ID 的深层路由访问，顶层导航没有可靠落点；没有资产时也缺少清晰的引导界面。

## Changes

- 在全局 Header 增加 `PlayTest` 入口与激活态。
- 新增受登录保护的 PlayTest 资产选择页，覆盖可试玩、待补帧、空状态和请求失败状态。
- 在角色详情页为具备动作帧的造型增加“试玩当前造型”入口。
- 增加彩色点阵横版场景，保留连续背景、跑跳人物、静止地面和障碍物。

## Implementation

- `/playtest` 作为稳定前置路由，具体试玩仍沿用 `/playtest/:characterId/:outfitId`。
- 动画使用 Canvas 绘制；人物与障碍物时序由纯模型提供，避免循环接缝并便于测试。
- 测试与业务实现分为独立提交，不包含本地账号、环境数据或调试数据库。

## Verification

- [x] `npm run format:check`：通过
- [x] `npm run lint`：通过，无警告
- [x] `npm run typecheck`：通过
- [x] `npm run test`：30 个测试文件、218 项测试通过
- [x] `npm run build`：通过
- [x] `uv run ruff check .`：通过
- [x] `uv run lint-imports`：2 个契约通过
- [x] `uv run pytest -q`：88 项测试通过
- [x] `git diff --check`：通过

## Screenshots

### Header

![Header PlayTest entry](https://raw.githubusercontent.com/huyanxius/Windup/pr-assets/playtest-213/.github/pr-assets/213/header.png)

### PlayTest Entry

![PlayTest asset selection entry](https://raw.githubusercontent.com/huyanxius/Windup/pr-assets/playtest-213/.github/pr-assets/213/playtest.png)

## Scope

- 本 PR 不包含 PlayTest 播放器本身的行为改造。
- 按本次要求仅提供桌面截图，不执行移动端截图验收。
