### PR TITLE
fix(generation): reduce image rate-limit pressure

### DIFF
--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -275,6 +275,7 @@ _MIN_IMAGE_BYTES = 5000
 _CONNECT_RETRIES = 3
 _RATE_LIMIT_TRIES = 3
 _MAX_RATE_LIMIT_WAIT = 30.0
+_IMAGE_TIMEOUT_MULTIPLIER = 1.5
 
 
 def _utc_now() -> datetime:
@@ -327,7 +328,7 @@ class SufyImageProvider(ImageProvider):
         return httpx.Client(
             base_url=self._cfg.normalized_base_url,
             headers={"Authorization": f"Bearer {self._cfg.api_key}"},
-            timeout=self._cfg.timeout,
+            timeout=self._cfg.timeout * _IMAGE_TIMEOUT_MULTIPLIER,
             # retries 只覆盖建连阶段的失败(SSL 握手、连接被重置)。本机走代理时这类抖动
             # 常见,已跑通的管线实现正是靠一层网络重试扛住的;不加会在人家能恢复的地方
             # 放弃。它不重试读超时与 5xx —— 那两种请求可能已达上游,重发会重复计费。

--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -23,9 +23,12 @@
 from __future__ import annotations
 
 import base64
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 import io
 import json
 import logging
+import math
 import re
 import time
 
@@ -273,6 +276,27 @@ _CONNECT_RETRIES = 3
 _RATE_LIMIT_TRIES = 3
 _MAX_RATE_LIMIT_WAIT = 30.0
 
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _retry_after_seconds(value: str) -> float | None:
+    try:
+        delay = float(value)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+        delay = (retry_at.astimezone(timezone.utc) - _utc_now()).total_seconds()
+    if not math.isfinite(delay):
+        return None
+    return min(max(delay, 0.0), _MAX_RATE_LIMIT_WAIT)
+
+
 # 从响应里捞 data URI。模型把图放在 message.content 里,而不同网关的包裹层级不一样
 # (有的 content 是字符串、有的是 parts 数组),故对整个响应 JSON 做一次正则,
 # 不去猜层级 —— 猜错的代价是"调用成功、费用已产生、但我们说没图"。
@@ -328,11 +352,9 @@ class SufyImageProvider(ImageProvider):
                     "请稍后重试或检查服务商额度"
                 )
             retry_after = resp.headers.get("Retry-After", "")
-            try:
-                delay = float(retry_after)
-            except ValueError:
+            delay = _retry_after_seconds(retry_after)
+            if delay is None:
                 delay = float(2**attempt)
-            delay = min(max(delay, 0.0), _MAX_RATE_LIMIT_WAIT)
             logger.warning(
                 "图像服务返回 429，第 %d/%d 次请求，%.2f 秒后重试",
                 attempt,

--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -270,6 +270,8 @@ DEFAULT_IMAGE_MODEL = "gemini-2.5-flash-image"
 _IMAGE_TRIES = 3
 _MIN_IMAGE_BYTES = 5000
 _CONNECT_RETRIES = 3
+_RATE_LIMIT_TRIES = 3
+_MAX_RATE_LIMIT_WAIT = 30.0
 
 # 从响应里捞 data URI。模型把图放在 message.content 里,而不同网关的包裹层级不一样
 # (有的 content 是字符串、有的是 parts 数组),故对整个响应 JSON 做一次正则,
@@ -309,14 +311,35 @@ class SufyImageProvider(ImageProvider):
         )
 
     def _post(self, client: httpx.Client, body: dict) -> dict:
-        """发一次请求。把"网关没有这个模型"翻译成能照着修的错误。
+        """发送请求，有限重试未被网关接收的 429。
 
         为什么值得专门处理:同一把 key 下不同网关的模型目录**不一样**。实测
         ``GET /v1/models``:一个网关 73 个模型、一个图像模型都没有;另一个 134 个、
         含本模块默认的那个(2026-08-10)。配错 ``AI_BASE_URL`` 时原始报错只是一条
         404,读的人无从知道该去改配置还是改模型名。
         """
-        resp = client.post(self._cfg.chat_completions_path, json=body)
+        for attempt in range(1, _RATE_LIMIT_TRIES + 1):
+            resp = client.post(self._cfg.chat_completions_path, json=body)
+            if resp.status_code != 429:
+                break
+            if attempt == _RATE_LIMIT_TRIES:
+                raise RuntimeError(
+                    f"图像服务请求过于频繁(HTTP 429)，已重试 {_RATE_LIMIT_TRIES} 次；"
+                    "请稍后重试或检查服务商额度"
+                )
+            retry_after = resp.headers.get("Retry-After", "")
+            try:
+                delay = float(retry_after)
+            except ValueError:
+                delay = float(2**attempt)
+            delay = min(max(delay, 0.0), _MAX_RATE_LIMIT_WAIT)
+            logger.warning(
+                "图像服务返回 429，第 %d/%d 次请求，%.2f 秒后重试",
+                attempt,
+                _RATE_LIMIT_TRIES,
+                delay,
+            )
+            time.sleep(delay)
         if resp.status_code in (400, 404):
             raise RuntimeError(
                 f"网关 {self._cfg.normalized_base_url} 拒绝了模型 {self._model!r}"

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -244,6 +244,21 @@ def _image_provider(handler):
     return p
 
 
+def test_image_provider_extends_request_timeout_by_half():
+    from windup_framework.config.provider import AIProviderSettings
+    from windup_framework.providers.sufy import SufyImageProvider
+
+    provider = SufyImageProvider(
+        config=AIProviderSettings(base_url="https://gw.example.com/v1", api_key="k", timeout=20),
+    )
+
+    with provider._client() as client:
+        assert client.timeout.connect == 30
+        assert client.timeout.read == 30
+        assert client.timeout.write == 30
+        assert client.timeout.pool == 30
+
+
 def test_gen_image_returns_the_decoded_png():
     """端点可达而 provider 必抛错 = 每个图像任务稳定 FAILED。实现后必须真能出图。"""
     def h(request):

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -9,6 +9,7 @@
    见 ``providers.sufy._download_request`` 的 docstring。
 """
 
+from datetime import datetime, timezone
 import json
 
 import httpx
@@ -18,6 +19,8 @@ from windup_framework.providers.sufy import (
     IncompleteDownloadError,
     UnsafeDownloadUrlError,
     _download,
+    _retry_after_seconds,
+    _utc_now,
 )
 
 VIDEO = b"\x00\x01mp4-bytes" * 64
@@ -367,7 +370,9 @@ def test_image_rate_limit_exhaustion_has_actionable_error(monkeypatch):
     assert calls["n"] == 3
 
 
-@pytest.mark.parametrize(("retry_after", "expected"), [("invalid", 2.0), ("300", 30.0)])
+@pytest.mark.parametrize(
+    ("retry_after", "expected"), [("invalid", 2.0), ("NaN", 2.0), ("300", 30.0)]
+)
 def test_image_rate_limit_wait_has_fallback_and_cap(monkeypatch, retry_after, expected):
     calls = {"n": 0}
     sleeps: list[float] = []
@@ -383,6 +388,42 @@ def test_image_rate_limit_wait_has_fallback_and_cap(monkeypatch, retry_after, ex
 
     assert _image_provider(h).gen_image("x", [])
     assert sleeps == [expected]
+
+
+def test_image_rate_limit_accepts_http_date(monkeypatch):
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    def h(request):
+        import httpx
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(
+                429, headers={"Retry-After": "Thu, 13 Aug 2026 03:00:10 GMT"}
+            )
+        return httpx.Response(200, json=_img_payload(_big_b64()))
+
+    monkeypatch.setattr(
+        "windup_framework.providers.sufy._utc_now",
+        lambda: datetime(2026, 8, 13, 3, 0, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", sleeps.append)
+
+    assert _image_provider(h).gen_image("x", [])
+    assert sleeps == [10.0]
+
+
+def test_retry_after_clock_is_utc():
+    assert _utc_now().tzinfo is timezone.utc
+
+
+def test_retry_after_accepts_date_without_timezone(monkeypatch):
+    monkeypatch.setattr(
+        "windup_framework.providers.sufy._utc_now",
+        lambda: datetime(2026, 8, 13, 3, 0, tzinfo=timezone.utc),
+    )
+
+    assert _retry_after_seconds("Thu, 13 Aug 2026 03:00:10") == 10.0
 
 
 def test_request_path_comes_from_config_not_a_literal():

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -332,6 +332,59 @@ def test_image_client_retries_connection_failures():
         client.close()
 
 
+def test_image_rate_limit_is_retried_after_retry_after(monkeypatch):
+    """429 表示请求未被网关接收，按 Retry-After 退避后应继续当前图片任务。"""
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    def h(request):
+        import httpx
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, headers={"Retry-After": "0.25"})
+        return httpx.Response(200, json=_img_payload(_big_b64()))
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", sleeps.append)
+
+    assert _image_provider(h).gen_image("x", [])
+    assert calls["n"] == 2
+    assert sleeps == [0.25]
+
+
+def test_image_rate_limit_exhaustion_has_actionable_error(monkeypatch):
+    """持续 429 不能泄漏 httpx 异常，也不能无限重试。"""
+    calls = {"n": 0}
+
+    def h(request):
+        import httpx
+        calls["n"] += 1
+        return httpx.Response(429, text='{"error":{"message":"quota exceeded"}}')
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
+
+    with pytest.raises(RuntimeError, match="稍后重试或检查服务商额度"):
+        _image_provider(h).gen_image("x", [])
+    assert calls["n"] == 3
+
+
+@pytest.mark.parametrize(("retry_after", "expected"), [("invalid", 2.0), ("300", 30.0)])
+def test_image_rate_limit_wait_has_fallback_and_cap(monkeypatch, retry_after, expected):
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    def h(request):
+        import httpx
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, headers={"Retry-After": retry_after})
+        return httpx.Response(200, json=_img_payload(_big_b64()))
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", sleeps.append)
+
+    assert _image_provider(h).gen_image("x", [])
+    assert sleeps == [expected]
+
+
 def test_request_path_comes_from_config_not_a_literal():
     """路径用配置里的 chat_completions_path —— 它此前零消费方,正是今天在删的那类字段。"""
 

--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -20,14 +20,13 @@ function taskData(overrides: Record<string, unknown> = {}) {
     project_id: 42,
     task_type: 'character_image',
     status: 'completed',
-    input_payload: { num_images: 4 },
+    input_payload: { num_images: 3 },
     result: {
       type: 'character_image',
       image_urls: [
         'https://cdn.test/candidate-1.png',
         'https://cdn.test/candidate-2.png',
         'https://cdn.test/candidate-3.png',
-        'https://cdn.test/candidate-4.png',
       ],
     },
     error_message: null,
@@ -47,7 +46,7 @@ function actionFrames(count: number) {
 }
 
 describe('createGenerationApis', () => {
-  it('固定请求并映射四张角色母版候选', async () => {
+  it('固定请求并映射三张角色母版候选', async () => {
     const request = vi.fn(async (_url: string, _init?: RequestInit) => success(taskData()))
     const stream = vi.fn(() => vi.fn())
     const apis = createGenerationApis({
@@ -76,7 +75,7 @@ describe('createGenerationApis', () => {
           negative_prompt: '',
           width: 64,
           height: 96,
-          num_images: 4,
+          num_images: 3,
         }),
       }),
     )
@@ -86,7 +85,6 @@ describe('createGenerationApis', () => {
         { url: 'https://cdn.test/candidate-1.png' },
         { url: 'https://cdn.test/candidate-2.png' },
         { url: 'https://cdn.test/candidate-3.png' },
-        { url: 'https://cdn.test/candidate-4.png' },
       ],
     })
   })
@@ -410,13 +408,13 @@ describe('createGenerationApis', () => {
     ['输入对象', { input_payload: [] }, '生成任务 input_payload 无效'],
     ['结果对象', { result: [] }, '生成任务 result 无效'],
     ['错误字段', { error_message: 1 }, '生成任务 error_message 无效'],
-    ['任务输入', { input_payload: { num_images: 3 } }, 'num_images 必须为 4'],
+    ['任务输入', { input_payload: { num_images: 4 } }, 'num_images 必须为 3'],
     [
       '图片结果类型',
-      { result: { type: 'video', image_urls: ['a', 'b', 'c', 'd'] } },
+      { result: { type: 'video', image_urls: ['a', 'b', 'c'] } },
       '角色图片结果 type 无效',
     ],
-    ['图片数量', { result: { type: 'character_image', image_urls: ['a'] } }, '必须包含 4 个候选'],
+    ['图片数量', { result: { type: 'character_image', image_urls: ['a'] } }, '必须包含 3 个候选'],
     ['完成结果', { result: null }, '完成任务缺少 result'],
   ])('校验%s', async (_label, overrides, message) => {
     const apis = createGenerationApis({

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -162,6 +162,8 @@ function expectedBackendType(type: GenerationType): BackendGenerationType {
   return type === 'character_template' ? 'character_image' : 'character_action'
 }
 
+const CHARACTER_TEMPLATE_CANDIDATE_COUNT = 3
+
 function nonEmptyString(value: unknown, field: string): string {
   if (typeof value !== 'string' || value.trim() === '') {
     throw new GenerationApiError(`${field} 无效`, 200)
@@ -182,8 +184,11 @@ function mapImageResult(result: Record<string, unknown>): GenerationResult {
   }
   const images = result.image_urls.map((url): GeneratedImage => ({ url: url as string }))
 
-  if (images.length !== 4) {
-    throw new GenerationApiError('角色母版结果必须包含 4 个候选', 200)
+  if (images.length !== CHARACTER_TEMPLATE_CANDIDATE_COUNT) {
+    throw new GenerationApiError(
+      `角色母版结果必须包含 ${CHARACTER_TEMPLATE_CANDIDATE_COUNT} 个候选`,
+      200,
+    )
   }
   return { type: 'character_template', images }
 }
@@ -289,8 +294,11 @@ function validateInputPayload(
     throw new GenerationApiError('生成任务缺少 input_payload', 200)
   }
   if (expectation.type === 'character_template') {
-    if (inputPayload.num_images !== 4) {
-      throw new GenerationApiError('角色母版任务 input_payload.num_images 必须为 4', 200)
+    if (inputPayload.num_images !== CHARACTER_TEMPLATE_CANDIDATE_COUNT) {
+      throw new GenerationApiError(
+        `角色母版任务 input_payload.num_images 必须为 ${CHARACTER_TEMPLATE_CANDIDATE_COUNT}`,
+        200,
+      )
     }
     return
   }
@@ -515,8 +523,8 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
         negative_prompt: '',
         width: inputPositiveInteger(input.spriteWidth, 'spriteWidth'),
         height: inputPositiveInteger(input.spriteHeight, 'spriteHeight'),
-        // 只有角色母版走图片接口，并且固定生成四个候选。
-        num_images: 4,
+        // 只有角色母版走图片接口；三张候选控制单次任务的供应商调用压力。
+        num_images: CHARACTER_TEMPLATE_CANDIDATE_COUNT,
       })
       expectations.set(generation.id, expectation)
       return generation as Generation<T['type']>


### PR DESCRIPTION
## What changed
- reduce Quick Start character preview candidates from four to three, cutting provider calls per task by 25%
- extend image request timeout by 50% (120 to 180 seconds by default) without changing other providers
- keep the backend generation API generic at 1-4 images for other callers
- retry image requests that receive HTTP 429, respecting numeric and HTTP-date Retry-After values
- cap waits at 30 seconds and stop after three attempts with an actionable error

## Verification
- frontend: 423 tests passed
- frontend: typecheck, lint, production build, and coverage passed
- backend provider tests: 40 passed
- backend: ruff and import contracts passed