### PR TITLE
fix(quick-start): fill the viewport canvas

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -149,6 +149,20 @@ function renderAt(path: string, service: QuickStartEntryService) {
 }
 
 describe('QuickStartPage', () => {
+  it('keeps the entry and run canvases at least viewport height', async () => {
+    const entry = renderAt('/quick-start', serviceFor(null))
+    expect(
+      entry.getByRole('heading', { name: /用一句角色设定/u }).closest('section')?.className,
+    ).toContain('min-h-screen')
+
+    entry.unmount()
+    const run = workflow(setupAndTemplate())
+    const runView = renderAt('/quick-start/run-1', serviceFor(run))
+    expect(
+      (await runView.findByRole('heading', { name: '像素骑士' })).closest('section')?.className,
+    ).toContain('min-h-screen')
+  })
+
   it('keeps the natural-language creation entry visible when no run is selected', () => {
     render(
       <MemoryRouter>

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -231,10 +231,10 @@ function QuickStartInput({
   }
 
   return (
-    <section className="relative min-h-[640px] overflow-hidden rounded-[2rem] border border-[#c9d0ca] bg-[#dfe3df] text-[#171817] shadow-[0_26px_80px_rgba(31,43,35,0.10)]">
+    <section className="relative min-h-screen overflow-hidden border border-[#c9d0ca] bg-[#dfe3df] text-[#171817] shadow-[0_26px_80px_rgba(31,43,35,0.10)]">
       <AmbientGrid />
 
-      <div className="relative z-10 grid min-h-[640px] grid-rows-[auto_1fr_auto] p-5 sm:p-8">
+      <div className="relative z-10 grid min-h-screen grid-rows-[auto_1fr_auto] p-5 sm:p-8">
         <header className="flex items-start justify-between gap-6">
           <div>
             <p className="font-mono text-[10px] font-bold tracking-[0.16em] text-[#687069]">
@@ -617,9 +617,9 @@ function QuickStartRun({
   }
 
   return (
-    <section className="relative min-h-[640px] overflow-hidden rounded-[2rem] border border-[#c9d0ca] bg-[#e3e7e2] text-[#171817] shadow-[0_26px_80px_rgba(31,43,35,0.10)]">
+    <section className="relative min-h-screen overflow-hidden border border-[#c9d0ca] bg-[#e3e7e2] text-[#171817] shadow-[0_26px_80px_rgba(31,43,35,0.10)]">
       <AmbientGrid />
-      <div className="relative z-10 grid min-h-[640px] grid-rows-[auto_1fr_auto] gap-6 p-5 sm:p-8">
+      <div className="relative z-10 grid min-h-screen grid-rows-[auto_1fr_auto] gap-6 p-5 sm:p-8">
         <header className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <p className="font-mono text-[10px] font-bold tracking-[0.16em] text-[#687069]">


### PR DESCRIPTION
修复 Quick Start 顶层画布在高视口下未铺满、四角异常露白的问题，并让入口态与运行态保持一致。

## Why

Quick Start 的顶层画布使用固定 `640px` 最小高度和 `32px` 圆角。高桌面窗口会在底部露出白色外壳，页面四角也会出现不属于设计的白色弧形缺口。

## Changes

- 将入口态与运行态的顶层画布、内部网格改为至少覆盖完整视口。
- 移除全屏画布的异常外层圆角，保留内部输入卡片等原有圆角。
- 增加入口态与运行态的视口高度回归测试。

## Verification

- [x] `npm test -- --run src/pages/quick-start/index.test.tsx`：15 tests passed。
- [x] `npm run typecheck`：通过。
- [x] `npx oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] 浏览器桌面检查：未覆盖高度 `0px`，四角半径 `0px`。
- [x] 浏览器窄屏检查（390 × 844）：未覆盖高度 `0px`，四角半径 `0px`，无横向溢出。

## Screenshots

### Desktop — Before

<img width="1470" height="956" alt="Quick Start before: white gap and rounded page corners" src="https://github.com/user-attachments/assets/be75914d-bd2b-4e74-b1da-d7cbb0a8ad78" />

### Desktop — After

<img width="1051" height="1004" alt="Quick Start after: full-height square canvas" src="https://github.com/user-attachments/assets/a982ea22-fafe-4a96-83eb-b7e4ca1c6fc6" />

### Mobile — After

<img width="390" height="844" alt="Quick Start mobile after" src="https://github.com/user-attachments/assets/83f85c55-2509-4bf8-9a80-46e29c0b7b36" />

## Scope

- 本 PR 仅调整 Quick Start 页面画布高度和顶层圆角。
- 不修改全站外壳、后端、生图流程或业务状态。

## Related Issues

Closes #226
