### PR TITLE
fix(workflow-editor): 接入真实生成任务

### DIFF
--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createGenerationApis, GenerationApiError } from '@/entities'
+import {
+  createAuthenticatedGenerationApis,
+  createGenerationApis,
+  GenerationApiError,
+} from '@/entities'
+import { registerApiAccessTokenProvider } from '@/shared/api'
 import { EventStreamError, type EventStreamOptions } from '@/shared/api/stream'
 
 import type { MediaReference } from '../media'
@@ -11,6 +16,13 @@ function success(data: unknown): Response {
   return new Response(JSON.stringify({ code: 200, message: 'success', data }), {
     status: 200,
     headers: { 'content-type': 'application/json' },
+  })
+}
+
+function eventStreamTask(data: unknown): Response {
+  return new Response(`event: completed\ndata: ${JSON.stringify(data)}\n\n`, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
   })
 }
 
@@ -47,6 +59,46 @@ function actionFrames(count: number) {
 }
 
 describe('createGenerationApis', () => {
+  it('生产适配器使用配置的 API 地址并携带当前会话 token', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test/')
+    const unregister = registerApiAccessTokenProvider(() => 'workflow-editor-token')
+    const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (new Headers(init?.headers).get('accept') === 'text/event-stream') {
+        return eventStreamTask(taskData())
+      }
+      return success(taskData())
+    })
+    const apis = createAuthenticatedGenerationApis(fetchFn as typeof fetch)
+
+    await apis.create({
+      type: 'character_template',
+      projectId: '42',
+      referenceMedia: [],
+      prompt: 'pixel hero',
+      spriteWidth: 64,
+      spriteHeight: 96,
+    })
+
+    const [url, init] = fetchFn.mock.calls[0]!
+    expect(url).toBe('https://api.windup.test/generation/image')
+    expect(new Headers(init?.headers).get('authorization')).toBe('Bearer workflow-editor-token')
+    expect(init?.credentials).toBe('include')
+
+    const onEvent = vi.fn()
+    const stop = apis.subscribe('42', '91', { type: 'character_template' }, onEvent, vi.fn())
+    await vi.waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ status: 'completed' })),
+    )
+    const [streamUrl, streamInit] = fetchFn.mock.calls[1]!
+    expect(streamUrl).toBe('https://api.windup.test/generation/tasks/91/stream?project_id=42')
+    expect(new Headers(streamInit?.headers).get('authorization')).toBe(
+      'Bearer workflow-editor-token',
+    )
+    stop()
+    unregister()
+    vi.unstubAllEnvs()
+  })
+
   it('固定请求并映射四张角色母版候选', async () => {
     const request = vi.fn(async (_url: string, _init?: RequestInit) => success(taskData()))
     const stream = vi.fn(() => vi.fn())

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -1,4 +1,9 @@
-import { EventStreamError, type EventStreamSubscriber } from '@/shared/api/stream'
+import { getApiAccessToken, recoverApiUnauthorized, resolveApiBaseUrl } from '@/shared/api'
+import {
+  createEventStreamSubscriber,
+  EventStreamError,
+  type EventStreamSubscriber,
+} from '@/shared/api/stream'
 
 import type {
   CompleteAnimationGenerationInput,
@@ -634,3 +639,27 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
 
   return apis
 }
+
+/** 为浏览器宿主装配统一的 Token、API 前缀和 SSE 恢复策略。 */
+export function createAuthenticatedGenerationApis(fetchFn: typeof fetch = fetch): GenerationApis {
+  const request: RequestFunction = (url, init) => {
+    const headers = new Headers(init?.headers)
+    const accessToken = getApiAccessToken()
+    if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`)
+    return fetchFn(`${resolveApiBaseUrl()}${url}`, { ...init, headers, credentials: 'include' })
+  }
+  const stream = createEventStreamSubscriber({
+    fetchFn,
+    getAccessToken: getApiAccessToken,
+    recoverUnauthorized: recoverApiUnauthorized,
+  })
+  return createGenerationApis({
+    transport: {
+      request,
+      stream: (url, options) => stream(`${resolveApiBaseUrl()}${url}`, options),
+    },
+  })
+}
+
+/** 页面默认使用的生产 Generation 适配器。 */
+export const generationApis = createAuthenticatedGenerationApis()

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -33,7 +33,12 @@ export { getOutfitPlayback } from './character/outfit-playback'
 export type { ActionTemplate, ActionTemplateApis } from './action-template'
 
 /* 生成 —— 业务数据，不是「调用生成能力」 */
-export { createGenerationApis, GenerationApiError } from './generation/api'
+export {
+  createAuthenticatedGenerationApis,
+  createGenerationApis,
+  generationApis,
+  GenerationApiError,
+} from './generation/api'
 export type {
   CharacterTemplateGenerationInput,
   CharacterTemplateGenerationResult,

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -10,7 +10,8 @@ import type {
   WorkflowRun,
   WorkflowRunApis,
 } from '@/entities'
-import { createRealWorkflowEditorSession, createUnavailableGenerationApis } from './runtime'
+import { characterApis, generationApis, projectApis, workflowRunApis } from '@/entities'
+import { createDefaultRealWorkflowEditorSession, createRealWorkflowEditorSession } from './runtime'
 
 describe('createRealWorkflowEditorSession', () => {
   it('通过公开 MediaApis 上传角色参考图并固定用途分类', async () => {
@@ -332,15 +333,47 @@ describe('createRealWorkflowEditorSession', () => {
   })
 })
 
-describe('createUnavailableGenerationApis', () => {
-  it('在 main 尚无 Generation HTTP 适配器时明确失败，不返回演示结果', async () => {
-    const apis = createUnavailableGenerationApis()
+describe('createDefaultRealWorkflowEditorSession', () => {
+  it('默认会话使用公共 Generation 生产适配器提交生成任务', async () => {
+    const workflow = readyCharacterTemplateWorkflowFixture()
+    vi.spyOn(workflowRunApis, 'get').mockResolvedValue(workflow)
+    vi.spyOn(workflowRunApis, 'update').mockImplementation(async (run) => ({
+      ...structuredClone(run),
+      version: run.version + 1,
+    }))
+    vi.spyOn(projectApis, 'get').mockResolvedValue(projectFixture())
+    vi.spyOn(characterApis, 'listByProject').mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 100,
+    })
+    const pendingGeneration = {
+      id: '91',
+      projectId: '1',
+      type: 'character_template' as const,
+      status: 'pending' as const,
+      result: null,
+      error: null,
+    }
+    const create = vi.spyOn(generationApis, 'create').mockResolvedValue(pendingGeneration)
+    vi.spyOn(generationApis, 'get').mockResolvedValue(pendingGeneration)
+    vi.spyOn(generationApis, 'subscribe').mockReturnValue(() => undefined)
 
-    await expect(apis.create(characterGenerationInput())).rejects.toThrow(
-      'GenerationApis 尚未接入真实后端',
+    const session = await createDefaultRealWorkflowEditorSession('42')
+    await session.controller.generateCharacterTemplate('setup', {
+      spriteWidth: 64,
+      spriteHeight: 64,
+    })
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'character_template',
+        projectId: '1',
+        prompt: '冒险家',
+      }),
     )
-    await expect(apis.get('1', '9')).rejects.toThrow('GenerationApis 尚未接入真实后端')
-    expect(() => apis.subscribe('1', '9', vi.fn())).not.toThrow()
+    vi.restoreAllMocks()
   })
 })
 
@@ -481,6 +514,23 @@ function selectingCharacterTemplateWorkflowFixture(): WorkflowRun {
   }
 }
 
+function readyCharacterTemplateWorkflowFixture(): WorkflowRun {
+  const workflow = selectingCharacterTemplateWorkflowFixture()
+  const template = workflow.nodes[1]!
+  return {
+    ...workflow,
+    nodes: [
+      workflow.nodes[0]!,
+      {
+        ...template,
+        status: 'active',
+        phase: 'ready',
+        generations: [],
+      },
+    ] as WorkflowRun['nodes'],
+  }
+}
+
 function reviewingWorkflowFixture(): WorkflowRun {
   return {
     id: '42',
@@ -571,16 +621,5 @@ function completeAnimationFixture(): Generation<'complete_animation'> {
         { index: 1, url: 'https://assets.windup.test/walk-02.png', durationMs: null },
       ],
     },
-  }
-}
-
-function characterGenerationInput() {
-  return {
-    type: 'character_template' as const,
-    projectId: '1',
-    prompt: '冒险家',
-    spriteWidth: 64,
-    spriteHeight: 64,
-    referenceMedia: [],
   }
 }

--- a/frontend/src/pages/workflow-editor/runtime.ts
+++ b/frontend/src/pages/workflow-editor/runtime.ts
@@ -10,7 +10,13 @@ import type {
   ReviewWorkflowNode,
   WorkflowRunApis,
 } from '@/entities'
-import { characterApis, createMediaApis, projectApis, workflowRunApis } from '@/entities'
+import {
+  characterApis,
+  createMediaApis,
+  generationApis,
+  projectApis,
+  workflowRunApis,
+} from '@/entities'
 import { createCharacterAssetPublisher } from '@/features/export'
 import { createWorkflowController, type WorkflowController } from '@/features/workflow-controller'
 
@@ -164,32 +170,18 @@ export async function createRealWorkflowEditorSession(
   }
 }
 
-/**
- * main 已提供真实 WorkflowRun、Project 与 Character 适配器；Generation 只有公开接口，
- * 尚无可合入的 HTTP 实现。这里明确拒绝生成，避免用演示数据污染正式 WorkflowRun。
- */
+/** 使用生产 Generation 适配器恢复并推进单条 WorkflowRun。 */
 export function createDefaultRealWorkflowEditorSession(
   runId: string,
 ): Promise<WorkflowEditorSession> {
   return createRealWorkflowEditorSession(runId, {
     workflowRunApis,
-    generationApis: createUnavailableGenerationApis(),
+    generationApis,
     mediaApis: createMediaApis(),
     projectApis,
     characterApis,
     onAsyncError: () => undefined,
   })
-}
-
-export function createUnavailableGenerationApis(): GenerationApis {
-  const unavailable = () =>
-    Promise.reject(new Error('GenerationApis 尚未接入真实后端，不能执行或恢复生成任务'))
-
-  return {
-    create: unavailable as GenerationApis['create'],
-    get: unavailable,
-    subscribe: () => () => undefined,
-  }
 }
 
 async function loadWorkflowCharacter(


### PR DESCRIPTION
## 改动
- 在 entities/generation 提供浏览器生产适配器，统一处理 API 前缀、会话 Token、SSE 授权恢复与既有轮询兜底
- Workflow Editor 默认会话改用真实 GenerationApis，不再使用必然失败的占位实现
- 补充生产适配器和 Workflow Editor 默认控制器的回归测试

## 范围
- 仅修改 5 个前端文件，共 156 行新增、39 行删除
- 不修改 Quick Start，与 #240 没有文件重叠
- 未包含真实服务地址、账号或密钥

## 验证
- npm run test:coverage：420 tests passed，Statements 88.71%，Branches 82.48%，Functions 90.75%，Lines 92.30%
- npm run typecheck
- npm run lint
- npm run build
- 变更文件 oxfmt --check