### PR TITLE
fix(quick-start): 修复生成图片时项目名参数错误

### DIFF
--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -258,9 +258,11 @@ describe('createQuickStartService', () => {
       id: 'project-1',
       spriteSize: { width: 256, height: 256 },
     })
+    const createdName = create.mock.calls[0]?.[0].name
+    expect(Array.from(createdName ?? '')).toHaveLength(20)
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: expect.stringMatching(/^一位名字特别长的像素角色设定用于…-/u),
+        name: expect.stringMatching(/^一位名字特别长的像…-/u),
         perspective: 'side',
         directionalMovement: 'single',
       }),

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -591,8 +591,16 @@ export function createQuickStartService({
 
 export function createAutoPrepareProject(projectApis: ProjectApis): PrepareQuickStartProject {
   return async (prompt) => {
-    const base = prompt.length > 16 ? `${prompt.slice(0, 16)}…` : prompt
-    const name = `${base}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
+    const timestamp = Date.now().toString(36).slice(-6).padStart(6, '0')
+    const nonce = Math.random().toString(36).slice(2, 5).padEnd(3, '0')
+    const suffix = `${timestamp}${nonce}`
+    const maxBaseLength = 20 - suffix.length - 1
+    const promptCharacters = Array.from(prompt)
+    const base =
+      promptCharacters.length > maxBaseLength
+        ? `${promptCharacters.slice(0, maxBaseLength - 1).join('')}…`
+        : promptCharacters.join('')
+    const name = `${base}-${suffix}`
     const project = await projectApis.create({
       name,
       perspective: 'side',


### PR DESCRIPTION
## 问题\nQuick Start 点击生成图片时会先自动创建项目。原自动项目名最长约 31 个字符，超过后端 project_name 最多 20 个字符的限制，因此在进入图片生成前返回请求参数校验失败。\n\n## 修改\n- 将自动项目名限制在 20 个 Unicode 字符内\n- 保留可读提示词前缀和固定长度时间戳/随机后缀\n- 补充项目名长度回归测试\n\n## 验证\n- Quick Start 定向测试：15 passed\n- 前端完整测试：413 passed\n- typecheck：通过\n- lint：通过\n- build：通过\n- 改动文件格式检查：通过