### PR TITLE
fix(quick-start): resolve characters across pages

### DIFF
--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -549,6 +549,53 @@ describe('createQuickStartService', () => {
     await expect(recoverySession.resolveCharacterInfo()).resolves.toBeNull()
   })
 
+  it('restores character info when the bound character is on a later project page', async () => {
+    const run = actionRun()
+    const setup = run.nodes.find((node) => node.type === 'character-setup')
+    if (!setup || setup.type !== 'character-setup') throw new Error('missing setup')
+    delete setup.input.characterId
+    const character = characterFixture({
+      workflowRunId: run.id,
+      outfits: [
+        {
+          id: 'outfit-1',
+          characterId: 'character-1',
+          name: '默认造型',
+          description: null,
+          previewUrl: 'template.png',
+          actions: [],
+        },
+      ],
+    })
+    const characterApis = mutableCharacterApis(
+      () => character,
+      () => undefined,
+    )
+    characterApis.listByProject = vi.fn(async (_projectId, query = {}) =>
+      query.page === 2
+        ? { items: [structuredClone(character)], total: 21, page: 2, pageSize: 20 }
+        : {
+            items: [characterFixture({ id: 'unrelated-character', workflowRunId: 'another-run' })],
+            total: 21,
+            page: 1,
+            pageSize: 20,
+          },
+    )
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis([run]),
+      generationApis: pendingGenerationApis(),
+      characterApis,
+      prepareProject: vi.fn(),
+    })
+
+    const session = await service.open(run.id)
+
+    await expect(session.resolveCharacterInfo()).resolves.toEqual({
+      characterId: character.id,
+      outfitId: 'outfit-1',
+    })
+  })
+
   it('reuses the character already bound to a run when replacing its template', async () => {
     const run: WorkflowRun = {
       id: 'run-existing-character',

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -5,6 +5,7 @@ import {
   projectApis,
   workflowRunApis,
   type Action,
+  type Character,
   type CharacterApis,
   type GenerationApis,
   type MediaReference,
@@ -283,8 +284,17 @@ export function createQuickStartService({
     const run = controller.getWorkflow()
     const firstFrame = latestActionFirstFrame(run)
     if (!firstFrame || firstFrame.type !== 'action-first-frame') return null
-    const page = await characterApis.listByProject(run.projectId)
-    const matches = page.items.filter((character) => character.workflowRunId === run.id)
+    const matches: Character[] = []
+    let page = 1
+    let pageSize: number | undefined
+    while (true) {
+      const result = await characterApis.listByProject(run.projectId, { page, pageSize })
+      matches.push(...result.items.filter((character) => character.workflowRunId === run.id))
+      if (matches.length > 1) return null
+      if (result.items.length === 0 || page * result.pageSize >= result.total) break
+      page += 1
+      pageSize = result.pageSize
+    }
     if (matches.length !== 1) return null
     const character = matches[0]!
     const outfit = character.outfits.find((item) => item.id === firstFrame.input.outfitId)


### PR DESCRIPTION
修复 Quick Start 只检查角色列表第一页的问题，使绑定角色位于后续页面时仍能完成最终批准与 Action 发布。

## Why

此前角色恢复逻辑只调用一次分页接口。项目超过 20 个角色且当前 WorkflowRun 绑定角色不在第一页时，前端会误报“缺少角色或造型绑定”。

## Changes

- 遍历角色分页结果，查找当前 WorkflowRun 绑定的角色。
- 保留“恰好匹配一个角色”的既有约束。
- 增加绑定角色位于第二页的回归测试。

## Verification

- `npm test -- src/pages/quick-start/service.test.ts`：15/15 通过。
- `npm run lint -- src/pages/quick-start/service.ts src/pages/quick-start/service.test.ts`：通过。
- `npm run format:check -- src/pages/quick-start/service.ts src/pages/quick-start/service.test.ts`：通过。
- `git diff --check`：通过。
- 按任务要求未运行全量门禁；PR CI 将独立执行仓库门禁。

## Scope

- 仅修改 Quick Start 前端服务及其定向测试。
- 不修改后端契约，不处理其他分页问题。

## Related Issues

Closes #218
