### PR TITLE
fix(prompt): 避免提示词断言角色装备

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/master_prep.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/master_prep.py
@@ -3,9 +3,14 @@
 **核心规律(三次实测验证,写死为契约):母版姿态决定动作,提示词只能微调。**
   - walk:母版**朝侧向**才不转身;正面母版配侧走词 → 模型靠转身调和图文矛盾。
   - jump:母版**顶部留白**才不被视频画面裁掉。
-  - attack:必须给**极限蓄力母版**(武器已拉到身后腰际)。用站立母版时,即使提示词写死
-    "武器不过头顶 / 不转身 / 只做一次",模型仍会抡过头顶、转到背面、劈两次 —— 强动作
+  - attack:必须给**极限蓄力母版**(出手那只手已拉到身后腰际)。用站立母版时,即使提示词
+    写死"不过头顶 / 不转身 / 只做一次",模型仍会抡过头顶、转到背面、劈两次 —— 强动作
     先验压不住;换蓄力母版后模型只能"接着往前挥",没有再抡起的空间。
+
+**姿势描述里不写装备名词(#195)。** 这几段是拿去生成母版的提示词,写"the weapon"等于
+断言角色持械 —— 空手角色会被凭空塞一把武器,而母版是整条 i2v 链的身份来源,污染会一路
+带到所有动作。改为"出手的那只手 / 手里若有东西"这类存在无关的写法,几何约束(拉到腰际、
+不过肩)一条不少。同 :mod:`.prompt.walk`。
 
 
 实测教训:母版里角色居中、占 ~70% 画面高时,i2v 跳跃会让角色**头顶顶出视频画面上沿**
@@ -31,20 +36,20 @@ MASTER_POSES = {
     "walk": "",     # 中性站立即可,但必须朝侧向
     "run": "",
     "idle": "",
-    # jump:与 attack 同理——重甲带剑角色的"跳跃"强动作先验压不住(站立母版会让模型摆
-    # 造型、只举剑不腾空,实测)。给**极限蓄力半蹲母版**,模型只能"接着往上蹬"。顶部留白
+    # jump:与 attack 同理——强动作先验压不住(实测拿重甲带剑角色跑,站立母版会让模型摆
+    # 造型、只举剑不腾空)。给**极限蓄力半蹲母版**,模型只能"接着往上蹬"。顶部留白
     # 由 prepare_master(add_headroom)保证。
     "jump": (
         "deep crouch coiled to spring straight upward: the knees bent low and the hips sunk down, "
         "both arms drawn back behind the body, the weight loaded onto both legs at the very moment "
-        "before springing straight up, the weapon kept in a fixed grip; "
+        "before springing straight up, anything held in the hands kept in a fixed grip; "
         "leave generous empty space above the head"
     ),
     "attack": (
-        "extreme wind-up stance for a horizontal slash: the weapon drawn far BACK behind the body "
-        "at WAIST height, the torso twisted back and coiled, weight fully loaded on the back leg, "
-        "both arms low and pulled back, the weapon staying BELOW the shoulders; "
-        "leave generous empty space on the swing side"
+        "extreme wind-up stance for a horizontal strike: the striking hand drawn far BACK behind "
+        "the body at WAIST height, the torso twisted back and coiled, weight fully loaded on the "
+        "back leg, both arms low and pulled back, that hand and anything held in it staying BELOW "
+        "the shoulders; leave generous empty space on the swing side"
     ),
 }
 

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/actions.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/actions.py
@@ -2,11 +2,14 @@
 
 措辞迁自 windup-pipeline 已验证的 prompt_library(idle / slash),按本模块的 facing 分流改写。
 
-- **idle**:循环类(tail_match)。只写躯干呼吸节律,武器与双脚显式锁定 —— 逐帧生成待机
+- **idle**:循环类(tail_match)。只写躯干呼吸节律,手持物与双脚显式锁定 —— 逐帧生成待机
   只会抖不会呼吸,故走 i2v 或程序化 Idle-B。
 - **attack**:一次性类。四条已验证的锁定:①"one single committed motion"防复读;
-  ②剑长与握点固定;③剑在身前、刃面朝观者(防 Z 轴穿模与刀刃翻转);④终态回戒备并保持。
-  节奏(蓄力慢/挥砍快/触点定格)在抽帧做,不写进 prompt。
+  ②手持物长度与握点固定;③手持物在身前、宽面朝观者(防 Z 轴穿模与刀刃翻转);④终态回戒备
+  并保持。节奏(蓄力慢/挥砍快/触点定格)在抽帧做,不写进 prompt。
+- **装备名词不进模板**(#195):②③两条锁定原先写成 "the sword ...",等于断言角色持剑。
+  现改为存在无关的 "anything held in that hand ..." —— 锁定效力不变(有持物就锁住它的
+  长度/握点/朝向),但不再给空手角色凭空塞一把剑。理由同 :mod:`.walk`。
 """
 
 from __future__ import annotations
@@ -19,27 +22,30 @@ _IDLE_SIDE = (
     "The character stands in place, seen from the side facing right: the chest breathes in one "
     "slow, even rhythm, the ribcage expanding and easing back while the shoulders stay level and "
     "settled at the same height, the torso rising and lowering in that same slow rhythm, "
-    "{weapon} resting steady at the side in a fixed grip, {garment} hanging and swaying in the "
-    "same rhythm, both boots planted firmly on the ground, weight centered, the character stays "
+    "anything held in the hands resting steady at the side in the same grip, whatever the "
+    "character already wears hanging and swaying in the "
+    "same rhythm, both feet planted firmly on the ground, weight centered, the character stays "
     "in the same spot and keeps facing right."
 )
 
 _IDLE_FRONT = (
     "The character stands in place facing the viewer: the chest breathes in one slow, even "
     "rhythm, the ribcage expanding and easing back while the shoulders stay level and settled at "
-    "the same height, the torso rising and lowering in that same slow rhythm, {weapon} resting "
-    "steady at the side in a fixed grip, {garment} hanging and swaying in the same rhythm, both "
-    "boots planted firmly on the ground, weight centered, the character keeps FACING THE VIEWER "
+    "the same height, the torso rising and lowering in that same slow rhythm, anything held in "
+    "the hands resting steady at the side in the same grip, whatever the character already wears "
+    "hanging and swaying in the same rhythm, both "
+    "feet planted firmly on the ground, weight centered, the character keeps FACING THE VIEWER "
     "and stays in the same spot."
 )
 
 _ATTACK_SIDE = (
     "Seen from the side facing right, the character makes ONE single committed attack, staying in "
     "STRICT SIDE VIEW the whole time: starting coiled with the weight on the back foot, the body "
-    "leans forward and the weight surges onto the front foot, the arm sweeping {weapon} through "
+    "leans forward and the weight surges onto the front foot, the leading arm sweeping through "
     "one smooth downward crescent arc from high behind the shoulder down across the front to full "
-    "extension low, {weapon} keeping its exact length and grip position and staying clearly in "
-    "front of the body with its flat side facing the viewer the whole way, {garment} swinging with "
+    "extension low, anything held in that hand keeping its exact length and grip position and "
+    "staying clearly in front of the body with its broad side facing the viewer the whole way, "
+    "whatever the character already wears swinging with "
     "the motion, then the body settles back upright into guard and holds that stance, standing "
     "steady. The torso and hips keep pointing to the right the entire time and the character never "
     "turns toward or away from the viewer."
@@ -47,41 +53,32 @@ _ATTACK_SIDE = (
 
 _ATTACK_FRONT = (
     "Facing the viewer, the character makes ONE single committed attack: starting coiled with the "
-    "weight on the back foot, the whole body uncoils forward, the arm sweeping {weapon} through "
-    "one smooth arc across the front to full extension, {weapon} keeping its exact length and grip "
-    "position and staying clearly in front of the body with its flat side facing the viewer the "
-    "whole way, {garment} swinging with the motion, then the body settles back upright into guard "
+    "weight on the back foot, the whole body uncoils forward, the leading arm sweeping through "
+    "one smooth arc across the front to full extension, anything held in that hand keeping its "
+    "exact length and grip position and staying clearly in front of the body with its broad side "
+    "facing the viewer the "
+    "whole way, whatever the character already wears swinging with the motion, then the body "
+    "settles back upright into guard "
     "and holds that stance, standing steady and keeping FACING THE VIEWER."
 )
 
-DEFAULT_WEAPON = "the sword"
-DEFAULT_GARMENT = "the cape"
 
-
-def _build(
-    side: str, front: str, weapon: str, garment: str, feet: str, facing: Facing | str
-) -> str:
+def _build(side: str, front: str, facing: Facing | str) -> str:
     # 非法值在此炸掉,别静默落到 FRONT 模板(理由见 walk.py 同处注释)。
-    tpl = side if Facing(facing) is Facing.SIDE else front
-    body = tpl.format(weapon=weapon, garment=garment)
-    return body.replace("boot", feet) if feet != "boot" else body
+    return side if Facing(facing) is Facing.SIDE else front
 
 
-def build_idle_prompt(
-    weapon: str = DEFAULT_WEAPON,
-    garment: str = DEFAULT_GARMENT,
-    feet: str = "boot",
-    facing: Facing | str = Facing.SIDE,
-) -> str:
-    """待机正文(循环类)。``facing`` 须与母版朝向一致。"""
-    return _build(_IDLE_SIDE, _IDLE_FRONT, weapon, garment, feet, facing)
+def build_idle_prompt(facing: Facing | str = Facing.SIDE) -> str:
+    """待机正文(循环类)。``facing`` 须与母版朝向一致。
+
+    注:``weapon`` / ``garment`` / ``feet`` 三个装备参数随 #195 删除,理由见 :mod:`.walk`。
+    """
+    return _build(_IDLE_SIDE, _IDLE_FRONT, facing)
 
 
-def build_attack_prompt(
-    weapon: str = DEFAULT_WEAPON,
-    garment: str = DEFAULT_GARMENT,
-    feet: str = "boot",
-    facing: Facing | str = Facing.SIDE,
-) -> str:
-    """攻击正文(一次性类)。``facing`` 须与母版朝向一致。"""
-    return _build(_ATTACK_SIDE, _ATTACK_FRONT, weapon, garment, feet, facing)
+def build_attack_prompt(facing: Facing | str = Facing.SIDE) -> str:
+    """攻击正文(一次性类)。``facing`` 须与母版朝向一致。
+
+    注:``weapon`` / ``garment`` / ``feet`` 三个装备参数随 #195 删除,理由见 :mod:`.walk`。
+    """
+    return _build(_ATTACK_SIDE, _ATTACK_FRONT, facing)

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/jump.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/jump.py
@@ -23,42 +23,36 @@ JUMP_PHASES = ("crouch", "rise", "apex", "fall", "land")
 
 JUMP_BODY_SIDE = (
     "The character performs ONE single jump in place, seen from the side facing right: "
-    "first the knees bend deep into a crouch and the arms drop back, then both boots push "
+    "first the knees bend deep into a crouch and the arms drop back, then both feet push "
     "off the ground and the whole body lifts straight upward a modest height with the legs "
-    "tucking up, the body reaches the top of the jump and hangs there for an instant with {garment} "
-    "floating upward, then the body falls back down with the legs reaching for the ground, "
-    "and both boots land together with the knees bending to absorb the impact, the weapon "
-    "stays held steady in a fixed grip the whole time. The character does this ONCE and "
+    "tucking up, the body reaches the top of the jump and hangs there for an instant with "
+    "whatever the character already wears floating upward, then the body falls back down "
+    "with the legs reaching for the ground, and both feet land together with the knees "
+    "bending to absorb the impact, anything held in the hands stays in the same grip at "
+    "the same angle the whole time. The character does this ONCE and "
     "then stays standing upright in the landing spot, staying centered in frame."
 )
 
 JUMP_BODY_FRONT = (
     "The character performs ONE single jump in place, facing the viewer: first the knees "
-    "bend deep into a crouch and the arms drop back, then both boots push off the ground "
+    "bend deep into a crouch and the arms drop back, then both feet push off the ground "
     "hard and the whole body launches straight upward with the knees tucking up toward the "
     "camera, the body reaches the top of the jump and hangs there for an instant with "
-    "{garment} floating upward, then the body falls back down with the legs reaching for "
-    "the ground, and both boots land together with the knees bending to absorb the impact, "
-    "the weapon stays held steady in a fixed grip the whole time. The character keeps "
+    "whatever the character already wears floating upward, then the body falls back down "
+    "with the legs reaching for the ground, and both feet land together with the knees "
+    "bending to absorb the impact, anything held in the hands stays in the same grip at "
+    "the same angle the whole time. The character keeps "
     "FACING THE VIEWER, does this ONCE and then stays standing upright, centered in frame."
 )
 
-DEFAULT_GARMENT = "the cape and tabard"
 
-
-def build_jump_prompt(
-    garment: str = DEFAULT_GARMENT, feet: str = "boot", facing: Facing | str = Facing.SIDE
-) -> str:
-    """按角色装备 + 母版朝向生成跳跃正文。
+def build_jump_prompt(facing: Facing | str = Facing.SIDE) -> str:
+    """按母版朝向生成跳跃正文。
 
     Args:
-        garment: 起跳时上飘的衣饰。
-        feet: 落脚部件用词(替换 boot)。
         facing: :class:`Facing` 成员(或其等价字符串),**必须与母版朝向一致**。
+
+    注:``garment`` / ``feet`` 两个装备参数随 #195 删除,理由见 :mod:`.walk` 同处。
     """
     facing = Facing(facing)   # 非法值在此炸掉,别静默落到 FRONT 模板(理由见 walk.py 同处注释)
-    template = JUMP_BODY_SIDE if facing is Facing.SIDE else JUMP_BODY_FRONT
-    body = template.format(garment=garment)
-    if feet != "boot":
-        body = body.replace("boot", feet)
-    return body
+    return JUMP_BODY_SIDE if facing is Facing.SIDE else JUMP_BODY_FRONT

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/walk.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/walk.py
@@ -6,56 +6,57 @@
   调和图文矛盾——早期"正面母版必转身"的结论正是这么造成的。故按 facing 分流:
   side(横版侧走)/ front(俯视·2.5D 朝观者行进),对应 Project.perspective。
 - "半侧"母版(头侧脸 + 身体略正)配 side 词,实测会被自然解析成正侧面走,不转身,够用。
-- 换角色只替换装备子句(如 骷髅:boot→骨足、cape→围巾),机制词保持不变。
+- **提示词只描述动作,不描述角色穿什么拿什么**(#195)。装备名词一旦写进模板就是在断言
+  该物件存在:母版没有斗篷,模型会为了满足文字凭空长一件出来,母版真有的特征(软管、
+  胸铠)反被挤掉。这与 ``ports.CharacterGeneratorPort`` 那条"身份由母版承载,身份描述
+  再写一遍反而会和母版打架"是同一条。故衣饰/手持物一律写成**存在无关**的保持句
+  ("whatever the character already wears or carries"),既锁住"别乱动",又不断言有什么。
 """
 
 from __future__ import annotations
 
 from windup_common.models import Facing
 
-__all__ = ["WALK_BODY_SIDE", "WALK_BODY_FRONT", "DEFAULT_GARMENT", "build_walk_prompt"]
+__all__ = ["WALK_BODY_SIDE", "WALK_BODY_FRONT", "build_walk_prompt"]
 
 # 侧走(横版):整体向右推进 + 锁侧视。
 WALK_BODY_SIDE = (
     "The character walks steadily to the right through the open space, the whole body "
-    "advancing with every stride: the front boot lifts, swings forward and plants heel "
-    "first, the rear boot pushes off the ground, the hips and torso carry the weight "
-    "forward over the planted foot, {garment} swing with the steps, the weapon stays held "
-    "low and steady at the side in a fixed grip, the upper body stays calm and upright, "
+    "advancing with every stride: the front foot lifts, swings forward and plants heel "
+    "first, the rear foot pushes off the ground, the hips and torso carry the weight "
+    "forward over the planted foot, whatever the character already wears or carries keeps "
+    "its own shape and sways with the steps, anything held in the hands stays in the same "
+    "grip at the same angle, the upper body stays calm and upright, "
     "SIDE VIEW facing right the whole time, the legs clearly visible."
 )
 
 # 正面走(俯视 / 2.5D):朝观者原地行进,身体始终正对观者、不转身。
 WALK_BODY_FRONT = (
     "The character walks in place toward the viewer, marching forward on the spot: each "
-    "boot lifts, swings forward and plants down in turn while the other pushes off, the "
+    "foot lifts, swings forward and plants down in turn while the other pushes off, the "
     "knees rise alternately toward the camera, the hips and shoulders sway naturally with "
-    "each step, {garment} sway with the steps, the weapon stays held low and steady in a "
-    "fixed grip, the upper body stays calm and upright, the character keeps FACING THE "
+    "each step, whatever the character already wears or carries keeps its own shape and "
+    "sways with the steps, anything held in the hands stays in the same grip at the same "
+    "angle, the upper body stays calm and upright, the character keeps FACING THE "
     "VIEWER the whole time and stays centered in frame, both legs clearly visible."
 )
 
-# 每个角色只替换 garment / feet 两处装备子句,机制词不动。
-DEFAULT_GARMENT = "the cape and tabard"
 
-
-def build_walk_prompt(
-    garment: str = DEFAULT_GARMENT, feet: str = "boot", facing: Facing | str = Facing.SIDE
-) -> str:
-    """按角色装备 + 母版朝向生成走路正文。
+def build_walk_prompt(facing: Facing | str = Facing.SIDE) -> str:
+    """按母版朝向生成走路正文。
 
     Args:
-        garment: 随步伐摆动的衣饰(如 "the cape and tabard" / "the red scarf and tabard")。
-        feet: 落脚部件用词(如 "boot" / "bare bony foot"),替换机制句里的 boot。
         facing: :class:`Facing` 成员(或其等价字符串)。**必须与母版朝向一致**,
             否则模型会靠转身调和矛盾。
+
+    注:曾有 ``garment`` / ``feet`` 两个装备参数(默认 "the cape and tabard" / "boot")。
+    2026-08-12 随 #195 删除 —— 零写入方(``strategy.concrete._build_prompt`` 只传
+    ``facing``),于是每个角色都拿那个持剑披风原型的默认值。要按角色定制装备文字得先有
+    地方存"这个角色穿什么拿什么",那是角色卡契约的事;在这里留一个没人传的参数,只会
+    让人以为该能力已经存在。
     """
     # 注解不是运行期约束:build_* 是普通函数,传 "sidee" 仍进得来。这里显式过一遍
     # Facing() 构造,非法值抛 ValueError —— 若改成 `if facing == Facing.SIDE else FRONT`
     # 的二分,"sidee" 会静默落到 FRONT 模板,拿到一段正面走的视频却没有任何报错。
     facing = Facing(facing)
-    template = WALK_BODY_SIDE if facing is Facing.SIDE else WALK_BODY_FRONT
-    body = template.format(garment=garment)
-    if feet != "boot":
-        body = body.replace("boot", feet)
-    return body
+    return WALK_BODY_SIDE if facing is Facing.SIDE else WALK_BODY_FRONT

--- a/backend/tests/test_character_contract.py
+++ b/backend/tests/test_character_contract.py
@@ -10,9 +10,12 @@
 """
 from __future__ import annotations
 
+import inspect
+
 import pytest
 from pydantic import ValidationError
 
+from windup_ai_engine.master_prep import MASTER_POSES
 from windup_ai_engine.prompt import (
     WALK_BODY_FRONT,
     WALK_BODY_SIDE,
@@ -21,6 +24,7 @@ from windup_ai_engine.prompt import (
     build_jump_prompt,
     build_walk_prompt,
 )
+from windup_ai_engine.strategy.concrete import VideoFrameStrategy
 from windup_common.models import (
     DEFAULT_N_FRAMES,
     ActionSpec,
@@ -128,8 +132,8 @@ def test_walk_prompt_picks_the_template_that_matches_facing():
     side = build_walk_prompt(facing=Facing.SIDE)
     front = build_walk_prompt(facing=Facing.FRONT)
     assert side != front
-    assert side == WALK_BODY_SIDE.format(garment="the cape and tabard")
-    assert front == WALK_BODY_FRONT.format(garment="the cape and tabard")
+    assert side == WALK_BODY_SIDE
+    assert front == WALK_BODY_FRONT
     assert "SIDE VIEW facing right" in side and "SIDE VIEW facing right" not in front
     assert "FACING THE VIEWER" in front and "FACING THE VIEWER" not in side
 
@@ -138,6 +142,65 @@ def test_walk_prompt_picks_the_template_that_matches_facing():
 def test_other_builders_also_switch_body_by_facing(build):
     assert build(facing=Facing.SIDE) != build(facing=Facing.FRONT)
     assert "FACING THE VIEWER" in build(facing=Facing.FRONT)
+
+
+# ── A1.5 提示词只描述动作，不断言角色装备（#195）────────────────────────────
+
+# 装备名词一旦进模板就是在断言该物件存在：母版没有斗篷，模型会为了满足文字凭空长一件，
+# 母版真有的特征反被挤掉（2026-08-11 拿一个完全无布料的刚性角色实跑复现）。
+# 这里连"角色确实持剑"的情形也一并禁掉——身份由母版承载，模板是所有角色共用的。
+_EQUIPMENT_NOUNS = (
+    "cape", "tabard", "cloak", "robe", "scarf",
+    "sword", "blade", "weapon", "shield", "axe", "spear",
+    "boot", "armor", "armour", "helmet", "gauntlet",
+)
+
+
+def _named_equipment(text: str) -> list[str]:
+    low = text.lower()
+    return [w for w in _EQUIPMENT_NOUNS if w in low]
+
+
+@pytest.mark.parametrize(
+    "build", [build_walk_prompt, build_jump_prompt, build_idle_prompt, build_attack_prompt]
+)
+@pytest.mark.parametrize("facing", [Facing.SIDE, Facing.FRONT])
+def test_prompt_names_no_equipment(build, facing):
+    """任一动作 × 任一朝向的正文里都不许出现装备名词。
+
+    这条是 #195 的回归闸。**光验"参数能传"验不出这个 bug** —— 原先 garment/weapon
+    确实是参数、确实能传，但零写入方，于是每个角色都吃到那个持剑披风原型的默认值。
+    """
+    named = _named_equipment(build(facing=facing))
+    assert not named, f"{build.__name__}({facing}) 断言了装备: {named}"
+
+
+def test_master_poses_name_no_equipment():
+    """母版姿势描述同样不许写装备 —— 母版是整条 i2v 链的身份来源，污染会传到所有动作。"""
+    for action, pose in MASTER_POSES.items():
+        named = _named_equipment(pose)
+        assert not named, f"MASTER_POSES[{action!r}] 断言了装备: {named}"
+
+
+@pytest.mark.parametrize(
+    "build", [build_walk_prompt, build_jump_prompt, build_idle_prompt, build_attack_prompt]
+)
+def test_prompt_builders_expose_facing_only(build):
+    """签名里只剩 facing。
+
+    锁的是 #195 的**根因**而不只是症状：装备参数一旦以"有默认值的可选参数"形态存在，
+    而调用侧（``strategy.concrete._build_prompt``）只传 facing，默认值就成了全体角色的
+    实际取值。要按角色定制装备文字，得先有地方存它，那是角色卡契约的事；在这里留一个
+    没人传的参数，只会让人以为该能力已经存在。
+    """
+    assert list(inspect.signature(build).parameters) == ["facing"]
+
+
+def test_strategy_passes_only_facing_into_prompt_builders():
+    """派生层确实只按朝向选模板，没有第二条把角色装备塞进提示词的通路。"""
+    src = inspect.getsource(VideoFrameStrategy._build_prompt)
+    for kw in ("garment", "weapon", "feet"):
+        assert kw not in src, f"_build_prompt 又开始传 {kw} 了"
 
 
 # ── A2 n_frames 是显式字段，不再由 len(poses) 推导 ──────────────────────────


### PR DESCRIPTION
## 问题

提示词模板里写死了某个原型角色的装备，于是**每个角色**都被要求穿斗篷罩袍、手持武器：

```python
prompt/walk.py:     DEFAULT_GARMENT = "the cape and tabard"
prompt/actions.py:  DEFAULT_WEAPON  = "the sword"
strategy/concrete.py: return build(facing=action.facing)   # 只传朝向，其余全走默认
```

根因不是"漏传参数"，是 `garment` / `weapon` / `feet` 三个参数**零写入方** —— `_build_prompt` 只传 `facing`，默认值就成了全体角色的实际取值。walk 模板里 weapon 那句更是写死的、连参数都没有。

## 机制

模板里出现装备名词，就是在**断言该物件存在**。母版没有斗篷时，模型会为了满足文字凭空长一件，而母版真有的特征反被挤掉。

这与 `ports.CharacterGeneratorPort` 已经写明的那条是同一回事：

> i2v 的角色身份完全由 `master` 这张母版图像承载，身份描述再写一遍反而会和母版打架

## 改法

不是"把句子删掉"，是换成**存在无关**的写法：

```
旧：{garment} swing with the steps, the weapon stays held low ...
新：whatever the character already wears or carries keeps its own shape and sways
    with the steps, anything held in the hands stays in the same grip ...
```

锁定效力没丢 —— 有持物就锁住它的长度/握点/朝向（attack 那四条已验证的锁定一条不少），没有就不凭空造。而 "whatever the character already wears" 把母版上真有的东西一并包含进来，所以它不再被一份具体装备清单挤掉。

同类处理：`boot` → `foot`（会给赤足/高跟角色套上靴子）、`master_prep.MASTER_POSES`（母版是整条 i2v 链的身份来源，污染会传到所有动作）。三个零写入方的参数一并删除 —— 留一个没人传的可选参数，只会让人以为该能力已经存在；要按角色定制装备文字，得先有地方存它，那是角色卡契约的事。

## 实测验证（¥1.50）

同一张母版、同一个模型（kling-v2-5-turbo）、同样 720×1280 / 5s，**只换提示词**复跑一次：

| | 旧提示词 | 本 PR |
|---|---|---|
| 斗篷 | **16 / 16 帧都有** | **0 / 20 帧** |
| 母版颈后空气管 | 被挤掉 | 回来了 |
| 手持武器 | 被塞了 | 空手（与母版一致）|

用的角色是当初**特意挑来避开斗篷的**：球形铜盔 + 贴身帆布服 + 厚底靴，全刚性、母版上一寸布料都没有。它照样长出斗篷，才使"是提示词求来的"这个假设可被检验；换掉提示词就没了，反证成立。归因干净。

## 测试

+14 条：装备名词黑名单扫**全部动作 × 全部朝向**、扫 `MASTER_POSES`、签名断言只剩 `facing`、派生层不得再传装备。

把这 14 条打在修复前的代码上：**13 条 FAIL**。唯一通过的那条是 `_build_prompt` 的护栏 —— 那一层本来就是干净的，锅在默认值。

## 不在本 PR 范围

腿前后互换 / 半周期闭环（#197）与本次无关，仍在。

Refs 1024XEngineer/Windup#195
