### PR TITLE
feat(workflow-editor): add reference image upload

### DIFF
--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -161,6 +161,33 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     })
   })
 
+  it('页面卸载时取消在途参考图上传并忽略迟到结果', async () => {
+    const pendingUpload = deferred<MediaReference>()
+    let uploadSignal: AbortSignal | undefined
+    const session = createSession(workflowFixture(), {
+      uploadReferenceImage: vi.fn((_file: File, signal?: AbortSignal) => {
+        uploadSignal = signal
+        return pendingUpload.promise
+      }),
+    })
+    const updateCharacterSetup = vi.spyOn(session.controller, 'updateCharacterSetup')
+    defaultSessionLoader.mockResolvedValue(session)
+    const view = renderEditor('/workflow-editor/42')
+
+    const file = new File(['pixels'], 'slow.png', { type: 'image/png' })
+    fireEvent.change(await screen.findByLabelText('角色参考图'), { target: { files: [file] } })
+    await waitFor(() => expect(uploadSignal).toBeDefined())
+
+    view.unmount()
+    expect(uploadSignal?.aborted).toBe(true)
+
+    await act(async () => {
+      pendingUpload.resolve('late-reference' as MediaReference)
+      await pendingUpload.promise
+    })
+    expect(updateCharacterSetup).not.toHaveBeenCalled()
+  })
+
   it('真实 Generation 尚未实现时展示接口错误，不回退到演示候选', async () => {
     defaultSessionLoader.mockResolvedValue(createSession())
     renderEditor('/workflow-editor/42')

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -9,6 +9,7 @@ import type {
   CharacterTemplateWorkflowNode,
   Generation,
   GenerationApis,
+  MediaReference,
   Project,
   WorkflowRun,
   WorkflowRunApis,
@@ -105,6 +106,59 @@ describe('WorkflowEditorPage real runtime boundary', () => {
       }),
     )
     await waitFor(() => expect(screen.queryByRole('textbox', { name: '角色描述' })).toBeNull())
+  })
+
+  it('上传角色参考图期间禁止生成，成功后写回 WorkflowRun', async () => {
+    const pendingUpload = deferred<MediaReference>()
+    const uploadReferenceImage = vi.fn(() => pendingUpload.promise)
+    const session = createSession(workflowFixture(), { uploadReferenceImage })
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    const promptInput = await screen.findByRole('textbox', { name: '角色描述' })
+    fireEvent.change(promptInput, { target: { value: '戴红围巾的短发少年冒险家' } })
+    const file = new File(['pixels'], 'reference.png', { type: 'image/png' })
+    fireEvent.change(screen.getByLabelText('角色参考图'), { target: { files: [file] } })
+
+    expect(screen.getByText('正在上传参考图…')).toBeTruthy()
+    expect(
+      (screen.getByRole('button', { name: '生成角色候选' }) as HTMLButtonElement).disabled,
+    ).toBe(true)
+
+    await act(async () => {
+      pendingUpload.resolve('opaque-reference-1' as MediaReference)
+      await pendingUpload.promise
+    })
+
+    await waitFor(() =>
+      expect(session.controller.getWorkflow().nodes[0]).toMatchObject({
+        input: {
+          prompt: '戴红围巾的短发少年冒险家',
+          referenceMedia: ['opaque-reference-1'],
+        },
+      }),
+    )
+    expect(screen.getByText('已关联 1 个参考媒体')).toBeTruthy()
+    expect(
+      (screen.getByRole('button', { name: '生成角色候选' }) as HTMLButtonElement).disabled,
+    ).toBe(false)
+  })
+
+  it('上传失败时提示错误且不写入 WorkflowRun', async () => {
+    const uploadReferenceImage = vi.fn().mockRejectedValue(new Error('对象存储暂不可用'))
+    const session = createSession(workflowFixture(), { uploadReferenceImage })
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    const file = new File(['pixels'], 'retry.png', { type: 'image/png' })
+    fireEvent.change(await screen.findByLabelText('角色参考图'), { target: { files: [file] } })
+
+    expect((await screen.findByRole('alert')).textContent).toContain('对象存储暂不可用')
+    expect(session.controller.getWorkflow().nodes[0]).toMatchObject({
+      status: 'active',
+      phase: 'configuring',
+      input: { referenceMedia: [] },
+    })
   })
 
   it('真实 Generation 尚未实现时展示接口错误，不回退到演示候选', async () => {
@@ -629,6 +683,7 @@ function renderEditor(path: string) {
 interface SessionFixtureOptions {
   character?: Character | null
   generationApis?: GenerationApis
+  uploadReferenceImage?: WorkflowEditorSession['uploadReferenceImage']
   publishReviewedAction?(reviewNodeId: string): Promise<Character>
 }
 
@@ -662,6 +717,9 @@ function createSession(
     controller,
     project: projectFixture(),
     character: options.character ?? null,
+    uploadReferenceImage:
+      options.uploadReferenceImage ??
+      vi.fn(() => Promise.reject(new Error('媒体上传服务尚未装配'))),
     confirmCharacterTemplate: async (nodeId, selectedImageUrl) => {
       await controller.confirmCharacterTemplate(nodeId, selectedImageUrl)
       return options.character ?? characterFixture()
@@ -889,6 +947,7 @@ function createGenerationRaceSession(
     controller,
     project: projectFixture(),
     character: null,
+    uploadReferenceImage: vi.fn(() => Promise.reject(new Error('媒体上传服务尚未装配'))),
     confirmCharacterTemplate: vi.fn(async () => characterFixture()),
     publishReviewedAction: vi.fn(async () => Promise.reject(new Error('资产发布未装配'))),
     subscribeErrors: () => () => undefined,
@@ -946,6 +1005,7 @@ function createRestartSelectionSession(options: { status?: Generation['status'] 
       controller,
       project: projectFixture(),
       character: null,
+      uploadReferenceImage: vi.fn(() => Promise.reject(new Error('媒体上传服务尚未装配'))),
       confirmCharacterTemplate: vi.fn(async () => characterFixture()),
       publishReviewedAction: vi.fn(async () => Promise.reject(new Error('资产发布未装配'))),
       subscribeErrors: () => () => undefined,

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -24,6 +24,7 @@ import {
   type CharacterSetupWorkflowNode,
   type CharacterTemplateWorkflowNode,
   type Generation,
+  type MediaReference,
   type Project,
   type ReviewWorkflowNode,
   type WorkflowGenerationRole,
@@ -266,6 +267,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
             run,
             controller: session.controller,
             confirmCharacterTemplate: session.confirmCharacterTemplate,
+            uploadReferenceImage: session.uploadReferenceImage,
             publishReviewedAction: session.publishReviewedAction,
             project: session.project,
             character,
@@ -440,6 +442,7 @@ interface ProjectionInput {
     nodeId: CharacterTemplateWorkflowNode['id'],
     selectedImageUrl: string,
   ): Promise<Character>
+  uploadReferenceImage(file: File): Promise<MediaReference>
   publishReviewedAction(reviewNodeId: ReviewWorkflowNode['id']): Promise<Character>
   project: Project
   character: Character | null
@@ -533,7 +536,31 @@ function CharacterSetupContent({
   const branchKey = branchKeyOf(node, input)
   const branchBusy = input.busyBranches.has(branchKey)
   const [prompt, setPrompt] = useState(node.input.prompt)
-  useEffect(() => setPrompt(node.input.prompt), [node.id, node.input.prompt])
+  const [uploadingReference, setUploadingReference] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setPrompt(node.input.prompt)
+  }, [node.id, node.input.prompt])
+
+  function uploadReferenceImage(file: File) {
+    setUploadingReference(true)
+    setUploadError(null)
+    void input
+      .uploadReferenceImage(file)
+      .then((reference) =>
+        input.controller.updateCharacterSetup(node.id, {
+          prompt,
+          referenceMedia: [reference],
+        }),
+      )
+      .catch((cause: unknown) => {
+        setUploadError(errorMessage(cause, '上传参考图失败'))
+      })
+      .finally(() => {
+        setUploadingReference(false)
+      })
+  }
 
   if (node.status === 'failed') return <StatusText node={node} input={input} />
   if (node.status === 'passed') return <p className={CARD_SUMMARY}>角色描述已确认</p>
@@ -546,7 +573,7 @@ function CharacterSetupContent({
           rows={4}
           className="min-h-[84px] w-full resize-y rounded-lg border border-[var(--editor-line)] bg-[#fbfcfb] px-3 py-2.5 font-[inherit] text-[11px] leading-[1.55] text-[var(--editor-ink)] focus:border-[#69866f] focus:outline focus:outline-2 focus:outline-offset-1 focus:outline-[rgb(105_134_111_/_18%)]"
           value={prompt}
-          disabled={branchBusy}
+          disabled={branchBusy || uploadingReference}
           onChange={(event) => setPrompt(event.target.value)}
         />
         {node.input.referenceMedia.length > 0 ? (
@@ -555,10 +582,38 @@ function CharacterSetupContent({
           </small>
         ) : null}
       </label>
+      <div className="grid gap-[7px]">
+        <span className="text-[9px] font-[750] text-[#626b64]">角色参考图（选填）</span>
+        <input
+          type="file"
+          accept="image/*"
+          aria-label="角色参考图"
+          className="block w-full rounded-lg border border-[var(--editor-line)] bg-[#f6f7f6] text-[10px] text-[var(--editor-muted)] file:mr-3 file:border-0 file:border-r file:border-[var(--editor-line)] file:bg-transparent file:px-3 file:py-2 file:text-[10px] file:font-[700] file:text-[var(--editor-ink)]"
+          disabled={branchBusy || uploadingReference}
+          onChange={(event) => {
+            const file = event.currentTarget.files?.[0]
+            event.currentTarget.value = ''
+            if (file) uploadReferenceImage(file)
+          }}
+        />
+        {uploadingReference ? (
+          <small role="status" className="text-[9px] font-[750] text-[#626b64]">
+            正在上传参考图…
+          </small>
+        ) : null}
+        {uploadError ? (
+          <p
+            role="alert"
+            className="m-0 rounded-lg border border-[#c98e82] bg-[#f7e9e5] px-2.5 py-2 text-[9px] leading-[1.5] text-[#7b3027]"
+          >
+            {uploadError}
+          </p>
+        ) : null}
+      </div>
       <button
         type="button"
         className={CARD_BUTTON}
-        disabled={branchBusy || !prompt.trim()}
+        disabled={branchBusy || uploadingReference || !prompt.trim()}
         onClick={() =>
           input.runCommand(branchKey, () =>
             input.controller.generateCharacterTemplate(node.id, {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -442,7 +442,7 @@ interface ProjectionInput {
     nodeId: CharacterTemplateWorkflowNode['id'],
     selectedImageUrl: string,
   ): Promise<Character>
-  uploadReferenceImage(file: File): Promise<MediaReference>
+  uploadReferenceImage(file: File, signal?: AbortSignal): Promise<MediaReference>
   publishReviewedAction(reviewNodeId: ReviewWorkflowNode['id']): Promise<Character>
   project: Project
   character: Character | null
@@ -538,26 +538,34 @@ function CharacterSetupContent({
   const [prompt, setPrompt] = useState(node.input.prompt)
   const [uploadingReference, setUploadingReference] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
+  const uploadAbortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     setPrompt(node.input.prompt)
   }, [node.id, node.input.prompt])
+  useEffect(() => () => uploadAbortRef.current?.abort(), [])
 
   function uploadReferenceImage(file: File) {
+    const uploadAbort = new AbortController()
+    uploadAbortRef.current = uploadAbort
     setUploadingReference(true)
     setUploadError(null)
     void input
-      .uploadReferenceImage(file)
-      .then((reference) =>
-        input.controller.updateCharacterSetup(node.id, {
+      .uploadReferenceImage(file, uploadAbort.signal)
+      .then((reference) => {
+        if (uploadAbort.signal.aborted) return
+        return input.controller.updateCharacterSetup(node.id, {
           prompt,
           referenceMedia: [reference],
-        }),
-      )
+        })
+      })
       .catch((cause: unknown) => {
+        if (uploadAbort.signal.aborted) return
         setUploadError(errorMessage(cause, '上传参考图失败'))
       })
       .finally(() => {
+        if (uploadAbort.signal.aborted) return
+        uploadAbortRef.current = null
         setUploadingReference(false)
       })
   }

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -20,9 +20,10 @@ describe('createRealWorkflowEditorSession', () => {
     }
     const { session } = await createCharacterTemplateSession({ mediaApis })
     const file = new File(['pixels'], 'reference.png', { type: 'image/png' })
+    const controller = new AbortController()
 
-    await expect(session.uploadReferenceImage(file)).resolves.toBe(uploaded)
-    expect(mediaApis.upload).toHaveBeenCalledWith(file, 'reference-image')
+    await expect(session.uploadReferenceImage(file, controller.signal)).resolves.toBe(uploaded)
+    expect(mediaApis.upload).toHaveBeenCalledWith(file, 'reference-image', controller.signal)
   })
 
   it('只用主仓库公开接口恢复 WorkflowRun 并装配 Controller', async () => {

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -4,6 +4,8 @@ import type {
   Character,
   Generation,
   GenerationApis,
+  MediaApis,
+  MediaReference,
   Project,
   WorkflowRun,
   WorkflowRunApis,
@@ -11,6 +13,18 @@ import type {
 import { createRealWorkflowEditorSession, createUnavailableGenerationApis } from './runtime'
 
 describe('createRealWorkflowEditorSession', () => {
+  it('通过公开 MediaApis 上传角色参考图并固定用途分类', async () => {
+    const uploaded = 'https://assets.windup.test/reference.png' as MediaReference
+    const mediaApis: Pick<MediaApis, 'upload'> = {
+      upload: vi.fn().mockResolvedValue(uploaded),
+    }
+    const { session } = await createCharacterTemplateSession({ mediaApis })
+    const file = new File(['pixels'], 'reference.png', { type: 'image/png' })
+
+    await expect(session.uploadReferenceImage(file)).resolves.toBe(uploaded)
+    expect(mediaApis.upload).toHaveBeenCalledWith(file, 'reference-image')
+  })
+
   it('只用主仓库公开接口恢复 WorkflowRun 并装配 Controller', async () => {
     const workflow = workflowFixture()
     const project = projectFixture()
@@ -50,6 +64,7 @@ describe('createRealWorkflowEditorSession', () => {
     const session = await createRealWorkflowEditorSession('42', {
       workflowRunApis,
       generationApis,
+      mediaApis: { upload: vi.fn() },
       projectApis,
       characterApis,
       onAsyncError: vi.fn(),
@@ -98,6 +113,7 @@ describe('createRealWorkflowEditorSession', () => {
           get: vi.fn(),
           subscribe: vi.fn(() => () => undefined),
         },
+        mediaApis: { upload: vi.fn() },
         projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
         characterApis,
         onAsyncError: vi.fn(),
@@ -120,6 +136,7 @@ describe('createRealWorkflowEditorSession', () => {
         get: vi.fn(),
         subscribe: vi.fn(() => () => undefined),
       },
+      mediaApis: { upload: vi.fn() },
       projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
       characterApis: {
         listByProject: vi.fn().mockResolvedValue({
@@ -165,6 +182,7 @@ describe('createRealWorkflowEditorSession', () => {
         get: vi.fn(),
         subscribe: vi.fn(() => () => undefined),
       },
+      mediaApis: { upload: vi.fn() },
       projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
       characterApis: {
         listByProject: vi.fn().mockResolvedValue({
@@ -276,6 +294,7 @@ describe('createRealWorkflowEditorSession', () => {
         get: vi.fn().mockResolvedValue(completeAnimationFixture()),
         subscribe: vi.fn(() => () => undefined),
       },
+      mediaApis: { upload: vi.fn() },
       projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
       characterApis: {
         listByProject: vi.fn().mockResolvedValue({
@@ -328,6 +347,7 @@ async function createCharacterTemplateSession(
   options: {
     workflow?: WorkflowRun
     characters?: Character[]
+    mediaApis?: Pick<MediaApis, 'upload'>
   } = {},
 ) {
   const workflow = options.workflow ?? selectingCharacterTemplateWorkflowFixture()
@@ -357,6 +377,7 @@ async function createCharacterTemplateSession(
       create,
       update,
     },
+    mediaApis: options.mediaApis ?? { upload: vi.fn() },
     onAsyncError: vi.fn(),
   })
   return { session, create, update }

--- a/frontend/src/pages/workflow-editor/runtime.ts
+++ b/frontend/src/pages/workflow-editor/runtime.ts
@@ -2,13 +2,15 @@ import type {
   Character,
   CharacterApis,
   GenerationApis,
+  MediaApis,
+  MediaReference,
   Project,
   ProjectApis,
   CharacterTemplateWorkflowNode,
   ReviewWorkflowNode,
   WorkflowRunApis,
 } from '@/entities'
-import { characterApis, projectApis, workflowRunApis } from '@/entities'
+import { characterApis, createMediaApis, projectApis, workflowRunApis } from '@/entities'
 import { createCharacterAssetPublisher } from '@/features/export'
 import { createWorkflowController, type WorkflowController } from '@/features/workflow-controller'
 
@@ -22,6 +24,8 @@ export interface WorkflowEditorSession {
     nodeId: CharacterTemplateWorkflowNode['id'],
     selectedImageUrl: string,
   ): Promise<Character>
+  /** 上传角色生成约束图；页面不接触 multipart 协议或用途枚举。 */
+  uploadReferenceImage(file: File): Promise<MediaReference>
   /** 幂等发布动作资产；审核节点仍由页面随后通过 Controller 推进。 */
   publishReviewedAction(reviewNodeId: ReviewWorkflowNode['id']): Promise<Character>
   subscribeErrors(listener: (error: Error) => void): () => void
@@ -31,6 +35,7 @@ export interface WorkflowEditorSession {
 export interface RealWorkflowEditorDependencies {
   workflowRunApis: WorkflowRunApis
   generationApis: GenerationApis
+  mediaApis: Pick<MediaApis, 'upload'>
   projectApis: Pick<ProjectApis, 'get'>
   characterApis: Pick<CharacterApis, 'listByProject' | 'create' | 'update'>
   onAsyncError(error: Error): void
@@ -77,6 +82,9 @@ export async function createRealWorkflowEditorSession(
     controller,
     project,
     character: loadedCharacter,
+    uploadReferenceImage(file) {
+      return dependencies.mediaApis.upload(file, 'reference-image')
+    },
     async confirmCharacterTemplate(nodeId, selectedImageUrl) {
       const imageUrl = selectedImageUrl.trim()
       if (!imageUrl) throw new Error('必须选择角色母版')
@@ -166,6 +174,7 @@ export function createDefaultRealWorkflowEditorSession(
   return createRealWorkflowEditorSession(runId, {
     workflowRunApis,
     generationApis: createUnavailableGenerationApis(),
+    mediaApis: createMediaApis(),
     projectApis,
     characterApis,
     onAsyncError: () => undefined,

--- a/frontend/src/pages/workflow-editor/runtime.ts
+++ b/frontend/src/pages/workflow-editor/runtime.ts
@@ -25,7 +25,7 @@ export interface WorkflowEditorSession {
     selectedImageUrl: string,
   ): Promise<Character>
   /** 上传角色生成约束图；页面不接触 multipart 协议或用途枚举。 */
-  uploadReferenceImage(file: File): Promise<MediaReference>
+  uploadReferenceImage(file: File, signal?: AbortSignal): Promise<MediaReference>
   /** 幂等发布动作资产；审核节点仍由页面随后通过 Controller 推进。 */
   publishReviewedAction(reviewNodeId: ReviewWorkflowNode['id']): Promise<Character>
   subscribeErrors(listener: (error: Error) => void): () => void
@@ -82,8 +82,8 @@ export async function createRealWorkflowEditorSession(
     controller,
     project,
     character: loadedCharacter,
-    uploadReferenceImage(file) {
-      return dependencies.mediaApis.upload(file, 'reference-image')
+    uploadReferenceImage(file, signal) {
+      return dependencies.mediaApis.upload(file, 'reference-image', signal)
     },
     async confirmCharacterTemplate(nodeId, selectedImageUrl) {
       const imageUrl = selectedImageUrl.trim()


### PR DESCRIPTION
角色设定卡片已接入现有媒体上传 API，上传成功后会把 MediaReference 写回当前 WorkflowRun。

## Why

通用上传适配已经合入，但 Workflow Editor 仍缺少参考图上传入口，导致已有 referenceMedia 链路无法从编辑器使用。

## Changes

- 在角色设定卡片加入单图片文件选择。
- 以 reference-image 分类调用共享 Media API，并通过 Controller 持久化返回引用。
- 上传期间禁止生成；失败时显示真实错误且不修改 WorkflowRun。
- 页面卸载时取消在途上传，并忽略迟到的上传结果。

## Verification

- [x] npm test -- --run src/pages/workflow-editor/runtime.test.ts src/pages/workflow-editor/index.test.tsx：2 个文件、40 项测试通过。
- [x] npm run typecheck：通过。

## Screenshots

### Desktop · Reference image upload

<img width="1280" height="720" alt="Workflow Editor reference image upload" src="https://github.com/user-attachments/assets/6d014c5a-5954-4c2e-97b8-d423a5610457" />

## Scope

- 本 PR 不包含图片预览、裁剪、多图、删除或额外重试状态机。
- 未修改工作台、宣传主页、Quick Start、全局路由和通用上传适配。

## Related Issues

Closes #217
Refs #111
