### PR TITLE
fix(security): 启动时校验 JWT 和数据库硬编码默认凭据

### DIFF
--- a/backend/packages/app/src/windup_app/bootstrap/app.py
+++ b/backend/packages/app/src/windup_app/bootstrap/app.py
@@ -12,7 +12,6 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from windup_framework.config import validate_settings
 from windup_framework.db import Base, engine
 
 # 模型导入：触发 Base.metadata 注册，确保 create_all 能发现所有表
@@ -71,8 +70,7 @@ def print_banner() -> None:
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
-    """应用启动时校验配置 → 建表 → 打印 banner,关闭时无特殊处理。"""
-    validate_settings()
+    """应用启动时建表 + 打印 banner,关闭时无特殊处理。"""
     Base.metadata.create_all(engine)
     print_banner()
     yield

--- a/backend/packages/app/src/windup_app/bootstrap/app.py
+++ b/backend/packages/app/src/windup_app/bootstrap/app.py
@@ -12,6 +12,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from windup_framework.config import validate_settings
 from windup_framework.db import Base, engine
 
 # 模型导入：触发 Base.metadata 注册，确保 create_all 能发现所有表
@@ -70,7 +71,8 @@ def print_banner() -> None:
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
-    """应用启动时建表 + 打印 banner,关闭时无特殊处理。"""
+    """应用启动时校验配置 → 建表 → 打印 banner,关闭时无特殊处理。"""
+    validate_settings()
     Base.metadata.create_all(engine)
     print_banner()
     yield

--- a/backend/packages/app/src/windup_app/server/user/service.py
+++ b/backend/packages/app/src/windup_app/server/user/service.py
@@ -44,7 +44,7 @@ logger = logging.getLogger("windup.user.service")
 
 # -- JWT 配置 -------------------------------------------------------------
 
-JWT_SECRET = jwt_settings.secret
+JWT_SECRET = jwt_settings.secret.get_secret_value()
 JWT_ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_SECONDS = 15 * 60        # 15 分钟
 REFRESH_TOKEN_EXPIRE_SECONDS = 7 * 24 * 3600  # 7 天

--- a/backend/packages/framework/src/windup_framework/config/__init__.py
+++ b/backend/packages/framework/src/windup_framework/config/__init__.py
@@ -1,14 +1,78 @@
 """framework 配置。"""
 
+import logging
+import os
+
 from windup_framework.config.database import DatabaseSettings, settings
+from windup_framework.config.jwt import JWTSettings, settings as jwt_settings
 from windup_framework.config.provider import AIProviderSettings, settings as provider_settings
 from windup_framework.config.storage import StorageSettings, settings as storage_settings
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "AIProviderSettings",
     "DatabaseSettings",
+    "JWTSettings",
     "StorageSettings",
     "provider_settings",
     "settings",
+    "jwt_settings",
     "storage_settings",
+    "validate_settings",
 ]
+
+# ── 硬编码默认凭据 ──────────────────────────────────────────────
+_INSECURE_JWT_SECRET = "change-me-in-production"
+_INSECURE_DB_PASSWORD = "admin123"
+
+
+def validate_settings() -> None:
+    """启动时校验关键配置,防止生产环境使用硬编码默认凭据。
+
+    校验规则:
+    1. ``JWT_SECRET`` 不能是公开的默认值 — 任何环境都不允许。
+    2. ``POSTGRES_PASSWORD`` 不能是默认示例值 — 生产环境直接拒绝,
+       开发环境仅警告。
+
+    可通过 ``WINDUP_ENV=dev`` 或 ``WINDUP_ENV=test`` 跳过数据库密码校验
+    (JWT 密钥始终校验)。
+    """
+    env = os.getenv("WINDUP_ENV", "production").strip().lower()
+    is_dev = env in ("dev", "development", "test", "local")
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # 1) JWT secret — 任何环境下都不能用默认值
+    if jwt_settings.secret == _INSECURE_JWT_SECRET:
+        errors.append(
+            "JWT_SECRET 仍在使用公开的默认值 'change-me-in-production',"
+            "任何人都可以伪造有效 token。"
+            "请在环境变量或 .env 中设置一个随机密钥:\n"
+            "  JWT_SECRET=$(openssl rand -hex 32)"
+        )
+
+    # 2) 数据库密码
+    if settings.password == _INSECURE_DB_PASSWORD:
+        if is_dev:
+            warnings.append(
+                "POSTGRES_PASSWORD 仍在使用默认值 'admin123',"
+                "本地开发可以但请确保不要在生产环境使用此密码。"
+            )
+        else:
+            errors.append(
+                "POSTGRES_PASSWORD 仍在使用默认值 'admin123',"
+                "生产环境必须设置强密码。"
+                "请在环境变量或 .env 中设置:\n"
+                "  POSTGRES_PASSWORD=<your-strong-password>"
+            )
+
+    # 输出警告
+    for w in warnings:
+        logger.warning("⚠️  %s", w)
+
+    # 有错误则拒绝启动
+    if errors:
+        msg = "启动安全校验失败:\n" + "\n".join(f"  ❌ {e}" for e in errors)
+        raise RuntimeError(msg)

--- a/backend/packages/framework/src/windup_framework/config/__init__.py
+++ b/backend/packages/framework/src/windup_framework/config/__init__.py
@@ -1,14 +1,14 @@
-"""framework 配置。"""
+"""framework 配置。
 
-import logging
-import os
+所有安全敏感字段(JWT_SECRET、POSTGRES_PASSWORD)均为必填项,
+Pydantic Settings 在模块导入(实例化)时即完成校验,缺失或不合规直接抛出
+``ValidationError`` — 进程在启动前失败(fail-fast)。
+"""
 
 from windup_framework.config.database import DatabaseSettings, settings
 from windup_framework.config.jwt import JWTSettings, settings as jwt_settings
 from windup_framework.config.provider import AIProviderSettings, settings as provider_settings
 from windup_framework.config.storage import StorageSettings, settings as storage_settings
-
-logger = logging.getLogger(__name__)
 
 __all__ = [
     "AIProviderSettings",
@@ -19,60 +19,4 @@ __all__ = [
     "settings",
     "jwt_settings",
     "storage_settings",
-    "validate_settings",
 ]
-
-# ── 硬编码默认凭据 ──────────────────────────────────────────────
-_INSECURE_JWT_SECRET = "change-me-in-production"
-_INSECURE_DB_PASSWORD = "admin123"
-
-
-def validate_settings() -> None:
-    """启动时校验关键配置,防止生产环境使用硬编码默认凭据。
-
-    校验规则:
-    1. ``JWT_SECRET`` 不能是公开的默认值 — 任何环境都不允许。
-    2. ``POSTGRES_PASSWORD`` 不能是默认示例值 — 生产环境直接拒绝,
-       开发环境仅警告。
-
-    可通过 ``WINDUP_ENV=dev`` 或 ``WINDUP_ENV=test`` 跳过数据库密码校验
-    (JWT 密钥始终校验)。
-    """
-    env = os.getenv("WINDUP_ENV", "production").strip().lower()
-    is_dev = env in ("dev", "development", "test", "local")
-
-    errors: list[str] = []
-    warnings: list[str] = []
-
-    # 1) JWT secret — 任何环境下都不能用默认值
-    if jwt_settings.secret == _INSECURE_JWT_SECRET:
-        errors.append(
-            "JWT_SECRET 仍在使用公开的默认值 'change-me-in-production',"
-            "任何人都可以伪造有效 token。"
-            "请在环境变量或 .env 中设置一个随机密钥:\n"
-            "  JWT_SECRET=$(openssl rand -hex 32)"
-        )
-
-    # 2) 数据库密码
-    if settings.password == _INSECURE_DB_PASSWORD:
-        if is_dev:
-            warnings.append(
-                "POSTGRES_PASSWORD 仍在使用默认值 'admin123',"
-                "本地开发可以但请确保不要在生产环境使用此密码。"
-            )
-        else:
-            errors.append(
-                "POSTGRES_PASSWORD 仍在使用默认值 'admin123',"
-                "生产环境必须设置强密码。"
-                "请在环境变量或 .env 中设置:\n"
-                "  POSTGRES_PASSWORD=<your-strong-password>"
-            )
-
-    # 输出警告
-    for w in warnings:
-        logger.warning("⚠️  %s", w)
-
-    # 有错误则拒绝启动
-    if errors:
-        msg = "启动安全校验失败:\n" + "\n".join(f"  ❌ {e}" for e in errors)
-        raise RuntimeError(msg)

--- a/backend/packages/framework/src/windup_framework/config/database.py
+++ b/backend/packages/framework/src/windup_framework/config/database.py
@@ -1,10 +1,12 @@
 """Postgres 数据库连接配置。
 
 从环境变量(或 ``.env``)读取,字段前缀 ``POSTGRES_``。
-本地开发默认值对应 Docker 容器 root/admin123@localhost:4000。
+
+``password`` 为必填项,无代码默认值 — 缺失时 Pydantic 在实例化阶段直接抛出
+``ValidationError``。本地开发请在 ``.env`` 或 ``.env.dev`` 中显式配置。
 """
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from sqlalchemy import URL
 
@@ -23,11 +25,21 @@ class DatabaseSettings(BaseSettings):
     host: str = "localhost"
     port: int = 4000
     user: str = "root"
-    password: str = "admin123"
+    password: str = Field(...)          # 必填,无默认值
     db: str = Field(default="windup")
     pool_size: int = 5
     max_overflow: int = 10
     pool_pre_ping: bool = True
+
+    @field_validator("password")
+    @classmethod
+    def _check_password_not_trivial(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError(
+                "POSTGRES_PASSWORD 长度不足 8 字符。"
+                "请使用强密码以保障数据库安全。"
+            )
+        return v
 
     @property
     def url(self) -> str:

--- a/backend/packages/framework/src/windup_framework/config/jwt.py
+++ b/backend/packages/framework/src/windup_framework/config/jwt.py
@@ -1,8 +1,12 @@
 """JWT 配置。
 
 从环境变量(或 ``.env``)读取,字段前缀 ``JWT_``。
+
+``secret`` 为必填项,无代码默认值 — 缺失时 Pydantic 在实例化阶段直接抛出
+``ValidationError``,进程在启动前即失败(fail-fast)。
 """
 
+from pydantic import SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,7 +20,19 @@ class JWTSettings(BaseSettings):
         extra="ignore",
     )
 
-    secret: str = "change-me-in-production"
+    secret: SecretStr
+
+    @field_validator("secret")
+    @classmethod
+    def _check_secret_strength(cls, v: SecretStr) -> SecretStr:
+        raw = v.get_secret_value()
+        if len(raw) < 32:
+            raise ValueError(
+                "JWT_SECRET 长度不足 32 字符,不符合安全要求。"
+                "请使用至少 32 字符的随机密钥:\n"
+                "  JWT_SECRET=$(openssl rand -hex 32)"
+            )
+        return v
 
 
 settings = JWTSettings()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,6 +5,13 @@ CI 友好。每个用例各自独立的 engine,互不污染。``Project`` 表按
 engine 上(不碰全局 Postgres engine)。
 """
 
+import os
+
+# CI 环境可能未配置真实凭据,在 import 触发 Settings 实例化前提供测试默认值。
+# setdefault 不覆盖已有的环境变量(本地 .env 或 CI secrets 优先生效)。
+os.environ.setdefault("JWT_SECRET", "test-secret-key-for-ci-only-32chars")
+os.environ.setdefault("POSTGRES_PASSWORD", "testpassword123")
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine

--- a/backend/tests/test_validate_settings.py
+++ b/backend/tests/test_validate_settings.py
@@ -1,115 +1,144 @@
-"""启动安全校验测试。
+"""配置安全校验测试。
 
-覆盖场景:
-- JWT_SECRET 使用默认值 → 任何环境都拒绝启动
-- POSTGRES_PASSWORD 使用默认值 → 生产环境拒绝,开发环境警告
-- 两者都已配置 → 正常通过
+直接实例化 Settings 类,覆盖:
+- 缺失必填字段 → ValidationError
+- 空值 → ValidationError
+- 弱值 / 格式错误 → ValidationError
+- 合法值 → 正常通过
+
+注意:测试中通过 ``_env_file=()`` 禁用 .env 文件读取,确保只受环境变量控制。
 """
 
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
-from windup_framework.config import (
-    _INSECURE_DB_PASSWORD,
-    _INSECURE_JWT_SECRET,
-    validate_settings,
-)
+from windup_framework.config.database import DatabaseSettings
+from windup_framework.config.jwt import JWTSettings
 
 
-class TestValidateSettings:
-    """``validate_settings`` 单元测试。"""
+# ── 辅助:禁用 .env 文件的 fixture ────────────────────────────────
 
-    def test_jwt_default_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """JWT_SECRET 为默认值时,任何环境下都应拒绝启动。"""
-        monkeypatch.setattr(
-            "windup_framework.config.jwt_settings",
-            type("S", (), {"secret": _INSECURE_JWT_SECRET})(),
-        )
-        monkeypatch.setattr(
-            "windup_framework.config.settings",
-            type("S", (), {"password": "real-password"})(),
-        )
-        monkeypatch.delenv("WINDUP_ENV", raising=False)
+@pytest.fixture(autouse=True)
+def _no_env_files(monkeypatch: pytest.MonkeyPatch):
+    """禁止 Settings 从 .env 文件读取,测试只通过环境变量控制。"""
+    monkeypatch.setattr(
+        "windup_framework.config.jwt.JWTSettings.model_config",
+        {**JWTSettings.model_config, "env_file": ()},
+    )
+    monkeypatch.setattr(
+        "windup_framework.config.database.DatabaseSettings.model_config",
+        {**DatabaseSettings.model_config, "env_file": ()},
+    )
 
-        with pytest.raises(RuntimeError, match="JWT_SECRET"):
-            validate_settings()
 
-    def test_jwt_default_raises_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """即使 WINDUP_ENV=dev,JWT 默认值也应拒绝。"""
-        monkeypatch.setattr(
-            "windup_framework.config.jwt_settings",
-            type("S", (), {"secret": _INSECURE_JWT_SECRET})(),
-        )
-        monkeypatch.setattr(
-            "windup_framework.config.settings",
-            type("S", (), {"password": "real-password"})(),
-        )
-        monkeypatch.setenv("WINDUP_ENV", "dev")
+# ── JWT_SECRET ────────────────────────────────────────────────────
 
-        with pytest.raises(RuntimeError, match="JWT_SECRET"):
-            validate_settings()
+class TestJWTSettings:
+    """``JWTSettings`` 校验:必填 + 最小长度 32 字符。"""
 
-    def test_db_default_raises_in_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """POSTGRES_PASSWORD 为默认值时,生产环境应拒绝启动。"""
-        monkeypatch.setattr(
-            "windup_framework.config.jwt_settings",
-            type("S", (), {"secret": "real-secret"})(),
-        )
-        monkeypatch.setattr(
-            "windup_framework.config.settings",
-            type("S", (), {"password": _INSECURE_DB_PASSWORD})(),
-        )
-        monkeypatch.delenv("WINDUP_ENV", raising=False)
+    def test_missing_secret_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JWT_SECRET 未设置 → ValidationError。"""
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        with pytest.raises(ValidationError, match="secret"):
+            JWTSettings()
 
-        with pytest.raises(RuntimeError, match="POSTGRES_PASSWORD"):
-            validate_settings()
+    def test_empty_secret_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JWT_SECRET 为空字符串 → ValidationError。"""
+        monkeypatch.setenv("JWT_SECRET", "")
+        with pytest.raises(ValidationError, match="secret"):
+            JWTSettings()
 
-    def test_db_default_warns_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """POSTGRES_PASSWORD 为默认值时,开发环境应警告但不拒绝。"""
-        monkeypatch.setattr(
-            "windup_framework.config.jwt_settings",
-            type("S", (), {"secret": "real-secret"})(),
-        )
-        monkeypatch.setattr(
-            "windup_framework.config.settings",
-            type("S", (), {"password": _INSECURE_DB_PASSWORD})(),
-        )
-        monkeypatch.setenv("WINDUP_ENV", "dev")
+    def test_short_secret_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JWT_SECRET 不足 32 字符 → ValidationError。"""
+        monkeypatch.setenv("JWT_SECRET", "short-key")
+        with pytest.raises(ValidationError, match="32"):
+            JWTSettings()
 
-        # 不应抛出异常
-        validate_settings()
+    def test_exactly_31_chars_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JWT_SECRET 恰好 31 字符 → 不满足 ≥32,拒绝。"""
+        monkeypatch.setenv("JWT_SECRET", "a" * 31)
+        with pytest.raises(ValidationError, match="32"):
+            JWTSettings()
 
-    def test_both_default_raises_combined(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """JWT 和数据库都使用默认值时,错误消息应包含两者。"""
-        monkeypatch.setattr(
-            "windup_framework.config.jwt_settings",
-            type("S", (), {"secret": _INSECURE_JWT_SECRET})(),
-        )
-        monkeypatch.setattr(
-            "windup_framework.config.settings",
-            type("S", (), {"password": _INSECURE_DB_PASSWORD})(),
-        )
-        monkeypatch.delenv("WINDUP_ENV", raising=False)
+    def test_exactly_32_chars_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JWT_SECRET 恰好 32 字符 → 边界通过。"""
+        monkeypatch.setenv("JWT_SECRET", "b" * 32)
+        s = JWTSettings()
+        assert s.secret.get_secret_value() == "b" * 32
 
-        with pytest.raises(RuntimeError) as exc_info:
-            validate_settings()
+    def test_valid_secret_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JWT_SECRET 足够长且随机 → 正常构造。"""
+        monkeypatch.setenv("JWT_SECRET", "a" * 64)
+        s = JWTSettings()
+        assert len(s.secret.get_secret_value()) == 64
 
-        msg = str(exc_info.value)
-        assert "JWT_SECRET" in msg
-        assert "POSTGRES_PASSWORD" in msg
 
-    def test_all_configured_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """所有凭据已正确配置时,应正常通过。"""
-        monkeypatch.setattr(
-            "windup_framework.config.jwt_settings",
-            type("S", (), {"secret": "my-super-secret-key"})(),
-        )
-        monkeypatch.setattr(
-            "windup_framework.config.settings",
-            type("S", (), {"password": "strong-password-123"})(),
-        )
-        monkeypatch.delenv("WINDUP_ENV", raising=False)
+# ── POSTGRES_PASSWORD ────────────────────────────────────────────
 
-        # 不应抛出任何异常
-        validate_settings()
+class TestDatabaseSettings:
+    """``DatabaseSettings`` 校验:必填 + 最小长度 8 字符。"""
+
+    def test_missing_password_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_PASSWORD 未设置 → ValidationError。"""
+        monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+        with pytest.raises(ValidationError, match="password"):
+            DatabaseSettings()
+
+    def test_empty_password_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_PASSWORD 为空字符串 → ValidationError。"""
+        monkeypatch.setenv("POSTGRES_PASSWORD", "")
+        with pytest.raises(ValidationError, match="password"):
+            DatabaseSettings()
+
+    def test_short_password_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_PASSWORD 不足 8 字符 → ValidationError。"""
+        monkeypatch.setenv("POSTGRES_PASSWORD", "short")
+        with pytest.raises(ValidationError, match="8"):
+            DatabaseSettings()
+
+    def test_exactly_7_chars_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_PASSWORD 恰好 7 字符 → 不满足 ≥8,拒绝。"""
+        monkeypatch.setenv("POSTGRES_PASSWORD", "a" * 7)
+        with pytest.raises(ValidationError, match="8"):
+            DatabaseSettings()
+
+    def test_exactly_8_chars_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_PASSWORD 恰好 8 字符 → 边界通过。"""
+        monkeypatch.setenv("POSTGRES_PASSWORD", "a" * 8)
+        s = DatabaseSettings()
+        assert s.password == "a" * 8
+
+    def test_valid_password_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_PASSWORD 合法 → 正常构造。"""
+        monkeypatch.setenv("POSTGRES_PASSWORD", "strongpassword123")
+        s = DatabaseSettings()
+        assert s.password == "strongpassword123"
+
+    def test_url_property_works(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """合法密码下,url 属性应正常返回连接串。"""
+        monkeypatch.setenv("POSTGRES_PASSWORD", "my_strong_pw")
+        s = DatabaseSettings()
+        assert "postgresql+psycopg" in s.url
+        assert "my_strong_pw" in s.url
+
+
+# ── 两者同时缺失 ──────────────────────────────────────────────────
+
+class TestBothMissing:
+    """JWT_SECRET 和 POSTGRES_PASSWORD 同时缺失。"""
+
+    def test_both_missing_raises_on_jwt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """两个都缺 → JWTSettings 先抛 ValidationError(Pydantic fail-fast)。"""
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+        with pytest.raises(ValidationError):
+            JWTSettings()
+
+    def test_both_missing_raises_on_db(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """两个都缺 → DatabaseSettings 同样抛 ValidationError。"""
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+        with pytest.raises(ValidationError):
+            DatabaseSettings()

--- a/backend/tests/test_validate_settings.py
+++ b/backend/tests/test_validate_settings.py
@@ -1,0 +1,115 @@
+"""启动安全校验测试。
+
+覆盖场景:
+- JWT_SECRET 使用默认值 → 任何环境都拒绝启动
+- POSTGRES_PASSWORD 使用默认值 → 生产环境拒绝,开发环境警告
+- 两者都已配置 → 正常通过
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from windup_framework.config import (
+    _INSECURE_DB_PASSWORD,
+    _INSECURE_JWT_SECRET,
+    validate_settings,
+)
+
+
+class TestValidateSettings:
+    """``validate_settings`` 单元测试。"""
+
+    def test_jwt_default_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JWT_SECRET 为默认值时,任何环境下都应拒绝启动。"""
+        monkeypatch.setattr(
+            "windup_framework.config.jwt_settings",
+            type("S", (), {"secret": _INSECURE_JWT_SECRET})(),
+        )
+        monkeypatch.setattr(
+            "windup_framework.config.settings",
+            type("S", (), {"password": "real-password"})(),
+        )
+        monkeypatch.delenv("WINDUP_ENV", raising=False)
+
+        with pytest.raises(RuntimeError, match="JWT_SECRET"):
+            validate_settings()
+
+    def test_jwt_default_raises_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """即使 WINDUP_ENV=dev,JWT 默认值也应拒绝。"""
+        monkeypatch.setattr(
+            "windup_framework.config.jwt_settings",
+            type("S", (), {"secret": _INSECURE_JWT_SECRET})(),
+        )
+        monkeypatch.setattr(
+            "windup_framework.config.settings",
+            type("S", (), {"password": "real-password"})(),
+        )
+        monkeypatch.setenv("WINDUP_ENV", "dev")
+
+        with pytest.raises(RuntimeError, match="JWT_SECRET"):
+            validate_settings()
+
+    def test_db_default_raises_in_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_PASSWORD 为默认值时,生产环境应拒绝启动。"""
+        monkeypatch.setattr(
+            "windup_framework.config.jwt_settings",
+            type("S", (), {"secret": "real-secret"})(),
+        )
+        monkeypatch.setattr(
+            "windup_framework.config.settings",
+            type("S", (), {"password": _INSECURE_DB_PASSWORD})(),
+        )
+        monkeypatch.delenv("WINDUP_ENV", raising=False)
+
+        with pytest.raises(RuntimeError, match="POSTGRES_PASSWORD"):
+            validate_settings()
+
+    def test_db_default_warns_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_PASSWORD 为默认值时,开发环境应警告但不拒绝。"""
+        monkeypatch.setattr(
+            "windup_framework.config.jwt_settings",
+            type("S", (), {"secret": "real-secret"})(),
+        )
+        monkeypatch.setattr(
+            "windup_framework.config.settings",
+            type("S", (), {"password": _INSECURE_DB_PASSWORD})(),
+        )
+        monkeypatch.setenv("WINDUP_ENV", "dev")
+
+        # 不应抛出异常
+        validate_settings()
+
+    def test_both_default_raises_combined(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """JWT 和数据库都使用默认值时,错误消息应包含两者。"""
+        monkeypatch.setattr(
+            "windup_framework.config.jwt_settings",
+            type("S", (), {"secret": _INSECURE_JWT_SECRET})(),
+        )
+        monkeypatch.setattr(
+            "windup_framework.config.settings",
+            type("S", (), {"password": _INSECURE_DB_PASSWORD})(),
+        )
+        monkeypatch.delenv("WINDUP_ENV", raising=False)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            validate_settings()
+
+        msg = str(exc_info.value)
+        assert "JWT_SECRET" in msg
+        assert "POSTGRES_PASSWORD" in msg
+
+    def test_all_configured_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """所有凭据已正确配置时,应正常通过。"""
+        monkeypatch.setattr(
+            "windup_framework.config.jwt_settings",
+            type("S", (), {"secret": "my-super-secret-key"})(),
+        )
+        monkeypatch.setattr(
+            "windup_framework.config.settings",
+            type("S", (), {"password": "strong-password-123"})(),
+        )
+        monkeypatch.delenv("WINDUP_ENV", raising=False)
+
+        # 不应抛出任何异常
+        validate_settings()


### PR DESCRIPTION
## 问题

生产环境如果不设置环境变量，应用会静默使用公开的默认凭据运行，导致严重的安全漏洞:
- `JWT_SECRET` 默认值 `"change-me-in-production"` → 任何人可伪造有效 JWT
- `POSTGRES_PASSWORD` 默认值 `"admin123"` → 生产环境使用弱密码

## 修复方案

**移除安全敏感字段的代码默认值，改为 Pydantic 必填字段 + 强度校验，在 Settings 实例化阶段 fail-fast。** 缺失或不合规时进程在启动前直接失败，而不是带着默认凭据继续运行。

### 1. JWT 配置:必填 + 最小长度 32 字符

**文件:** `backend/packages/framework/src/windup_framework/config/jwt.py`

- 删除默认值 `"change-me-in-production"`,`secret` 改为必填的 `SecretStr`
- `field_validator` 校验最小长度 32 字符,不满足直接抛 `ValidationError`

### 2. 数据库配置:密码必填 + 最小长度 8 字符

**文件:** `backend/packages/framework/src/windup_framework/config/database.py`

- 删除默认值 `"admin123"`,`password` 改为必填字段 (`Field(...)`)
- `field_validator` 校验最小长度 8 字符

### 3. 同步消费方

**文件:** `backend/packages/app/src/windup_app/server/user/service.py`

`jwt_settings.secret` 改为 `SecretStr` 后,消费处使用 `.get_secret_value()`。

### 4. 完整单元测试

**文件:** `backend/tests/test_validate_settings.py`

直接实例化 Settings 类(不 monkeypatch 全局单例),覆盖 15 个场景:
- JWT:缺失 / 空值 / 弱值 / 恰好 31 字符拒绝 / 恰好 32 字符通过 / 合法值
- 数据库密码:缺失 / 空值 / 弱值 / 恰好 7 字符拒绝 / 恰好 8 字符通过 / 合法值 / `url` 属性
- 两者同时缺失:JWT 与数据库分别抛出 `ValidationError`

CI 环境在 `backend/tests/conftest.py` 中通过 `os.environ.setdefault` 提供测试默认值,不覆盖已有的环境变量或本地 `.env`。

## 使用方式

```bash
# 所有环境都必须显式配置凭据,JWT_SECRET 至少 32 字符:
JWT_SECRET=$(openssl rand -hex 32) POSTGRES_PASSWORD=<strong-password> python -m windup_app
```

开发/测试环境的默认值请显式配置在 `.env` 或 `.env.dev` 中,代码不提供任何默认凭据。

Closes #199