### PR TITLE
fix(storage): reject browser-inaccessible Qiniu S3 download URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,8 @@ SERPAPI_API_KEY=your-serpapi-key
 QINIU_ACCESS_KEY=your-access-key
 QINIU_SECRET_KEY=your-secret-key
 QINIU_BUCKET_NAME=your-bucket
-QINIU_BUCKET_DOMAIN=your-domain.com
+# Bucket 绑定的浏览器可访问 HTTPS Kodo/CDN 域名，不能填 *.s3.*.qiniucs.com API 端点
+QINIU_BUCKET_DOMAIN=https://cdn.example.com
 QINIU_PRIVATE_SPACE=false
 
 # ── AI Provider ──

--- a/backend/packages/app/src/windup_app/server/media/service.py
+++ b/backend/packages/app/src/windup_app/server/media/service.py
@@ -22,6 +22,7 @@ class ObjectStorageMediaService(MediaService):
         data: bytes,
         metadata: MediaUploadInput,
     ) -> MediaUploadResult:
+        download_base = storage_settings.download_base
         suffix = _file_suffix(metadata.filename)
         object_key = f"media/{metadata.category}/{uuid4().hex}{suffix}"
 
@@ -39,7 +40,7 @@ class ObjectStorageMediaService(MediaService):
             msg = f"七牛上传失败: status={resp.status_code}, body={resp.text}"
             raise RuntimeError(msg)
 
-        url = f"{storage_settings.download_base}/{object_key}"
+        url = f"{download_base}/{object_key}"
         return MediaUploadResult(
             url=url,
             object_key=object_key,

--- a/backend/packages/framework/src/windup_framework/config/storage.py
+++ b/backend/packages/framework/src/windup_framework/config/storage.py
@@ -4,6 +4,8 @@
 本地开发需在 ``.env`` 填入 AccessKey / SecretKey / Bucket / 绑定域名。
 """
 
+from urllib.parse import urlsplit
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -32,10 +34,19 @@ class StorageSettings(BaseSettings):
 
     @property
     def download_base(self) -> str:
-        """下载 URL 基础域名,去掉末尾 ``/``,客户端拼接 key 即可。"""
+        """返回浏览器可访问的下载域名。"""
         domain = self.bucket_domain.rstrip("/")
         if domain and not domain.startswith(("http://", "https://")):
             domain = f"https://{domain}"
+        hostname = (urlsplit(domain).hostname or "").lower()
+        labels = hostname.split(".")
+        if hostname.endswith(".qiniucs.com") and any(
+            label == "s3" or label.startswith("s3-") for label in labels
+        ):
+            raise ValueError(
+                "QINIU_BUCKET_DOMAIN 不能使用七牛 S3 API 端点；"
+                "请填写 Bucket 绑定的 HTTPS Kodo/CDN 下载域名"
+            )
         return domain
 
 

--- a/backend/tests/test_orchestrator_hardening.py
+++ b/backend/tests/test_orchestrator_hardening.py
@@ -85,6 +85,45 @@ def test_media_upload_rejects_s3_endpoint_before_uploading(monkeypatch):
     put_data.assert_not_called()
 
 
+def test_media_upload_uses_validated_download_base(monkeypatch):
+    import qiniu
+    import windup_app.server.media.service as media_service_module
+
+    monkeypatch.setattr(
+        media_service_module.storage_settings,
+        "bucket_domain",
+        "cdn.example.com",
+    )
+    monkeypatch.setattr(
+        media_service_module.storage_settings,
+        "bucket_name",
+        "example-bucket",
+    )
+    auth = Mock()
+    auth.upload_token.return_value = "upload-token"
+    monkeypatch.setattr(qiniu, "Auth", Mock(return_value=auth))
+    response = Mock(status_code=200)
+    put_data = Mock(return_value=({"key": "uploaded"}, response))
+    monkeypatch.setattr(qiniu, "put_data", put_data)
+
+    metadata = MediaUploadInput(
+        filename="character.png",
+        content_type="image/png",
+        size=3,
+        category=MediaCategory.REFERENCE_IMAGE,
+    )
+    result = ObjectStorageMediaService().upload(b"png", metadata)
+
+    assert result.url == f"https://cdn.example.com/{result.object_key}"
+    auth.upload_token.assert_called_once_with("example-bucket", result.object_key)
+    put_data.assert_called_once_with(
+        "upload-token",
+        result.object_key,
+        b"png",
+        mime_type="image/png",
+    )
+
+
 # ── ① 真实装配路径不能引用已删除的路线 ────────────────────────────────────
 
 

--- a/backend/tests/test_orchestrator_hardening.py
+++ b/backend/tests/test_orchestrator_hardening.py
@@ -44,6 +44,19 @@ def test_storage_download_base_accepts_documented_bare_domain(configured, expect
     assert StorageSettings(bucket_domain=configured).download_base == expected
 
 
+@pytest.mark.parametrize(
+    "configured",
+    [
+        "example-bucket.s3.cn-east-1.qiniucs.com",
+        "https://example-bucket.s3.cn-east-1.qiniucs.com",
+        "https://s3-cn-east-1.qiniucs.com/example-bucket",
+    ],
+)
+def test_storage_download_base_rejects_qiniu_s3_api_endpoint(configured):
+    with pytest.raises(ValueError, match="S3 API"):
+        StorageSettings(bucket_domain=configured).download_base
+
+
 # ── ① 真实装配路径不能引用已删除的路线 ────────────────────────────────────
 
 

--- a/backend/tests/test_orchestrator_hardening.py
+++ b/backend/tests/test_orchestrator_hardening.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from unittest.mock import Mock
 
 import httpx
 import pytest
 
+from windup_app.server.media.model import MediaUploadInput
+from windup_app.server.media.service import ObjectStorageMediaService
 from windup_app.server.orchestrator._fetch import (
     MAX_FETCH_BYTES,
     FetchNotAllowed,
@@ -29,6 +32,7 @@ from windup_app.web.api.generation import (
     CharacterImageGenerateRequest,
     _EventBus,
 )
+from windup_common.enums.media import MediaCategory
 from windup_framework.config.storage import StorageSettings
 
 
@@ -55,6 +59,30 @@ def test_storage_download_base_accepts_documented_bare_domain(configured, expect
 def test_storage_download_base_rejects_qiniu_s3_api_endpoint(configured):
     with pytest.raises(ValueError, match="S3 API"):
         StorageSettings(bucket_domain=configured).download_base
+
+
+def test_media_upload_rejects_s3_endpoint_before_uploading(monkeypatch):
+    import qiniu
+    import windup_app.server.media.service as media_service_module
+
+    monkeypatch.setattr(
+        media_service_module.storage_settings,
+        "bucket_domain",
+        "https://example-bucket.s3.cn-east-1.qiniucs.com",
+    )
+    put_data = Mock()
+    monkeypatch.setattr(qiniu, "put_data", put_data)
+
+    metadata = MediaUploadInput(
+        filename="character.png",
+        content_type="image/png",
+        size=3,
+        category=MediaCategory.REFERENCE_IMAGE,
+    )
+    with pytest.raises(ValueError, match="S3 API"):
+        ObjectStorageMediaService().upload(b"png", metadata)
+
+    put_data.assert_not_called()
 
 
 # ── ① 真实装配路径不能引用已删除的路线 ────────────────────────────────────


### PR DESCRIPTION
## 问题

对象存储上传成功后，后端直接用 `QINIU_BUCKET_DOMAIN` 拼接媒体 URL。如果这里误填七牛 S3 API 端点，任务会被标记为成功，但浏览器无法匿名访问返回的图片地址。

## 修复

- 自动为文档允许的裸域名补全 HTTPS
- 拒绝将 `*.s3.*.qiniucs.com` 类 API 端点当作浏览器下载域名
- 更新 `.env.example`，明确要求 Bucket 绑定的 HTTPS Kodo/CDN 域名
- 增加裸域名、完整 URL 和 path-style S3 端点回归测试

## 验证

- `uv run ruff check .`
- `uv run lint-imports`
- `uv run pytest -q --cov=packages --cov-report=term-missing --cov-report=xml:coverage.xml`
- 431 passed，总覆盖率 89%

## 部署注意

合并后还需将服务端 `QINIU_BUCKET_DOMAIN` 设为当前 Bucket 绑定的 HTTPS 下载域名并重启。旧任务已持久化的错误 URL 不会自动改写，需要重新生成。