### PR TITLE
feat(navigation): add back button and preview-stage naming

### DIFF
--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -121,7 +121,7 @@ describe('AppRoutes authentication boundary', () => {
         '/?account=login&returnTo=%2Fplaytest',
       ),
     )
-    expect(screen.queryByRole('heading', { name: '选择可试玩资产' })).toBeNull()
+    expect(screen.queryByRole('heading', { name: '选择可预览资产' })).toBeNull()
   })
 
   it('protects direct account-center visits and returns there after login', async () => {

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -40,12 +40,15 @@ function LocationProbe() {
   )
 }
 
-function renderHeader(entry = '/', apis = createApis()) {
+function renderHeader(entry = '/', apis = createApis(), previousEntry?: string) {
   return {
     apis,
     ...render(
       <AuthSessionProvider apis={apis}>
-        <MemoryRouter initialEntries={[entry]}>
+        <MemoryRouter
+          initialEntries={previousEntry ? [previousEntry, entry] : [entry]}
+          initialIndex={previousEntry ? 1 : 0}
+        >
           <Routes>
             <Route
               path="*"
@@ -66,9 +69,38 @@ function renderHeader(entry = '/', apis = createApis()) {
 afterEach(() => {
   cleanup()
   window.localStorage.clear()
+  window.history.replaceState({ idx: 0 }, '')
 })
 
 describe('AppHeader', () => {
+  it.each([
+    ['/quick-start/run-42', '/quick-start'],
+    ['/playtest/7/outfit-8', '/playtest'],
+    ['/projects/new', '/projects'],
+    ['/workflow-editor/run-42', '/workspace'],
+    ['/workspace', '/'],
+    ['/account', '/workspace'],
+  ])('直接打开 %s 时按页面层级返回 %s', (entry, expected) => {
+    window.history.replaceState({ idx: 0 }, '')
+    renderHeader(entry)
+
+    const back = screen.getByRole('button', { name: '返回上一页' })
+    expect(back.getAttribute('title')).toBe('返回上一页')
+    expect(back.className).toContain('h-9')
+    expect(back.className).toContain('w-9')
+
+    fireEvent.click(back)
+    expect(screen.getByTestId('location').textContent).toBe(expected)
+  })
+
+  it('存在站内浏览历史时返回真实上一页', () => {
+    window.history.replaceState({ idx: 1 }, '')
+    renderHeader('/quick-start', createApis(), '/projects')
+
+    fireEvent.click(screen.getByRole('button', { name: '返回上一页' }))
+    expect(screen.getByTestId('location').textContent).toBe('/projects')
+  })
+
   it('提供 PlayTest 入口，并将工作流路由归入创作', () => {
     renderHeader('/workflow-editor/run-1')
 

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -101,7 +101,7 @@ describe('AppHeader', () => {
     expect(screen.getByTestId('location').textContent).toBe('/projects')
   })
 
-  it('提供 PlayTest 入口，并将工作流路由归入创作', () => {
+  it('提供预览台入口，并将工作流路由归入创作', () => {
     renderHeader('/workflow-editor/run-1')
 
     expect(screen.getByRole('banner').getAttribute('data-surface')).toBe('frosted-bar')
@@ -111,7 +111,7 @@ describe('AppHeader', () => {
     )
     expect(screen.getByRole('link', { name: '项目资产' }).getAttribute('href')).toBe('/projects')
     expect(screen.getByRole('link', { name: '创作' }).getAttribute('aria-current')).toBe('page')
-    expect(screen.getByRole('link', { name: 'PlayTest' }).getAttribute('href')).toBe('/playtest')
+    expect(screen.getByRole('link', { name: '预览台' }).getAttribute('href')).toBe('/playtest')
   })
 
   it('在工作台首页只高亮首页一项', () => {
@@ -120,7 +120,7 @@ describe('AppHeader', () => {
     expect(screen.getByRole('link', { name: '首页' }).getAttribute('aria-current')).toBe('page')
     expect(screen.getByRole('link', { name: '项目资产' }).getAttribute('aria-current')).toBeNull()
     expect(screen.getByRole('link', { name: '创作' }).getAttribute('aria-current')).toBeNull()
-    expect(screen.getByRole('link', { name: 'PlayTest' }).getAttribute('aria-current')).toBeNull()
+    expect(screen.getByRole('link', { name: '预览台' }).getAttribute('aria-current')).toBeNull()
   })
 
   it('切换页面后继续播放与品牌一致的文字波浪', () => {
@@ -163,14 +163,14 @@ describe('AppHeader', () => {
     expect(projects.classList.contains('app-header-text-wave')).toBe(true)
   })
 
-  it('在资产选择页和具体试玩台高亮 PlayTest 入口', () => {
+  it('在资产选择页和具体预览台高亮预览台入口', () => {
     const { unmount } = renderHeader('/playtest')
 
-    expect(screen.getByRole('link', { name: 'PlayTest' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('link', { name: '预览台' }).getAttribute('aria-current')).toBe('page')
 
     unmount()
     renderHeader('/playtest/51/outfit-default')
-    expect(screen.getByRole('link', { name: 'PlayTest' }).getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('link', { name: '预览台' }).getAttribute('aria-current')).toBe('page')
   })
 
   it('为访客提供可发现的登录入口并保留完整站内回跳地址', async () => {
@@ -286,7 +286,7 @@ describe('AppHeader', () => {
       screen.getByRole('link', { name: '首页' }),
       screen.getByRole('link', { name: '项目资产' }),
       screen.getByRole('link', { name: '创作' }),
-      screen.getByRole('link', { name: 'PlayTest' }),
+      screen.getByRole('link', { name: '预览台' }),
     ]
     for (const entry of animatedEntries) {
       expect(entry.getAttribute('data-motion')).toBe('text-wave')

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 
 import { useAuthSession } from '@/features/auth-session'
+import { PageBackButton } from './page-back-button'
 
 interface ProductNavigationItem {
   motionKey: string
@@ -113,20 +114,23 @@ export function AppHeader() {
       className="fixed inset-x-0 top-0 z-50 border-b border-[#1c231e]/10 bg-transparent text-[#1c231e] shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] backdrop-blur-xl"
     >
       <div className="relative mx-auto grid min-h-14 w-full max-w-[90rem] grid-cols-[auto_1fr_auto] items-center gap-4 px-4 sm:px-6 lg:px-8">
-        <Link
-          to="/workspace"
-          aria-label="返回 Windup 工作台"
-          data-motion="text-wave"
-          onClick={() => playTextWave('brand')}
-          className={`flex min-h-11 shrink-0 items-center gap-2.5 pr-1 text-[#1c231e] focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] ${
-            wave.entry === 'brand' ? 'app-header-text-wave' : ''
-          }`}
-        >
-          <img src="/windup-mark.svg" alt="" className="h-7 w-7" />
-          <strong className="hidden font-serif text-[1.0625rem] leading-none sm:inline">
-            <WaveText playId={wave.entry === 'brand' ? wave.playId : 0} text="Windup" />
-          </strong>
-        </Link>
+        <div className="flex min-w-0 items-center gap-1.5">
+          <PageBackButton />
+          <Link
+            to="/workspace"
+            aria-label="返回 Windup 工作台"
+            data-motion="text-wave"
+            onClick={() => playTextWave('brand')}
+            className={`flex min-h-11 shrink-0 items-center gap-2.5 pr-1 text-[#1c231e] focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] max-[360px]:hidden ${
+              wave.entry === 'brand' ? 'app-header-text-wave' : ''
+            }`}
+          >
+            <img src="/windup-mark.svg" alt="" className="h-7 w-7" />
+            <strong className="hidden font-serif text-[1.0625rem] leading-none sm:inline">
+              <WaveText playId={wave.entry === 'brand' ? wave.playId : 0} text="Windup" />
+            </strong>
+          </Link>
+        </div>
 
         <nav
           aria-label="产品导航"

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -41,7 +41,7 @@ const productNavigation: ProductNavigationItem[] = [
   {
     motionKey: 'playtest',
     to: '/playtest',
-    label: 'PlayTest',
+    label: '预览台',
     isActive: (pathname) => pathname.startsWith('/playtest'),
   },
 ]

--- a/frontend/src/app/layout/page-back-button.tsx
+++ b/frontend/src/app/layout/page-back-button.tsx
@@ -1,0 +1,46 @@
+import { useLocation, useNavigate } from 'react-router'
+
+function fallbackPath(pathname: string): string {
+  if (/^\/quick-start\/[^/]+$/.test(pathname)) return '/quick-start'
+  if (/^\/playtest\/[^/]+\/[^/]+$/.test(pathname)) return '/playtest'
+  if (pathname === '/projects/new') return '/projects'
+  if (pathname.startsWith('/workflow-editor/')) return '/workspace'
+  if (pathname === '/workspace') return '/'
+  return '/workspace'
+}
+
+function hasInternalHistory(): boolean {
+  const state = window.history.state as { idx?: unknown } | null
+  return typeof state?.idx === 'number' && state.idx > 0
+}
+
+/**
+ * 产品页统一后退入口。
+ * React Router 提醒 navigate(-1) 可能没有历史项或退到站外，因此直达页面使用稳定父级兜底。
+ */
+export function PageBackButton() {
+  const { pathname } = useLocation()
+  const navigate = useNavigate()
+
+  function goBack() {
+    if (hasInternalHistory()) {
+      navigate(-1)
+      return
+    }
+    navigate(fallbackPath(pathname), { replace: true })
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label="返回上一页"
+      title="返回上一页"
+      onClick={goBack}
+      className="inline-grid h-9 w-9 shrink-0 place-items-center rounded-md border border-[#25342a]/12 bg-white/35 text-[#34483a] transition-[background-color,color,transform] duration-150 hover:bg-white/75 hover:text-[#1f3326] active:translate-y-px active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331] motion-reduce:transform-none"
+    >
+      <span aria-hidden="true" className="text-[1.2rem] leading-none">
+        ←
+      </span>
+    </button>
+  )
+}

--- a/frontend/src/pages/character-detail/index.test.tsx
+++ b/frontend/src/pages/character-detail/index.test.tsx
@@ -42,7 +42,7 @@ describe('CharacterDetailPage', () => {
     expect(screen.queryByText('GIF')).toBeNull()
     expect(screen.getByRole('button', { name: '增加动作' }).hasAttribute('disabled')).toBe(true)
     expect(screen.getByRole('button', { name: '导出资产包' }).hasAttribute('disabled')).toBe(true)
-    expect(screen.getByRole('link', { name: '试玩当前造型' }).getAttribute('href')).toBe(
+    expect(screen.getByRole('link', { name: '在预览台打开当前造型' }).getAttribute('href')).toBe(
       '/playtest/51/outfit-default',
     )
   })
@@ -72,6 +72,6 @@ describe('CharacterDetailPage', () => {
     expect(await screen.findByRole('heading', { name: '待定角色' })).toBeTruthy()
     expect(screen.getByRole('combobox', { name: '选择造型' })).toBeTruthy()
     expect(screen.getByText('这个造型还没有动作')).toBeTruthy()
-    expect(screen.queryByRole('link', { name: '试玩当前造型' })).toBeNull()
+    expect(screen.queryByRole('link', { name: '在预览台打开当前造型' })).toBeNull()
   })
 })

--- a/frontend/src/pages/character-detail/index.tsx
+++ b/frontend/src/pages/character-detail/index.tsx
@@ -119,10 +119,10 @@ export function CharacterDetailPage() {
             {selectedOutfit && canPlaytest ? (
               <Link
                 to={`/playtest/${character.id}/${selectedOutfit.id}`}
-                aria-label="试玩当前造型"
+                aria-label="在预览台打开当前造型"
                 className="inline-flex min-h-9 items-center rounded-full bg-[#294433] px-4 text-xs font-semibold text-white transition-colors hover:bg-[#1f3828] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#294433]"
               >
-                试玩当前造型
+                在预览台打开
               </Link>
             ) : null}
             <button

--- a/frontend/src/pages/landing/capabilities-rail.tsx
+++ b/frontend/src/pages/landing/capabilities-rail.tsx
@@ -10,7 +10,7 @@ const capabilities = [
   },
   {
     statement: '让他真正走起来，再决定下一步。',
-    title: 'PlayTest',
+    title: '预览台',
   },
   {
     statement: '同一个角色，在每一个动作里仍然是他自己。',
@@ -75,7 +75,7 @@ export function CapabilitiesRail() {
           角色做出来，还要留下来、跑起来。
         </h2>
         <p className="mt-6 max-w-[28em] text-lead text-ink-muted">
-          资产库保存角色的全部来路，PlayTest 检验动作真正的样子，工作流画布让质量不靠一次碰运气。
+          资产库保存角色的全部来路，预览台检验动作真正的样子，工作流画布让质量不靠一次碰运气。
         </p>
       </div>
 

--- a/frontend/src/pages/landing/index.tsx
+++ b/frontend/src/pages/landing/index.tsx
@@ -28,7 +28,7 @@ const productCapabilities = [
     outcome:
       '选择已经完成的角色与造型，就能在浏览器里切换动作、控制移动，亲手感受播放节奏与动作衔接。这里读取的不是演示动画，而是项目里真实保存的动作帧。',
     statement: '让他真正走起来，再决定下一步。',
-    title: 'PlayTest',
+    title: '预览台',
   },
   {
     outcome:
@@ -42,7 +42,7 @@ const assetLevels = [
   ['Project', '项目约束', '题材、画风、视角与精灵尺寸'],
   ['Character', '角色身份', '稳定的人物特征与参考基准'],
   ['Outfit', '角色造型', '一套穿戴与对应角色母版'],
-  ['Action', '动作资产', '可审核、可试玩、可继续扩展的帧序列'],
+  ['Action', '动作资产', '可审核、可预览、可继续扩展的帧序列'],
 ] as const
 
 const styleShowcaseItems = [
@@ -141,7 +141,7 @@ function PlayTestScene() {
     <div
       className={`${capabilitySceneClassName} [opacity:var(--play-opacity)] [transform:scale(var(--play-scale))] motion-reduce:hidden`}
     >
-      <p className={capabilityMediaNoteClassName}>此处将展示 PlayTest 的真实运行画面。</p>
+      <p className={capabilityMediaNoteClassName}>此处将展示预览台的真实运行画面。</p>
     </div>
   )
 }
@@ -310,7 +310,7 @@ function CapabilityStory() {
             className={`${floatingCardClassName} h-32 w-56`}
           >
             <p className="absolute bottom-[0.9rem] left-[0.9rem] text-[0.6rem] text-[#9b9e98]">
-              PlayTest 画面待接入
+              预览台画面待接入
             </p>
           </article>
         </div>

--- a/frontend/src/pages/playtest/entry.test.tsx
+++ b/frontend/src/pages/playtest/entry.test.tsx
@@ -39,10 +39,10 @@ describe('PlaytestEntryPage', () => {
   it('links playable outfits to their concrete Playtest route', async () => {
     renderEntry()
 
-    expect(await screen.findByRole('heading', { name: '选择可试玩资产' })).toBeTruthy()
+    expect(await screen.findByRole('heading', { name: '选择可预览资产' })).toBeTruthy()
     expect(screen.getByTestId('playtest-pixel-stage').getAttribute('aria-hidden')).toBe('true')
     expect(
-      (await screen.findByRole('link', { name: '试玩 轻装信使 · 常态造型' })).getAttribute('href'),
+      (await screen.findByRole('link', { name: '预览 轻装信使 · 常态造型' })).getAttribute('href'),
     ).toBe('/playtest/51/outfit-default')
     expect(screen.getByText('2 个动作 · 5 帧')).toBeTruthy()
     expect(screen.getByText('尚无可播放帧')).toBeTruthy()
@@ -51,7 +51,7 @@ describe('PlaytestEntryPage', () => {
   it('directs an empty account back to character creation', async () => {
     renderEntry(0)
 
-    expect(await screen.findByText('还没有可试玩的角色')).toBeTruthy()
+    expect(await screen.findByText('还没有可预览的角色')).toBeTruthy()
     expect(screen.getByRole('link', { name: '开始创作' }).getAttribute('href')).toBe('/quick-start')
     expect(screen.getByRole('link', { name: '查看项目资产' }).getAttribute('href')).toBe(
       '/projects',
@@ -61,8 +61,8 @@ describe('PlaytestEntryPage', () => {
   it('keeps a failed asset request distinct from an empty account', async () => {
     renderEntryWith(() => Promise.reject(new TypeError('network unavailable')))
 
-    expect(await screen.findByText('可试玩资产暂时无法读取')).toBeTruthy()
-    expect(screen.queryByText('还没有可试玩的角色')).toBeNull()
+    expect(await screen.findByText('可预览资产暂时无法读取')).toBeTruthy()
+    expect(screen.queryByText('还没有可预览的角色')).toBeNull()
   })
 
   it('loads every project and character page before presenting the asset count', async () => {

--- a/frontend/src/pages/playtest/entry.tsx
+++ b/frontend/src/pages/playtest/entry.tsx
@@ -44,7 +44,7 @@ function characterName(character: Character) {
 
 /**
  * Playtest 的全局入口只负责定位已落入 Character 资产树的 Outfit。
- * 它不生成测试数据；具体操控仍交给带 characterId 与 outfitId 的试玩台。
+ * 它不生成测试数据；具体操控仍交给带 characterId 与 outfitId 的预览台。
  */
 export function PlaytestEntryPage() {
   const [state, setState] = useState<EntryState>(initialState)
@@ -69,7 +69,7 @@ export function PlaytestEntryPage() {
           if (active) setState({ groups, error: null })
         },
         () => {
-          if (active) setState({ groups: [], error: '可试玩资产暂时无法读取' })
+          if (active) setState({ groups: [], error: '可预览资产暂时无法读取' })
         },
       )
 
@@ -98,7 +98,7 @@ export function PlaytestEntryPage() {
                 id="playtest-entry-title"
                 className="font-serif text-4xl font-medium tracking-[-0.045em] text-[#1f211e]"
               >
-                选择可试玩资产
+                选择可预览资产
               </h1>
               <p className="mt-2 max-w-2xl text-sm leading-6 text-[#696e67]">
                 选择一套已有造型，检查动作衔接、移动反馈和实际播放效果。
@@ -116,7 +116,7 @@ export function PlaytestEntryPage() {
         {state.error ? (
           <ErrorState />
         ) : state.groups === null ? (
-          <p className="mt-8 text-sm text-[#70766f]">正在整理可试玩资产…</p>
+          <p className="mt-8 text-sm text-[#70766f]">正在整理可预览资产…</p>
         ) : outfitCount === 0 ? (
           <EmptyState />
         ) : (
@@ -200,7 +200,7 @@ function OutfitCard({ character, outfit }: { character: Character; outfit: Outfi
               : 'border-[#cdd2cc] bg-[#f4f5f1]/95 text-[#7a817a]'
           }`}
         >
-          {playable ? '可试玩' : '待补帧'}
+          {playable ? '可预览' : '待补帧'}
         </span>
       </div>
       <div className="p-4">
@@ -225,7 +225,7 @@ function OutfitCard({ character, outfit }: { character: Character; outfit: Outfi
   return (
     <Link
       to={`/playtest/${character.id}/${outfit.id}`}
-      aria-label={`试玩 ${name} · ${outfit.name}`}
+      aria-label={`预览 ${name} · ${outfit.name}`}
       className="block rounded-[1.4rem] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#294433]"
     >
       {content}
@@ -237,7 +237,7 @@ function EmptyState() {
   return (
     <div className="mt-7 rounded-[1.5rem] border border-dashed border-[#c9cec6] bg-[#f7f8f4] p-7 sm:p-9">
       <h2 className="font-serif text-2xl font-medium tracking-[-0.03em] text-[#252a25]">
-        还没有可试玩的角色
+        还没有可预览的角色
       </h2>
       <p className="mt-2 max-w-xl text-sm leading-6 text-[#6d736c]">
         完成角色与动作制作后，可以在这里检查移动和动画效果。
@@ -263,7 +263,7 @@ function EmptyState() {
 function ErrorState() {
   return (
     <div className="mt-7 rounded-[1.5rem] border border-[#d8c7bd] bg-[#fff8f2] p-7">
-      <h2 className="font-semibold text-[#6f3928]">可试玩资产暂时无法读取</h2>
+      <h2 className="font-semibold text-[#6f3928]">可预览资产暂时无法读取</h2>
       <p className="mt-2 text-sm text-[#7a5548]">稍后刷新页面，或先回项目资产检查角色数据。</p>
       <Link
         to="/projects"

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -36,7 +36,7 @@ function renderPlaytest(path: string, fetchFn?: typeof globalThis.fetch) {
 }
 
 function stageFrameUrl() {
-  return screen.getByRole('region', { name: '试玩舞台' }).querySelector('img')?.getAttribute('src')
+  return screen.getByRole('region', { name: '预览舞台' }).querySelector('img')?.getAttribute('src')
 }
 
 describe('PlaytestPage', () => {
@@ -75,7 +75,7 @@ describe('PlaytestPage', () => {
   it('reports a missing outfit instead of falling back to another one', async () => {
     renderPlaytest('/playtest/51/outfit-missing')
 
-    expect(await screen.findByText('找不到指定造型，无法进入试玩。')).toBeTruthy()
+    expect(await screen.findByText('找不到指定造型，无法进入预览台。')).toBeTruthy()
   })
 
   it('maps the business not-found code to a stable message', async () => {

--- a/frontend/src/pages/playtest/index.tsx
+++ b/frontend/src/pages/playtest/index.tsx
@@ -25,7 +25,7 @@ function isNotFoundError(error: unknown): boolean {
 }
 
 /**
- * 核验台：用角色造型里已经确认的动作帧真实操控角色。
+ * 预览台：用角色造型里已经确认的动作帧真实操控角色。
  * 页面只读 Character，不写回资产树，也不参与生成与审核。
  * 读不到角色时直接报错，不退回任何内置数据。
  */
@@ -60,10 +60,10 @@ export function PlaytestPage() {
   }, [characterId])
 
   if (characterId === undefined || outfitId === undefined)
-    return <PlaytestPageMessage>Playtest 路由参数不完整</PlaytestPageMessage>
+    return <PlaytestPageMessage>预览台路由参数不完整</PlaytestPageMessage>
   if (data.error !== null) return <PlaytestPageMessage>{data.error}</PlaytestPageMessage>
   if (data.loading || data.character === null)
-    return <PlaytestPageMessage>加载 Playtest 数据中</PlaytestPageMessage>
+    return <PlaytestPageMessage>正在加载预览台数据</PlaytestPageMessage>
 
   return (
     <PlaytestWorkbench
@@ -76,7 +76,7 @@ export function PlaytestPage() {
 
 function PlaytestPageMessage({ children }: { children: string }) {
   return (
-    <main aria-label="Playtest" className="grid min-h-screen place-items-center bg-[#dfe3df] p-6">
+    <main aria-label="预览台" className="grid min-h-screen place-items-center bg-[#dfe3df] p-6">
       <p className="text-sm font-medium text-[#3d443f]">{children}</p>
     </main>
   )

--- a/frontend/src/pages/playtest/workbench/index.tsx
+++ b/frontend/src/pages/playtest/workbench/index.tsx
@@ -27,9 +27,9 @@ export function PlaytestWorkbench({
 
   if (!result.ok) {
     return (
-      <main aria-label="Playtest" className="grid min-h-screen place-items-center bg-[#dfe3df] p-6">
+      <main aria-label="预览台" className="grid min-h-screen place-items-center bg-[#dfe3df] p-6">
         <p className="rounded-full border border-[#c6ccc6] bg-[#f4f3ed] px-5 py-3 text-sm text-[#555b56]">
-          找不到指定造型，无法进入试玩。
+          找不到指定造型，无法进入预览台。
         </p>
       </main>
     )
@@ -60,14 +60,14 @@ function PlaytestExperience({
   // 顶栏悬浮不占布局高度，满幅页面自己让出避让空间；pt-24 与 PageContainer 同源，改顶栏尺寸时一起改。
   return (
     <main
-      aria-label="Playtest"
+      aria-label="预览台"
       className="flex h-screen flex-col bg-[#dfe3df] px-3 pb-4 pt-24 text-[#171817] sm:px-5 sm:pb-5"
     >
       <div className="mx-auto flex w-full max-w-[1600px] flex-1 flex-col gap-4">
         <header className="flex flex-wrap items-end justify-between gap-3 px-1">
           <div>
             <p className="font-mono text-[10px] font-semibold tracking-[0.2em] text-[#747973]">
-              PLAYTEST
+              预览台
             </p>
             <h1
               aria-label={`${model.characterId} · ${model.outfitName}`}

--- a/frontend/src/pages/playtest/workbench/minimal-workbench.test.tsx
+++ b/frontend/src/pages/playtest/workbench/minimal-workbench.test.tsx
@@ -77,7 +77,7 @@ describe('PlaytestWorkbench minimal control path', () => {
   it('shows one stage, the bound actions, and direct character controls', () => {
     renderWorkbench()
 
-    expect(screen.getByRole('region', { name: '试玩舞台' })).toBeTruthy()
+    expect(screen.getByRole('region', { name: '预览舞台' })).toBeTruthy()
     expect(screen.getByRole('group', { name: '角色操控' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '绑定动作：待机' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '绑定动作：行走' })).toBeTruthy()

--- a/frontend/src/pages/playtest/workbench/stage.test.tsx
+++ b/frontend/src/pages/playtest/workbench/stage.test.tsx
@@ -15,7 +15,7 @@ function renderStage(x: number) {
       onBoundsChange={() => undefined}
     />,
   )
-  return screen.getByRole('region', { name: '试玩舞台' }).querySelector('img')
+  return screen.getByRole('region', { name: '预览舞台' }).querySelector('img')
 }
 
 describe('PlaytestStage', () => {

--- a/frontend/src/pages/playtest/workbench/stage.tsx
+++ b/frontend/src/pages/playtest/workbench/stage.tsx
@@ -40,7 +40,7 @@ export function PlaytestStage({ frame, x, facing, onBoundsChange }: PlaytestStag
     <div
       ref={stageRef}
       role="region"
-      aria-label="试玩舞台"
+      aria-label="预览舞台"
       className="relative h-full min-h-[520px] overflow-hidden rounded-[1.8rem] border border-black/5 bg-[#eee] shadow-[0_24px_70px_rgba(22,29,25,0.12)]"
       style={{
         backgroundImage:

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -391,7 +391,7 @@ describe('QuickStartPage', () => {
     })
     renderAt('/quick-start/run-1', service)
     expect((await screen.findByRole('alert')).textContent).toContain('没有找到对应的角色资产')
-    fireEvent.click(screen.getByRole('button', { name: '重新导入 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '重新导入预览台' }))
     await waitFor(() => expect(service.approveReview).toHaveBeenCalledTimes(2))
   })
 

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -129,7 +129,7 @@ function QuickStartActionInput({
         to={playtestPath(target.characterId, target.outfitId)}
         className="text-xs font-semibold text-[#59635b] hover:text-[#2f4e38]"
       >
-        ← 返回当前 Playtest
+        ← 返回当前预览台
       </Link>
       <div className="mx-auto mt-14 max-w-2xl">
         <p className="font-mono text-[10px] font-bold text-[#687069]">ADD ACTION</p>
@@ -495,7 +495,7 @@ function QuickStartRun({
       const actionId = approvedAction?.type === 'action-full-frame' ? approvedAction.id : undefined
       navigate(playtestPath(info.characterId, info.outfitId, actionId))
     } catch (cause) {
-      setError(errorMessage(cause, '导入 Playtest 失败'))
+      setError(errorMessage(cause, '导入预览台失败'))
     } finally {
       setPublishing(false)
     }
@@ -882,7 +882,7 @@ function QuickStartRun({
                   disabled={publishing}
                   className="rounded-lg bg-[#2a5284] px-4 py-2 text-xs font-bold text-white transition hover:bg-[#3668a0] disabled:cursor-wait disabled:opacity-60"
                 >
-                  {publishing ? '正在自动导入…' : '重新导入 Playtest'}
+                  {publishing ? '正在自动导入…' : '重新导入预览台'}
                 </button>
               ) : null}
               {candidates.length || workflowHasFailure(run) ? (
@@ -948,7 +948,7 @@ function describeRun(_run: WorkflowRun, workflow: WorkflowRun) {
   if (actionStep?.status === 'passed') {
     return {
       title: '动作生成完成',
-      description: '动作帧已回传，正在自动写入并载入 Playtest 工作台。',
+      description: '动作帧已回传，正在自动写入并载入预览台。',
       error: null,
     }
   }

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -433,7 +433,7 @@ export function createQuickStartService({
         return controller.getWorkflow()
       },
       async approveReview() {
-        if (!characterApis) throw new Error('角色服务尚未配置，不能导入 Playtest')
+        if (!characterApis) throw new Error('角色服务尚未配置，不能导入预览台')
         const run = controller.getWorkflow()
         const fullFrame = latestFullFrame(run)
         if (!fullFrame || fullFrame.type !== 'action-full-frame') {

--- a/frontend/src/pages/workspace/index.test.tsx
+++ b/frontend/src/pages/workspace/index.test.tsx
@@ -241,7 +241,7 @@ describe('WorkspacePage', () => {
     )
     expect(screen.getByRole('button', { name: '继续已有工作流' })).toBeTruthy()
     expect(screen.getByRole('link', { name: '进入资产库' }).getAttribute('href')).toBe('/projects')
-    expect(screen.getByRole('button', { name: '选择 Playtest' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '选择预览台' })).toBeTruthy()
 
     expect(await screen.findByRole('heading', { name: '最近项目' })).toBeTruthy()
     expect(
@@ -297,16 +297,16 @@ describe('WorkspacePage', () => {
     renderWorkspace()
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
 
-    expect(screen.getByRole('heading', { name: '选择可试玩造型' })).toBeTruthy()
-    expect(screen.queryByRole('link', { name: /^试玩 / })).toBeNull()
+    expect(screen.getByRole('heading', { name: '选择可预览造型' })).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /^预览 / })).toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
     fireEvent.click(await screen.findByRole('button', { name: '选择角色 轻装信使' }))
 
     expect(
-      (await screen.findByRole('link', { name: '试玩 轻装信使 · 常态造型' })).getAttribute('href'),
+      (await screen.findByRole('link', { name: '预览 轻装信使 · 常态造型' })).getAttribute('href'),
     ).toBe('/playtest/51/outfit-default')
     expect(screen.getByText('2 个动作 · 5 帧')).toBeTruthy()
   })
@@ -315,7 +315,7 @@ describe('WorkspacePage', () => {
     const { releaseDeferred } = renderWorkspace({ defer: 'characters' })
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
     expect(screen.getByRole('status').textContent).toContain('正在读取角色')
     releaseDeferred()
@@ -407,7 +407,7 @@ describe('WorkspacePage', () => {
     renderWorkspace({ characterCount: 0 })
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
 
     expect(await screen.findByText('这个项目还没有角色')).toBeTruthy()
@@ -420,7 +420,7 @@ describe('WorkspacePage', () => {
     renderWorkspace({ fail: 'characters' })
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
 
     expect((await screen.findByRole('alert')).textContent).toContain('角色资产暂时无法读取')
@@ -431,7 +431,7 @@ describe('WorkspacePage', () => {
     renderWorkspace({ failOnce: 'characters' })
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
     expect((await screen.findByRole('alert')).textContent).toContain('角色资产暂时无法读取')
     fireEvent.click(screen.getByRole('button', { name: '重试读取角色' }))
@@ -443,7 +443,7 @@ describe('WorkspacePage', () => {
     renderWorkspace({ outfitCount: 0 })
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
     fireEvent.click(await screen.findByRole('button', { name: '选择角色 轻装信使' }))
 
@@ -457,16 +457,16 @@ describe('WorkspacePage', () => {
     renderWorkspace()
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
     fireEvent.click(await screen.findByRole('button', { name: '选择角色 待定角色' }))
 
     expect(await screen.findByText('尚无可播放帧')).toBeTruthy()
-    expect(screen.queryByRole('link', { name: /试玩 待定角色/ })).toBeNull()
+    expect(screen.queryByRole('link', { name: /预览 待定角色/ })).toBeNull()
     expect(screen.getByRole('link', { name: '查看当前项目资产' }).getAttribute('href')).toBe(
       '/projects/42/assets',
     )
-    expect(screen.getByRole('link', { name: '查看全部可试玩资产' }).getAttribute('href')).toBe(
+    expect(screen.getByRole('link', { name: '查看全部可预览资产' }).getAttribute('href')).toBe(
       '/playtest',
     )
   })
@@ -475,10 +475,10 @@ describe('WorkspacePage', () => {
     renderWorkspace()
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
     fireEvent.click(await screen.findByRole('button', { name: '选择角色 轻装信使' }))
-    await screen.findByRole('link', { name: '试玩 轻装信使 · 常态造型' })
+    await screen.findByRole('link', { name: '预览 轻装信使 · 常态造型' })
 
     fireEvent.click(screen.getByRole('button', { name: '重新选择角色' }))
     expect(await screen.findByRole('button', { name: '选择角色 轻装信使' })).toBeTruthy()
@@ -516,7 +516,7 @@ describe('WorkspacePage', () => {
     renderWorkspace({ characterCount: 5 })
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
     await screen.findByRole('button', { name: '选择角色 轻装信使' })
 
@@ -529,14 +529,14 @@ describe('WorkspacePage', () => {
     renderWorkspace({ outfitCount: 5 })
     await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })
 
-    fireEvent.click(screen.getByRole('button', { name: '选择 Playtest' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择预览台' }))
     fireEvent.click(screen.getByRole('button', { name: '选择项目 点灯人 · MVP' }))
     fireEvent.click(await screen.findByRole('button', { name: '选择角色 轻装信使' }))
 
-    expect(screen.queryByRole('link', { name: '试玩 轻装信使 · 常态造型 5' })).toBeNull()
+    expect(screen.queryByRole('link', { name: '预览 轻装信使 · 常态造型 5' })).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: '下一页' }))
     expect(
-      (await screen.findByRole('link', { name: '试玩 轻装信使 · 常态造型 5' })).getAttribute(
+      (await screen.findByRole('link', { name: '预览 轻装信使 · 常态造型 5' })).getAttribute(
         'href',
       ),
     ).toBe('/playtest/51/outfit-5')

--- a/frontend/src/pages/workspace/index.tsx
+++ b/frontend/src/pages/workspace/index.tsx
@@ -40,13 +40,13 @@ function workflowProgress(run: WorkflowRun) {
 
 function contextTitle(mode: WorkspaceMode) {
   if (mode === 'workflow') return '选择工作流'
-  if (mode === 'playtest') return '选择可试玩造型'
+  if (mode === 'playtest') return '选择可预览造型'
   return '最近项目'
 }
 
 function contextDescription(mode: WorkspaceMode) {
   if (mode === 'workflow') return '先定位项目，再继续一条真实的制作流程。'
-  if (mode === 'playtest') return '按项目、角色和造型逐层定位可试玩资产。'
+  if (mode === 'playtest') return '按项目、角色和造型逐层定位可预览资产。'
   return '从最近更新的真实项目回到角色资产与制作现场。'
 }
 
@@ -192,7 +192,7 @@ export function WorkspacePage() {
     contextContent = (
       <EmptyState
         title="还没有项目"
-        description="先建立一个项目，角色、工作流和可试玩造型才会有归属。"
+        description="先建立一个项目，角色、工作流和可预览造型才会有归属。"
       >
         <PrimaryContextLink to="/projects/new" aria-label="新建项目">
           新建项目
@@ -267,8 +267,8 @@ export function WorkspacePage() {
             onSelect={choosePlaytestProject}
           />
           <ContextFooter>
-            <ContextLink to="/playtest" aria-label="查看全部可试玩资产">
-              查看全部可试玩资产
+            <ContextLink to="/playtest" aria-label="查看全部可预览资产">
+              查看全部可预览资产
             </ContextLink>
           </ContextFooter>
         </div>
@@ -292,7 +292,7 @@ export function WorkspacePage() {
           ) : characters.total === 0 ? (
             <EmptyState
               title="这个项目还没有角色"
-              description="先在项目里完成角色与动作制作，再进入 Playtest。"
+              description="先在项目里完成角色与动作制作，再进入预览台。"
             />
           ) : selectedCharacter === null ? (
             <CharacterSelection
@@ -317,7 +317,7 @@ export function WorkspacePage() {
               {selectedCharacter.outfits.length === 0 ? (
                 <EmptyState
                   title="这个角色还没有造型"
-                  description="先回项目资产完成造型与动作制作，再进入 Playtest。"
+                  description="先回项目资产完成造型与动作制作，再进入预览台。"
                 />
               ) : (
                 <OutfitSelection
@@ -335,8 +335,8 @@ export function WorkspacePage() {
             >
               查看项目资产
             </ContextLink>
-            <ContextLink to="/playtest" aria-label="查看全部可试玩资产">
-              查看全部可试玩资产
+            <ContextLink to="/playtest" aria-label="查看全部可预览资产">
+              查看全部可预览资产
             </ContextLink>
           </ContextFooter>
         </div>
@@ -378,9 +378,9 @@ export function WorkspacePage() {
               description="按项目整理角色、造型、动作与逐帧资产。"
             />
             <SelectableEntranceCard
-              ariaLabel="选择 Playtest"
+              ariaLabel="选择预览台"
               kind="playtest"
-              title="Playtest"
+              title="预览台"
               description="选择已有造型，核验移动与动画播放。"
               selected={mode === 'playtest'}
               onClick={() => selectMode('playtest')}
@@ -816,7 +816,7 @@ function OutfitSelection({
                       : 'border-[#cdd2cc] bg-[#f4f5f1] text-[#777e77]'
                   }`}
                 >
-                  {playback.playable ? '可试玩' : '待补帧'}
+                  {playback.playable ? '可预览' : '待补帧'}
                 </span>
               </span>
               <span className="mt-2 flex items-end justify-between gap-3">
@@ -841,7 +841,7 @@ function OutfitSelection({
             <Link
               key={outfit.id}
               to={`/playtest/${character.id}/${outfit.id}`}
-              aria-label={`试玩 ${name} · ${outfit.name}`}
+              aria-label={`预览 ${name} · ${outfit.name}`}
               className="group block rounded-[1.1rem] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#284331]"
             >
               {card}


### PR DESCRIPTION
## What changed
- add a compact back button to the top-left of protected product pages
- use real in-app history when available, with safe parent routes for direct deep links
- rename all user-facing PlayTest / Playtest / 试玩台 wording to 预览台
- keep the internal /playtest route, module names, and data contracts unchanged
- preserve the centered navigation on 320px-wide screens

Project asset pages keep their existing contextual back links.

## Verification
- npm run typecheck
- npm run lint
- npm test: 430 passed
- npm run test:coverage: 88.79% statements, 82.54% branches, 92.38% lines
- npm run build