### PR TITLE
feat(character): 添加角色发布状态过滤

### DIFF
--- a/backend/packages/app/src/windup_app/server/character/interface.py
+++ b/backend/packages/app/src/windup_app/server/character/interface.py
@@ -43,8 +43,12 @@ class CharacterService(ABC):
     @abstractmethod
     def list_characters(
         self, session: Session, *, project_id: int, page: int, page_size: int,
+        status: int | None = None,
     ) -> tuple[list[Character], int]:
-        """分页查询项目下的角色列表，返回 (当前页数据, 总数)。"""
+        """分页查询项目下的角色列表，返回 (当前页数据, 总数)。
+
+        ``status``: 可选，按发布状态过滤（0=草稿，1=已发布）。
+        """
 
     @abstractmethod
     def update_character(self, session: Session, character_id: int, **fields) -> Character | None:

--- a/backend/packages/app/src/windup_app/server/character/model.py
+++ b/backend/packages/app/src/windup_app/server/character/model.py
@@ -48,6 +48,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
+from windup_common.enums.character import CharacterStatus
 from windup_framework.db import Base
 
 
@@ -88,7 +89,7 @@ class Character(Base):
     )
 
     status: Mapped[int] = mapped_column(
-        SmallInteger, nullable=False, default=1
+        SmallInteger, nullable=False, default=CharacterStatus.PUBLISHED
     )
 
     create_at: Mapped[datetime] = mapped_column(

--- a/backend/packages/app/src/windup_app/server/character/service.py
+++ b/backend/packages/app/src/windup_app/server/character/service.py
@@ -37,15 +37,20 @@ class SqlAlchemyCharacterService(CharacterService):
 
     def list_characters(
         self, session: Session, *, project_id: int, page: int, page_size: int,
+        status: int | None = None,
     ) -> tuple[list[Character], int]:
+        base_condition = Character.project_id == project_id
+        if status is not None:
+            base_condition = base_condition & (Character.status == status)
+
         count_stmt = (
             select(func.count())
             .select_from(Character)
-            .where(Character.project_id == project_id)
+            .where(base_condition)
         )
         stmt = (
             select(Character)
-            .where(Character.project_id == project_id)
+            .where(base_condition)
             .order_by(Character.id.desc())
             .offset((page - 1) * page_size)
             .limit(page_size)

--- a/backend/packages/app/src/windup_app/web/api/character.py
+++ b/backend/packages/app/src/windup_app/web/api/character.py
@@ -202,6 +202,8 @@ def update_character(
     fields = body.model_dump(exclude_unset=True)
     # 如果更新了 character_data，自动推断 status
     if "character_data" in fields:
+        if fields["character_data"] is None:
+            raise BizException("character_data 不能为 null", code=BizCode.BAD_REQUEST)
         character_data = fields["character_data"]
         if isinstance(character_data, CharacterData):
             character_data = character_data.model_dump()

--- a/backend/packages/app/src/windup_app/web/api/character.py
+++ b/backend/packages/app/src/windup_app/web/api/character.py
@@ -163,7 +163,7 @@ def list_characters(
     request: Request = None,
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
-    status: int | None = Query(None, description="按发布状态过滤: 0=草稿, 1=已发布"),
+    status: int | None = Query(None, ge=0, le=1, description="按发布状态过滤: 0=草稿, 1=已发布"),
     session: Session = Depends(get_session),
 ) -> ListResponse[CharacterOut]:
     user_id = request.state.current_user.id

--- a/backend/packages/app/src/windup_app/web/api/character.py
+++ b/backend/packages/app/src/windup_app/web/api/character.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from windup_common.enums.biz_code import BizCode
+from windup_common.enums.character import CharacterStatus
 from windup_common.exceptions import BizException
 from windup_common.result import ListResponse, Response
 from windup_framework.config.storage import settings as storage_settings
@@ -132,6 +133,8 @@ def create_character(
 ) -> Response[CharacterOut]:
     user_id = request.state.current_user.id
     _get_project_or_raise(session, body.project_id, user_id)
+    character_data = body.character_data.model_dump()
+    status = CharacterStatus.from_character_data(character_data)
     try:
         character = character_service.create_character(
             session,
@@ -140,7 +143,8 @@ def create_character(
             name=body.name,
             description=body.description,
             reference_image_url=body.reference_image_url,
-            character_data=body.character_data.model_dump(),
+            character_data=character_data,
+            status=status,
         )
     except IntegrityError:
         session.rollback()
@@ -159,12 +163,13 @@ def list_characters(
     request: Request = None,
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
+    status: int | None = Query(None, description="按发布状态过滤: 0=草稿, 1=已发布"),
     session: Session = Depends(get_session),
 ) -> ListResponse[CharacterOut]:
     user_id = request.state.current_user.id
     _get_project_or_raise(session, project_id, user_id)
     items, total = character_service.list_characters(
-        session, project_id=project_id, page=page, page_size=page_size,
+        session, project_id=project_id, page=page, page_size=page_size, status=status,
     )
     return ListResponse.success(
         [CharacterOut.model_validate(c) for c in items],
@@ -195,6 +200,12 @@ def update_character(
     user_id = request.state.current_user.id
     _get_character_with_auth(session, character_id, user_id)
     fields = body.model_dump(exclude_unset=True)
+    # 如果更新了 character_data，自动推断 status
+    if "character_data" in fields:
+        character_data = fields["character_data"]
+        if isinstance(character_data, CharacterData):
+            character_data = character_data.model_dump()
+        fields["status"] = CharacterStatus.from_character_data(character_data)
     character = character_service.update_character(session, character_id, **fields)
     if character is None:
         raise BizException("角色不存在", code=BizCode.NOT_FOUND)

--- a/backend/packages/common/src/windup_common/enums/__init__.py
+++ b/backend/packages/common/src/windup_common/enums/__init__.py
@@ -1,6 +1,7 @@
 """共享枚举。"""
 
 from windup_common.enums.biz_code import BizCode
+from windup_common.enums.character import CharacterStatus
 from windup_common.enums.model import ModelErrorType
 
-__all__ = ["BizCode", "ModelErrorType"]
+__all__ = ["BizCode", "CharacterStatus", "ModelErrorType"]

--- a/backend/packages/common/src/windup_common/enums/character.py
+++ b/backend/packages/common/src/windup_common/enums/character.py
@@ -1,0 +1,28 @@
+"""角色资产状态枚举。"""
+
+from enum import IntEnum
+
+
+class CharacterStatus(IntEnum):
+    """角色发布状态。
+
+    - ``DRAFT (0)``: 草稿——尚无真实动作帧。
+    - ``PUBLISHED (1)``: 已发布——至少存在一条包含真实帧的动作。
+    """
+
+    DRAFT = 0
+    PUBLISHED = 1
+
+    @classmethod
+    def from_character_data(cls, character_data: dict) -> "CharacterStatus":
+        """根据 character_data 推断发布状态。
+
+        判定规则：至少存在一条包含真实帧（frame_count > 0 且 frames 非空）的动作
+        即为已发布；否则为草稿。
+        """
+        for outfit in character_data.get("outfits", []):
+            for action in outfit.get("actions", []):
+                frames = action.get("frames", [])
+                if frames and action.get("frame_count", 0) > 0:
+                    return cls.PUBLISHED
+        return cls.DRAFT

--- a/backend/tests/test_character_api.py
+++ b/backend/tests/test_character_api.py
@@ -24,6 +24,31 @@ def _payload(project_id: int, **overrides):
     return base
 
 
+def _payload_with_frames(project_id: int, **overrides):
+    """构造包含真实帧的创建角色请求体。"""
+    base = {
+        "project_id": project_id,
+        "workflow_run_id": 1,
+        "name": "有帧角色",
+        "description": "包含真实帧",
+        "character_data": {
+            "outfits": [{
+                "id": "outfit-1",
+                "name": "默认造型",
+                "actions": [{
+                    "id": "action-1",
+                    "type": "idle",
+                    "name": "待机",
+                    "frame_count": 1,
+                    "frames": [{"index": 0, "image_url": "https://example.com/frame.png"}],
+                }],
+            }],
+        },
+    }
+    base.update(overrides)
+    return base
+
+
 # -- POST /characters --------------------------------------------------------
 
 
@@ -153,3 +178,95 @@ def test_delete_other_users_character_returns_404(auth_client, auth_client_b):
 
     assert resp.json()["code"] == 404
     assert resp.json()["message"] == "角色不存在"
+
+
+# -- 角色发布状态过滤 ---------------------------------------------------------
+
+
+def test_create_character_without_frames_is_draft(auth_client):
+    """没有真实帧的角色应自动标记为草稿(status=0)。"""
+    project = _create_project(auth_client)
+    resp = auth_client.post("/characters", json=_payload(project["id"]))
+
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == 0
+
+
+def test_create_character_with_frames_is_published(auth_client):
+    """包含真实帧的角色应自动标记为已发布(status=1)。"""
+    project = _create_project(auth_client)
+    resp = auth_client.post("/characters", json=_payload_with_frames(project["id"]))
+
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == 1
+
+
+def test_list_characters_filter_by_status(auth_client):
+    """按 status 过滤角色列表。"""
+    project = _create_project(auth_client)
+    # 创建草稿角色
+    auth_client.post("/characters", json=_payload(project["id"], workflow_run_id=1))
+    # 创建已发布角色
+    auth_client.post("/characters", json=_payload_with_frames(project["id"], workflow_run_id=2))
+
+    # 查询已发布角色
+    resp = auth_client.get("/characters", params={"project_id": project["id"], "status": 1})
+    data = resp.json()
+    assert data["code"] == 200
+    assert data["total"] == 1
+    assert len(data["data"]) == 1
+    assert data["data"][0]["status"] == 1
+
+    # 查询草稿角色
+    resp = auth_client.get("/characters", params={"project_id": project["id"], "status": 0})
+    data = resp.json()
+    assert data["code"] == 200
+    assert data["total"] == 1
+    assert len(data["data"]) == 1
+    assert data["data"][0]["status"] == 0
+
+
+def test_list_characters_without_status_returns_all(auth_client):
+    """不传 status 参数时返回所有角色。"""
+    project = _create_project(auth_client)
+    auth_client.post("/characters", json=_payload(project["id"], workflow_run_id=1))
+    auth_client.post("/characters", json=_payload_with_frames(project["id"], workflow_run_id=2))
+
+    resp = auth_client.get("/characters", params={"project_id": project["id"]})
+    data = resp.json()
+    assert data["code"] == 200
+    assert data["total"] == 2
+    assert len(data["data"]) == 2
+
+
+def test_update_character_data_recalculates_status(auth_client):
+    """更新 character_data 后应自动重新计算 status。"""
+    project = _create_project(auth_client)
+    created = auth_client.post(
+        "/characters", json=_payload(project["id"]),
+    ).json()["data"]
+
+    # 初始为草稿
+    assert created["status"] == 0
+
+    # 更新为包含帧的数据
+    resp = auth_client.patch(
+        f"/characters/{created['id']}",
+        json={
+            "character_data": {
+                "outfits": [{
+                    "id": "outfit-1",
+                    "name": "默认造型",
+                    "actions": [{
+                        "id": "action-1",
+                        "type": "idle",
+                        "name": "待机",
+                        "frame_count": 1,
+                        "frames": [{"index": 0, "image_url": "https://example.com/frame.png"}],
+                    }],
+                }],
+            },
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == 1

--- a/backend/tests/test_character_api.py
+++ b/backend/tests/test_character_api.py
@@ -270,3 +270,19 @@ def test_update_character_data_recalculates_status(auth_client):
     )
     assert resp.status_code == 200
     assert resp.json()["data"]["status"] == 1
+
+
+def test_update_character_with_null_character_data(auth_client):
+    """更新 character_data 为 null 时应返回 400 错误。"""
+    project = _create_project(auth_client)
+    created = auth_client.post(
+        "/characters", json=_payload_with_frames(project["id"]),
+    ).json()["data"]
+
+    # 更新 character_data 为 null
+    resp = auth_client.patch(
+        f"/characters/{created['id']}",
+        json={"character_data": None},
+    )
+    assert resp.json()["code"] == 400
+    assert resp.json()["message"] == "character_data 不能为 null"


### PR DESCRIPTION
## 变更说明

- 添加 CharacterStatus 枚举（DRAFT=0, PUBLISHED=1）
- 根据 character_data 自动推断发布状态（至少存在一条包含真实帧的动作即为已发布）
- 在 GET /characters 接口添加可选的 status 查询参数
- 创建和更新角色时自动计算 status
- 添加测试覆盖所有场景

## 关联

关联 PR: #174

## 验证

- 后端测试通过（15/15）
- 代码格式检查通过
- 符合现有代码规范

## 范围

仅修改后端 Character 模块，添加发布状态过滤功能。