### PR TITLE
fix(quick-start): 打通自定义动作完整生成

### DIFF
--- a/backend/packages/ai_engine/pyproject.toml
+++ b/backend/packages/ai_engine/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pillow>=10.4",
     "numpy>=1.26",
     "imageio>=2.36",
+    "imageio-ffmpeg>=0.6",
     "av>=14.0",              # imageio pyav 后端(视频抽帧)
     # "rembg",             # 抠图(按需启用)
 ]

--- a/backend/packages/ai_engine/src/windup_ai_engine/postprocess/rootmotion.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/postprocess/rootmotion.py
@@ -27,6 +27,7 @@ DEFAULT_FPS_MS = {
     "jump": 110,
     "attack": 90,
     "hit": 90,
+    "custom": 90,
 }
 
 

--- a/backend/packages/ai_engine/src/windup_ai_engine/slicing/extract.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/slicing/extract.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+from pathlib import Path
 
 from PIL import Image
 
@@ -21,18 +22,18 @@ __all__ = ["extract_frames_bytes", "extract_all_frames_bytes"]
 
 def extract_frames_bytes(video: bytes, n: int) -> list[Image.Image]:
     """从视频 bytes 均匀抽 ``n`` 帧（供后端 strategy 用，provider 返回的是 bytes）。"""
-    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=True) as f:
-        f.write(video)
-        f.flush()
-        return _extract_frames(f.name, n)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "source.mp4"
+        path.write_bytes(video)
+        return _extract_frames(str(path), n)
 
 
 def extract_all_frames_bytes(video: bytes, cap: int = 150) -> list[Image.Image]:
     """抽视频全部帧（至多 ``cap``，均匀降采样），供周期检测用。"""
-    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=True) as f:
-        f.write(video)
-        f.flush()
-        return _extract_frames(f.name, cap)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "source.mp4"
+        path.write_bytes(video)
+        return _extract_frames(str(path), cap)
 
 
 def _uniform_indices(total: int, n: int) -> list[int]:
@@ -90,10 +91,11 @@ def _extract_frames(video_path: str, n: int) -> list[Image.Image]:
 
     import glob
     import subprocess
+    from imageio_ffmpeg import get_ffmpeg_exe
 
     with tempfile.TemporaryDirectory() as tmp:
         subprocess.run(
-            ["ffmpeg", "-y", "-i", video_path, "-vsync", "0",
+            [get_ffmpeg_exe(), "-y", "-i", video_path, "-vsync", "0",
              os.path.join(tmp, "f_%04d.png")],
             capture_output=True, check=True,
         )

--- a/backend/packages/ai_engine/src/windup_ai_engine/strategy/base.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/strategy/base.py
@@ -24,6 +24,7 @@ ROUTE_MATRIX: dict[ActionType, GenRoute] = {
     ActionType.RUN: GenRoute.VIDEO_I2V,
     ActionType.JUMP: GenRoute.VIDEO_I2V,
     ActionType.ATTACK: GenRoute.VIDEO_I2V,
+    ActionType.CUSTOM: GenRoute.VIDEO_I2V,
     ActionType.HIT: GenRoute.PER_FRAME,
     # idle 走 i2v(build_idle_prompt:躯干缓慢起伏呼吸)。
     # **2026-08-07 定案**:#53 原设计的 ¥0 程序化 Idle-B(局部网格呼吸)放弃 —— 做不出

--- a/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
@@ -46,6 +46,17 @@ class VideoFrameStrategy(DerivationStrategy):
 
     def _build_prompt(self, action: ActionSpec) -> str:
         """按动作类型选提示词;朝向随 ActionSpec.facing。"""
+        if action.motion_prompt:
+            facing = (
+                "SIDE VIEW facing right"
+                if action.facing.value == "side"
+                else "FACING THE VIEWER"
+            )
+            return (
+                f"Perform exactly this motion: {action.motion_prompt}. {facing}. "
+                "One single committed motion, preserving the character's identity, proportions, "
+                "clothing, and colors. Keep the whole body visible and return to a stable pose."
+            )
         builders = {
             ActionType.JUMP: build_jump_prompt,
             ActionType.IDLE: build_idle_prompt,

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -25,6 +25,7 @@ from windup_common.models import ActionSpec, ActionType as EngineActionType, Cha
 from windup_app.server.orchestrator import task_repo
 from windup_app.server.orchestrator._fetch import fetch_own_media
 from windup_app.server.orchestrator.model import (
+    ActionType,
     CharacterActionInput,
     CharacterImageInput,
     TaskStatus,
@@ -141,7 +142,7 @@ class _LogProgress:
 def _to_engine_action(t) -> EngineActionType:
     """generation.ActionType → 引擎 common.ActionType(按值映射)。
 
-    walk/idle/attack 直通;custom 等引擎未覆盖的类型暂不支持视频路线。
+    所有 API 动作类型都按值映射到引擎动作类型。
     """
     try:
         return EngineActionType(t.value)
@@ -229,6 +230,7 @@ class ActionTaskExecutor:
         card = CharacterCard(name=f"char-{input.character_id}", desc=" ".join(desc_parts))
         action = ActionSpec(
             action=_to_engine_action(input.action_type),
+            motion_prompt=input.custom_prompt if input.action_type is ActionType.CUSTOM else None,
             poses=[""] * input.num_frames,
             facing=cons.facing,
             stylize=cons.stylize,

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from sqlalchemy import event
 from sqlalchemy.orm import Session
 
@@ -174,6 +174,15 @@ class CharacterActionGenerateRequest(BaseModel):
     reference_image_urls: list[str] = Field(default_factory=list)
     # 同上:帧数决定抽帧与逐帧抠图的工作量,上界 64 已远超引擎能出的有效周期长度。
     num_frames: int = Field(default=16, ge=1, le=64)
+
+    @model_validator(mode="after")
+    def require_custom_prompt(self):
+        if self.action_type is ActionType.CUSTOM:
+            prompt = (self.custom_prompt or "").strip()
+            if not prompt:
+                raise ValueError("custom 动作必须提供 custom_prompt")
+            self.custom_prompt = prompt
+        return self
 
 
 class GenerationTaskOut(BaseModel):

--- a/backend/packages/common/src/windup_common/models/character.py
+++ b/backend/packages/common/src/windup_common/models/character.py
@@ -49,6 +49,7 @@ class ActionType(str, Enum):
     JUMP = "jump"      # 一次性动作,且要按状态切段(见 postprocess.split_jump_phases)
     ATTACK = "attack"  # slash / thrust / dash 归此
     HIT = "hit"
+    CUSTOM = "custom"
 
 
 class GenRoute(str, Enum):
@@ -149,6 +150,8 @@ class ActionSpec(BaseModel):
     model_config = _STRICT
 
     action: ActionType
+    # 自由动作的视频运动描述。仅在调用方明确提供时覆盖固定动作模板。
+    motion_prompt: str | None = Field(default=None, min_length=1)
 
     # 出帧数。**显式字段,不再由 len(poses) 推导**:视频路线根本不读 poses(见
     # strategy.concrete.VideoFrameStrategy),推导意味着"想要 16 帧就得先编 16 条用不上的

--- a/backend/packages/framework/src/windup_framework/config/storage.py
+++ b/backend/packages/framework/src/windup_framework/config/storage.py
@@ -33,7 +33,10 @@ class StorageSettings(BaseSettings):
     @property
     def download_base(self) -> str:
         """下载 URL 基础域名,去掉末尾 ``/``,客户端拼接 key 即可。"""
-        return self.bucket_domain.rstrip("/")
+        domain = self.bucket_domain.rstrip("/")
+        if domain and not domain.startswith(("http://", "https://")):
+            domain = f"https://{domain}"
+        return domain
 
 
 settings = StorageSettings()

--- a/backend/tests/test_ai_engine_skeleton.py
+++ b/backend/tests/test_ai_engine_skeleton.py
@@ -62,6 +62,7 @@ def test_route_matrix_is_the_measured_contract():
     assert ROUTE_MATRIX[ActionType.WALK] is GenRoute.VIDEO_I2V
     assert ROUTE_MATRIX[ActionType.RUN] is GenRoute.VIDEO_I2V
     assert ROUTE_MATRIX[ActionType.ATTACK] is GenRoute.VIDEO_I2V
+    assert ROUTE_MATRIX[ActionType.CUSTOM] is GenRoute.VIDEO_I2V
     assert ROUTE_MATRIX[ActionType.JUMP] is GenRoute.VIDEO_I2V
     assert ROUTE_MATRIX[ActionType.HIT] is GenRoute.PER_FRAME
     assert ROUTE_MATRIX[ActionType.IDLE] is GenRoute.VIDEO_I2V
@@ -175,6 +176,31 @@ def test_video_strategy_prompt_follows_facing(monkeypatch):
         )
     assert "SIDE VIEW facing right" in seen[0]
     assert "FACING THE VIEWER" in seen[1]
+
+
+def test_video_strategy_uses_custom_motion_prompt(monkeypatch):
+    seen: list[str] = []
+
+    class _SpyVideo:
+        def i2v(self, first_frame, prompt, seconds=5, size="1280x720"):
+            seen.append(prompt)
+            return b"fake-mp4"
+
+    strat = _offline_video_strategy(monkeypatch, video=_SpyVideo())
+    strat.derive(
+        CharacterCard(name="hero", desc=""),
+        ActionSpec(
+            action=ActionType.ATTACK,
+            motion_prompt="wave hello with the right hand",
+            stylize=Stylize.NONE,
+            n_frames=4,
+        ),
+        master=_tiny_png(),
+        progress=_NullProgress(),
+    )
+
+    assert "wave hello with the right hand" in seen[0]
+    assert "SIDE VIEW facing right" in seen[0]
 
 
 def test_real_video_strategy_is_registered_for_video_route():

--- a/backend/tests/test_extract_streaming.py
+++ b/backend/tests/test_extract_streaming.py
@@ -112,6 +112,19 @@ def test_bytes_entry_point_streams_too(video, monkeypatch):
         assert len(extract_frames_bytes(f.read(), 4)) == 4
 
 
+def test_bundled_ffmpeg_is_used_when_pyav_cannot_decode(video, monkeypatch):
+    import imageio.v3 as iio
+    from imageio_ffmpeg import get_ffmpeg_exe
+
+    monkeypatch.setattr(iio, "improps", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no pyav")))
+    monkeypatch.setattr(iio, "imiter", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no pyav")))
+
+    frames = _extract_frames(video, 4)
+
+    assert get_ffmpeg_exe()
+    assert len(frames) == 4
+
+
 # ── 帧数元数据不可信时的兜底 ─────────────────────────────────────────────────
 
 

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -142,6 +142,7 @@ class _SpyGenerator:
     def __init__(self, honour_canvas: bool = True) -> None:
         self.seen_facing: str | None = None
         self.seen_canvas: tuple[int, int] | None = None
+        self.seen_action = None
         self._honour = honour_canvas
 
     def generate(self, card, action, master, progress, canvas=None):
@@ -149,6 +150,7 @@ class _SpyGenerator:
 
         self.seen_facing = action.facing
         self.seen_canvas = canvas
+        self.seen_action = action
         size = canvas if (canvas and self._honour) else (256, 256)
         # 不传 fps:GeneratedAction 早已删掉该字段(播放时序的唯一真相源是 durations)。
         # 这个 spy 之前一直在传,构造直接 TypeError、任务被判 FAILED —— 而当时的用例
@@ -191,6 +193,31 @@ def test_project_perspective_constrains_facing(session_factory):
     executor.run_action_task(task_id, action_input, project_id)  # 带项目约束
 
     assert spy.seen_facing == "front", "项目 perspective 应约束生成朝向"
+
+
+def test_custom_action_reuses_oneshot_route_and_preserves_prompt(session_factory):
+    spy = _SpyGenerator()
+    executor = ActionTaskExecutor(
+        generator=spy,
+        upload=lambda _png: "https://cdn.example.com/f.png",
+        fetch_master=lambda _input: _tiny_png(),
+        session_factory=session_factory,
+    )
+    action_input = CharacterActionInput(
+        character_id=1,
+        action_type=ActionType.CUSTOM,
+        custom_prompt="wave hello with the right hand",
+        num_frames=2,
+    )
+    with session_factory() as s:
+        task = AiGenerationService().generate_character_action(s, user_id=1, input=action_input)
+        s.commit()
+        task_id = task.id
+
+    executor.run_action_task(task_id, action_input)
+
+    assert spy.seen_action.action.value == "custom"
+    assert spy.seen_action.motion_prompt == "wave hello with the right hand"
 
 
 def test_action_task_marks_failed_on_error(session_factory):

--- a/backend/tests/test_orchestrator_hardening.py
+++ b/backend/tests/test_orchestrator_hardening.py
@@ -29,6 +29,19 @@ from windup_app.web.api.generation import (
     CharacterImageGenerateRequest,
     _EventBus,
 )
+from windup_framework.config.storage import StorageSettings
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("cdn.example.com", "https://cdn.example.com"),
+        ("https://cdn.example.com/", "https://cdn.example.com"),
+        ("", ""),
+    ],
+)
+def test_storage_download_base_accepts_documented_bare_domain(configured, expected):
+    assert StorageSettings(bucket_domain=configured).download_base == expected
 
 
 # ── ① 真实装配路径不能引用已删除的路线 ────────────────────────────────────
@@ -338,6 +351,24 @@ def test_num_frames_is_bounded():
         CharacterActionGenerateRequest(project_id=42, character_id=1, action_type="walk", num_frames=0)
     ok = CharacterActionGenerateRequest(project_id=42, character_id=1, action_type="walk", num_frames=16)
     assert ok.num_frames == 16
+
+
+def test_custom_action_requires_a_non_empty_prompt():
+    for prompt in (None, "", "   "):
+        with pytest.raises(ValueError):
+            CharacterActionGenerateRequest(
+                project_id=42,
+                character_id=1,
+                action_type="custom",
+                custom_prompt=prompt,
+            )
+    request = CharacterActionGenerateRequest(
+        project_id=42,
+        character_id=1,
+        action_type="custom",
+        custom_prompt="  wave hello  ",
+    )
+    assert request.custom_prompt == "wave hello"
 
 
 # ── ⑥ 请求里的尺寸必须真的生效（2026-08-10 对抗复查）────────────────────────

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -625,6 +625,20 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a" },
+]
+
+[[package]]
 name = "import-linter"
 version = "2.13"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
@@ -2106,6 +2120,7 @@ source = { editable = "packages/ai_engine" }
 dependencies = [
     { name = "av" },
     { name = "imageio" },
+    { name = "imageio-ffmpeg" },
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "numpy" },
@@ -2118,6 +2133,7 @@ dependencies = [
 requires-dist = [
     { name = "av", specifier = ">=14.0" },
     { name = "imageio", specifier = ">=2.36" },
+    { name = "imageio-ffmpeg", specifier = ">=0.6" },
     { name = "langchain-core", specifier = ">=0.3" },
     { name = "langgraph", specifier = ">=0.2" },
     { name = "numpy", specifier = ">=1.26" },

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -369,6 +369,14 @@ describe('createQuickStartService', () => {
     expect(secondSession.runId).toBe(firstSession.runId)
     expect(secondRun.nodes.filter((node) => node.type === 'action-first-frame')).toHaveLength(2)
     expect(generationApis.create).toHaveBeenCalledTimes(2)
+    expect(generationApis.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ actionType: 'custom', prompt: '挥手' }),
+    )
+    expect(generationApis.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ actionType: 'jump', prompt: '跳跃' }),
+    )
   })
 
   it('preserves backend frame metadata while approving and importing a completed action', async () => {

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -365,10 +365,16 @@ describe('createQuickStartService', () => {
       { characterId: 'character-1', outfitId: savedCharacter.outfits[0]!.id },
       '跳跃',
     )
-    const secondRun = secondSession.getWorkflow()
+    const target = { characterId: 'character-1', outfitId: savedCharacter.outfits[0]!.id }
+    await service.startAction(target, '跑步')
+    await service.startAction(target, '攻击')
+    await service.startAction(target, '站立挥手')
+    const finalSession = await service.startAction(target, '跑步攻击')
+    const finalRun = finalSession.getWorkflow()
     expect(secondSession.runId).toBe(firstSession.runId)
-    expect(secondRun.nodes.filter((node) => node.type === 'action-first-frame')).toHaveLength(2)
-    expect(generationApis.create).toHaveBeenCalledTimes(2)
+    expect(finalSession.runId).toBe(firstSession.runId)
+    expect(finalRun.nodes.filter((node) => node.type === 'action-first-frame')).toHaveLength(6)
+    expect(generationApis.create).toHaveBeenCalledTimes(6)
     expect(generationApis.create).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ actionType: 'custom', prompt: '挥手' }),
@@ -376,6 +382,22 @@ describe('createQuickStartService', () => {
     expect(generationApis.create).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ actionType: 'jump', prompt: '跳跃' }),
+    )
+    expect(generationApis.create).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ actionType: 'walk', prompt: '跑步' }),
+    )
+    expect(generationApis.create).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({ actionType: 'attack', prompt: '攻击' }),
+    )
+    expect(generationApis.create).toHaveBeenNthCalledWith(
+      5,
+      expect.objectContaining({ actionType: 'custom', prompt: '站立挥手' }),
+    )
+    expect(generationApis.create).toHaveBeenNthCalledWith(
+      6,
+      expect.objectContaining({ actionType: 'custom', prompt: '跑步攻击' }),
     )
   })
 

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -82,6 +82,16 @@ export interface CreateQuickStartServiceOptions {
   onAsyncError?: (error: Error) => void
 }
 
+type GeneratableActionType = 'idle' | 'walk' | 'jump' | 'attack' | 'custom'
+
+function inferGeneratableActionType(description: string): GeneratableActionType {
+  const normalized = description.trim().toLowerCase()
+  if (!normalized || /(待机|站立|呼吸|idle|stand|breathe)/u.test(normalized)) return 'idle'
+  if (/(跳|跃|jump|leap|hop)/u.test(normalized)) return 'jump'
+  if (/(走|步行|跑|冲刺|walk|run|sprint)/u.test(normalized)) return 'walk'
+  return 'custom'
+}
+
 /**
  * Quick Start 与 Workflow Editor 都推进同一份节点图；这里仅把自然语言输入翻译为连续命令。
  * Controller 按 run 实例化，避免一个全局内存对象误把两个角色的流程混在一起。
@@ -203,7 +213,7 @@ export function createQuickStartService({
     actionDescription: string,
   ) {
     const name = actionDescription.trim() || '待机'
-    const type = actionDescription.trim() ? 'custom' : 'idle'
+    const type = inferGeneratableActionType(actionDescription)
     await controller.addAction({
       input: { outfitId, name, type, prompt: actionDescription.trim() || null, fps: 12 },
     })

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -86,9 +86,10 @@ type GeneratableActionType = 'idle' | 'walk' | 'jump' | 'attack' | 'custom'
 
 function inferGeneratableActionType(description: string): GeneratableActionType {
   const normalized = description.trim().toLowerCase()
-  if (!normalized || /(待机|站立|呼吸|idle|stand|breathe)/u.test(normalized)) return 'idle'
-  if (/(跳|跃|jump|leap|hop)/u.test(normalized)) return 'jump'
-  if (/(走|步行|跑|冲刺|walk|run|sprint)/u.test(normalized)) return 'walk'
+  if (!normalized || /^(待机|站立|呼吸|idle|stand|breathe)$/u.test(normalized)) return 'idle'
+  if (/^(跳|跃|跳跃|jump|leap|hop)$/u.test(normalized)) return 'jump'
+  if (/^(走|步行|跑|跑步|冲刺|walk|run|sprint)$/u.test(normalized)) return 'walk'
+  if (/^(攻击|attack)$/u.test(normalized)) return 'attack'
   return 'custom'
 }
 


### PR DESCRIPTION
## 变更

- 将 Quick Start 自由动作作为独立 `custom` 路线，保留用户动作描述并传入视频生成
- 在 API 边界拒绝空的自定义动作描述，避免生成错误资产
- 修复 Windows 下视频临时文件锁，并使用随依赖安装的 FFmpeg 作为跨平台兜底
- 兼容对象存储裸域名，默认补全 HTTPS

## 验证

- 真实链路：自定义动作首帧 -> 32 帧完整动作 -> 角色资产持久化 -> Playtest 播放
- 后端：完整测试 403 项通过；最终边界调整后相关测试 96 项通过
- 前端：完整测试 413 项通过；最终调整后 Quick Start 测试 15 项通过
- 类型检查、Lint、构建、Ruff、导入边界和锁文件检查均通过

## 隐私检查

- 已扫描本 PR 相对最新 main 的完整差异
- 未包含 .env、API Key、Token、密码、真实服务或存储地址、测试账号、本地数据库和 E2E 临时脚本
- 差异中的网址仅为测试占位地址、代码域名占位符及依赖锁文件中的公开包下载地址