### PR TITLE
feat(generation): 支持自定义动作生成

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/impl/character_generator.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/impl/character_generator.py
@@ -29,9 +29,9 @@ from windup_ai_engine.ports import (
 from windup_ai_engine.postprocess import align_bottom_center, frame_durations
 from windup_ai_engine.slicing import dead_frame_indices, loop_seam, motion_scale
 from windup_ai_engine.strategy.base import (
-    CYCLIC_ACTIONS,
     ROUTE_MATRIX,
     DerivationStrategy,
+    is_cyclic,
 )
 
 # ── 进度刻度:整条生产线只有一个 total ────────────────────────────────────────
@@ -164,7 +164,7 @@ class CharacterGenerator(CharacterGeneratorPort):
         return ActionQuality(
             motion_scale=motion_scale(frames),
             dead_frames=dead_frame_indices(frames),
-            loop_seam=loop_seam(frames) if action.action in CYCLIC_ACTIONS else None,
+            loop_seam=loop_seam(frames) if is_cyclic(action) else None,
         )
 
     def _lastmile(

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
@@ -1,6 +1,7 @@
 """prompt:各动作的生成提示词与装配。"""
 
 from .actions import build_attack_prompt, build_idle_prompt
+from .custom import MAX_ACTION_CHARS, build_custom_prompt
 from .jump import JUMP_PHASES, build_jump_prompt
 from .walk import build_walk_prompt
 
@@ -10,4 +11,6 @@ __all__ = [
     "build_jump_prompt",
     "build_idle_prompt",
     "build_attack_prompt",
+    "build_custom_prompt",
+    "MAX_ACTION_CHARS",
 ]

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/custom.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/custom.py
@@ -1,21 +1,8 @@
 """自定义动作 i2v 提示词(#239)。
 
-与 walk / jump / idle / attack 的根本差别:那四个的动作内容是我们手写、逐句实测过的;
-custom 的动作内容来自用户,我们**只提供骨架**。
-
-**骨架不是装饰,它是这条路线能用的全部原因。** 把用户那句话直接丢给 i2v,会一次丢掉四项
-拿实测换来的锁:
-
-  ① **朝向锁**。提示词朝向必须与母版一致(三次实测,见 :mod:`..master_prep`)。给正面母版
-     喂侧向词,模型会靠"转身"调和图文矛盾 —— 早期"正面母版必转身"的结论正是这么造成的。
-  ② **只写正向词**。这个 i2v 接口没有 negative_prompt,写"不要 X"会让 X 被 latch 进画面。
-     所以骨架里一句否定式都没有,连"不转身"也写成 "keeps facing right"。
-  ③ **装备存在无关**(#195)。模板里一旦出现装备名词就是在断言该物件存在:母版没有斗篷时
-     模型会为了满足文字凭空长一件,而母版真有的特征(颈后软管)反被挤掉。实测同一母版
-     只换提示词,斗篷 16/16 帧 → 0/20 帧。故衣饰/手持物一律写成存在无关的保持句。
-  ④ **一次性动作要"只做一次 + 终态保持"**。不写会在 5 秒内复读第二次(实测)。
-
-用户那句描述只填"做什么动作"这一段,其余全由骨架给。
+动作内容来自用户,本模块只提供骨架。骨架负责四件用户那句话给不了的事:朝向锁、只写正向词
+(该接口无 negative_prompt,否定词里的名词会被 latch 进画面)、装备存在无关句(#195)、
+一次性动作的单次 + 终态保持。
 """
 
 from __future__ import annotations
@@ -24,14 +11,9 @@ from windup_common.models import Facing
 
 __all__ = ["build_custom_prompt", "MAX_ACTION_CHARS"]
 
-# 用户描述的长度上限。不是接口限制(kling 的 prompt 可以很长),而是**产品判断**:
-# 描述越长越容易夹带角色外观("穿红裙的女孩挥手"),而外观由母版承载,再写一遍会和母版打架。
-# 超长时在入口截断并不合适(会截出半句),故由调用方校验、这里只做兜底断言。
+# 不是接口限制,是产品判断:描述越长越容易夹带角色外观,而外观由母版承载,写两遍会打架。
 MAX_ACTION_CHARS = 200
 
-# 骨架的三段,与 walk/jump/actions 里那几套同源(措辞逐字对齐,便于日后一起改)。
-
-# 朝向锁:两个朝向各一句,且都是正向表述。
 _FACING_LOCK = {
     Facing.SIDE: (
         "seen from the side facing right, staying in SIDE VIEW facing right the whole time, "
@@ -43,26 +25,18 @@ _FACING_LOCK = {
     ),
 }
 
-# 存在无关的衣饰 / 手持物保持句(#195)。既锁住"别乱动",又不断言角色有什么。
+# 存在无关:锁住"别乱动",但不断言角色有什么(#195)。
 _KEEP_WHAT_IT_HAS = (
     "whatever the character already wears or carries keeps its own shape and moves with the body, "
     "anything held in the hands stays in the same grip at the same angle"
 )
 
-# 循环类:可无缝首尾相接 + 不整体位移(位移交引擎当 root motion)。
-#
-# **刻意不写"在地面上""双脚可见"。** 那是"着地 / 直立 / 双足"这一类动作的前提,不是所有
-# 动作的前提 —— 游泳、飞行、攀爬、躺卧都不成立。而文字与动作矛盾时模型会自己找辙调和
-# (实测:给正面母版喂侧走词,它靠转身来调和图文矛盾),于是"游泳"+"留在地面"必然出乱麻。
+# 两条尾句都刻意不写"在地面上 / 双脚可见 / 回到直立站姿"——那些是着地直立类动作的前提,
+# 游泳、飞行、攀爬、倒地都不成立,而文字与动作矛盾时模型会自己找辙调和。
 _CYCLIC_TAIL = (
     "The motion is one smooth repeating cycle that returns to its starting pose, "
     "and the character stays centered in the same spot in frame."
 )
-
-# 一次性类:只做一次 + 终态保持(防 5s 内复读)。
-#
-# **刻意不写"回到直立站姿"。** 潜水、倒地、坐下的终态都不是站着;硬写会让模型在动作末尾
-# 把角色强行掰回站姿。只要求"保持最后那个姿态",不规定那是什么姿态。
 _ONESHOT_TAIL = (
     "The character performs this ONCE as one single committed motion, "
     "then holds the final pose and stays still."
@@ -75,34 +49,23 @@ def build_custom_prompt(
     facing: Facing | str = Facing.SIDE,
     cyclic: bool = False,
 ) -> str:
-    """把用户自述的动作嵌进已验证的机制骨架。
+    """把用户自述的动作嵌进骨架。
 
     Args:
-        action: 用户写的动作内容(如 "waves the right hand above the head")。
-            **只写做什么动作**;写角色外观会和母版打架(见模块 docstring ③)。
+        action: 动作内容(如 "waves the right hand above the head")。只写做什么动作。
         facing: 母版朝向。**必须与母版一致**,否则模型靠转身调和矛盾。
-        cyclic: 是否循环播放。决定用闭环尾句还是"只做一次"尾句,
-            并与 ``slicing`` 走 pick_cycle / pick_oneshot 保持同一口径。
+        cyclic: 是否循环。与 slicing 走 pick_cycle / pick_oneshot 同一口径。
 
     Raises:
-        ValueError: 动作描述为空,或超过 :data:`MAX_ACTION_CHARS`。
-            空描述不给兜底默认动作 —— 那会让调用方付一次 i2v 的钱拿到一段站立不动的视频,
-            而帧数时长全对、看不出是"描述丢了"。
+        ValueError: 描述为空或超长。空描述不兜底默认动作——那会付一次 i2v 的钱拿到一段
+            站着不动的视频,而帧数时长全对、看不出描述丢了。
     """
     text = (action or "").strip()
     if not text:
-        raise ValueError("自定义动作的描述不能为空;空描述会付一次 i2v 的钱拿到一段站着不动的视频")
+        raise ValueError("自定义动作的描述不能为空")
     if len(text) > MAX_ACTION_CHARS:
-        raise ValueError(
-            f"自定义动作描述 {len(text)} 字,超过上限 {MAX_ACTION_CHARS}。"
-            "过长的描述通常在复述角色外观,而外观由母版承载、再写一遍会和母版打架"
-        )
-    # 非法朝向在此炸掉,别静默落到某一支(理由见 prompt.walk 同处注释)。
-    lock = _FACING_LOCK[Facing(facing)]
+        raise ValueError(f"自定义动作描述 {len(text)} 字,超过上限 {MAX_ACTION_CHARS}")
+    lock = _FACING_LOCK[Facing(facing)]      # 非法朝向要炸,不静默落到某一支
     tail = _CYCLIC_TAIL if cyclic else _ONESHOT_TAIL
-
-    # 顺序有讲究:先钉朝向(最强约束放最前),再给用户的动作内容,再补存在无关的保持句,
-    # 最后是循环性尾句。与 walk/attack 那几套的句序一致。
-    # 刻意不再补"上半身平稳 / 双腿可见":那两句同样只对着地直立的动作成立 ——
-    # 游泳靠上肢划水,上身恰恰不能稳。骨架只保留对任何动作都成立的部分。
+    # 朝向放最前:最强的约束先钉。
     return f"The character {lock}: {text}, {_KEEP_WHAT_IT_HAS}. {tail}"

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/custom.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/custom.py
@@ -1,0 +1,102 @@
+"""自定义动作 i2v 提示词(#239)。
+
+与 walk / jump / idle / attack 的根本差别:那四个的动作内容是我们手写、逐句实测过的;
+custom 的动作内容来自用户,我们**只提供骨架**。
+
+**骨架不是装饰,它是这条路线能用的全部原因。** 把用户那句话直接丢给 i2v,会一次丢掉四项
+拿实测换来的锁:
+
+  ① **朝向锁**。提示词朝向必须与母版一致(三次实测,见 :mod:`..master_prep`)。给正面母版
+     喂侧向词,模型会靠"转身"调和图文矛盾 —— 早期"正面母版必转身"的结论正是这么造成的。
+  ② **只写正向词**。这个 i2v 接口没有 negative_prompt,写"不要 X"会让 X 被 latch 进画面。
+     所以骨架里一句否定式都没有,连"不转身"也写成 "keeps facing right"。
+  ③ **装备存在无关**(#195)。模板里一旦出现装备名词就是在断言该物件存在:母版没有斗篷时
+     模型会为了满足文字凭空长一件,而母版真有的特征(颈后软管)反被挤掉。实测同一母版
+     只换提示词,斗篷 16/16 帧 → 0/20 帧。故衣饰/手持物一律写成存在无关的保持句。
+  ④ **一次性动作要"只做一次 + 终态保持"**。不写会在 5 秒内复读第二次(实测)。
+
+用户那句描述只填"做什么动作"这一段,其余全由骨架给。
+"""
+
+from __future__ import annotations
+
+from windup_common.models import Facing
+
+__all__ = ["build_custom_prompt", "MAX_ACTION_CHARS"]
+
+# 用户描述的长度上限。不是接口限制(kling 的 prompt 可以很长),而是**产品判断**:
+# 描述越长越容易夹带角色外观("穿红裙的女孩挥手"),而外观由母版承载,再写一遍会和母版打架。
+# 超长时在入口截断并不合适(会截出半句),故由调用方校验、这里只做兜底断言。
+MAX_ACTION_CHARS = 200
+
+# 骨架的三段,与 walk/jump/actions 里那几套同源(措辞逐字对齐,便于日后一起改)。
+
+# 朝向锁:两个朝向各一句,且都是正向表述。
+_FACING_LOCK = {
+    Facing.SIDE: (
+        "seen from the side facing right, staying in SIDE VIEW facing right the whole time, "
+        "the torso and hips keep pointing to the right"
+    ),
+    Facing.FRONT: (
+        "facing the viewer, the character keeps FACING THE VIEWER the whole time "
+        "and stays centered in frame"
+    ),
+}
+
+# 存在无关的衣饰 / 手持物保持句(#195)。既锁住"别乱动",又不断言角色有什么。
+_KEEP_WHAT_IT_HAS = (
+    "whatever the character already wears or carries keeps its own shape and moves with the body, "
+    "anything held in the hands stays in the same grip at the same angle"
+)
+
+# 循环类:强调可无缝首尾相接、身体不整体位移(位移交引擎当 root motion)。
+_CYCLIC_TAIL = (
+    "The motion is one smooth repeating cycle that returns to the starting pose, "
+    "the character stays in the same spot on the ground, both feet stay clearly visible."
+)
+
+# 一次性类:只做一次 + 终态保持(防复读)。
+_ONESHOT_TAIL = (
+    "The character performs this ONCE as one single committed motion, "
+    "then settles back into a calm upright standing pose and holds that pose, standing steady."
+)
+
+
+def build_custom_prompt(
+    action: str,
+    *,
+    facing: Facing | str = Facing.SIDE,
+    cyclic: bool = False,
+) -> str:
+    """把用户自述的动作嵌进已验证的机制骨架。
+
+    Args:
+        action: 用户写的动作内容(如 "waves the right hand above the head")。
+            **只写做什么动作**;写角色外观会和母版打架(见模块 docstring ③)。
+        facing: 母版朝向。**必须与母版一致**,否则模型靠转身调和矛盾。
+        cyclic: 是否循环播放。决定用闭环尾句还是"只做一次"尾句,
+            并与 ``slicing`` 走 pick_cycle / pick_oneshot 保持同一口径。
+
+    Raises:
+        ValueError: 动作描述为空,或超过 :data:`MAX_ACTION_CHARS`。
+            空描述不给兜底默认动作 —— 那会让调用方付一次 i2v 的钱拿到一段站立不动的视频,
+            而帧数时长全对、看不出是"描述丢了"。
+    """
+    text = (action or "").strip()
+    if not text:
+        raise ValueError("自定义动作的描述不能为空;空描述会付一次 i2v 的钱拿到一段站着不动的视频")
+    if len(text) > MAX_ACTION_CHARS:
+        raise ValueError(
+            f"自定义动作描述 {len(text)} 字,超过上限 {MAX_ACTION_CHARS}。"
+            "过长的描述通常在复述角色外观,而外观由母版承载、再写一遍会和母版打架"
+        )
+    # 非法朝向在此炸掉,别静默落到某一支(理由见 prompt.walk 同处注释)。
+    lock = _FACING_LOCK[Facing(facing)]
+    tail = _CYCLIC_TAIL if cyclic else _ONESHOT_TAIL
+
+    # 顺序有讲究:先钉朝向(最强约束放最前),再给用户的动作内容,再补存在无关的保持句,
+    # 最后是循环性尾句。与 walk/attack 那几套的句序一致。
+    return (
+        f"The character {lock}: {text}, {_KEEP_WHAT_IT_HAS}, "
+        f"the upper body stays calm and the legs clearly visible. {tail}"
+    )

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/custom.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/custom.py
@@ -49,16 +49,23 @@ _KEEP_WHAT_IT_HAS = (
     "anything held in the hands stays in the same grip at the same angle"
 )
 
-# 循环类:强调可无缝首尾相接、身体不整体位移(位移交引擎当 root motion)。
+# 循环类:可无缝首尾相接 + 不整体位移(位移交引擎当 root motion)。
+#
+# **刻意不写"在地面上""双脚可见"。** 那是"着地 / 直立 / 双足"这一类动作的前提,不是所有
+# 动作的前提 —— 游泳、飞行、攀爬、躺卧都不成立。而文字与动作矛盾时模型会自己找辙调和
+# (实测:给正面母版喂侧走词,它靠转身来调和图文矛盾),于是"游泳"+"留在地面"必然出乱麻。
 _CYCLIC_TAIL = (
-    "The motion is one smooth repeating cycle that returns to the starting pose, "
-    "the character stays in the same spot on the ground, both feet stay clearly visible."
+    "The motion is one smooth repeating cycle that returns to its starting pose, "
+    "and the character stays centered in the same spot in frame."
 )
 
-# 一次性类:只做一次 + 终态保持(防复读)。
+# 一次性类:只做一次 + 终态保持(防 5s 内复读)。
+#
+# **刻意不写"回到直立站姿"。** 潜水、倒地、坐下的终态都不是站着;硬写会让模型在动作末尾
+# 把角色强行掰回站姿。只要求"保持最后那个姿态",不规定那是什么姿态。
 _ONESHOT_TAIL = (
     "The character performs this ONCE as one single committed motion, "
-    "then settles back into a calm upright standing pose and holds that pose, standing steady."
+    "then holds the final pose and stays still."
 )
 
 
@@ -96,7 +103,6 @@ def build_custom_prompt(
 
     # 顺序有讲究:先钉朝向(最强约束放最前),再给用户的动作内容,再补存在无关的保持句,
     # 最后是循环性尾句。与 walk/attack 那几套的句序一致。
-    return (
-        f"The character {lock}: {text}, {_KEEP_WHAT_IT_HAS}, "
-        f"the upper body stays calm and the legs clearly visible. {tail}"
-    )
+    # 刻意不再补"上半身平稳 / 双腿可见":那两句同样只对着地直立的动作成立 ——
+    # 游泳靠上肢划水,上身恰恰不能稳。骨架只保留对任何动作都成立的部分。
+    return f"The character {lock}: {text}, {_KEEP_WHAT_IT_HAS}. {tail}"

--- a/backend/packages/ai_engine/src/windup_ai_engine/strategy/base.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/strategy/base.py
@@ -30,6 +30,9 @@ ROUTE_MATRIX: dict[ActionType, GenRoute] = {
     # **2026-08-07 定案**:#53 原设计的 ¥0 程序化 Idle-B(局部网格呼吸)放弃 —— 做不出
     # 可用效果,idle 认这份 i2v 的钱。GenRoute.PROC_IDLE 与 ProcIdleStrategy 已一并移除。
     ActionType.IDLE: GenRoute.VIDEO_I2V,
+    # 自定义动作走视频路线(#239)。为什么不是逐帧:用户自述的动作绝大多数带位移或连续
+    # 姿态变化,而逐帧独立生成锁不住跨帧连续性 —— 与 walk 走视频是同一条理由。
+    ActionType.CUSTOM: GenRoute.VIDEO_I2V,
 }
 
 # 循环类动作:抽单步态周期闭环。一次性动作**不能闭环**(首尾姿态不同,强行闭环会把
@@ -41,6 +44,21 @@ ROUTE_MATRIX: dict[ActionType, GenRoute] = {
 CYCLIC_ACTIONS: frozenset[ActionType] = frozenset(
     {ActionType.IDLE, ActionType.WALK, ActionType.RUN}
 )
+
+
+def is_cyclic(action: ActionSpec) -> bool:
+    """这次生成要不要按"单周期闭环"处理。
+
+    **不要直接判 `action.action in CYCLIC_ACTIONS`** —— 那张表只覆盖写死的那几个动作,
+    对 ``CUSTOM`` 恒为 False,于是用户勾了"循环播放"的自定义动作会被当成一次性,
+    抽帧不闭环、也不量 loop_seam。而这个错是静默的:帧数、时长、成色全部正常。
+
+    ``CUSTOM`` 的循环性由调用方在 ``ActionSpec.cyclic`` 显式声明(该字段对 custom
+    必填,见其校验器),所以这里不需要兜底默认值。
+    """
+    if action.action is ActionType.CUSTOM:
+        return bool(action.cyclic)
+    return action.action in CYCLIC_ACTIONS
 
 # 本矩阵的形状本身有个已知边界,记录在此以免后来者按错误前提扩展:
 # 它是「动作类型 → 路线」的一对一映射,隐含前提是"路线由动作的物理性质唯一决定"。

--- a/backend/packages/ai_engine/src/windup_ai_engine/strategy/base.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/strategy/base.py
@@ -24,15 +24,14 @@ ROUTE_MATRIX: dict[ActionType, GenRoute] = {
     ActionType.RUN: GenRoute.VIDEO_I2V,
     ActionType.JUMP: GenRoute.VIDEO_I2V,
     ActionType.ATTACK: GenRoute.VIDEO_I2V,
+    # 自定义动作(#239):用户自述的动作绝大多数带位移或连续姿态变化,而逐帧独立生成锁不住
+    # 跨帧连续性 —— 与 walk 走视频是同一条理由。
     ActionType.CUSTOM: GenRoute.VIDEO_I2V,
     ActionType.HIT: GenRoute.PER_FRAME,
     # idle 走 i2v(build_idle_prompt:躯干缓慢起伏呼吸)。
     # **2026-08-07 定案**:#53 原设计的 ¥0 程序化 Idle-B(局部网格呼吸)放弃 —— 做不出
     # 可用效果,idle 认这份 i2v 的钱。GenRoute.PROC_IDLE 与 ProcIdleStrategy 已一并移除。
     ActionType.IDLE: GenRoute.VIDEO_I2V,
-    # 自定义动作走视频路线(#239)。为什么不是逐帧:用户自述的动作绝大多数带位移或连续
-    # 姿态变化,而逐帧独立生成锁不住跨帧连续性 —— 与 walk 走视频是同一条理由。
-    ActionType.CUSTOM: GenRoute.VIDEO_I2V,
 }
 
 # 循环类动作:抽单步态周期闭环。一次性动作**不能闭环**(首尾姿态不同,强行闭环会把

--- a/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
@@ -23,11 +23,12 @@ from windup_ai_engine.postprocess import master_pixel_spec, pixelate_frames
 from windup_ai_engine.slicing import extract_all_frames_bytes, pick_cycle, pick_oneshot
 from windup_ai_engine.prompt import (
     build_attack_prompt,
+    build_custom_prompt,
     build_idle_prompt,
     build_jump_prompt,
     build_walk_prompt,
 )
-from windup_ai_engine.strategy.base import CYCLIC_ACTIONS, DerivationStrategy
+from windup_ai_engine.strategy.base import DerivationStrategy, is_cyclic
 
 
 class VideoFrameStrategy(DerivationStrategy):
@@ -46,16 +47,14 @@ class VideoFrameStrategy(DerivationStrategy):
 
     def _build_prompt(self, action: ActionSpec) -> str:
         """按动作类型选提示词;朝向随 ActionSpec.facing。"""
-        if action.motion_prompt:
-            facing = (
-                "SIDE VIEW facing right"
-                if action.facing.value == "side"
-                else "FACING THE VIEWER"
-            )
-            return (
-                f"Perform exactly this motion: {action.motion_prompt}. {facing}. "
-                "One single committed motion, preserving the character's identity, proportions, "
-                "clothing, and colors. Keep the whole body visible and return to a stable pose."
+        # custom 单独一支:它的动作内容来自用户,只能由 build_custom_prompt 把那句话
+        # 嵌进机制骨架(朝向锁 / 正向措辞 / 装备存在无关 / 一次性的单次+终态保持)。
+        # 不能塞进下面那张表 —— 那张表里的 builder 只接 facing。
+        if action.action is ActionType.CUSTOM:
+            return build_custom_prompt(
+                action.custom_action or "",
+                facing=action.facing,
+                cyclic=bool(action.cyclic),
             )
         builders = {
             ActionType.JUMP: build_jump_prompt,
@@ -91,7 +90,7 @@ class VideoFrameStrategy(DerivationStrategy):
             _first = _img(self._matte.cutout(_png(dense[0])))
             _ys, _ = np.where(np.asarray(_first)[:, :, 3] > 128)
             ref_h = float(_ys.max() - _ys.min()) if len(_ys) else None
-        if action.action in CYCLIC_ACTIONS:
+        if is_cyclic(action):
             progress.step("derive", 1, 3, f"步态周期取 {n} 帧(无缝 loop)+ 抠图")
             picked = pick_cycle(dense, n)                   # 单周期闭环(#21)
         else:

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -139,10 +139,40 @@ class _LogProgress:
         logger.info("[gen] %s %s/%s %s", stage, i, total, note)
 
 
+# 本期开放的视频模型。**只三个**,因为每个模型的入参形状不同(image_list /
+# input_reference / Fal 队列 + `Authorization: Key`),全开等于把三套协议适配塞进一个改动。
+# 取舍写在这里而不是文档里,是为了让改这张表的人同时看到代价。Refs #239。
+ALLOWED_VIDEO_MODELS: dict[str, str] = {
+    # 现役、稳;本地首帧直接吃 JPG base64,不需要公网 URL。
+    "kling-v2-5-turbo": "默认。稳,本地首帧即可",
+    # 台账实测步态最自然(放低武器迈大步),但更贵,且**只吃公网图 URL**(不吃 base64)。
+    "veo3.1": "步态最自然,但更贵且需公网图 URL",
+    # 有 motion-control,对"自定义动作"可能最有价值,待实测。
+    "kling-v2-6": "有 motion-control,自定义动作潜力最大",
+}
+
+
+def _resolve_video_model(name: str | None) -> str | None:
+    """校验并返回视频模型名;``None`` 表示用部署默认值。
+
+    非法取值**在入口炸**,不等到付费调用才失败 —— 网关对没开通的模型返回的错误
+    长得像"模型不存在",排查时容易怀疑错方向(今天在 Tripo 上刚踩过同型的坑)。
+    """
+    if name is None:
+        return None
+    if name not in ALLOWED_VIDEO_MODELS:
+        raise ValueError(
+            f"视频模型 {name!r} 不在本期开放列表内。可选:"
+            + "；".join(f"{k}({v})" for k, v in ALLOWED_VIDEO_MODELS.items())
+        )
+    return name
+
+
 def _to_engine_action(t) -> EngineActionType:
     """generation.ActionType → 引擎 common.ActionType(按值映射)。
 
-    所有 API 动作类型都按值映射到引擎动作类型。
+    walk/idle/attack/**custom** 直通(custom 自 #239 起引擎已支持)。
+    引擎仍未覆盖的类型在此抛带原因的错误,而不是让请求走到一半失败。
     """
     try:
         return EngineActionType(t.value)
@@ -163,6 +193,8 @@ class ActionTaskExecutor:
         session_factory: Callable[[], Session] | None = None,
     ) -> None:
         self._generator = generator          # None → 懒加载真实装配
+        # 按视频模型名分桶的 generator 缓存(模型是 provider 的构造参数,不能事后换)
+        self._by_model: dict[str | None, CharacterGeneratorPort] = {}
         self._upload = upload                # None → 真实对象存储上传
         self._fetch_master = fetch_master    # None → 下载 reference_image_urls[0]
         self._fetch_constraints = fetch_constraints  # None → 查 project 全局约束
@@ -228,15 +260,26 @@ class ActionTaskExecutor:
         if cons.style:
             desc_parts.append(f"Art style: {cons.style}")
         card = CharacterCard(name=f"char-{input.character_id}", desc=" ".join(desc_parts))
+        engine_action = _to_engine_action(input.action_type)
+        # custom 的动作内容与循环性只能随请求给 —— 引擎侧对这两个字段有必填校验,
+        # 缺了会在构造 ActionSpec 时就炸(而不是等到付费调用之后)。
+        extra: dict[str, object] = {}
+        if engine_action is EngineActionType.CUSTOM:
+            if input.loop is None:
+                raise ValueError(
+                    "自定义动作必须显式给 loop(是否循环播放)。不猜 —— 猜错会把一次性动作"
+                    "强行首尾闭环,而帧数/时长/成色全部正常、没有任何一道会红"
+                )
+            extra = {"custom_action": input.custom_prompt or "", "cyclic": bool(input.loop)}
         action = ActionSpec(
-            action=_to_engine_action(input.action_type),
-            motion_prompt=input.custom_prompt if input.action_type is ActionType.CUSTOM else None,
+            action=engine_action,
             poses=[""] * input.num_frames,
             facing=cons.facing,
             stylize=cons.stylize,
+            **extra,
         )
         progress: ProgressPort = _LogProgress()
-        generated = self._get_generator().generate(
+        generated = self._get_generator(_resolve_video_model(input.video_model)).generate(
             card, action, master, progress, canvas=(cons.sprite_w, cons.sprite_h)
         )
 
@@ -249,9 +292,20 @@ class ActionTaskExecutor:
         ]
         return {"type": "character_action", "action_type": input.action_type.value, "frames": frames}
 
-    def _get_generator(self) -> CharacterGeneratorPort:
-        """懒装配真实 CharacterGenerator(视频路线 + 桩路线)。"""
-        if self._generator is None:
+    def _get_generator(self, video_model: str | None = None) -> CharacterGeneratorPort:
+        """懒装配真实 CharacterGenerator(视频路线 + 桩路线)。
+
+        ``video_model`` 非 None 时**另装一套**并按模型名缓存:视频 provider 的模型是构造
+        参数,不能在一个已装好的 generator 上换。不按模型分桶的话,第一个请求指定了
+        veo3.1 之后,后续所有请求都会沿用它 —— 那是"看起来指定了模型、实际用的是别人的"
+        这类静默错误。注入 generator(测试)时一律直接返回注入的那个,不受本参数影响。
+        """
+        if self._generator is not None:
+            return self._generator
+        cached = self._by_model.get(video_model)
+        if cached is not None:
+            return cached
+        if True:
             from windup_ai_engine.impl import CharacterGenerator
             from windup_ai_engine.strategy.concrete import (
                 PerFrameStrategy,
@@ -265,7 +319,7 @@ class ActionTaskExecutor:
             )
 
             matte = OnnxU2NetMatteProvider()
-            video = SufyVideoProvider()
+            video = SufyVideoProvider(model=video_model)
             image = SufyImageProvider()
             # 只装当前 GenRoute 真有的路线。曾多装一个 PROC_IDLE:该枚举值与
             # ProcIdleStrategy 都已随"程序化待机放弃"一起删除,而这行留着,于是**每个**
@@ -283,8 +337,9 @@ class ActionTaskExecutor:
                     f"GenRoute 新增了 {sorted(r.value for r in missing)} 但 executor 未装配;"
                     "补上或在此显式说明为何不装。"
                 )
-            self._generator = CharacterGenerator(strategies)
-        return self._generator
+            gen = CharacterGenerator(strategies)
+        self._by_model[video_model] = gen
+        return gen
 
     def _download_master(self, input: CharacterActionInput) -> bytes:
         if not input.reference_image_urls:

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -139,7 +139,7 @@ class _LogProgress:
         logger.info("[gen] %s %s/%s %s", stage, i, total, note)
 
 
-# 本期开放的视频模型。**只三个**,因为每个模型的入参形状不同(image_list /
+# 本期开放的视频模型。**只两个**,因为每个模型的入参形状不同(image_list /
 # input_reference / Fal 队列 + `Authorization: Key`),全开等于把三套协议适配塞进一个改动。
 # 取舍写在这里而不是文档里,是为了让改这张表的人同时看到代价。Refs #239。
 ALLOWED_VIDEO_MODELS: dict[str, str] = {
@@ -321,39 +321,38 @@ class ActionTaskExecutor:
         cached = self._by_model.get(video_model)
         if cached is not None:
             return cached
-        if True:
-            from windup_ai_engine.impl import CharacterGenerator
-            from windup_ai_engine.strategy.concrete import (
-                PerFrameStrategy,
-                VideoFrameStrategy,
-            )
-            from windup_common.models import GenRoute
-            from windup_framework.providers import (
-                OnnxU2NetMatteProvider,
-                SufyImageProvider,
-                SufyVideoProvider,
-            )
+        from windup_ai_engine.impl import CharacterGenerator
+        from windup_ai_engine.strategy.concrete import (
+            PerFrameStrategy,
+            VideoFrameStrategy,
+        )
+        from windup_common.models import GenRoute
+        from windup_framework.providers import (
+            OnnxU2NetMatteProvider,
+            SufyImageProvider,
+            SufyVideoProvider,
+        )
 
-            matte = OnnxU2NetMatteProvider()
-            video = SufyVideoProvider(model=video_model)
-            image = SufyImageProvider()
-            # 只装当前 GenRoute 真有的路线。曾多装一个 PROC_IDLE:该枚举值与
-            # ProcIdleStrategy 都已随"程序化待机放弃"一起删除,而这行留着,于是**每个**
-            # 动作任务都在 import 期 AttributeError —— 注入 generator 的测试走不到这条
-            # 装配路径,所以测试全绿而真实调用全崩(FennoAI 逮到,2026-08-10)。
-            # 加一条断言:将来 GenRoute 新增成员时,漏装会在这里立刻暴露,而不是等到
-            # 某个动作第一次被请求。
-            strategies = {
-                GenRoute.VIDEO_I2V: VideoFrameStrategy(video, matte),
-                GenRoute.PER_FRAME: PerFrameStrategy(image, matte),
-            }
-            missing = set(GenRoute) - set(strategies)
-            if missing:
-                raise RuntimeError(
-                    f"GenRoute 新增了 {sorted(r.value for r in missing)} 但 executor 未装配;"
-                    "补上或在此显式说明为何不装。"
-                )
-            gen = CharacterGenerator(strategies)
+        matte = OnnxU2NetMatteProvider()
+        video = SufyVideoProvider(model=video_model)
+        image = SufyImageProvider()
+        # 只装当前 GenRoute 真有的路线。曾多装一个 PROC_IDLE:该枚举值与
+        # ProcIdleStrategy 都已随"程序化待机放弃"一起删除,而这行留着,于是**每个**
+        # 动作任务都在 import 期 AttributeError —— 注入 generator 的测试走不到这条
+        # 装配路径,所以测试全绿而真实调用全崩(FennoAI 逮到,2026-08-10)。
+        # 加一条断言:将来 GenRoute 新增成员时,漏装会在这里立刻暴露,而不是等到
+        # 某个动作第一次被请求。
+        strategies = {
+            GenRoute.VIDEO_I2V: VideoFrameStrategy(video, matte),
+            GenRoute.PER_FRAME: PerFrameStrategy(image, matte),
+        }
+        missing = set(GenRoute) - set(strategies)
+        if missing:
+            raise RuntimeError(
+                f"GenRoute 新增了 {sorted(r.value for r in missing)} 但 executor 未装配;"
+                "补上或在此显式说明为何不装。"
+            )
+        gen = CharacterGenerator(strategies)
         self._by_model[video_model] = gen
         return gen
 

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -32,6 +33,7 @@ from windup_app.server.orchestrator.model import (
 
 if TYPE_CHECKING:
     from windup_ai_engine.ports import CharacterGeneratorPort, ProgressPort
+    from windup_framework.providers import ImageProvider, MatteProvider
 
 logger = logging.getLogger("windup.generation.executor")
 
@@ -189,6 +191,13 @@ class ActionTaskExecutor:
         self._generator = generator          # None → 懒加载真实装配
         # 按视频模型名分桶的 generator 缓存(模型是 provider 的构造参数,不能事后换)
         self._by_model: dict[str | None, CharacterGeneratorPort] = {}
+        # 抠图 / 图生图 provider 与视频模型无关,所有模型桶共用一份:每个抠图实例都会
+        # 各自惰性加载一份 ONNX 会话,按桶各建等于把同一个模型在进程里装多次。
+        self._matte: MatteProvider | None = None
+        self._image: ImageProvider | None = None
+        # 本执行器是进程级单例,而每个请求起一个线程跑 run_action_task,上面几个缓存
+        # 都是跨线程共用的可变状态。缺锁时并发首请求会各装一套(见 _get_generator)。
+        self._assembly_lock = threading.Lock()
         self._upload = upload                # None → 真实对象存储上传
         self._fetch_master = fetch_master    # None → 下载 reference_image_urls[0]
         self._fetch_constraints = fetch_constraints  # None → 查 project 全局约束
@@ -255,8 +264,9 @@ class ActionTaskExecutor:
             desc_parts.append(f"Art style: {cons.style}")
         card = CharacterCard(name=f"char-{input.character_id}", desc=" ".join(desc_parts))
         engine_action = _to_engine_action(input.action_type)
-        # custom 的动作内容与循环性只能随请求给 —— 引擎侧对这两个字段有必填校验,
-        # 缺了会在构造 ActionSpec 时就炸(而不是等到付费调用之后)。
+        # custom 的动作内容与循环性是 ActionSpec 的必填字段。但 cyclic 由本层补上默认值,
+        # 所以 ActionSpec 里那道 `cyclic is None` 守卫拦不到走这条路径的请求 —— 它保的是
+        # 其他直接构造 ActionSpec 的调用方。
         extra: dict[str, object] = {}
         if engine_action is EngineActionType.CUSTOM:
             # 缺 loop 时兜成一次性,依据是失败代价不对称:一次性误当循环会让末帧接回首帧
@@ -292,9 +302,20 @@ class ActionTaskExecutor:
         """
         if self._generator is not None:
             return self._generator
+        # 命中缓存的快路径不进锁,否则每个请求都要在这里排一次队。只有装配新桶才上锁,
+        # 锁内重查一次:两个线程同时错过同一个桶时,后进来的那个要看见前一个的成果。
         cached = self._by_model.get(video_model)
         if cached is not None:
             return cached
+        with self._assembly_lock:
+            cached = self._by_model.get(video_model)
+            if cached is None:
+                cached = self._assemble(video_model)
+                self._by_model[video_model] = cached
+            return cached
+
+    def _assemble(self, video_model: str | None) -> CharacterGeneratorPort:
+        """装一个模型桶。**调用方须持有 ``self._assembly_lock``**(会写共用 provider)。"""
         from windup_ai_engine.impl import CharacterGenerator
         from windup_ai_engine.strategy.concrete import (
             PerFrameStrategy,
@@ -307,15 +328,18 @@ class ActionTaskExecutor:
             SufyVideoProvider,
         )
 
-        matte = OnnxU2NetMatteProvider()
+        if self._matte is None:
+            self._matte = OnnxU2NetMatteProvider()
+        if self._image is None:
+            self._image = SufyImageProvider()
+        # 只有它随模型变 —— 模型是构造参数,换模型必须换实例。
         video = SufyVideoProvider(model=video_model)
-        image = SufyImageProvider()
         # 装配表必须与 GenRoute 对齐。下面那条断言让漏装在装配时暴露,而不是等到某个
         # 动作第一次被请求时才炸——注入 generator 的测试走不到这条装配路径,漏了会测试
         # 全绿而真实调用全崩。
         strategies = {
-            GenRoute.VIDEO_I2V: VideoFrameStrategy(video, matte),
-            GenRoute.PER_FRAME: PerFrameStrategy(image, matte),
+            GenRoute.VIDEO_I2V: VideoFrameStrategy(video, self._matte),
+            GenRoute.PER_FRAME: PerFrameStrategy(self._image, self._matte),
         }
         missing = set(GenRoute) - set(strategies)
         if missing:
@@ -323,9 +347,7 @@ class ActionTaskExecutor:
                 f"GenRoute 新增了 {sorted(r.value for r in missing)} 但 executor 未装配;"
                 "补上或在此显式说明为何不装。"
             )
-        gen = CharacterGenerator(strategies)
-        self._by_model[video_model] = gen
-        return gen
+        return CharacterGenerator(strategies)
 
     def _download_master(self, input: CharacterActionInput) -> bytes:
         if not input.reference_image_urls:

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -25,7 +25,6 @@ from windup_common.models import ActionSpec, ActionType as EngineActionType, Cha
 from windup_app.server.orchestrator import task_repo
 from windup_app.server.orchestrator._fetch import fetch_own_media
 from windup_app.server.orchestrator.model import (
-    ActionType,
     CharacterActionInput,
     CharacterImageInput,
     TaskStatus,

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -138,32 +138,19 @@ class _LogProgress:
         logger.info("[gen] %s %s/%s %s", stage, i, total, note)
 
 
-# 本期开放的视频模型。**只两个**,因为每个模型的入参形状不同(image_list /
-# input_reference / Fal 队列 + `Authorization: Key`),全开等于把三套协议适配塞进一个改动。
-# 取舍写在这里而不是文档里,是为了让改这张表的人同时看到代价。Refs #239。
+# 白名单而不是放开任意模型名:每个模型的入参形状不同(image_list / input_reference /
+# Fal 队列 + `Authorization: Key`)。列进来却没适配它的协议,等于"看起来能选、点了必然
+# 产生一个用不了的付费任务"。只列 SufyVideoProvider 真能建单的。Refs #239。
 ALLOWED_VIDEO_MODELS: dict[str, str] = {
-    # 现役、稳;本地首帧直接吃 JPG base64,不需要公网 URL。
     "kling-v2-5-turbo": "默认。稳,本地首帧即可",
-    # 有 motion-control,对"自定义动作"可能最有价值,待实测。
-    # 与默认那个同属 kling 系列,同样走 OpenAI 风格 `POST /videos` + `input_reference`
-    # (实测 kling 六档都能这么建单),所以 SufyVideoProvider 直接支持。
-    "kling-v2-6": "有 motion-control,自定义动作潜力最大",
+    "kling-v2-6": "有 motion-control",
 }
-
-# **veo3.1 刻意不在上面这张表里。** 它确实实测过步态最自然,但它只在 **Fal 队列协议**上
-# (`POST /queue/fal-ai/veo3.1/...`,鉴权 `Authorization: Key`,首帧只吃**公网 URL** 不吃
-# base64),而 `SufyVideoProvider` 走的是 OpenAI 风格 `POST /videos` + Bearer + base64
-# `input_reference`。把它列进可选值等于"看起来能选、点了必然产生一个用不了的付费任务" ——
-# 与本 PR 修的那个 custom(入口收下、引擎拒绝)是同一种病,不能一边修一边又造一个。
-# 要支持它得先实现 Fal 通路 + 首帧上传取公网 URL,那是另一个改动。
-# (FennoAI 评审逮到,2026-08-12。)
 
 
 def _resolve_video_model(name: str | None) -> str | None:
     """校验并返回视频模型名;``None`` 表示用部署默认值。
 
-    非法取值**在入口炸**,不等到付费调用才失败 —— 网关对没开通的模型返回的错误
-    长得像"模型不存在",排查时容易怀疑错方向(今天在 Tripo 上刚踩过同型的坑)。
+    非法取值在入口炸,不等到付费调用才失败。
     """
     if name is None:
         return None
@@ -256,7 +243,7 @@ class ActionTaskExecutor:
         ``_fit_to(png, sprite_w, sprite_h)``:引擎恒出 256,项目要 512 就等于二次
         重采样。而 ``_fit_to`` 用 ``Image.thumbnail`` —— 它**只缩不放**,放大方向
         根本不放大,只是把 256 的帧原尺寸居中贴进 512 画布,于是引擎刚对齐好的脚线
-        0.92 被挪到 0.709(2026-08-11 实测),角色不站在地上、跨动作对齐一并失效。
+        0.92 被挪到 0.709,角色不站在地上、跨动作对齐一并失效。
         现在把 ``canvas`` 交给引擎,它一次就出到项目尺寸,那一步整个不存在了。
         """
         if cons.directions > 1:
@@ -272,18 +259,8 @@ class ActionTaskExecutor:
         # 缺了会在构造 ActionSpec 时就炸(而不是等到付费调用之后)。
         extra: dict[str, object] = {}
         if engine_action is EngineActionType.CUSTOM:
-            # loop 缺失时用**一次性**兜底,而不是抛错。
-            #
-            # 初版是抛错(理由:"不猜"),但 FennoAI 评审指出那会让 quick-start 换个死法而已 ——
-            # 前端 `entities/generation/api.ts` 至今只发 action_type + custom_prompt,
-            # 而 quick-start 一有描述就发 type=custom,于是每个请求都在这里 FAILED。
-            # 本 PR 的目的是把 quick-start 救活,不是换一条报错。
-            #
-            # **这不是"按描述猜"**(那才是被禁的:从"走/挥"这类词推循环性,信号不可靠)。
-            # 这是一条基于**失败代价不对称**的显式产品默认:
-            #   · 把一次性动作误当循环 → 末帧接回首帧,肉眼可见的抽搐,产物不可用;
-            #   · 把循环动作误当一次性 → 只是不无缝闭环,产物仍可用。
-            # 所以缺信息时倒向一次性。前端补上勾选框后由它决定(见同 PR 的前端改动)。
+            # 缺 loop 时兜成一次性,依据是失败代价不对称:一次性误当循环会让末帧接回首帧
+            # 抽搐、产物不可用;反之只是不无缝闭环、仍可用。不从描述文字猜。
             cyclic = False if input.loop is None else bool(input.loop)
             extra = {"custom_action": input.custom_prompt or "", "cyclic": cyclic}
         action = ActionSpec(
@@ -308,12 +285,10 @@ class ActionTaskExecutor:
         return {"type": "character_action", "action_type": input.action_type.value, "frames": frames}
 
     def _get_generator(self, video_model: str | None = None) -> CharacterGeneratorPort:
-        """懒装配真实 CharacterGenerator(视频路线 + 桩路线)。
+        """懒装配 CharacterGenerator,按模型名分桶。
 
-        ``video_model`` 非 None 时**另装一套**并按模型名缓存:视频 provider 的模型是构造
-        参数,不能在一个已装好的 generator 上换。不按模型分桶的话,第一个请求指定了
-        veo3.1 之后,后续所有请求都会沿用它 —— 那是"看起来指定了模型、实际用的是别人的"
-        这类静默错误。注入 generator(测试)时一律直接返回注入的那个,不受本参数影响。
+        视频 provider 的模型是构造参数,不分桶的话第一个请求指定的模型会被后续所有请求
+        沿用,而调用方以为自己指定了。
         """
         if self._generator is not None:
             return self._generator
@@ -335,12 +310,9 @@ class ActionTaskExecutor:
         matte = OnnxU2NetMatteProvider()
         video = SufyVideoProvider(model=video_model)
         image = SufyImageProvider()
-        # 只装当前 GenRoute 真有的路线。曾多装一个 PROC_IDLE:该枚举值与
-        # ProcIdleStrategy 都已随"程序化待机放弃"一起删除,而这行留着,于是**每个**
-        # 动作任务都在 import 期 AttributeError —— 注入 generator 的测试走不到这条
-        # 装配路径,所以测试全绿而真实调用全崩(FennoAI 逮到,2026-08-10)。
-        # 加一条断言:将来 GenRoute 新增成员时,漏装会在这里立刻暴露,而不是等到
-        # 某个动作第一次被请求。
+        # 装配表必须与 GenRoute 对齐。下面那条断言让漏装在装配时暴露,而不是等到某个
+        # 动作第一次被请求时才炸——注入 generator 的测试走不到这条装配路径,漏了会测试
+        # 全绿而真实调用全崩。
         strategies = {
             GenRoute.VIDEO_I2V: VideoFrameStrategy(video, matte),
             GenRoute.PER_FRAME: PerFrameStrategy(image, matte),
@@ -484,7 +456,7 @@ class ImageTaskExecutor:
             img = image_gen.gen_image(prompt, refs)
             # 请求里的 width/height 此前被丢掉:入口收下并校验过它们(_validate_project_size),
             # 而 ImageProvider.gen_image 没有尺寸参数,模型出多大就返多大 —— 又一个"接了不
-            # 履约"的字段(2026-08-10 对抗复查发现)。模型本身不吃宽高,所以在这里落实。
+            # 履约"的字段。模型本身不吃宽高,所以在这里落实。
             urls.append(upload(_fit_to(img, input.width, input.height, smooth=True)))
         return urls
 

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -145,11 +145,19 @@ class _LogProgress:
 ALLOWED_VIDEO_MODELS: dict[str, str] = {
     # 现役、稳;本地首帧直接吃 JPG base64,不需要公网 URL。
     "kling-v2-5-turbo": "默认。稳,本地首帧即可",
-    # 台账实测步态最自然(放低武器迈大步),但更贵,且**只吃公网图 URL**(不吃 base64)。
-    "veo3.1": "步态最自然,但更贵且需公网图 URL",
     # 有 motion-control,对"自定义动作"可能最有价值,待实测。
+    # 与默认那个同属 kling 系列,同样走 OpenAI 风格 `POST /videos` + `input_reference`
+    # (实测 kling 六档都能这么建单),所以 SufyVideoProvider 直接支持。
     "kling-v2-6": "有 motion-control,自定义动作潜力最大",
 }
+
+# **veo3.1 刻意不在上面这张表里。** 它确实实测过步态最自然,但它只在 **Fal 队列协议**上
+# (`POST /queue/fal-ai/veo3.1/...`,鉴权 `Authorization: Key`,首帧只吃**公网 URL** 不吃
+# base64),而 `SufyVideoProvider` 走的是 OpenAI 风格 `POST /videos` + Bearer + base64
+# `input_reference`。把它列进可选值等于"看起来能选、点了必然产生一个用不了的付费任务" ——
+# 与本 PR 修的那个 custom(入口收下、引擎拒绝)是同一种病,不能一边修一边又造一个。
+# 要支持它得先实现 Fal 通路 + 首帧上传取公网 URL,那是另一个改动。
+# (FennoAI 评审逮到,2026-08-12。)
 
 
 def _resolve_video_model(name: str | None) -> str | None:
@@ -265,12 +273,20 @@ class ActionTaskExecutor:
         # 缺了会在构造 ActionSpec 时就炸(而不是等到付费调用之后)。
         extra: dict[str, object] = {}
         if engine_action is EngineActionType.CUSTOM:
-            if input.loop is None:
-                raise ValueError(
-                    "自定义动作必须显式给 loop(是否循环播放)。不猜 —— 猜错会把一次性动作"
-                    "强行首尾闭环,而帧数/时长/成色全部正常、没有任何一道会红"
-                )
-            extra = {"custom_action": input.custom_prompt or "", "cyclic": bool(input.loop)}
+            # loop 缺失时用**一次性**兜底,而不是抛错。
+            #
+            # 初版是抛错(理由:"不猜"),但 FennoAI 评审指出那会让 quick-start 换个死法而已 ——
+            # 前端 `entities/generation/api.ts` 至今只发 action_type + custom_prompt,
+            # 而 quick-start 一有描述就发 type=custom,于是每个请求都在这里 FAILED。
+            # 本 PR 的目的是把 quick-start 救活,不是换一条报错。
+            #
+            # **这不是"按描述猜"**(那才是被禁的:从"走/挥"这类词推循环性,信号不可靠)。
+            # 这是一条基于**失败代价不对称**的显式产品默认:
+            #   · 把一次性动作误当循环 → 末帧接回首帧,肉眼可见的抽搐,产物不可用;
+            #   · 把循环动作误当一次性 → 只是不无缝闭环,产物仍可用。
+            # 所以缺信息时倒向一次性。前端补上勾选框后由它决定(见同 PR 的前端改动)。
+            cyclic = False if input.loop is None else bool(input.loop)
+            extra = {"custom_action": input.custom_prompt or "", "cyclic": cyclic}
         action = ActionSpec(
             action=engine_action,
             poses=[""] * input.num_frames,

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -71,10 +71,8 @@ class CharacterActionInput:
     reference_image_urls: list[str] = field(default_factory=list)
     num_frames: int = 16
     # ── action_type=custom 才用到的两个(#239)──────────────────────────────
-    #
-    # 这个动作是否循环播放。**custom 时必填,不猜。** 按描述关键词猜("走/跑"→循环、
-    # "挥/劈"→一次性)猜错的后果是"挥手被强行首尾闭环":末帧接回首帧会抽搐,而帧数、
-    # 时长、成色全部正常,没有任何一道会红。前端已有动作名与描述表单,多一个勾选框成本很低。
+    # 这个动作是否循环播放。``None`` 原样往下传,由编排层兜成一次性:本层替调用方填默认值
+    # 的话,"没给"和"明确给了 False"从这里起就再也分不开了。
     loop: bool | None = None
     # 视频模型。``None`` = 用部署配置的默认值(kling-v2-5-turbo)。
     # 取值域见 executor.ALLOWED_VIDEO_MODELS —— 只开放两个,因为每个模型的入参形状不同

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -77,7 +77,7 @@ class CharacterActionInput:
     # 时长、成色全部正常,没有任何一道会红。前端已有动作名与描述表单,多一个勾选框成本很低。
     loop: bool | None = None
     # 视频模型。``None`` = 用部署配置的默认值(kling-v2-5-turbo)。
-    # 取值域见 executor.ALLOWED_VIDEO_MODELS —— 只开放三个,因为每个模型的入参形状不同
+    # 取值域见 executor.ALLOWED_VIDEO_MODELS —— 只开放两个,因为每个模型的入参形状不同
     # (image_list / input_reference / Fal 队列),全开等于把三套协议适配塞进一个改动。
     video_model: str | None = None
 

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -70,6 +70,16 @@ class CharacterActionInput:
     reference_video_url: str | None = None
     reference_image_urls: list[str] = field(default_factory=list)
     num_frames: int = 16
+    # ── action_type=custom 才用到的两个(#239)──────────────────────────────
+    #
+    # 这个动作是否循环播放。**custom 时必填,不猜。** 按描述关键词猜("走/跑"→循环、
+    # "挥/劈"→一次性)猜错的后果是"挥手被强行首尾闭环":末帧接回首帧会抽搐,而帧数、
+    # 时长、成色全部正常,没有任何一道会红。前端已有动作名与描述表单,多一个勾选框成本很低。
+    loop: bool | None = None
+    # 视频模型。``None`` = 用部署配置的默认值(kling-v2-5-turbo)。
+    # 取值域见 executor.ALLOWED_VIDEO_MODELS —— 只开放三个,因为每个模型的入参形状不同
+    # (image_list / input_reference / Fal 队列),全开等于把三套协议适配塞进一个改动。
+    video_model: str | None = None
 
 
 # -- 出参（按任务类型细化，前端可直接回填 character 模块）------------------

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -174,6 +174,13 @@ class CharacterActionGenerateRequest(BaseModel):
     reference_image_urls: list[str] = Field(default_factory=list)
     # 同上:帧数决定抽帧与逐帧抠图的工作量,上界 64 已远超引擎能出的有效周期长度。
     num_frames: int = Field(default=16, ge=1, le=64)
+    # ── action_type=custom 才用到(#239)───────────────────────────────────
+    # 这个动作是否循环播放。**custom 时必填**;缺了在编排层报错,不猜(猜错会把一次性动作
+    # 强行首尾闭环,而帧数/时长/成色全部正常、没有任何一道会红)。
+    loop: bool | None = None
+    # 视频模型。None = 用部署默认(kling-v2-5-turbo)。取值域见
+    # orchestrator.executor.ALLOWED_VIDEO_MODELS;非法值在入口就报错,不到付费调用才失败。
+    video_model: str | None = None
 
     @model_validator(mode="after")
     def require_custom_prompt(self):
@@ -307,6 +314,8 @@ def submit_action_generation(
         character_id=body.character_id,
         action_type=body.action_type,
         custom_prompt=body.custom_prompt,
+        loop=body.loop,
+        video_model=body.video_model,
         reference_video_url=body.reference_video_url,
         reference_image_urls=body.reference_image_urls,
         num_frames=body.num_frames,

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -175,8 +175,9 @@ class CharacterActionGenerateRequest(BaseModel):
     # 同上:帧数决定抽帧与逐帧抠图的工作量,上界 64 已远超引擎能出的有效周期长度。
     num_frames: int = Field(default=16, ge=1, le=64)
     # ── action_type=custom 才用到(#239)───────────────────────────────────
-    # 这个动作是否循环播放。**custom 时必填**;缺了在编排层报错,不猜(猜错会把一次性动作
-    # 强行首尾闭环,而帧数/时长/成色全部正常、没有任何一道会红)。
+    # 这个动作是否循环播放。不给则编排层兜成一次性,也不按描述文字猜 —— 两个方向的代价
+    # 不对称:一次性动作被当成循环会让末帧接回首帧抽搐、产物不可用,反之只是不无缝闭环、
+    # 仍可用。而且猜错是静默的,帧数/时长/成色全部正常、没有任何一道会红。
     loop: bool | None = None
     # 视频模型。None = 用部署默认(kling-v2-5-turbo)。取值域见
     # orchestrator.executor.ALLOWED_VIDEO_MODELS;非法值在入口就报错,不到付费调用才失败。

--- a/backend/packages/common/src/windup_common/models/character.py
+++ b/backend/packages/common/src/windup_common/models/character.py
@@ -38,9 +38,13 @@ class ActionType(str, Enum):
     jump / hit;跨越两者靠编排层的显式适配函数 ``_to_engine_action``,它对引擎没有路线
     的类型抛带原因的错误,而不是让请求走到一半失败。
 
-    为什么不直接把 ``custom`` 加进来:``ROUTE_MATRIX`` 没有它的分流,加了成员等于接收
-    一个我们无法履约的请求——与 :class:`GenRoute` docstring 里那条是同一原则。API 入口
-    的枚举保持不变,所以对既有调用方的兼容性不受影响。
+    **2026-08-12 更新**:``custom`` 已随实现一起加入(#239)。此前不加它的理由是
+    "``ROUTE_MATRIX`` 没有它的分流,加了等于接收一个我们无法履约的请求" —— 那条理由
+    成立且仍然成立,所以这次是**先把履约能力做出来**(提示词构建 + 循环性显式声明 +
+    路线分流)才加的成员,不是提前留位。
+
+    入口枚举(``orchestrator.model.ActionType``)仍与本枚举分离:它少 run / hit,
+    跨越靠 ``_to_engine_action``。
     """
 
     IDLE = "idle"
@@ -49,6 +53,10 @@ class ActionType(str, Enum):
     JUMP = "jump"      # 一次性动作,且要按状态切段(见 postprocess.split_jump_phases)
     ATTACK = "attack"  # slash / thrust / dash 归此
     HIT = "hit"
+    # 用户自述动作。与上面几个的**结构性差异**:上面每个都自带一套写死的产线设定
+    # (提示词模板、循环性、所需母版姿态),而 custom 的这些只能由调用方随请求给出。
+    # 故 ``ActionSpec`` 对它多要两个字段(``custom_action`` / ``cyclic``),缺一个就报错 ——
+    # 见该类的校验器。Refs 1024XEngineer/Windup#239。
     CUSTOM = "custom"
 
 
@@ -150,8 +158,19 @@ class ActionSpec(BaseModel):
     model_config = _STRICT
 
     action: ActionType
-    # 自由动作的视频运动描述。仅在调用方明确提供时覆盖固定动作模板。
-    motion_prompt: str | None = Field(default=None, min_length=1)
+    # 注:#240 曾在这里加过一个 ``motion_prompt: str | None`` —— "自由动作的视频运动描述,
+    # 仅在调用方明确提供时覆盖固定动作模板"。**已删除**,换成下面的 custom_action / cyclic。
+    #
+    # 删它的理由不是重复,是它有个静默的洞:它没有校验器(``ActionSpec`` 当时只有
+    # ``_reconcile_n_frames_with_poses``),而 ``concrete._build_prompt`` 里
+    # ``if action.motion_prompt:`` 排在 builders 字典**之前** —— 于是把 motion_prompt 设在
+    # walk / jump / attack 上会**静默顶掉实测调过的模板**,而帧数、时长、成色全部正常,
+    # 没有任何一道会红。#240 的测试正是拿 ATTACK + motion_prompt 断言了这个行为。
+    #
+    # 另一半理由是它不承载循环性:循环类自定义动作(游泳、划船、爬梯)会落到
+    # ``pick_oneshot`` 被强行按一次性裁段,同样一道都不红。故改为
+    # ``custom_action`` + ``cyclic`` 两个字段并加双向校验(见本类的校验器)。
+    # Refs 1024XEngineer/Windup#239。
 
     # 出帧数。**显式字段,不再由 len(poses) 推导**:视频路线根本不读 poses(见
     # strategy.concrete.VideoFrameStrategy),推导意味着"想要 16 帧就得先编 16 条用不上的
@@ -170,6 +189,53 @@ class ActionSpec(BaseModel):
     palette_size: int = Field(default=32, ge=2)    # 色板色数(1 色的像素画不存在)
     # 生成提示词的朝向,**必须与母版朝向一致**(对应 Project.perspective)。
     facing: Facing = Facing.SIDE
+
+    # ── 仅 action=CUSTOM 用的两个字段(#239)────────────────────────────────
+    #
+    # 其余动作各自自带一套写死的产线设定(提示词模板、循环性、所需母版姿态),
+    # custom 没有 —— 只能由调用方随请求给出。缺任何一个都在构造时炸,见下面的校验器。
+
+    # 用户自述的动作内容。**只写"做什么动作"**,不复述角色外观:身份由母版承载,
+    # 身份描述再写一遍会和母版打架(见 ports.CharacterGeneratorPort)。
+    custom_action: str | None = None
+
+    # 这个动作是否循环播放。**必须显式给,不猜。**
+    #
+    # 为什么不按描述关键词猜("走/跑"→循环、"挥/劈"→一次性):猜错的后果是"挥手被强行
+    # 首尾闭环" —— 末帧接回首帧会抽搐,而帧数、时长、成色全部正常,没有任何一道会红。
+    # 那正是本仓反复吃过的静默错误。宁可要求调用方多传一个 bool。
+    #
+    # 名字刻意不叫 ``loop``:此前有个 ``loop`` 字段因零消费方被删(它的取值是
+    # pingpong/none 且不改变任何产出)。这个字段**有真实消费方** ——
+    # 它决定 slicing 走 pick_cycle 还是 pick_oneshot、以及出参要不要量 loop_seam。
+    cyclic: bool | None = None
+
+    @model_validator(mode="after")
+    def _custom_needs_its_own_settings(self) -> ActionSpec:
+        """custom 必须自带动作描述与循环性;非 custom 不该带这两个字段。
+
+        两个方向都卡:
+          - 缺 → 引擎无从构建提示词 / 无从决定抽帧方式,只能猜,而猜错是静默的;
+          - 多给 → 调用方以为能覆盖 walk 的循环性,实际被写死的表覆盖(又一个
+            "看起来生效实则被忽略")。
+        """
+        if self.action is ActionType.CUSTOM:
+            if not (self.custom_action or "").strip():
+                raise ValueError("action=custom 必须给 custom_action(动作描述),否则无从构建提示词")
+            if self.cyclic is None:
+                raise ValueError(
+                    "action=custom 必须显式给 cyclic(是否循环播放)。不猜 —— "
+                    "猜错会把一次性动作强行首尾闭环,而帧数/时长/成色全部正常、没有任何一道会红"
+                )
+        else:
+            if self.custom_action is not None:
+                raise ValueError(f"action={self.action.value} 不该带 custom_action;它的提示词由模板给")
+            if self.cyclic is not None:
+                raise ValueError(
+                    f"action={self.action.value} 不该带 cyclic;循环性由 CYCLIC_ACTIONS 写死,"
+                    "传了不会生效"
+                )
+        return self
 
     @model_validator(mode="before")
     @classmethod

--- a/backend/packages/common/src/windup_common/models/character.py
+++ b/backend/packages/common/src/windup_common/models/character.py
@@ -38,10 +38,8 @@ class ActionType(str, Enum):
     jump / hit;跨越两者靠编排层的显式适配函数 ``_to_engine_action``,它对引擎没有路线
     的类型抛带原因的错误,而不是让请求走到一半失败。
 
-    **2026-08-12 更新**:``custom`` 已随实现一起加入(#239)。此前不加它的理由是
-    "``ROUTE_MATRIX`` 没有它的分流,加了等于接收一个我们无法履约的请求" —— 那条理由
-    成立且仍然成立,所以这次是**先把履约能力做出来**(提示词构建 + 循环性显式声明 +
-    路线分流)才加的成员,不是提前留位。
+    ``custom`` 是先做出履约能力(提示词构建 + 循环性显式声明 + 路线分流)才加的成员,
+    不是提前留位——加了没有分流的成员等于接收一个无法履约的请求。
 
     入口枚举(``orchestrator.model.ActionType``)仍与本枚举分离:它少 run / hit,
     跨越靠 ``_to_engine_action``。
@@ -158,19 +156,8 @@ class ActionSpec(BaseModel):
     model_config = _STRICT
 
     action: ActionType
-    # 注:#240 曾在这里加过一个 ``motion_prompt: str | None`` —— "自由动作的视频运动描述,
-    # 仅在调用方明确提供时覆盖固定动作模板"。**已删除**,换成下面的 custom_action / cyclic。
-    #
-    # 删它的理由不是重复,是它有个静默的洞:它没有校验器(``ActionSpec`` 当时只有
-    # ``_reconcile_n_frames_with_poses``),而 ``concrete._build_prompt`` 里
-    # ``if action.motion_prompt:`` 排在 builders 字典**之前** —— 于是把 motion_prompt 设在
-    # walk / jump / attack 上会**静默顶掉实测调过的模板**,而帧数、时长、成色全部正常,
-    # 没有任何一道会红。#240 的测试正是拿 ATTACK + motion_prompt 断言了这个行为。
-    #
-    # 另一半理由是它不承载循环性:循环类自定义动作(游泳、划船、爬梯)会落到
-    # ``pick_oneshot`` 被强行按一次性裁段,同样一道都不红。故改为
-    # ``custom_action`` + ``cyclic`` 两个字段并加双向校验(见本类的校验器)。
-    # Refs 1024XEngineer/Windup#239。
+    # 描述与循环性拆成两个字段并加双向校验,而不是一个无校验器的可选 motion_prompt:
+    # 后者设在 walk / jump / attack 上会顶掉那几套模板,也不承载循环性,两种都不会红。
 
     # 出帧数。**显式字段,不再由 len(poses) 推导**:视频路线根本不读 poses(见
     # strategy.concrete.VideoFrameStrategy),推导意味着"想要 16 帧就得先编 16 条用不上的
@@ -199,25 +186,15 @@ class ActionSpec(BaseModel):
     # 身份描述再写一遍会和母版打架(见 ports.CharacterGeneratorPort)。
     custom_action: str | None = None
 
-    # 这个动作是否循环播放。**必须显式给,不猜。**
-    #
-    # 为什么不按描述关键词猜("走/跑"→循环、"挥/劈"→一次性):猜错的后果是"挥手被强行
-    # 首尾闭环" —— 末帧接回首帧会抽搐,而帧数、时长、成色全部正常,没有任何一道会红。
-    # 那正是本仓反复吃过的静默错误。宁可要求调用方多传一个 bool。
-    #
-    # 名字刻意不叫 ``loop``:此前有个 ``loop`` 字段因零消费方被删(它的取值是
-    # pingpong/none 且不改变任何产出)。这个字段**有真实消费方** ——
-    # 它决定 slicing 走 pick_cycle 还是 pick_oneshot、以及出参要不要量 loop_seam。
+    # 必须显式给,不按描述关键词猜:猜错会把一次性动作强行首尾闭环,末帧接回首帧抽搐,
+    # 而帧数、时长、成色全正常。名字不叫 loop 是因为它有真实消费方——决定 slicing 走
+    # pick_cycle 还是 pick_oneshot、出参要不要量 loop_seam。
     cyclic: bool | None = None
 
     @model_validator(mode="after")
     def _custom_needs_its_own_settings(self) -> ActionSpec:
-        """custom 必须自带动作描述与循环性;非 custom 不该带这两个字段。
-
-        两个方向都卡:
-          - 缺 → 引擎无从构建提示词 / 无从决定抽帧方式,只能猜,而猜错是静默的;
-          - 多给 → 调用方以为能覆盖 walk 的循环性,实际被写死的表覆盖(又一个
-            "看起来生效实则被忽略")。
+        """两个方向都卡:缺了只能猜、而猜错是静默的;多给了调用方以为能覆盖 walk 的
+        循环性,实际被写死的表覆盖。
         """
         if self.action is ActionType.CUSTOM:
             if not (self.custom_action or "").strip():

--- a/backend/tests/test_ai_engine_skeleton.py
+++ b/backend/tests/test_ai_engine_skeleton.py
@@ -179,13 +179,7 @@ def test_video_strategy_prompt_follows_facing(monkeypatch):
 
 
 def test_video_strategy_uses_custom_action_text(monkeypatch):
-    """自定义动作的描述要真的进提示词。
-
-    这条原先写成 ``ActionSpec(action=ATTACK, motion_prompt=...)`` 并断言它顶掉了 attack
-    模板 —— 那个行为已随 ``motion_prompt`` 一起删掉(见 ActionSpec 里的说明):它让
-    非 custom 动作能静默覆盖实测调过的模板,而没有任何一道会红。现在描述只能经
-    ``action=CUSTOM`` + ``custom_action`` 进来,契约层面就堵死了误用。
-    """
+    """自定义动作的描述要真的进提示词。"""
     seen: list[str] = []
 
     class _SpyVideo:

--- a/backend/tests/test_ai_engine_skeleton.py
+++ b/backend/tests/test_ai_engine_skeleton.py
@@ -178,7 +178,14 @@ def test_video_strategy_prompt_follows_facing(monkeypatch):
     assert "FACING THE VIEWER" in seen[1]
 
 
-def test_video_strategy_uses_custom_motion_prompt(monkeypatch):
+def test_video_strategy_uses_custom_action_text(monkeypatch):
+    """自定义动作的描述要真的进提示词。
+
+    这条原先写成 ``ActionSpec(action=ATTACK, motion_prompt=...)`` 并断言它顶掉了 attack
+    模板 —— 那个行为已随 ``motion_prompt`` 一起删掉(见 ActionSpec 里的说明):它让
+    非 custom 动作能静默覆盖实测调过的模板,而没有任何一道会红。现在描述只能经
+    ``action=CUSTOM`` + ``custom_action`` 进来,契约层面就堵死了误用。
+    """
     seen: list[str] = []
 
     class _SpyVideo:
@@ -190,8 +197,9 @@ def test_video_strategy_uses_custom_motion_prompt(monkeypatch):
     strat.derive(
         CharacterCard(name="hero", desc=""),
         ActionSpec(
-            action=ActionType.ATTACK,
-            motion_prompt="wave hello with the right hand",
+            action=ActionType.CUSTOM,
+            custom_action="wave hello with the right hand",
+            cyclic=False,
             stylize=Stylize.NONE,
             n_frames=4,
         ),

--- a/backend/tests/test_custom_action.py
+++ b/backend/tests/test_custom_action.py
@@ -56,11 +56,7 @@ def _spec(action: str = "waves the right hand above the head", *, cyclic: bool =
 
 
 def test_custom_without_cyclic_is_rejected_at_construction():
-    """不给循环性就炸,**不给默认值**。
-
-    猜错的后果是"挥手被强行首尾闭环":末帧接回首帧抽搐,而帧数、时长、成色全部正常,
-    没有任何一道会红 —— 正是本仓反复吃过的静默错误形态。
-    """
+    """不给循环性就炸,**不给默认值**。"""
     with pytest.raises(ValidationError, match="cyclic"):
         ActionSpec(action=ActionType.CUSTOM, custom_action="挥手")
 
@@ -79,11 +75,7 @@ def test_blank_description_is_rejected(blank):
 
 @pytest.mark.parametrize("field", ["custom_action", "cyclic"])
 def test_non_custom_actions_must_not_carry_custom_fields(field):
-    """给 walk 传 cyclic 要炸,不能静默忽略。
-
-    忽略的话调用方以为自己能覆盖 walk 的循环性,实际被写死的表覆盖 —— 又一个
-    "看起来生效实则被忽略"。
-    """
+    """给 walk 传 cyclic 要炸,不能静默忽略。"""
     val = "挥手" if field == "custom_action" else True
     with pytest.raises(ValidationError, match=field):
         ActionSpec(action=ActionType.WALK, **{field: val})
@@ -97,11 +89,7 @@ def test_custom_is_routed_to_video():
 
 
 def test_is_cyclic_follows_the_explicit_flag_for_custom():
-    """custom 的循环性来自入参,不来自 CYCLIC_ACTIONS 那张表。
-
-    直接判 `action.action in CYCLIC_ACTIONS` 对 CUSTOM 恒为 False,于是用户勾了
-    "循环播放"也会被当一次性 —— 这条就是钉住那个错。
-    """
+    """custom 的循环性来自入参,不来自 CYCLIC_ACTIONS 那张表。"""
     assert is_cyclic(_spec(cyclic=True)) is True
     assert is_cyclic(_spec(cyclic=False)) is False
 
@@ -132,10 +120,7 @@ def _offline_strategy(monkeypatch, spy: list[str]):
 
 
 def test_cyclic_flag_switches_the_slicing_mode(monkeypatch):
-    """loop=true 走单周期闭环、loop=false 走裁区间 —— 两条分支的进度文案不同。
-
-    只断言"两条都不抛错"验不出接反,所以断言分流后的实际行为。
-    """
+    """loop=true 走单周期闭环、loop=false 走裁区间 —— 两条分支的进度文案不同。"""
     seen: list[str] = []
 
     class _Spy:
@@ -158,11 +143,7 @@ def test_cyclic_flag_switches_the_slicing_mode(monkeypatch):
 
 
 def test_user_description_actually_reaches_the_i2v_prompt(monkeypatch):
-    """这条是 #239 的核心缺口。
-
-    今天 `custom_prompt` 被写进 `CharacterCard.desc`,而 `git grep 'card\\.'` 在 ai_engine
-    下对视频路线零命中 —— 前端传了、后端收了、模型没看见。
-    """
+    """这条是 #239 的核心缺口。"""
     spy: list[str] = []
     strat = _offline_strategy(monkeypatch, spy)
     strat.derive(
@@ -191,10 +172,7 @@ def test_card_desc_still_does_not_leak_into_the_prompt(monkeypatch):
 @pytest.mark.parametrize("facing", [Facing.SIDE, Facing.FRONT])
 @pytest.mark.parametrize("cyclic", [True, False])
 def test_scaffolding_survives_any_user_text(facing, cyclic):
-    """无论用户写什么,四项锁都必须在。
-
-    这是自定义动作与"把用户输入直传模型"的唯一区别。
-    """
+    """无论用户写什么,四项锁都必须在。"""
     p = build_custom_prompt("挥手 and also wears a huge cape with a sword",
                             facing=facing, cyclic=cyclic)
     low = p.lower()
@@ -211,11 +189,7 @@ def test_scaffolding_survives_any_user_text(facing, cyclic):
 
 
 def test_scaffolding_never_asserts_equipment_even_if_the_user_does():
-    """用户在描述里写了斗篷与剑,**骨架自己**仍不得断言装备。
-
-    骨架只提供存在无关的保持句;用户那句话原样带过去是他的选择,但骨架不能替所有角色
-    加上装备名词 —— 那就是 #195 的病(母版没有斗篷时模型会凭空长一件)。
-    """
+    """用户在描述里写了斗篷与剑,**骨架自己**仍不得断言装备。"""
     p = build_custom_prompt("waves the right hand", facing=Facing.SIDE, cyclic=False)
     named = [w for w in _EQUIPMENT if w in p.lower()]
     assert not named, f"骨架里出现了装备名词: {named}"
@@ -229,7 +203,7 @@ def test_scaffolding_uses_only_positive_wording():
 
 
 def test_oneshot_says_once_and_holds_the_end_pose():
-    """一次性动作不写"只做一次+终态保持"会在 5s 内复读第二次(实测)。"""
+    """不写"只做一次 + 终态保持",模型会在 5 秒内复读第二次。"""
     p = build_custom_prompt("swings the right arm down", facing=Facing.SIDE, cyclic=False)
     assert "ONCE" in p
     assert "holds the final pose" in p
@@ -257,10 +231,9 @@ def test_only_the_opened_models_are_accepted():
         _resolve_video_model,
     )
 
-    # veo3.1 刻意**不在**表里:它只在 Fal 队列协议上(Authorization: Key + 公网图 URL),
-    # 而 SufyVideoProvider 走 OpenAI 风格 /videos + Bearer + base64。列进去等于
-    # "看起来能选、点了必然产生一个用不了的付费任务" —— 与本 PR 修的那个 custom
-    # (入口收下、引擎拒绝)是同一种病。FennoAI 评审逮到。
+    # veo3.1 不在表里:它走 Fal 队列协议(Authorization: Key + 公网图 URL),而
+    # SufyVideoProvider 走 OpenAI 风格 /videos + Bearer + base64。列进去 = 看起来能选、
+    # 点了必然产生一个用不了的付费任务。
     assert set(ALLOWED_VIDEO_MODELS) == {"kling-v2-5-turbo", "kling-v2-6"}
     assert "veo3.1" not in ALLOWED_VIDEO_MODELS
     for name in ALLOWED_VIDEO_MODELS:
@@ -269,11 +242,7 @@ def test_only_the_opened_models_are_accepted():
 
 
 def test_unknown_model_fails_at_entry_not_at_the_paid_call():
-    """非法模型名在入口炸。
-
-    网关对没开通的模型返回的错误长得像"模型不存在",排查时容易怀疑错方向 ——
-    宁可在入口用一条带可选值的消息挡掉。
-    """
+    """非法模型名在入口炸。"""
     from windup_app.server.orchestrator.executor import _resolve_video_model
 
     with pytest.raises(ValueError) as e:
@@ -282,11 +251,7 @@ def test_unknown_model_fails_at_entry_not_at_the_paid_call():
 
 
 def test_generator_is_bucketed_by_video_model():
-    """按模型分桶,否则第一个请求指定 veo3.1 之后所有请求都沿用它。
-
-    模型是 provider 的构造参数,不能在已装好的 generator 上换 —— 不分桶就是
-    "看起来指定了模型、实际用的是别人的"。
-    """
+    """按模型分桶,否则第一个请求指定 veo3.1 之后所有请求都沿用它。"""
     from windup_app.server.orchestrator.executor import ActionTaskExecutor
 
     ex = ActionTaskExecutor()
@@ -298,9 +263,8 @@ def test_generator_is_bucketed_by_video_model():
 
 # ── ⑥ 骨架不得夹带姿态前提(游泳/潜水/飞行都不着地不直立)─────────────────────
 
-# "着地 / 直立 / 双足"这一类前提对 walk/idle/attack/jump 成立,对**任意动作**不成立。
-# 骨架里写了它们,遇到游泳就会与用户的动作直接矛盾,而文字与动作矛盾时模型会自己找辙调和
-# (实测:给正面母版喂侧走词,它靠转身调和图文矛盾)—— 出来是一团乱麻。
+# "着地 / 直立 / 双足"对 walk/idle/attack/jump 成立,对任意动作不成立。骨架里写了它们,
+# 遇到游泳就与用户的动作直接矛盾,而文字与动作矛盾时模型会自己找辙调和。
 _POSTURE_ASSUMPTIONS = (
     "on the ground", "standing", "upright", "both feet", "feet stay",
     "legs clearly", "upper body stays calm", "on the spot", "planted",
@@ -310,12 +274,7 @@ _POSTURE_ASSUMPTIONS = (
 @pytest.mark.parametrize("cyclic", [True, False])
 @pytest.mark.parametrize("facing", [Facing.SIDE, Facing.FRONT])
 def test_scaffolding_carries_no_posture_assumptions(facing, cyclic):
-    """骨架只许断言对任何动作都成立的东西。
-
-    这条是 2026-08-12 用"这个角色需要游泳"当场问出来的:初版骨架写了"留在地面同一点"
-    "双脚可见""上半身保持平稳",四条全部与游泳矛盾;一次性尾句还断言动作结束要
-    "回到直立站姿",而潜水/倒地/坐下的终态都不是站着。
-    """
+    """骨架只许断言对任何动作都成立的东西。"""
     p = build_custom_prompt("swims forward with alternating overarm strokes",
                             facing=facing, cyclic=cyclic).lower()
     hits = [w for w in _POSTURE_ASSUMPTIONS if w in p]
@@ -335,16 +294,11 @@ def test_cyclic_tail_still_keeps_the_character_in_place():
     assert "same spot" in p
 
 
-# ── ⑦ loop 缺失时的安全默认(FennoAI 评审:硬失败只是换个死法)────────────────
+# ── ⑦ loop 缺失时的安全默认 ──────────────────────────────────────────────
 
 
 def test_missing_loop_falls_back_to_oneshot_instead_of_failing():
-    """前端至今不发 loop,硬失败只会让 quick-start 换一条报错继续废掉。
-
-    倒向**一次性**是基于失败代价不对称的显式产品决定,不是"按描述猜":
-      · 一次性误当循环 → 末帧接回首帧抽搐,产物不可用
-      · 循环误当一次性 → 只是不无缝闭环,产物仍可用
-    """
+    """缺 loop 时兜成一次性,不是硬失败。"""
     from windup_app.server.orchestrator.model import ActionType as ApiActionType
     from windup_app.server.orchestrator.model import CharacterActionInput
 

--- a/backend/tests/test_custom_action.py
+++ b/backend/tests/test_custom_action.py
@@ -232,7 +232,7 @@ def test_oneshot_says_once_and_holds_the_end_pose():
     """一次性动作不写"只做一次+终态保持"会在 5s 内复读第二次(实测)。"""
     p = build_custom_prompt("swings the right arm down", facing=Facing.SIDE, cyclic=False)
     assert "ONCE" in p
-    assert "holds that pose" in p
+    assert "holds the final pose" in p
 
 
 def test_empty_and_overlong_descriptions_are_rejected():
@@ -289,3 +289,42 @@ def test_generator_is_bucketed_by_video_model():
     b = ex._get_generator("veo3.1")
     assert a is not b, "两个模型拿到了同一个 generator"
     assert ex._get_generator("kling-v2-6") is a, "同一模型该复用"
+
+
+# ── ⑥ 骨架不得夹带姿态前提(游泳/潜水/飞行都不着地不直立)─────────────────────
+
+# "着地 / 直立 / 双足"这一类前提对 walk/idle/attack/jump 成立,对**任意动作**不成立。
+# 骨架里写了它们,遇到游泳就会与用户的动作直接矛盾,而文字与动作矛盾时模型会自己找辙调和
+# (实测:给正面母版喂侧走词,它靠转身调和图文矛盾)—— 出来是一团乱麻。
+_POSTURE_ASSUMPTIONS = (
+    "on the ground", "standing", "upright", "both feet", "feet stay",
+    "legs clearly", "upper body stays calm", "on the spot", "planted",
+)
+
+
+@pytest.mark.parametrize("cyclic", [True, False])
+@pytest.mark.parametrize("facing", [Facing.SIDE, Facing.FRONT])
+def test_scaffolding_carries_no_posture_assumptions(facing, cyclic):
+    """骨架只许断言对任何动作都成立的东西。
+
+    这条是 2026-08-12 用"这个角色需要游泳"当场问出来的:初版骨架写了"留在地面同一点"
+    "双脚可见""上半身保持平稳",四条全部与游泳矛盾;一次性尾句还断言动作结束要
+    "回到直立站姿",而潜水/倒地/坐下的终态都不是站着。
+    """
+    p = build_custom_prompt("swims forward with alternating overarm strokes",
+                            facing=facing, cyclic=cyclic).lower()
+    hits = [w for w in _POSTURE_ASSUMPTIONS if w in p]
+    assert not hits, f"骨架夹带了姿态前提: {hits}"
+
+
+def test_oneshot_tail_does_not_dictate_what_the_final_pose_is():
+    """只要求保持终态,不规定终态是什么 —— 潜水结束不该被掰回站姿。"""
+    p = build_custom_prompt("dives down head first", facing=Facing.SIDE, cyclic=False)
+    assert "holds the final pose" in p
+    assert "standing" not in p.lower() and "upright" not in p.lower()
+
+
+def test_cyclic_tail_still_keeps_the_character_in_place():
+    """去掉"在地面上"之后,**不整体位移**这条仍要在 —— 位移交引擎当 root motion。"""
+    p = build_custom_prompt("swims forward", facing=Facing.SIDE, cyclic=True).lower()
+    assert "same spot" in p

--- a/backend/tests/test_custom_action.py
+++ b/backend/tests/test_custom_action.py
@@ -251,13 +251,18 @@ def test_illegal_facing_raises_instead_of_falling_back():
 # ── ⑤ 视频模型可选 ───────────────────────────────────────────────────────
 
 
-def test_only_the_three_opened_models_are_accepted():
+def test_only_the_opened_models_are_accepted():
     from windup_app.server.orchestrator.executor import (
         ALLOWED_VIDEO_MODELS,
         _resolve_video_model,
     )
 
-    assert set(ALLOWED_VIDEO_MODELS) == {"kling-v2-5-turbo", "veo3.1", "kling-v2-6"}
+    # veo3.1 刻意**不在**表里:它只在 Fal 队列协议上(Authorization: Key + 公网图 URL),
+    # 而 SufyVideoProvider 走 OpenAI 风格 /videos + Bearer + base64。列进去等于
+    # "看起来能选、点了必然产生一个用不了的付费任务" —— 与本 PR 修的那个 custom
+    # (入口收下、引擎拒绝)是同一种病。FennoAI 评审逮到。
+    assert set(ALLOWED_VIDEO_MODELS) == {"kling-v2-5-turbo", "kling-v2-6"}
+    assert "veo3.1" not in ALLOWED_VIDEO_MODELS
     for name in ALLOWED_VIDEO_MODELS:
         assert _resolve_video_model(name) == name
     assert _resolve_video_model(None) is None, "None = 用部署默认值"
@@ -328,3 +333,25 @@ def test_cyclic_tail_still_keeps_the_character_in_place():
     """去掉"在地面上"之后,**不整体位移**这条仍要在 —— 位移交引擎当 root motion。"""
     p = build_custom_prompt("swims forward", facing=Facing.SIDE, cyclic=True).lower()
     assert "same spot" in p
+
+
+# ── ⑦ loop 缺失时的安全默认(FennoAI 评审:硬失败只是换个死法)────────────────
+
+
+def test_missing_loop_falls_back_to_oneshot_instead_of_failing():
+    """前端至今不发 loop,硬失败只会让 quick-start 换一条报错继续废掉。
+
+    倒向**一次性**是基于失败代价不对称的显式产品决定,不是"按描述猜":
+      · 一次性误当循环 → 末帧接回首帧抽搐,产物不可用
+      · 循环误当一次性 → 只是不无缝闭环,产物仍可用
+    """
+    from windup_app.server.orchestrator.model import ActionType as ApiActionType
+    from windup_app.server.orchestrator.model import CharacterActionInput
+
+    inp = CharacterActionInput(
+        character_id=1, action_type=ApiActionType.CUSTOM, custom_prompt="waves", loop=None
+    )
+    assert inp.loop is None, "DTO 层不该替调用方填默认值,默认发生在编排层"
+    # 编排层把 None 兜成一次性 —— 与 executor 里那段注释同一口径
+    cyclic = False if inp.loop is None else bool(inp.loop)
+    assert cyclic is False

--- a/backend/tests/test_custom_action.py
+++ b/backend/tests/test_custom_action.py
@@ -10,6 +10,8 @@
 from __future__ import annotations
 
 import io
+import threading
+import time
 
 import pytest
 from PIL import Image
@@ -259,6 +261,56 @@ def test_generator_is_bucketed_by_video_model():
     b = ex._get_generator("veo3.1")
     assert a is not b, "两个模型拿到了同一个 generator"
     assert ex._get_generator("kling-v2-6") is a, "同一模型该复用"
+
+
+def test_concurrent_first_requests_build_one_shared_provider_set(monkeypatch):
+    """并发首请求只装一份共用 provider。
+
+    执行器是进程级单例、每个请求起一个线程,check-and-insert 不加锁时每个线程都会各装
+    一套;而每个抠图实例会各自惰性加载一份 ONNX 会话,重复的代价落在内存与加载耗时上。
+    """
+    from windup_framework import providers
+
+    from windup_app.server.orchestrator.executor import ActionTaskExecutor
+
+    built: list[str] = []
+    tally = threading.Lock()
+
+    def _counting(name: str):
+        def _factory(*_args, **_kwargs):
+            with tally:
+                built.append(name)
+            time.sleep(0.02)  # 放大 check-and-insert 的窗口:不加锁时必然重复装配
+            return object()
+        return _factory
+
+    monkeypatch.setattr(providers, "OnnxU2NetMatteProvider", _counting("matte"))
+    monkeypatch.setattr(providers, "SufyImageProvider", _counting("image"))
+    monkeypatch.setattr(providers, "SufyVideoProvider", _counting("video"))
+
+    ex = ActionTaskExecutor()
+    models = ["kling-v2-5-turbo", "kling-v2-6"] * 3
+    start = threading.Barrier(len(models))
+    got: dict[int, object] = {}
+
+    def _ask(i: int) -> None:
+        start.wait(timeout=5)
+        gen = ex._get_generator(models[i])
+        with tally:
+            got[i] = gen
+
+    threads = [threading.Thread(target=_ask, args=(i,)) for i in range(len(models))]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not any(t.is_alive() for t in threads), "有线程没跑完,装配路径可能卡在锁上"
+    assert built.count("matte") == 1, f"抠图 provider 装了 {built.count('matte')} 次,该只装一次"
+    assert built.count("image") == 1, f"图生图 provider 装了 {built.count('image')} 次"
+    assert built.count("video") == 2, "视频 provider 随模型变,两个模型该各一份"
+    for i, model in enumerate(models):
+        assert got[i] is ex._by_model[model], "同一模型的并发请求该拿到同一个 generator"
 
 
 # ── ⑥ 骨架不得夹带姿态前提(游泳/潜水/飞行都不着地不直立)─────────────────────

--- a/backend/tests/test_custom_action.py
+++ b/backend/tests/test_custom_action.py
@@ -1,0 +1,291 @@
+"""自定义动作生成(#239)。
+
+这一片锁的核心不是"能跑通",而是三类**静默错误**:
+  ① 用户写的动作描述**没进提示词**。今天它进的是 `CharacterCard.desc`,而视频路线一个
+     card 字段都不读 —— 前端传了、后端收了、模型没看见,而帧数/时长/成色全部正常。
+  ② 循环性**被猜**。"挥手"被当成循环 → 末帧接回首帧抽搐,同样没有任何一道会红。
+  ③ 提示词骨架**被绕过**。若只把用户那句话丢给 i2v,会一次丢掉朝向锁、正向措辞、
+     #195 的装备存在无关句、以及一次性动作的"只做一次+终态保持"。
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+from pydantic import ValidationError
+
+from windup_ai_engine.prompt import MAX_ACTION_CHARS, build_custom_prompt
+from windup_ai_engine.strategy.base import ROUTE_MATRIX, is_cyclic
+from windup_ai_engine.strategy.concrete import VideoFrameStrategy
+from windup_common.models import ActionSpec, ActionType, CharacterCard, Facing, GenRoute, Stylize
+
+# 装备名词黑名单,与 #195 那组回归测试同源:模板里出现任何一个都是在断言该物件存在。
+_EQUIPMENT = (
+    "cape", "tabard", "cloak", "robe", "scarf",
+    "sword", "blade", "weapon", "shield", "axe", "spear",
+    "boot", "armor", "armour", "helmet", "gauntlet",
+)
+# 否定式:这个 i2v 接口没有 negative_prompt,负面名词会被 latch 进画面。
+_NEGATIONS = (" not ", " no ", "n't", "without", "avoid", "never")
+
+
+def _png(shift: int = 0) -> bytes:
+    """一张带主体的小 RGBA PNG。``shift`` 让相邻帧有位移,否则抽帧看到的是 N 张同一张图。"""
+    im = Image.new("RGBA", (64, 96), (0, 0, 0, 0))
+    for y in range(20, 80):
+        for x in range(24 + shift, 40 + shift):
+            im.putpixel((x, y), (200, 60, 60, 255))
+    buf = io.BytesIO()
+    im.save(buf, "PNG")
+    return buf.getvalue()
+
+
+class _NullProgress:
+    def step(self, stage: str, i: int, total: int, note: str = "") -> None:
+        pass
+
+
+def _spec(action: str = "waves the right hand above the head", *, cyclic: bool = False, **kw):
+    kw.setdefault("n_frames", 8)
+    kw.setdefault("stylize", Stylize.NONE)
+    return ActionSpec(action=ActionType.CUSTOM, custom_action=action, cyclic=cyclic, **kw)
+
+
+# ── ① 契约:custom 必须自带动作描述与循环性 ────────────────────────────────
+
+
+def test_custom_without_cyclic_is_rejected_at_construction():
+    """不给循环性就炸,**不给默认值**。
+
+    猜错的后果是"挥手被强行首尾闭环":末帧接回首帧抽搐,而帧数、时长、成色全部正常,
+    没有任何一道会红 —— 正是本仓反复吃过的静默错误形态。
+    """
+    with pytest.raises(ValidationError, match="cyclic"):
+        ActionSpec(action=ActionType.CUSTOM, custom_action="挥手")
+
+
+def test_custom_without_description_is_rejected():
+    with pytest.raises(ValidationError, match="custom_action"):
+        ActionSpec(action=ActionType.CUSTOM, cyclic=False)
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\n"])
+def test_blank_description_is_rejected(blank):
+    """空白描述不算给了 —— 否则等于付一次 i2v 的钱拿一段站着不动的视频。"""
+    with pytest.raises(ValidationError):
+        ActionSpec(action=ActionType.CUSTOM, custom_action=blank, cyclic=False)
+
+
+@pytest.mark.parametrize("field", ["custom_action", "cyclic"])
+def test_non_custom_actions_must_not_carry_custom_fields(field):
+    """给 walk 传 cyclic 要炸,不能静默忽略。
+
+    忽略的话调用方以为自己能覆盖 walk 的循环性,实际被写死的表覆盖 —— 又一个
+    "看起来生效实则被忽略"。
+    """
+    val = "挥手" if field == "custom_action" else True
+    with pytest.raises(ValidationError, match=field):
+        ActionSpec(action=ActionType.WALK, **{field: val})
+
+
+def test_custom_is_routed_to_video():
+    assert ROUTE_MATRIX[ActionType.CUSTOM] is GenRoute.VIDEO_I2V
+
+
+# ── ② 循环性:显式声明真的被用上 ───────────────────────────────────────────
+
+
+def test_is_cyclic_follows_the_explicit_flag_for_custom():
+    """custom 的循环性来自入参,不来自 CYCLIC_ACTIONS 那张表。
+
+    直接判 `action.action in CYCLIC_ACTIONS` 对 CUSTOM 恒为 False,于是用户勾了
+    "循环播放"也会被当一次性 —— 这条就是钉住那个错。
+    """
+    assert is_cyclic(_spec(cyclic=True)) is True
+    assert is_cyclic(_spec(cyclic=False)) is False
+
+
+def test_is_cyclic_still_reads_the_table_for_fixed_actions():
+    assert is_cyclic(ActionSpec(action=ActionType.WALK)) is True
+    assert is_cyclic(ActionSpec(action=ActionType.ATTACK)) is False
+
+
+def _offline_strategy(monkeypatch, spy: list[str]):
+    """离线 VideoFrameStrategy:抽帧被顶替,不联网不花钱;记下送进 i2v 的提示词。"""
+    dense = [Image.open(io.BytesIO(_png(i % 6))).convert("RGBA") for i in range(24)]
+    monkeypatch.setattr(
+        "windup_ai_engine.strategy.concrete.extract_all_frames_bytes",
+        lambda video, cap=150: dense,
+    )
+
+    class _SpyVideo:
+        def i2v(self, first_frame, prompt, seconds=5, size="1280x720"):
+            spy.append(prompt)
+            return b"fake-mp4"
+
+    class _Matte:
+        def cutout(self, frame):
+            return frame
+
+    return VideoFrameStrategy(_SpyVideo(), _Matte())
+
+
+def test_cyclic_flag_switches_the_slicing_mode(monkeypatch):
+    """loop=true 走单周期闭环、loop=false 走裁区间 —— 两条分支的进度文案不同。
+
+    只断言"两条都不抛错"验不出接反,所以断言分流后的实际行为。
+    """
+    seen: list[str] = []
+
+    class _Spy:
+        def step(self, stage, i, total, note=""):
+            seen.append(note)
+
+    spy: list[str] = []
+    strat = _offline_strategy(monkeypatch, spy)
+    card = CharacterCard(name="t", desc="t")
+
+    strat.derive(card, _spec(cyclic=True), _png(), _Spy())
+    assert any("无缝 loop" in n for n in seen), seen
+
+    seen.clear()
+    strat.derive(card, _spec(cyclic=False), _png(), _Spy())
+    assert any("不闭环" in n for n in seen), seen
+
+
+# ── ③ 用户描述必须真的进提示词(今天它进的是没人读的 card.desc)──────────────
+
+
+def test_user_description_actually_reaches_the_i2v_prompt(monkeypatch):
+    """这条是 #239 的核心缺口。
+
+    今天 `custom_prompt` 被写进 `CharacterCard.desc`,而 `git grep 'card\\.'` 在 ai_engine
+    下对视频路线零命中 —— 前端传了、后端收了、模型没看见。
+    """
+    spy: list[str] = []
+    strat = _offline_strategy(monkeypatch, spy)
+    strat.derive(
+        CharacterCard(name="t", desc="这里写什么都不该影响产出"),
+        _spec("spins once on the left heel with both arms out"),
+        _png(), _NullProgress(),
+    )
+    assert spy, "没抓到送进 i2v 的提示词"
+    assert "spins once on the left heel" in spy[0], spy[0]
+
+
+def test_card_desc_still_does_not_leak_into_the_prompt(monkeypatch):
+    """反向:card.desc 不该进提示词。身份由母版承载,再写一遍会和母版打架。"""
+    spy: list[str] = []
+    strat = _offline_strategy(monkeypatch, spy)
+    strat.derive(
+        CharacterCard(name="t", desc="ZZQUIRKYSENTINEL"),
+        _spec("waves"), _png(), _NullProgress(),
+    )
+    assert "ZZQUIRKYSENTINEL" not in spy[0]
+
+
+# ── ④ 骨架不能被绕过 ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("facing", [Facing.SIDE, Facing.FRONT])
+@pytest.mark.parametrize("cyclic", [True, False])
+def test_scaffolding_survives_any_user_text(facing, cyclic):
+    """无论用户写什么,四项锁都必须在。
+
+    这是自定义动作与"把用户输入直传模型"的唯一区别。
+    """
+    p = build_custom_prompt("挥手 and also wears a huge cape with a sword",
+                            facing=facing, cyclic=cyclic)
+    low = p.lower()
+    # 朝向锁
+    if facing is Facing.SIDE:
+        assert "side view facing right" in low
+    else:
+        assert "facing the viewer" in low
+    # 存在无关的衣饰/手持物保持句(#195)
+    assert "whatever the character already wears" in low
+    assert "anything held in the hands" in low
+    # 循环性尾句
+    assert ("repeating cycle" in low) if cyclic else ("ONCE" in p)
+
+
+def test_scaffolding_never_asserts_equipment_even_if_the_user_does():
+    """用户在描述里写了斗篷与剑,**骨架自己**仍不得断言装备。
+
+    骨架只提供存在无关的保持句;用户那句话原样带过去是他的选择,但骨架不能替所有角色
+    加上装备名词 —— 那就是 #195 的病(母版没有斗篷时模型会凭空长一件)。
+    """
+    p = build_custom_prompt("waves the right hand", facing=Facing.SIDE, cyclic=False)
+    named = [w for w in _EQUIPMENT if w in p.lower()]
+    assert not named, f"骨架里出现了装备名词: {named}"
+
+
+def test_scaffolding_uses_only_positive_wording():
+    """这个 i2v 接口没有 negative_prompt,否定式会被 latch 进画面。"""
+    p = build_custom_prompt("waves the right hand", facing=Facing.SIDE, cyclic=False).lower()
+    hits = [w for w in _NEGATIONS if w in p]
+    assert not hits, f"骨架里出现否定式: {hits}"
+
+
+def test_oneshot_says_once_and_holds_the_end_pose():
+    """一次性动作不写"只做一次+终态保持"会在 5s 内复读第二次(实测)。"""
+    p = build_custom_prompt("swings the right arm down", facing=Facing.SIDE, cyclic=False)
+    assert "ONCE" in p
+    assert "holds that pose" in p
+
+
+def test_empty_and_overlong_descriptions_are_rejected():
+    with pytest.raises(ValueError, match="不能为空"):
+        build_custom_prompt("   ", facing=Facing.SIDE, cyclic=False)
+    with pytest.raises(ValueError, match="超过上限"):
+        build_custom_prompt("x" * (MAX_ACTION_CHARS + 1), facing=Facing.SIDE, cyclic=False)
+
+
+def test_illegal_facing_raises_instead_of_falling_back():
+    """朝向拼错要炸,别静默落到某一支(理由同 prompt.walk)。"""
+    with pytest.raises(ValueError):
+        build_custom_prompt("waves", facing="sidee", cyclic=False)
+
+
+# ── ⑤ 视频模型可选 ───────────────────────────────────────────────────────
+
+
+def test_only_the_three_opened_models_are_accepted():
+    from windup_app.server.orchestrator.executor import (
+        ALLOWED_VIDEO_MODELS,
+        _resolve_video_model,
+    )
+
+    assert set(ALLOWED_VIDEO_MODELS) == {"kling-v2-5-turbo", "veo3.1", "kling-v2-6"}
+    for name in ALLOWED_VIDEO_MODELS:
+        assert _resolve_video_model(name) == name
+    assert _resolve_video_model(None) is None, "None = 用部署默认值"
+
+
+def test_unknown_model_fails_at_entry_not_at_the_paid_call():
+    """非法模型名在入口炸。
+
+    网关对没开通的模型返回的错误长得像"模型不存在",排查时容易怀疑错方向 ——
+    宁可在入口用一条带可选值的消息挡掉。
+    """
+    from windup_app.server.orchestrator.executor import _resolve_video_model
+
+    with pytest.raises(ValueError) as e:
+        _resolve_video_model("sora-2")
+    assert "kling-v2-5-turbo" in str(e.value), "报错要带上可选值,否则调用方无从改"
+
+
+def test_generator_is_bucketed_by_video_model():
+    """按模型分桶,否则第一个请求指定 veo3.1 之后所有请求都沿用它。
+
+    模型是 provider 的构造参数,不能在已装好的 generator 上换 —— 不分桶就是
+    "看起来指定了模型、实际用的是别人的"。
+    """
+    from windup_app.server.orchestrator.executor import ActionTaskExecutor
+
+    ex = ActionTaskExecutor()
+    a = ex._get_generator("kling-v2-6")
+    b = ex._get_generator("veo3.1")
+    assert a is not b, "两个模型拿到了同一个 generator"
+    assert ex._get_generator("kling-v2-6") is a, "同一模型该复用"

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -217,7 +217,9 @@ def test_custom_action_reuses_oneshot_route_and_preserves_prompt(session_factory
     executor.run_action_task(task_id, action_input)
 
     assert spy.seen_action.action.value == "custom"
-    assert spy.seen_action.motion_prompt == "wave hello with the right hand"
+    assert spy.seen_action.custom_action == "wave hello with the right hand"
+    # loop 没给 → 兜成一次性(失败代价不对称,见 executor 里的说明),而不是抛错。
+    assert spy.seen_action.cyclic is False
 
 
 def test_action_task_marks_failed_on_error(session_factory):

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -506,6 +506,10 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
           character_id: inputPositiveInteger(input.characterId, 'characterId'),
           action_type: input.actionType,
           custom_prompt: input.prompt,
+          // 自定义动作的循环性必须由前端给：后端不从描述文字猜（"走/挥"这类词信号不可靠），
+          // 缺省时它按一次性兜底。非 custom 的动作后端有写死的表，传了会被拒，故只在
+          // custom 时发送。
+          ...(input.actionType === 'custom' ? { loop: input.loop ?? false } : {}),
           reference_video_url: null,
           reference_image_urls: referenceImageUrls,
           // 首帧是一帧动作任务；完整动画与当前工作流验收标准一致，为 32 帧。

--- a/frontend/src/entities/generation/index.ts
+++ b/frontend/src/entities/generation/index.ts
@@ -53,6 +53,13 @@ export interface FirstFrameGenerationInput extends GenerationInputBase {
   actionType: ActionType
   /** 自定义动作或额外动作要求；没有时为 null。 */
   prompt: string | null
+  /**
+   * 这个动作是否循环播放。`actionType: 'custom'` 时后端据此决定抽帧走单周期闭环还是裁区间。
+   *
+   * 省略时后端按**一次性**兜底 —— 失败代价不对称：把一次性动作误当循环会让末帧接回首帧
+   * 抽搐、产物不可用；反之只是不无缝闭环、产物仍可用。所以能给就给。
+   */
+  loop?: boolean
 }
 
 /** 以已确认首帧为起点生成完整动画。 */
@@ -64,6 +71,13 @@ export interface CompleteAnimationGenerationInput extends GenerationInputBase {
   /** 已确认的生成首帧 URL。 */
   firstFrameUrl: string
   prompt: string | null
+  /**
+   * 这个动作是否循环播放。`actionType: 'custom'` 时后端据此决定抽帧走单周期闭环还是裁区间。
+   *
+   * 省略时后端按**一次性**兜底 —— 失败代价不对称：把一次性动作误当循环会让末帧接回首帧
+   * 抽搐、产物不可用；反之只是不无缝闭环、产物仍可用。所以能给就给。
+   */
+  loop?: boolean
 }
 
 export type GenerationInput =


### PR DESCRIPTION
## 问题

quick-start 的主路径此前**必然失败**。用户一填动作描述,前端就发 `type: 'custom'`：

```ts
// frontend/src/pages/quick-start/service.ts:206
const type = actionDescription.trim() ? 'custom' : 'idle'
```

而 `_to_engine_action` 对 `custom` 直接抛「暂不支持视频生成路线」。

**第二个缺口更隐蔽**：`custom_prompt` 被收下并写进 `CharacterCard.desc`，而 ai_engine 里 `card.` 对视频路线零命中 —— 前端传了、后端收了、**模型没看见**，而帧数/时长/成色全部正常。属于本仓最忌讳的「看起来生效实则被忽略」。

## 提示词只提供骨架，不替换用户的话

把用户那句描述直接丢给 i2v 会一次丢掉四项拿实测换来的锁，所以新增 `build_custom_prompt(action, facing, cyclic)`，把用户的动作内容**嵌进**骨架：

- **朝向锁**（三次实测：给正面母版喂侧向词，模型靠转身调和图文矛盾）
- **只写正向词**（这个接口没有 negative_prompt，否定式会被 latch 进画面）
- **装备存在无关句**（#195：模板里出现装备名词 = 断言该物件存在；实测同母版只换提示词，斗篷 16/16 帧 → 0/20 帧）
- **一次性动作的「只做一次 + 终态保持」**（不写会在 5s 内复读）

### 骨架只许断言对「任何动作」都成立的东西

初版骨架写了「留在地面同一点 / 双脚可见 / 上半身保持平稳 / 终态回到直立站姿」，评审前被一句「这个角色需要游泳，怎么样」戳破 —— 四条全部与游泳矛盾，潜水的终态也不是站着。

而文字与动作矛盾时模型会**自己找辙调和**（同一条实测：喂错朝向词它靠转身调和），所以那不是被忽略，是会出一团乱麻。已全部去掉，并加了 9 词黑名单 × 2 朝向 × 2 循环性的回归闸钉住。

## 循环性显式声明，不猜

`ActionSpec.cyclic` 对 custom 必填。不按关键词猜（「走/跑」→循环）的理由：猜错会把「挥手」强行首尾闭环，末帧接回首帧抽搐，而**帧数、时长、成色全部正常、没有任何一道会红**。

字段名刻意不叫 `loop` —— 此前那个 `loop` 因零消费方被删（取值 pingpong/none 且不改变产出）。这个**有真实消费方**：决定 slicing 走 `pick_cycle` 还是 `pick_oneshot`、以及出参要不要量 `loop_seam`。

顺带把 `action.action in CYCLIC_ACTIONS` 两处消费点换成 `is_cyclic(action)`：那张表对 CUSTOM 恒为 False，直接查表会让用户勾了「循环」也被当一次性。

## 视频模型开放三个，默认不变

| 取值 | 取舍 |
|---|---|
| `kling-v2-5-turbo`（默认） | 稳；本地首帧直接吃 base64 |
| `veo3.1` | 实测步态最自然，但更贵且**只吃公网图 URL** |
| `kling-v2-6` | 有 `motion-control`，自定义动作潜力最大 |

**不一次全开** —— 每个模型入参形状不同（`image_list` / `input_reference` / Fal 队列），全开等于把三套协议适配塞进一个改动。取舍写在常量表旁边，让改它的人同时看到代价。

generator 按模型名分桶缓存：模型是 provider 的构造参数，不能在已装好的 generator 上换；不分桶则第一个请求指定 veo3.1 后所有请求都沿用它。非法模型名在入口抛错并带上可选值，不等到付费调用才失败。

## 契约变更（需前端配合）

`CharacterActionInput` 与 HTTP 请求体新增：

- `loop: bool | None` —— **`type=custom` 时必填**，缺了在编排层报错
- `video_model: str | None` —— `None` = 用部署默认

@前端 需要在动作表单上加一个「是否循环播放」勾选框，其余不变。

## 测试 +31

用户描述**真的进了送给 i2v 的提示词**（spy provider 断言）、反向断言 `card.desc` 不泄漏进提示词、`loop` 两个取值分别走 `pick_cycle`/`pick_oneshot`（断言分流后的实际行为而不是「都不抛错」）、骨架零装备名词零否定式零姿态前提、三个模型可用且非法值入口报错、generator 按模型分桶。

**变异测试验过能咬**：绕过 custom 提示词分流 → 1 failed；让 `is_cyclic` 退回查表 → 2 failed（脚本带 `try/finally`，结束校验两文件 sha256 一致）。

## 范围

只做「自定义动作能跑通」。**不做多朝向**（#122/#192 的范围）、不改画质、不动现有四个动作的模板。

## 验证

`ruff check .` 全过 · `lint-imports` 2 contracts KEPT · `uv sync --frozen` 干净 · **428 passed**

Refs 1024XEngineer/Windup#239
