### PR TITLE
fix(workflow-editor): use authenticated generation runtime

### DIFF
--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -53,7 +53,7 @@ describe('createGenerationApis', () => {
   it('生产适配器把 SSE 订阅接到配置的 API 地址', async () => {
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
     const fetchFn = vi.fn(
-      async () =>
+      async (_input: string | URL | Request, _init?: RequestInit) =>
         new Response(
           `event: failed\ndata: ${JSON.stringify({
             ...taskData({ status: 'failed', result: null, error_message: 'provider unavailable' }),

--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createGenerationApis, GenerationApiError } from '@/entities'
+import {
+  createAuthenticatedGenerationApis,
+  createGenerationApis,
+  GenerationApiError,
+} from '@/entities'
 import { EventStreamError, type EventStreamOptions } from '@/shared/api/stream'
 
 import type { MediaReference } from '../media'
@@ -46,6 +50,33 @@ function actionFrames(count: number) {
 }
 
 describe('createGenerationApis', () => {
+  it('生产适配器把 SSE 订阅接到配置的 API 地址', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+    const fetchFn = vi.fn(
+      async () =>
+        new Response(
+          `event: failed\ndata: ${JSON.stringify({
+            ...taskData({ status: 'failed', result: null, error_message: 'provider unavailable' }),
+          })}\n\n`,
+          { headers: { 'content-type': 'text/event-stream' } },
+        ),
+    )
+    const apis = createAuthenticatedGenerationApis(fetchFn as typeof fetch)
+    const onEvent = vi.fn()
+
+    const stop = apis.subscribe('42', '91', { type: 'character_template' }, onEvent, vi.fn())
+
+    try {
+      await vi.waitFor(() => expect(onEvent).toHaveBeenCalled())
+      expect(String(fetchFn.mock.calls[0]?.[0])).toBe(
+        'https://api.windup.test/generation/tasks/91/stream?project_id=42',
+      )
+    } finally {
+      stop()
+      vi.unstubAllEnvs()
+    }
+  })
+
   it('固定请求并映射三张角色母版候选', async () => {
     const request = vi.fn(async (_url: string, _init?: RequestInit) => success(taskData()))
     const stream = vi.fn(() => vi.fn())

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -1,4 +1,14 @@
-import { EventStreamError, type EventStreamSubscriber } from '@/shared/api/stream'
+import {
+  createApiClient,
+  getApiAccessToken,
+  recoverApiUnauthorized,
+  resolveApiBaseUrl,
+} from '@/shared/api'
+import {
+  createEventStreamSubscriber,
+  EventStreamError,
+  type EventStreamSubscriber,
+} from '@/shared/api/stream'
 
 import type {
   CompleteAnimationGenerationInput,
@@ -641,4 +651,29 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
   }
 
   return apis
+}
+
+/** 为浏览器宿主装配统一的 API 前缀、会话恢复与 SSE 鉴权。 */
+export function createAuthenticatedGenerationApis(
+  fetchFn: typeof fetch = globalThis.fetch,
+): GenerationApis {
+  const client = createApiClient({ fetchFn, getAccessToken: getApiAccessToken })
+  const stream = createEventStreamSubscriber({
+    fetchFn,
+    getAccessToken: getApiAccessToken,
+    recoverUnauthorized: recoverApiUnauthorized,
+  })
+
+  return createGenerationApis({
+    transport: {
+      async request(url, init) {
+        const data = await client.request<unknown>(url, { ...init, credentials: 'include' })
+        return new Response(JSON.stringify({ code: 200, message: 'success', data }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      },
+      stream: (url, options) => stream(`${resolveApiBaseUrl()}${url}`, options),
+    },
+  })
 }

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -36,7 +36,11 @@ export { getOutfitPlayback } from './character/outfit-playback'
 export type { ActionTemplate, ActionTemplateApis } from './action-template'
 
 /* 生成 —— 业务数据，不是「调用生成能力」 */
-export { createGenerationApis, GenerationApiError } from './generation/api'
+export {
+  createAuthenticatedGenerationApis,
+  createGenerationApis,
+  GenerationApiError,
+} from './generation/api'
 export type {
   CharacterTemplateGenerationInput,
   CharacterTemplateGenerationResult,

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -10,7 +10,8 @@ import type {
   WorkflowRun,
   WorkflowRunApis,
 } from '@/entities'
-import { createRealWorkflowEditorSession, createUnavailableGenerationApis } from './runtime'
+import { registerApiAccessTokenProvider, registerApiUnauthorizedRecovery } from '@/shared/api'
+import { createDefaultRealWorkflowEditorSession, createRealWorkflowEditorSession } from './runtime'
 
 describe('createRealWorkflowEditorSession', () => {
   it('通过公开 MediaApis 上传角色参考图并固定用途分类', async () => {
@@ -332,15 +333,90 @@ describe('createRealWorkflowEditorSession', () => {
   })
 })
 
-describe('createUnavailableGenerationApis', () => {
-  it('在 main 尚无 Generation HTTP 适配器时明确失败，不返回演示结果', async () => {
-    const apis = createUnavailableGenerationApis()
+describe('createDefaultRealWorkflowEditorSession', () => {
+  it('使用真实 Generation 接口恢复任务，并在业务 401 后携带新 token 重放一次', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+    let accessToken = 'expired-token'
+    const unregisterToken = registerApiAccessTokenProvider(() => accessToken)
+    const recover = vi.fn(async () => {
+      accessToken = 'refreshed-token'
+      return true
+    })
+    const unregisterRecovery = registerApiUnauthorizedRecovery(recover)
+    const generationTokens: Array<string | null> = []
+    const workflow = selectingCharacterTemplateWorkflowFixture()
+    workflow.nodes[1]!.generations = [{ taskId: '91', role: 'character_template' }]
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url === 'https://api.windup.test/workflow-runs/42') {
+        return apiSuccess({
+          id: 42,
+          project_id: 1,
+          nodes: workflow.nodes,
+          status: 'active',
+          version: 4,
+        })
+      }
+      if (url === 'https://api.windup.test/projects/1') {
+        return apiSuccess({
+          id: 1,
+          workflow_id: null,
+          project_name: '正式项目',
+          character_perspective: 1,
+          directional_movement: 1,
+          sprite_width: 64,
+          sprite_height: 64,
+          game_style: null,
+          sprite_sample_url: null,
+          create_at: '2026-08-10T00:00:00.000Z',
+          update_at: '2026-08-10T00:00:00.000Z',
+        })
+      }
+      if (url === 'https://api.windup.test/characters?project_id=1&page=1&page_size=100') {
+        return apiSuccess([], { total: 0, page: 1, page_size: 100 })
+      }
+      if (url === 'https://api.windup.test/generation/tasks/91?project_id=1') {
+        generationTokens.push(new Headers(init?.headers).get('authorization'))
+        if (generationTokens.length === 1) {
+          return new Response(
+            JSON.stringify({ code: 401, message: 'access token expired', data: null }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          )
+        }
+        return apiSuccess({
+          id: 91,
+          project_id: 1,
+          task_type: 'character_image',
+          status: 'failed',
+          input_payload: { num_images: 3 },
+          result: null,
+          error_message: 'provider unavailable',
+        })
+      }
+      throw new Error(`意外请求：${url}`)
+    })
 
-    await expect(apis.create(characterGenerationInput())).rejects.toThrow(
-      'GenerationApis 尚未接入真实后端',
-    )
-    await expect(apis.get('1', '9')).rejects.toThrow('GenerationApis 尚未接入真实后端')
-    expect(() => apis.subscribe('1', '9', vi.fn())).not.toThrow()
+    try {
+      const session = await createDefaultRealWorkflowEditorSession('42')
+
+      await expect(
+        session.controller.getGeneration('template', 'character_template'),
+      ).resolves.toMatchObject({
+        id: '91',
+        projectId: '1',
+        type: 'character_template',
+        status: 'failed',
+        error: 'provider unavailable',
+      })
+      expect(recover).toHaveBeenCalledOnce()
+      expect(generationTokens).toEqual(['Bearer expired-token', 'Bearer refreshed-token'])
+      session.dispose()
+    } finally {
+      fetchSpy.mockRestore()
+      unregisterRecovery()
+      unregisterToken()
+      vi.unstubAllEnvs()
+    }
   })
 })
 
@@ -574,13 +650,9 @@ function completeAnimationFixture(): Generation<'complete_animation'> {
   }
 }
 
-function characterGenerationInput() {
-  return {
-    type: 'character_template' as const,
-    projectId: '1',
-    prompt: '冒险家',
-    spriteWidth: 64,
-    spriteHeight: 64,
-    referenceMedia: [],
-  }
+function apiSuccess(data: unknown, extra: Record<string, unknown> = {}) {
+  return new Response(JSON.stringify({ code: 200, message: 'success', data, ...extra }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
 }

--- a/frontend/src/pages/workflow-editor/runtime.ts
+++ b/frontend/src/pages/workflow-editor/runtime.ts
@@ -10,7 +10,13 @@ import type {
   ReviewWorkflowNode,
   WorkflowRunApis,
 } from '@/entities'
-import { characterApis, createMediaApis, projectApis, workflowRunApis } from '@/entities'
+import {
+  characterApis,
+  createAuthenticatedGenerationApis,
+  createMediaApis,
+  projectApis,
+  workflowRunApis,
+} from '@/entities'
 import { createCharacterAssetPublisher } from '@/features/export'
 import { createWorkflowController, type WorkflowController } from '@/features/workflow-controller'
 
@@ -164,32 +170,18 @@ export async function createRealWorkflowEditorSession(
   }
 }
 
-/**
- * main 已提供真实 WorkflowRun、Project 与 Character 适配器；Generation 只有公开接口，
- * 尚无可合入的 HTTP 实现。这里明确拒绝生成，避免用演示数据污染正式 WorkflowRun。
- */
+/** 使用生产 Generation 适配器恢复并推进单条 WorkflowRun。 */
 export function createDefaultRealWorkflowEditorSession(
   runId: string,
 ): Promise<WorkflowEditorSession> {
   return createRealWorkflowEditorSession(runId, {
     workflowRunApis,
-    generationApis: createUnavailableGenerationApis(),
+    generationApis: createAuthenticatedGenerationApis(),
     mediaApis: createMediaApis(),
     projectApis,
     characterApis,
     onAsyncError: () => undefined,
   })
-}
-
-export function createUnavailableGenerationApis(): GenerationApis {
-  const unavailable = () =>
-    Promise.reject(new Error('GenerationApis 尚未接入真实后端，不能执行或恢复生成任务'))
-
-  return {
-    create: unavailable as GenerationApis['create'],
-    get: unavailable,
-    subscribe: () => () => undefined,
-  }
 }
 
 async function loadWorkflowCharacter(


### PR DESCRIPTION
Workflow Editor 默认会话现已接入真实 Generation 生产适配器，可恢复已有任务，并在 access token 过期时沿用共享会话恢复流程。

## Why

最新 `main` 仍向 Workflow Editor 注入 `createUnavailableGenerationApis()`，导致包含 Generation 引用的 WorkflowRun 必然显示“GenerationApis 尚未接入真实后端”，重试也不会访问后端。

## Changes

- 将 Workflow Editor 默认会话切换到真实 Generation 生产适配器。
- 复用共享 API client 的当前 token、业务 `code: 401` 恢复和单次重放。
- 保留 SSE 鉴权恢复与既有轮询兜底。
- 删除仅用于主动拒绝请求的占位 GenerationApis。
- 增加已有任务恢复及刷新后新 token 重放的回归测试。

## Implementation

- Generation 实体继续负责 DTO 校验与三类前端生成阶段映射。
- 浏览器装配层统一补齐 API 前缀、cookie、Bearer token 和会话恢复，不把认证状态引入实体契约。
- Workflow Editor 仍通过现有 WorkflowController 恢复和推进同一条 WorkflowRun。

## Verification

- [x] `npm test -- src/entities/generation/api.test.ts src/shared/api/index.test.ts src/shared/api/stream.test.ts src/features/workflow-controller/controller.test.ts src/pages/workflow-editor/runtime.test.ts`：5 个测试文件、125 tests passed。
- [x] `npm run build`：通过。
- [x] `npx oxfmt --check src/entities/generation/api.ts src/entities/index.ts src/pages/workflow-editor/runtime.ts src/pages/workflow-editor/runtime.test.ts`：通过。
- [x] `npx oxlint src/entities/generation/api.ts src/entities/index.ts src/pages/workflow-editor/runtime.ts src/pages/workflow-editor/runtime.test.ts`：通过。
- [x] `git diff --check upstream/main...HEAD`：通过。
- [x] 生产环境基线只读复现占位错误；验证过程中未创建新的 Generation 任务。

## Scope

- 本 PR 不修改 Quick Start、后端、WorkflowRun、WorkflowController、生产数据或队友 PR #246。
- QnAIGC 的 `525 SSL Handshake Failed` 是独立上游故障，不在本 PR 范围内。

## Related Issues

Closes #262
Refs #120
