### PR TITLE
feat(header): unify application navigation

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -164,6 +164,33 @@ describe('AppHeader', () => {
     expect(apis.logout).toHaveBeenCalledWith('rotated-refresh-token')
   })
 
+  it('远端退出失败时仍清除本地会话并返回首页', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    const apis = createApis()
+    apis.logout.mockRejectedValue(new Error('退出请求失败'))
+    renderHeader('/projects', apis)
+
+    fireEvent.click(await screen.findByRole('button', { name: '打开账号菜单' }))
+    fireEvent.click(screen.getByRole('button', { name: '退出登录' }))
+
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'))
+    expect(await screen.findByRole('link', { name: '登录 / 注册' })).toBeTruthy()
+  })
+
+  it('没有昵称时使用邮箱展示账号身份', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    const apis = createApis()
+    apis.refresh.mockResolvedValue({
+      ...tokens(),
+      user: { ...user, nickname: '' },
+    })
+    renderHeader('/workspace', apis)
+
+    const accountMenu = await screen.findByRole('button', { name: '打开账号菜单' })
+    expect(accountMenu.textContent).toContain('reader@example.com')
+    expect(accountMenu.textContent).toContain('r')
+  })
+
   it('让登录用户从 Header 的账号信息进入账号中心', async () => {
     window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
     renderHeader('/account')
@@ -183,6 +210,14 @@ describe('AppHeader', () => {
     expect(account.getAttribute('aria-current')).toBe('page')
     expect(accountMenu.textContent).toContain('Reader')
     expect(screen.queryByText('资料与登录安全')).toBeNull()
+
+    fireEvent.click(account)
+    expect(menuSurface.getAttribute('data-state')).toBe('closing')
+    expect(screen.getByTestId('location').textContent).toBe('/account')
+    fireEvent.animationEnd(menuSurface)
+    await waitFor(() => expect(menuSurface.getAttribute('data-state')).toBe('closed'))
+
+    fireEvent.click(accountMenu)
 
     fireEvent.click(accountMenu)
     expect(menuSurface.getAttribute('data-state')).toBe('closing')

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -72,6 +72,8 @@ describe('AppHeader', () => {
   it('提供 PlayTest 入口，并将工作流路由归入创作', () => {
     renderHeader('/workflow-editor/run-1')
 
+    expect(screen.getByRole('banner').getAttribute('data-surface')).toBe('frosted-bar')
+    expect(screen.getByRole('banner').getAttribute('data-motion')).toBeNull()
     expect(screen.getByRole('link', { name: '返回 Windup 工作台' }).getAttribute('href')).toBe(
       '/workspace',
     )
@@ -87,6 +89,46 @@ describe('AppHeader', () => {
     expect(screen.getByRole('link', { name: '项目资产' }).getAttribute('aria-current')).toBeNull()
     expect(screen.getByRole('link', { name: '创作' }).getAttribute('aria-current')).toBeNull()
     expect(screen.getByRole('link', { name: 'PlayTest' }).getAttribute('aria-current')).toBeNull()
+  })
+
+  it('切换页面后继续播放与品牌一致的文字波浪', () => {
+    renderHeader('/workspace')
+
+    const projects = screen.getByRole('link', { name: '项目资产' })
+    fireEvent.click(projects)
+
+    expect(projects.classList.contains('app-header-text-wave')).toBe(true)
+    expect(
+      screen
+        .getByRole('link', { name: '返回 Windup 工作台' })
+        .classList.contains('app-header-text-wave'),
+    ).toBe(false)
+    expect(screen.getByTestId('location').textContent).toBe('/projects')
+  })
+
+  it('品牌与首页分别播放文字波浪', () => {
+    renderHeader('/projects')
+
+    const brand = screen.getByRole('link', { name: '返回 Windup 工作台' })
+    const home = screen.getByRole('link', { name: '首页' })
+    fireEvent.click(brand)
+
+    expect(brand.classList.contains('app-header-text-wave')).toBe(true)
+    expect(home.classList.contains('app-header-text-wave')).toBe(false)
+  })
+
+  it('连续激活同一入口会重新开始文字波浪', () => {
+    renderHeader('/workspace')
+
+    const projects = screen.getByRole('link', { name: '项目资产' })
+    fireEvent.click(projects)
+    const firstGlyph = projects.querySelector('.app-header-wave-glyph')
+
+    fireEvent.click(projects)
+    const replayedGlyph = projects.querySelector('.app-header-wave-glyph')
+
+    expect(replayedGlyph).not.toBe(firstGlyph)
+    expect(projects.classList.contains('app-header-text-wave')).toBe(true)
   })
 
   it('在资产选择页和具体试玩台高亮 PlayTest 入口', () => {
@@ -112,7 +154,9 @@ describe('AppHeader', () => {
     window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
     const { apis } = renderHeader('/projects')
 
-    expect(await screen.findByText('Reader')).toBeTruthy()
+    const accountMenu = await screen.findByRole('button', { name: '打开账号菜单' })
+    expect(accountMenu.textContent).toContain('Reader')
+    fireEvent.click(accountMenu)
     fireEvent.click(screen.getByRole('button', { name: '退出登录' }))
 
     await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'))
@@ -124,10 +168,65 @@ describe('AppHeader', () => {
     window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
     renderHeader('/account')
 
-    const account = await screen.findByRole('link', { name: '打开账号中心' })
+    const accountMenu = await screen.findByRole('button', { name: '打开账号菜单' })
+    const menuSurface = screen.getByTestId('account-menu')
+    expect(menuSurface.getAttribute('data-state')).toBe('closed')
+    expect(menuSurface.getAttribute('aria-hidden')).toBe('true')
+    expect(screen.queryByRole('link', { name: '打开账号中心' })).toBeNull()
+
+    fireEvent.click(accountMenu)
+    expect(menuSurface.getAttribute('data-state')).toBe('open')
+    expect(menuSurface.getAttribute('data-motion')).toBe('scale-fade')
+    expect(menuSurface.getAttribute('aria-hidden')).toBeNull()
+    const account = screen.getByRole('link', { name: '打开账号中心' })
     expect(account.getAttribute('href')).toBe('/account')
     expect(account.getAttribute('aria-current')).toBe('page')
-    expect(account.textContent).toContain('Reader')
-    expect(screen.getByText('资料与登录安全')).toBeTruthy()
+    expect(accountMenu.textContent).toContain('Reader')
+    expect(screen.queryByText('资料与登录安全')).toBeNull()
+
+    fireEvent.click(accountMenu)
+    expect(menuSurface.getAttribute('data-state')).toBe('closing')
+    expect(menuSurface.getAttribute('aria-hidden')).toBe('true')
+    expect(menuSurface.classList.contains('app-header-account-menu-out')).toBe(true)
+    expect(menuSurface.classList.contains('invisible')).toBe(false)
+    expect(screen.queryByRole('link', { name: '打开账号中心' })).toBeNull()
+
+    await waitFor(() => expect(menuSurface.getAttribute('data-state')).toBe('closed'))
+    expect(menuSurface.classList.contains('invisible')).toBe(true)
+  })
+
+  it('使用贴顶毛玻璃栏承载品牌、产品导航与账号入口', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    renderHeader('/workspace')
+
+    const header = screen.getByRole('banner')
+    const navigation = screen.getByRole('navigation', { name: '产品导航' })
+    expect(header.getAttribute('data-layout')).toBe('unified')
+    expect(header.getAttribute('data-surface')).toBe('frosted-bar')
+    expect(header.className).toContain('inset-x-0')
+    expect(header.className).toContain('top-0')
+    expect(header.className).toContain('bg-transparent')
+    expect(header.className).toContain('backdrop-blur-xl')
+    expect(header.className).not.toContain('bg-[#f3f2ec]')
+    expect(header.className).not.toContain('rounded-[10px]')
+    expect(header.className).not.toContain('-translate-x-1/2')
+    expect(navigation.className).not.toContain('hidden')
+    expect(await screen.findByRole('button', { name: '打开账号菜单' })).toBeTruthy()
+    expect(screen.queryByText('角色资产工作台')).toBeNull()
+
+    const animatedEntries = [
+      screen.getByRole('link', { name: '返回 Windup 工作台' }),
+      screen.getByRole('link', { name: '首页' }),
+      screen.getByRole('link', { name: '项目资产' }),
+      screen.getByRole('link', { name: '创作' }),
+      screen.getByRole('link', { name: 'PlayTest' }),
+    ]
+    for (const entry of animatedEntries) {
+      expect(entry.getAttribute('data-motion')).toBe('text-wave')
+    }
+
+    expect(
+      screen.getByRole('link', { name: '项目资产' }).querySelectorAll('.app-header-wave-glyph'),
+    ).toHaveLength('项目资产项目'.length)
   })
 })

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -1,98 +1,149 @@
+import { useEffect, useState, type AnimationEvent } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 
 import { useAuthSession } from '@/features/auth-session'
 
 interface ProductNavigationItem {
+  motionKey: string
   to: string
   label: string
   compactLabel?: string
   isActive: (pathname: string) => boolean
 }
 
+type AccountMenuState = 'closed' | 'open' | 'closing'
+
+const accountMenuExitDurationMs = 260
+
 /** 四个入口对应四种去处：回首页、看资产、做新东西、核验已完成的造型。 */
 const productNavigation: ProductNavigationItem[] = [
   {
+    motionKey: 'home',
     to: '/workspace',
     label: '首页',
     isActive: (pathname) => pathname === '/workspace',
   },
   {
+    motionKey: 'projects',
     to: '/projects',
     label: '项目资产',
     compactLabel: '项目',
     isActive: (pathname) => pathname.startsWith('/projects'),
   },
   {
+    motionKey: 'create',
     to: '/quick-start',
     label: '创作',
     isActive: (pathname) =>
       pathname.startsWith('/quick-start') || pathname.startsWith('/workflow-editor'),
   },
   {
+    motionKey: 'playtest',
     to: '/playtest',
     label: 'PlayTest',
     isActive: (pathname) => pathname.startsWith('/playtest'),
   },
 ]
 
-/** 左侧标牌上的第二行，随所在区域变化，让用户知道自己在哪一片。 */
-function getWorkspaceLabel(pathname: string): { title: string; detail: string } {
-  if (pathname.startsWith('/account')) {
-    return { title: '账号中心', detail: '资料与登录安全' }
-  }
-
-  if (pathname.startsWith('/projects') || pathname.startsWith('/playtest')) {
-    return { title: '项目资产', detail: '角色、造型与动作' }
-  }
-
-  if (pathname.startsWith('/quick-start') || pathname.startsWith('/workflow-editor')) {
-    return { title: '创作工作流', detail: '设定、生成与审核' }
-  }
-
-  return { title: '角色资产工作台', detail: 'Windup' }
+function WaveText({ playId, text }: { playId: number; text: string }) {
+  return (
+    <span key={playId} aria-hidden="true" className="whitespace-pre">
+      {[...text].map((character, index, characters) => (
+        <span
+          key={`${character}-${index}`}
+          data-wave-last={index === characters.length - 1 ? 'true' : undefined}
+          className="app-header-wave-glyph inline-block"
+          style={{ animationDelay: `${index * 26}ms` }}
+        >
+          {character}
+        </span>
+      ))}
+    </span>
+  )
 }
 
 /**
- * 跨页面悬浮 Bar 知道产品路由，因此属于 app 外壳，不下沉到 shared/ui。
- * 它读 pathname 只用于高亮当前项与切换标牌文案，不据此决定自己出不出现——
- * 谁带外壳是路由表的事，见 app.tsx。
- * 悬浮不占布局高度，页面顶部留白由页面或 PageContainer 自己让出。
+ * 跨页面顶栏知道产品路由，因此属于 app 外壳，不下沉到 shared/ui。
+ * 品牌、主导航和账号共用一个平面，避免三个功能层被误读成彼此独立的卡片。
  */
 export function AppHeader() {
   const { pathname, search, hash } = useLocation()
   const navigate = useNavigate()
   const session = useAuthSession()
-  const workspace = getWorkspaceLabel(pathname)
+  const [accountMenuState, setAccountMenuState] = useState<AccountMenuState>('closed')
+  const accountMenuOpen = accountMenuState === 'open'
+  const [wave, setWave] = useState({ entry: '', playId: 0 })
   const accountEntry = `/?${new URLSearchParams({
     account: 'login',
     returnTo: `${pathname}${search}${hash}`,
   })}`
+
+  useEffect(() => {
+    if (accountMenuState !== 'closing') {
+      return
+    }
+
+    const timer = window.setTimeout(() => setAccountMenuState('closed'), accountMenuExitDurationMs)
+    return () => window.clearTimeout(timer)
+  }, [accountMenuState])
 
   function signOut() {
     const returnHome = () => navigate('/', { replace: true })
     void session.logout().then(returnHome, returnHome)
   }
 
+  function toggleAccountMenu() {
+    setAccountMenuState((state) => (state === 'open' ? 'closing' : 'open'))
+  }
+
+  function finishAccountMenuMotion() {
+    if (accountMenuState === 'closing') {
+      setAccountMenuState('closed')
+    }
+  }
+
+  function playTextWave(entry: string) {
+    setWave(({ playId }) => ({ entry, playId: playId + 1 }))
+  }
+
+  function finishTextWave(entry: string, event: AnimationEvent<HTMLElement>) {
+    const glyph = event.target as HTMLElement
+    if (glyph.dataset.waveLast !== 'true') {
+      return
+    }
+
+    if (wave.entry === entry) {
+      setWave(({ playId }) => ({ entry: '', playId }))
+    }
+  }
+
   return (
-    <header className="pointer-events-none fixed inset-x-0 top-3.5 z-50 flex items-start justify-between gap-2 px-3 text-[#1c231e] sm:gap-4 sm:px-[18px]">
-      <div className="pointer-events-auto flex min-h-[3.625rem] min-w-0 items-center gap-3 rounded-xl border border-[#171817]/14 bg-[#dfe3df] px-2.5 py-[7px] sm:min-w-[min(26rem,42vw)] sm:px-3.5">
+    <header
+      data-layout="unified"
+      data-surface="frosted-bar"
+      className="fixed inset-x-0 top-0 z-50 border-b border-[#1c231e]/10 bg-transparent text-[#1c231e] shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-xl"
+    >
+      <div className="relative mx-auto grid min-h-14 w-full max-w-[90rem] grid-cols-[auto_1fr_auto] items-center gap-4 px-4 sm:px-6 lg:px-8">
         <Link
           to="/workspace"
           aria-label="返回 Windup 工作台"
-          className="flex min-h-11 min-w-11 shrink-0 items-center justify-center gap-2 text-[#1c231e] focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] sm:min-w-0 sm:justify-start md:border-r md:border-[#2d3b31]/12 md:pr-3"
+          data-motion="text-wave"
+          onClick={() => playTextWave('brand')}
+          onAnimationEnd={(event) => finishTextWave('brand', event)}
+          className={`flex min-h-11 shrink-0 items-center gap-2.5 pr-1 text-[#1c231e] focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] ${
+            wave.entry === 'brand' ? 'app-header-text-wave' : ''
+          }`}
         >
-          <img src="/windup-mark.svg" alt="" className="h-[1.6875rem] w-[1.6875rem]" />
-          <strong className="hidden font-serif text-base leading-none sm:inline">Windup</strong>
+          <img src="/windup-mark.svg" alt="" className="h-7 w-7" />
+          <strong className="hidden font-serif text-[1.0625rem] leading-none sm:inline">
+            <WaveText playId={wave.entry === 'brand' ? wave.playId : 0} text="Windup" />
+          </strong>
         </Link>
 
-        <span className="hidden min-w-0 gap-0.5 md:grid">
-          <strong className="truncate text-[11px] font-semibold">{workspace.title}</strong>
-          <small className="truncate text-[8px] text-[#737d75]">{workspace.detail}</small>
-        </span>
-      </div>
-
-      <div className="pointer-events-auto flex min-h-[3.625rem] min-w-0 items-center gap-1 rounded-xl border border-[#171817]/14 bg-[#dfe3df] p-[7px]">
-        <nav aria-label="产品导航" className="flex min-w-0 items-center gap-[3px]">
+        <nav
+          aria-label="产品导航"
+          className="absolute left-1/2 flex -translate-x-1/2 items-stretch gap-0 sm:gap-1"
+        >
           {productNavigation.map((item) => {
             const active = item.isActive(pathname)
 
@@ -102,33 +153,46 @@ export function AppHeader() {
                 to={item.to}
                 aria-label={item.label}
                 aria-current={active ? 'page' : undefined}
-                style={{ fontSize: '13px', fontWeight: 600 }}
-                className={`inline-flex min-h-11 items-center rounded-[0.5625rem] px-2.5 whitespace-nowrap transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331] ${
+                data-motion="text-wave"
+                onClick={() => playTextWave(item.motionKey)}
+                onAnimationEnd={(event) => finishTextWave(item.motionKey, event)}
+                className={`relative inline-flex min-h-11 items-center px-1.5 text-[12px] font-medium whitespace-nowrap transition-colors after:absolute after:inset-x-1.5 after:bottom-0 after:h-[2px] after:origin-center after:bg-[#284331] after:transition-transform focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331] sm:px-3 sm:text-[13px] sm:after:inset-x-3 ${
                   active
-                    ? 'bg-[#dce9df] text-[#284331]'
-                    : 'text-[#5b655d] hover:bg-[#e7eee8] hover:text-[#26372c]'
-                }`}
+                    ? 'text-[#243c2c] after:scale-x-100'
+                    : 'text-[#667068] after:scale-x-0 hover:text-[#26372c]'
+                } ${wave.entry === item.motionKey ? 'app-header-text-wave' : ''}`}
               >
                 {item.compactLabel ? (
                   <>
-                    <span className="hidden md:inline">{item.label}</span>
-                    <span className="md:hidden">{item.compactLabel}</span>
+                    <span className="hidden md:inline">
+                      <WaveText
+                        playId={wave.entry === item.motionKey ? wave.playId : 0}
+                        text={item.label}
+                      />
+                    </span>
+                    <span className="md:hidden">
+                      <WaveText
+                        playId={wave.entry === item.motionKey ? wave.playId : 0}
+                        text={item.compactLabel}
+                      />
+                    </span>
                   </>
                 ) : (
-                  item.label
+                  <WaveText
+                    playId={wave.entry === item.motionKey ? wave.playId : 0}
+                    text={item.label}
+                  />
                 )}
               </Link>
             )
           })}
         </nav>
 
-        <span aria-hidden="true" className="mx-0.5 h-7 w-px shrink-0 bg-[#2d3b31]/14" />
-
-        <div aria-label="账号" className="flex min-w-0 items-center gap-1">
+        <div aria-label="账号" className="relative col-start-3 ml-auto shrink-0">
           {session.state.status === 'booting' ? (
             <span
               aria-label="正在恢复登录状态"
-              className="inline-grid min-h-11 min-w-11 place-items-center text-sm text-[#778078] sm:min-w-20"
+              className="inline-grid min-h-11 min-w-11 place-items-center text-sm text-[#778078]"
             >
               …
             </span>
@@ -136,31 +200,77 @@ export function AppHeader() {
             <Link
               to={accountEntry}
               aria-label="登录 / 注册"
-              className="inline-flex min-h-11 items-center rounded-[0.5625rem] border border-[#2d3b31]/14 bg-white/35 px-3 text-[13px] font-semibold whitespace-nowrap text-[#34483a] transition-colors hover:border-[#2d3b31]/22 hover:bg-[#edf2ed] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331]"
+              className="inline-flex min-h-10 items-center rounded-lg border border-[#2d3b31]/14 bg-white/45 px-3 text-[13px] font-medium whitespace-nowrap text-[#34483a] transition-colors hover:bg-white/75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331]"
             >
               <span className="hidden sm:inline">登录 / 注册</span>
               <span className="sm:hidden">登录</span>
             </Link>
           ) : (
-            <div className="flex min-w-0 items-center overflow-hidden rounded-[0.5625rem] border border-[#2d3b31]/14 bg-white/35">
-              <Link
-                to="/account"
-                aria-label="打开账号中心"
-                aria-current={pathname.startsWith('/account') ? 'page' : undefined}
-                title={session.state.user.email}
-                className="inline-flex min-h-11 max-w-16 items-center truncate px-3 text-xs font-semibold text-[#34483a] transition-colors hover:bg-[#dce9df] hover:text-[#26372c] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#284331] sm:max-w-28"
-              >
-                {session.state.user.nickname || session.state.user.email}
-              </Link>
+            <>
               <button
                 type="button"
-                onClick={signOut}
-                aria-label="退出登录"
-                className="inline-flex min-h-11 min-w-11 items-center justify-center border-l border-[#2d3b31]/12 px-2.5 text-xs font-semibold text-[#68736a] transition-colors hover:bg-[#dce9df] hover:text-[#26372c] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#284331]"
+                aria-label="打开账号菜单"
+                aria-expanded={accountMenuOpen}
+                title={session.state.user.email}
+                onClick={toggleAccountMenu}
+                className={`inline-flex min-h-10 max-w-24 items-center gap-2 rounded-lg px-2.5 text-xs font-medium text-[#3e4941] transition-[color,background-color,transform] duration-150 ease-out hover:bg-[#e5e8e3] hover:text-[#26372c] active:translate-y-px active:scale-[0.97] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] motion-reduce:transform-none sm:max-w-36 ${
+                  accountMenuOpen ? 'bg-[#e5e8e3] text-[#26372c]' : ''
+                }`}
               >
-                退出
+                <span
+                  className={`grid h-7 w-7 shrink-0 place-items-center rounded-full bg-[#dfe5df] font-serif text-[11px] text-[#284331] transition-transform duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none ${
+                    accountMenuOpen ? 'scale-110' : 'scale-100'
+                  }`}
+                >
+                  {(session.state.user.nickname || session.state.user.email).slice(0, 1)}
+                </span>
+                <span className="hidden truncate sm:inline">
+                  {session.state.user.nickname || session.state.user.email}
+                </span>
+                <span
+                  aria-hidden="true"
+                  className={`text-[10px] text-[#7b847d] transition-transform duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none ${
+                    accountMenuOpen ? 'rotate-180' : 'rotate-0'
+                  }`}
+                >
+                  ↓
+                </span>
               </button>
-            </div>
+
+              <div
+                data-testid="account-menu"
+                data-state={accountMenuState}
+                data-motion="scale-fade"
+                aria-hidden={accountMenuOpen ? undefined : true}
+                inert={!accountMenuOpen}
+                onAnimationEnd={finishAccountMenuMotion}
+                className={`absolute top-[calc(100%+0.5rem)] right-0 grid min-w-44 origin-top-right overflow-hidden rounded-lg border border-[#1c231e]/12 bg-[#f8f7f2] p-1.5 shadow-[0_8px_24px_rgba(28,35,30,0.10)] ${
+                  accountMenuState === 'open'
+                    ? 'visible app-header-account-menu-in'
+                    : accountMenuState === 'closing'
+                      ? 'visible pointer-events-none app-header-account-menu-out'
+                      : 'invisible pointer-events-none -translate-y-2 scale-[0.82] opacity-0'
+                }`}
+              >
+                <Link
+                  to="/account"
+                  aria-label="打开账号中心"
+                  aria-current={pathname.startsWith('/account') ? 'page' : undefined}
+                  onClick={() => setAccountMenuState('closing')}
+                  className="flex min-h-10 items-center rounded-md px-3 text-[13px] text-[#3f4942] transition-colors hover:bg-[#e8ebe7] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#284331]"
+                >
+                  账号中心
+                </Link>
+                <button
+                  type="button"
+                  onClick={signOut}
+                  aria-label="退出登录"
+                  className="flex min-h-10 items-center rounded-md px-3 text-left text-[13px] text-[#707871] transition-colors hover:bg-[#e8ebe7] hover:text-[#26372c] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#284331]"
+                >
+                  退出登录
+                </button>
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type AnimationEvent } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 
 import { useAuthSession } from '@/features/auth-session'
@@ -106,17 +106,6 @@ export function AppHeader() {
     setWave(({ playId }) => ({ entry, playId: playId + 1 }))
   }
 
-  function finishTextWave(entry: string, event: AnimationEvent<HTMLElement>) {
-    const glyph = event.target as HTMLElement
-    if (glyph.dataset.waveLast !== 'true') {
-      return
-    }
-
-    if (wave.entry === entry) {
-      setWave(({ playId }) => ({ entry: '', playId }))
-    }
-  }
-
   return (
     <header
       data-layout="unified"
@@ -129,7 +118,6 @@ export function AppHeader() {
           aria-label="返回 Windup 工作台"
           data-motion="text-wave"
           onClick={() => playTextWave('brand')}
-          onAnimationEnd={(event) => finishTextWave('brand', event)}
           className={`flex min-h-11 shrink-0 items-center gap-2.5 pr-1 text-[#1c231e] focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] ${
             wave.entry === 'brand' ? 'app-header-text-wave' : ''
           }`}
@@ -155,7 +143,6 @@ export function AppHeader() {
                 aria-current={active ? 'page' : undefined}
                 data-motion="text-wave"
                 onClick={() => playTextWave(item.motionKey)}
-                onAnimationEnd={(event) => finishTextWave(item.motionKey, event)}
                 className={`relative inline-flex min-h-11 items-center px-1.5 text-[12px] font-medium whitespace-nowrap transition-colors after:absolute after:inset-x-1.5 after:bottom-0 after:h-[2px] after:origin-center after:bg-[#284331] after:transition-transform focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[#284331] sm:px-3 sm:text-[13px] sm:after:inset-x-3 ${
                   active
                     ? 'text-[#243c2c] after:scale-x-100'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,6 +7,88 @@ body,
   height: 100%;
 }
 
+@keyframes app-header-glyph-wave {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+  30% {
+    transform: translate3d(-0.5px, -4px, 0) rotate(-2deg);
+  }
+  58% {
+    transform: translate3d(0.6px, 1px, 0) rotate(1.25deg);
+  }
+  78% {
+    transform: translate3d(-0.2px, -0.75px, 0) rotate(-0.4deg);
+  }
+}
+
+.app-header-text-wave .app-header-wave-glyph {
+  transform-origin: center 80%;
+  animation: app-header-glyph-wave 380ms cubic-bezier(0.2, 0.75, 0.25, 1) both;
+}
+
+@keyframes app-header-account-menu-in {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, -8px, 0) scale(0.82);
+  }
+  56% {
+    opacity: 1;
+    transform: translate3d(0, 1.5px, 0) scale(1.025);
+  }
+  78% {
+    transform: translate3d(0, -0.5px, 0) scale(0.996);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+.app-header-account-menu-in,
+.app-header-account-menu-out {
+  backface-visibility: hidden;
+  will-change: opacity, transform;
+}
+
+.app-header-account-menu-in {
+  animation: app-header-account-menu-in 340ms cubic-bezier(0.22, 0.8, 0.25, 1) both;
+}
+
+@keyframes app-header-account-menu-out {
+  0% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  38% {
+    opacity: 1;
+    transform: translate3d(0, 1px, 0) scale(1.015);
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(0, -8px, 0) scale(0.82);
+  }
+}
+
+.app-header-account-menu-out {
+  animation: app-header-account-menu-out 260ms cubic-bezier(0.55, 0, 1, 0.45) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-header-text-wave .app-header-wave-glyph {
+    animation: none;
+  }
+
+  .app-header-account-menu-in {
+    animation: none;
+  }
+
+  .app-header-account-menu-out {
+    animation: app-header-account-menu-out 0.01ms both;
+  }
+}
+
 /*
  * 宣传页设计令牌。
  *

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -86,7 +86,9 @@ describe('AccountPage', () => {
     expect(screen.getByDisplayValue('Fresh Reader')).toBeTruthy()
     expect(screen.getByText('reader@example.com')).toBeTruthy()
     expect(document.querySelector('time')?.getAttribute('datetime')).toBe('2026-08-09T08:30:00Z')
-    expect(screen.getByRole('link', { name: '打开账号中心' }).textContent).toContain('Fresh Reader')
+    expect(screen.getByRole('button', { name: '打开账号菜单' }).textContent).toContain(
+      'Fresh Reader',
+    )
   })
 
   it('reports a profile refresh failure without claiming the data is synchronized', async () => {
@@ -109,7 +111,7 @@ describe('AccountPage', () => {
 
     await waitFor(() => expect(apis.updateNickname).toHaveBeenCalledWith('New Reader'))
     expect(await screen.findByText('昵称已更新。')).toBeTruthy()
-    expect(screen.getByRole('link', { name: '打开账号中心' }).textContent).toContain('New Reader')
+    expect(screen.getByRole('button', { name: '打开账号菜单' }).textContent).toContain('New Reader')
   })
 
   it('preserves the edited nickname when the backend rejects it', async () => {


### PR DESCRIPTION
统一产品页面的 App Header：改为全宽贴顶的透明毛玻璃顶栏，统一品牌、主导航与账号菜单的视觉和交互动效，并保留移动端四入口可达性。

## Why

原 Header 由左右两块悬浮区域拼接，品牌、产品导航和账号入口缺乏稳定的共同层级；页面切换、导航反馈和账号菜单开合也没有统一的交互语言。

## Changes

- 将 App Header 收敛为全宽贴顶的透明毛玻璃顶栏，保留轻量发丝边界。
- 为品牌与四个产品入口增加可重复播放的逐字波浪反馈，并保持路由高亮。
- 将登录用户入口收敛为账号菜单，补齐按压、缩放淡入和完整退场动画。
- 在移动端保留四个主导航入口，通过紧凑字号与隐藏次要账号文字避免入口丢失。
- 为菜单关闭阶段增加 `aria-hidden`、`inert`、动画结束与定时兜底，并兼容 reduced motion。
- 将账号页集成测试的昵称断言对齐到新的账号菜单触发按钮。

## Implementation

- Header 的路由、交互和菜单状态继续由 `AppHeader` 负责。
- 动画关键帧集中在全局样式中的 `app-header-*` 命名空间，不影响其他页面动画。
- 未修改 Marketing Header、页面内部布局、业务路由、接口或认证协议。

## Verification

- [x] `npm test -- --configLoader runner src/app/layout/app-header.test.tsx`：10/10 passed
- [x] `npm test -- --configLoader runner src/app/layout/app-header.test.tsx src/pages/account/index.test.tsx`：19/19 passed
- [x] `npm run test:coverage -- --configLoader runner src/app/layout/app-header.test.tsx src/pages/account/index.test.tsx`：Header statements 94.59%、branches 94%、functions 95.23%、lines 93.75%
- [x] `npm run format:check -- src/app/layout/app-header.tsx src/app/layout/app-header.test.tsx src/pages/account/index.test.tsx src/index.css`：passed
- [x] `npx oxlint src/app/layout/app-header.tsx src/app/layout/app-header.test.tsx src/pages/account/index.test.tsx`：passed
- [x] `npx tsc -p tsconfig.app.json --incremental false`：passed
- [x] `npx tsc -p tsconfig.node.json --incremental false`：passed
- [x] `npm run build`：passed
- [x] `git diff --check upstream/main...HEAD`：passed

## Screenshots

### Desktop

本地真实浏览器已验收 `/workspace` 顶栏、导航高亮与账号菜单开合状态。截图工具当前输出存在重复拼接，因此未附失真图片。

### Mobile

520px 视口真实浏览器检查：品牌入口、四个产品导航入口与账号入口均可见，页面 `scrollWidth` 与视口宽度一致，无导航隐藏或额外横向溢出。截图工具当前输出存在重复拼接，因此未附失真图片。

## Scope

- 本 PR 不包含：Marketing Header、宣传页、Workspace、Workflow Editor、Quick Start、资产库或 Playtest 页面内部重设计；账号页仅调整 Header 集成测试断言。
- 本 PR 不修改：后端接口、业务路由、认证协议、依赖与构建配置。

## Related Issues

Closes #236
Refs #98
Refs #164
Refs #210
Refs #216
