### PR TITLE
fix(ui): honor reduced motion preferences

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -136,7 +136,7 @@ body,
   .account-dialog-backdrop,
   .account-dialog-panel,
   .project-pixel-mark i {
-    animation: none;
+    animation: none !important;
   }
 }
 

--- a/frontend/src/pages/home/brand-bird.test.tsx
+++ b/frontend/src/pages/home/brand-bird.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { HomeBrandBird } from './brand-bird'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('HomeBrandBird', () => {
+  it('stops the running animation when reduced motion is enabled', () => {
+    const preference = createReducedMotionPreference(false)
+    const frames = new Map<number, FrameRequestCallback>()
+    let nextFrameId = 1
+    const images: EventTarget[] = []
+    const pixels = new Uint8ClampedArray(48 * 48 * 4)
+    pixels[3] = 255
+    const context = {
+      arc: vi.fn(),
+      beginPath: vi.fn(),
+      clearRect: vi.fn(),
+      drawImage: vi.fn(),
+      fill: vi.fn(),
+      fillStyle: '',
+      getImageData: vi.fn(() => ({ data: pixels })),
+      setTransform: vi.fn(),
+    }
+
+    class FakeResizeObserver {
+      observe() {}
+      disconnect() {}
+    }
+
+    class TestImage extends EventTarget {
+      decoding: 'async' | 'sync' | 'auto' = 'auto'
+      src = ''
+
+      constructor() {
+        super()
+        images.push(this)
+      }
+    }
+
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver)
+    vi.stubGlobal('Image', TestImage)
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => preference.query),
+    )
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      const frameId = nextFrameId
+      nextFrameId += 1
+      frames.set(frameId, callback)
+      return frameId
+    })
+    vi.stubGlobal('cancelAnimationFrame', (frameId: number) => {
+      frames.delete(frameId)
+    })
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+      () => context as unknown as CanvasRenderingContext2D,
+    )
+    vi.spyOn(HTMLCanvasElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 640,
+      height: 360,
+    } as DOMRect)
+
+    render(<HomeBrandBird />)
+    const image = images[0]
+    if (!image) throw new Error('HomeBrandBird did not create its image')
+    image.dispatchEvent(new Event('load'))
+    expect(frames.size).toBe(1)
+
+    preference.setMatches(true)
+
+    expect(frames.size).toBe(0)
+  })
+})
+
+interface ReducedMotionPreference {
+  query: MediaQueryList
+  setMatches(matches: boolean): void
+}
+
+function createReducedMotionPreference(initialMatches: boolean): ReducedMotionPreference {
+  let matches = initialMatches
+  const listeners = new Set<(event: MediaQueryListEvent) => void>()
+  const query = {
+    get matches() {
+      return matches
+    },
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+      if (typeof listener === 'function') {
+        listeners.add(listener as (event: MediaQueryListEvent) => void)
+      }
+    },
+    removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) => {
+      if (typeof listener === 'function') {
+        listeners.delete(listener as (event: MediaQueryListEvent) => void)
+      }
+    },
+  } as MediaQueryList
+
+  return {
+    query,
+    setMatches(nextMatches) {
+      matches = nextMatches
+      const event = { matches, media: query.media } as MediaQueryListEvent
+      for (const listener of listeners) listener(event)
+    },
+  }
+}

--- a/frontend/src/pages/home/brand-bird.tsx
+++ b/frontend/src/pages/home/brand-bird.tsx
@@ -55,7 +55,8 @@ export function HomeBrandBird() {
     const context = canvas.getContext('2d')
     if (!context) return
 
-    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const motionPreference = window.matchMedia('(prefers-reduced-motion: reduce)')
+    let reduceMotion = motionPreference.matches
     const image = new Image()
     image.decoding = 'async'
     image.src = '/windup-mark.svg'
@@ -125,6 +126,14 @@ export function HomeBrandBird() {
       animationFrame = window.requestAnimationFrame(animate)
     }
 
+    function handleMotionPreferenceChange(event: MediaQueryListEvent) {
+      reduceMotion = event.matches
+      window.cancelAnimationFrame(animationFrame)
+      animationFrame = 0
+      draw()
+      if (!reduceMotion && points.length) animationFrame = window.requestAnimationFrame(animate)
+    }
+
     function load() {
       points = sampleMark(image)
       draw()
@@ -134,12 +143,14 @@ export function HomeBrandBird() {
     const observer = new ResizeObserver(resize)
     observer.observe(canvas)
     image.addEventListener('load', load, { once: true })
+    motionPreference.addEventListener('change', handleMotionPreferenceChange)
     resize()
 
     return () => {
       window.cancelAnimationFrame(animationFrame)
       observer.disconnect()
       image.removeEventListener('load', load)
+      motionPreference.removeEventListener('change', handleMotionPreferenceChange)
     }
   }, [])
 


### PR DESCRIPTION
## Why

#206 在系统开启“减少动态效果”后，项目像素标记仍会被后置状态样式重新启动动画；首页 Canvas 动画也不会响应运行时偏好变化。

## Changes

- 提高 reduced-motion 动画禁用规则的优先级。
- 监听 reduced-motion 偏好变化，及时停止或恢复首页 Canvas 动画，并在卸载时清理监听。
- 增加聚焦回归测试。

## Verification

- 聚焦测试：12/12 通过。
- TypeScript 类型检查通过。
- 相关文件格式检查与 diff 检查通过。
- 浏览器确认 reduced-motion 规则生效，控制台无 warning/error。

## Screenshots

不适用：本修复只改变系统 reduced-motion 偏好下的动画执行状态，静态截图无法展示差异。

## Scope

仅修复 #206，不涉及其他动画重构、后端或依赖变更。

## Related Issues

Closes #206
