### PR TITLE
fix(providers): 生图重试确定未达上游的 52x

### DIFF
--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -277,13 +277,28 @@ _POST_TRIES = 3
 _MAX_RETRY_WAIT = 30.0
 _IMAGE_TIMEOUT_MULTIPLIER = 1.5
 
-# Cloudflare 52x 里唯一能确定"请求根本没到源站"的三个:521 源站拒绝连接、
-# 522 CF 与源站建连超时、523 源站不可达。三者都止步于 TCP 层,上游不可能已经开始生成,
-# 所以重发不会重复扣费 —— 这是它们可以重试、而其余 5xx 一律不可以的唯一理由。
+# 521 源站拒绝连接、522 建连超时、523 源站不可达:三者都止步于 TCP 层,上游不可能已经
+# 开始生成,所以重发不会重复扣费。
 #
-# **520 与 524 不属于这一组,不要加进来**:它们意味着连接已经建立、请求可能已在源站
-# 处理中(524 就是"源站 100 秒没答完"),重发一次就是为同一张图付两次钱。
-_UNREACHED_UPSTREAM_STATUS = frozenset({521, 522, 523})
+# **但这层含义是 Cloudflare 私有的,不是这三个数字的普遍含义** —— ``AI_BASE_URL`` 可指向
+# 任意 OpenAI 兼容网关,它或它前面的代理完全可以在把请求转发给上游之后返回同样的数字。
+# 所以判据是"码 + 来源"两者皆需,见 :func:`_from_cloudflare_edge`。
+#
+# **520 与 524 即使来自 Cloudflare 也不在此列**:连接已建立、请求可能正在源站处理中
+# (524 就是"源站 100 秒没答完"),重发一次就是为同一张图付两次钱。
+_CLOUDFLARE_UNREACHED_STATUS = frozenset({521, 522, 523})
+
+
+def _from_cloudflare_edge(response: httpx.Response) -> bool:
+    """响应是否由 Cloudflare 边缘自己生成 —— 52x 的"未达上游"只在这个前提下成立。
+
+    单看 ``cf-ray`` 不够:中继可以把上游的响应头原样拷进自己的错误响应,那时请求已经到过
+    上游,得靠 ``server: cloudflare`` 把这种中继排掉。两个信号缺一即判否 —— 错重试一次要
+    多付一张图的钱,错放弃只损失一次本可自动恢复的失败。
+    """
+    return bool(response.headers.get("cf-ray")) and (
+        response.headers.get("server", "").strip().lower().startswith("cloudflare")
+    )
 
 
 def _utc_now() -> datetime:
@@ -357,7 +372,7 @@ class SufyImageProvider(ImageProvider):
         )
 
     def _post(self, client: httpx.Client, body: dict) -> dict:
-        """发送请求，只重试确定没被上游收下的失败(429 与 ``_UNREACHED_UPSTREAM_STATUS``)。
+        """发送请求，只重试确定没被上游收下的失败(429，以及 Cloudflare 自己发的 52x)。
 
         为什么把 400 / 404 单独挑出来说:同一把 key 下不同网关的模型目录**不一样**。实测
         ``GET /v1/models``:一个网关 73 个模型、一个图像模型都没有;另一个 134 个、
@@ -367,7 +382,10 @@ class SufyImageProvider(ImageProvider):
         for attempt in range(1, _POST_TRIES + 1):
             resp = client.post(self._cfg.chat_completions_path, json=body)
             code = resp.status_code
-            if code != 429 and code not in _UNREACHED_UPSTREAM_STATUS:
+            retryable = code == 429 or (
+                code in _CLOUDFLARE_UNREACHED_STATUS and _from_cloudflare_edge(resp)
+            )
+            if not retryable:
                 break
             if attempt == _POST_TRIES:
                 raise RuntimeError(_retry_exhausted_message(code, _POST_TRIES))

--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -273,9 +273,17 @@ DEFAULT_IMAGE_MODEL = "gemini-2.5-flash-image"
 _IMAGE_TRIES = 3
 _MIN_IMAGE_BYTES = 5000
 _CONNECT_RETRIES = 3
-_RATE_LIMIT_TRIES = 3
-_MAX_RATE_LIMIT_WAIT = 30.0
+_POST_TRIES = 3
+_MAX_RETRY_WAIT = 30.0
 _IMAGE_TIMEOUT_MULTIPLIER = 1.5
+
+# Cloudflare 52x 里唯一能确定"请求根本没到源站"的三个:521 源站拒绝连接、
+# 522 CF 与源站建连超时、523 源站不可达。三者都止步于 TCP 层,上游不可能已经开始生成,
+# 所以重发不会重复扣费 —— 这是它们可以重试、而其余 5xx 一律不可以的唯一理由。
+#
+# **520 与 524 不属于这一组,不要加进来**:它们意味着连接已经建立、请求可能已在源站
+# 处理中(524 就是"源站 100 秒没答完"),重发一次就是为同一张图付两次钱。
+_UNREACHED_UPSTREAM_STATUS = frozenset({521, 522, 523})
 
 
 def _utc_now() -> datetime:
@@ -295,7 +303,20 @@ def _retry_after_seconds(value: str) -> float | None:
         delay = (retry_at.astimezone(timezone.utc) - _utc_now()).total_seconds()
     if not math.isfinite(delay):
         return None
-    return min(max(delay, 0.0), _MAX_RATE_LIMIT_WAIT)
+    return min(max(delay, 0.0), _MAX_RETRY_WAIT)
+
+
+def _retry_exhausted_message(status: int, tries: int) -> str:
+    """带上状态码与次数,否则排障的人只知道"失败了",不知道是限流还是网关连不上上游。"""
+    if status == 429:
+        return (
+            f"图像服务请求过于频繁(HTTP {status})，已重试 {tries} 次；"
+            "请稍后重试或检查服务商额度"
+        )
+    return (
+        f"图像网关未能连上上游(HTTP {status})，已重试 {tries} 次；"
+        "该请求未到达模型服务、未产生费用，可稍后重试"
+    )
 
 
 # 从响应里捞 data URI。模型把图放在 message.content 里,而不同网关的包裹层级不一样
@@ -336,30 +357,29 @@ class SufyImageProvider(ImageProvider):
         )
 
     def _post(self, client: httpx.Client, body: dict) -> dict:
-        """发送请求，有限重试未被网关接收的 429。
+        """发送请求，只重试确定没被上游收下的失败(429 与 ``_UNREACHED_UPSTREAM_STATUS``)。
 
-        为什么值得专门处理:同一把 key 下不同网关的模型目录**不一样**。实测
+        为什么把 400 / 404 单独挑出来说:同一把 key 下不同网关的模型目录**不一样**。实测
         ``GET /v1/models``:一个网关 73 个模型、一个图像模型都没有;另一个 134 个、
         含本模块默认的那个(2026-08-10)。配错 ``AI_BASE_URL`` 时原始报错只是一条
         404,读的人无从知道该去改配置还是改模型名。
         """
-        for attempt in range(1, _RATE_LIMIT_TRIES + 1):
+        for attempt in range(1, _POST_TRIES + 1):
             resp = client.post(self._cfg.chat_completions_path, json=body)
-            if resp.status_code != 429:
+            code = resp.status_code
+            if code != 429 and code not in _UNREACHED_UPSTREAM_STATUS:
                 break
-            if attempt == _RATE_LIMIT_TRIES:
-                raise RuntimeError(
-                    f"图像服务请求过于频繁(HTTP 429)，已重试 {_RATE_LIMIT_TRIES} 次；"
-                    "请稍后重试或检查服务商额度"
-                )
-            retry_after = resp.headers.get("Retry-After", "")
-            delay = _retry_after_seconds(retry_after)
+            if attempt == _POST_TRIES:
+                raise RuntimeError(_retry_exhausted_message(code, _POST_TRIES))
+            delay = _retry_after_seconds(resp.headers.get("Retry-After", ""))
             if delay is None:
-                delay = float(2**attempt)
+                # 上限同样兜住指数退避:上游挂掉时不该把一个图像任务堵成长时间阻塞。
+                delay = min(float(2**attempt), _MAX_RETRY_WAIT)
             logger.warning(
-                "图像服务返回 429，第 %d/%d 次请求，%.2f 秒后重试",
+                "图像服务返回 %d，第 %d/%d 次请求，%.2f 秒后重试",
+                code,
                 attempt,
-                _RATE_LIMIT_TRIES,
+                _POST_TRIES,
                 delay,
             )
             time.sleep(delay)

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -226,6 +226,10 @@ def _big_b64(n: int = 6000) -> str:
     return base64.b64encode(b"\x89PNG" + b"\x00" * n).decode()
 
 
+# Cloudflare 边缘自己生成 52x 时带的两个头;缺任何一个，52x 的"未达上游"含义就不成立。
+_CF_EDGE = {"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "cloudflare"}
+
+
 def _image_provider(handler):
     import httpx
 
@@ -459,14 +463,14 @@ def test_request_path_comes_from_config_not_a_literal():
 
 @pytest.mark.parametrize("code", [521, 522, 523])
 def test_unreached_upstream_is_retried_then_succeeds(monkeypatch, code):
-    """521/522/523 止步于 TCP 层，请求没到源站也就没计费，重发安全。"""
+    """Cloudflare 自己发的 521/522/523 止步于 TCP 层，请求没到源站也就没计费，重发安全。"""
     calls = {"n": 0}
 
     def h(request):
         import httpx
         calls["n"] += 1
         if calls["n"] < 3:
-            return httpx.Response(code, text="Connection timed out")
+            return httpx.Response(code, headers=_CF_EDGE, text="Connection timed out")
         return httpx.Response(200, json=_img_payload(_big_b64()))
 
     monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
@@ -475,10 +479,18 @@ def test_unreached_upstream_is_retried_then_succeeds(monkeypatch, code):
     assert calls["n"] == 3, "必须真的重发，而不是靠外层出图循环碰运气"
 
 
-@pytest.mark.parametrize("code", [520, 524, 500, 502, 503])
-def test_upstream_that_may_have_billed_is_never_retried(monkeypatch, code):
-    """524 是"连上了但源站 100 秒没答完"、520 是源站自己出错 —— 请求都已到达，
-    重发就是为同一张图付两次钱。这条单独钉住，防止后来者把 5xx 一刀切成可重试。
+@pytest.mark.parametrize("headers", [
+    pytest.param({}, id="no-signal"),
+    # 中继把上游的响应头原样拷了过来 —— 带着 cf-ray，可请求已经到过上游
+    pytest.param({"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "nginx"}, id="relayed-cf-ray"),
+    pytest.param({"server": "cloudflare"}, id="no-cf-ray"),
+])
+@pytest.mark.parametrize("code", [521, 522, 523])
+def test_52x_without_a_cloudflare_signature_is_never_retried(monkeypatch, code, headers):
+    """52x 的"未达上游"是 Cloudflare 私有含义，任何网关都能在转发给上游之后返回同样的数字。
+
+    所以来源存疑时按"可能已计费"处理：错重试一次要多付一张图的钱，错放弃只损失一次
+    本可自动恢复的失败。
     """
     import httpx
 
@@ -486,7 +498,27 @@ def test_upstream_that_may_have_billed_is_never_retried(monkeypatch, code):
 
     def h(request):
         calls["n"] += 1
-        return httpx.Response(code, text="upstream error")
+        return httpx.Response(code, headers=headers, text="Connection timed out")
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        _image_provider(h).gen_image("x", [])
+    assert calls["n"] == 1, f"HTTP {code} 来源存疑，不得重发"
+
+
+@pytest.mark.parametrize("code", [520, 524, 500, 502, 503])
+def test_upstream_that_may_have_billed_is_never_retried(monkeypatch, code):
+    """524 是"连上了但源站 100 秒没答完"、520 是源站自己出错 —— 请求都已到达，
+    重发就是为同一张图付两次钱。带上 Cloudflare 来源头，钉的才是"码"这一维。
+    """
+    import httpx
+
+    calls = {"n": 0}
+
+    def h(request):
+        calls["n"] += 1
+        return httpx.Response(code, headers=_CF_EDGE, text="upstream error")
 
     monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
 
@@ -504,7 +536,7 @@ def test_persistent_unreached_upstream_reports_tries_and_status(monkeypatch):
     def h(request):
         import httpx
         calls["n"] += 1
-        return httpx.Response(522, text="Connection timed out")
+        return httpx.Response(522, headers=_CF_EDGE, text="Connection timed out")
 
     monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
 
@@ -521,7 +553,7 @@ def test_unreached_upstream_backoff_is_capped(monkeypatch):
 
     def h(request):
         import httpx
-        return httpx.Response(522, headers={"Retry-After": "9999"})
+        return httpx.Response(522, headers={**_CF_EDGE, "Retry-After": "9999"})
 
     monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", sleeps.append)
 
@@ -532,9 +564,26 @@ def test_unreached_upstream_backoff_is_capped(monkeypatch):
 
 def test_retryable_set_excludes_the_codes_that_may_have_billed():
     """常量本身也钉一道:改集合的人不必先读懂 _post 才发现自己开了重复计费的洞。"""
-    from windup_framework.providers.sufy import _UNREACHED_UPSTREAM_STATUS
+    from windup_framework.providers.sufy import _CLOUDFLARE_UNREACHED_STATUS
 
-    assert _UNREACHED_UPSTREAM_STATUS == {521, 522, 523}
+    assert _CLOUDFLARE_UNREACHED_STATUS == {521, 522, 523}
+
+
+@pytest.mark.parametrize(("headers", "expected"), [
+    ({"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "cloudflare"}, True),
+    ({"CF-Ray": "8f2b1c4d5e6a7890-SJC", "Server": "Cloudflare"}, True),
+    ({"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "cloudflare-nginx"}, True),
+    ({"cf-ray": "", "server": "cloudflare"}, False),
+    ({"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "nginx"}, False),
+    ({"cf-ray": "8f2b1c4d5e6a7890-SJC"}, False),
+    ({"server": "cloudflare"}, False),
+    ({}, False),
+])
+def test_cloudflare_origin_needs_both_signals(headers, expected):
+    """判据是"两个信号皆需"，不是"沾上 cloudflare 字样就算"。"""
+    from windup_framework.providers.sufy import _from_cloudflare_edge
+
+    assert _from_cloudflare_edge(httpx.Response(522, headers=headers)) is expected
 
 
 @pytest.mark.parametrize("code", [400, 404])

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -457,6 +457,86 @@ def test_request_path_comes_from_config_not_a_literal():
     assert seen["path"].endswith("/v9/custom-chat"), seen["path"]
 
 
+@pytest.mark.parametrize("code", [521, 522, 523])
+def test_unreached_upstream_is_retried_then_succeeds(monkeypatch, code):
+    """521/522/523 止步于 TCP 层，请求没到源站也就没计费，重发安全。"""
+    calls = {"n": 0}
+
+    def h(request):
+        import httpx
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return httpx.Response(code, text="Connection timed out")
+        return httpx.Response(200, json=_img_payload(_big_b64()))
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
+
+    assert _image_provider(h).gen_image("x", [])
+    assert calls["n"] == 3, "必须真的重发，而不是靠外层出图循环碰运气"
+
+
+@pytest.mark.parametrize("code", [520, 524, 500, 502, 503])
+def test_upstream_that_may_have_billed_is_never_retried(monkeypatch, code):
+    """524 是"连上了但源站 100 秒没答完"、520 是源站自己出错 —— 请求都已到达，
+    重发就是为同一张图付两次钱。这条单独钉住，防止后来者把 5xx 一刀切成可重试。
+    """
+    import httpx
+
+    calls = {"n": 0}
+
+    def h(request):
+        calls["n"] += 1
+        return httpx.Response(code, text="upstream error")
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        _image_provider(h).gen_image("x", [])
+    assert calls["n"] == 1, f"HTTP {code} 不得重发"
+
+
+def test_persistent_unreached_upstream_reports_tries_and_status(monkeypatch):
+    """报错要说清重试了几次、最后一次是什么码，别只留一句裸 HTTPStatusError。"""
+    from windup_framework.providers.sufy import _POST_TRIES
+
+    calls = {"n": 0}
+
+    def h(request):
+        import httpx
+        calls["n"] += 1
+        return httpx.Response(522, text="Connection timed out")
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
+
+    with pytest.raises(RuntimeError, match=r"522.*已重试 3 次"):
+        _image_provider(h).gen_image("x", [])
+    assert calls["n"] == _POST_TRIES
+
+
+def test_unreached_upstream_backoff_is_capped(monkeypatch):
+    """上游挂掉时不该把一个图像任务堵成长时间阻塞。"""
+    from windup_framework.providers.sufy import _MAX_RETRY_WAIT
+
+    sleeps: list[float] = []
+
+    def h(request):
+        import httpx
+        return httpx.Response(522, headers={"Retry-After": "9999"})
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", sleeps.append)
+
+    with pytest.raises(RuntimeError, match="522"):
+        _image_provider(h).gen_image("x", [])
+    assert sleeps and max(sleeps) <= _MAX_RETRY_WAIT
+
+
+def test_retryable_set_excludes_the_codes_that_may_have_billed():
+    """常量本身也钉一道:改集合的人不必先读懂 _post 才发现自己开了重复计费的洞。"""
+    from windup_framework.providers.sufy import _UNREACHED_UPSTREAM_STATUS
+
+    assert _UNREACHED_UPSTREAM_STATUS == {521, 522, 523}
+
+
 @pytest.mark.parametrize("code", [400, 404])
 def test_model_missing_from_the_gateway_catalogue_says_so(code):
     """同一把 key 下不同网关的模型目录不一样(实测:一个 73 个模型零图像模型、


### PR DESCRIPTION
## 变更内容

`SufyImageProvider._post()` 现在也重试 **521 / 522 / 523**，复用原有的 429 退避路径。

## 关联

Refs 1024XEngineer/Windup#269

## 为什么只加这三个，不是"给 5xx 加重试"

生图按次计费，**盲目重试 5xx = 重复扣费**。原有代码是有意不重试它们的，`_client()` 里那条注释写着「那两种请求可能已达上游，重发会重复计费」——这条没被推翻，也不该推翻。

Cloudflare 52x 细分之后能分出安全的一组：

| 码 | 请求到源站了吗 | 能否重试 |
|---|---|---|
| 521 源站拒绝连接 / **522 建连超时** / 523 源站不可达 | **没到**，止步 TCP 层 | ✅ 不可能计费 |
| 520 未知错误 / 524 源站 100s 没答完 | **到了**，可能已在处理 | ❌ 重发就是为同一张图付两次钱 |

这个判据写在常量正上方，并显式点名「520 与 524 不属于这一组，不要加进来」——否则下一个人很容易顺手把整组 5xx 加进去，把洞开回来。

**为什么必须做在 `_post` 内部**：`gen_image` 外层确实还有一个 `_IMAGE_TRIES` 循环，但它只在 `_post` **成功返回 JSON 之后**才判图有效性；`_post` 抛的异常直接穿透。指望外层兜住是错的。

顺带两处：指数退避分支原先没过上限（只有 `Retry-After` 那条走了 `min`），上游挂掉时会把图像任务堵成长时间阻塞，已补；报错文案现在带状态码与重试次数，429 与 52x 分开说，排障的人能直接看出是限流还是网关连不上上游。

常量随语义改名（`_RATE_LIMIT_TRIES` → `_POST_TRIES`、`_MAX_RATE_LIMIT_WAIT` → `_MAX_RETRY_WAIT`），全仓无其他引用。

**只改生图这一个 provider**。同类约束也适用于视频与 3D 那些计费面，但那要各自评估，不在一次改动里横跨多个计费面。

## 本地验证

- `uv run ruff check .` → All checks passed
- `uv run lint-imports` → Contracts: 2 kept, 0 broken
- `uv run pytest -q` → **473 passed, 0 failed**（基线 462，+11）
- 前端门禁未跑 —— 本 PR 零前端文件改动

新增 11 个用例，都用 `httpx.MockTransport`、不联网：

- 521/522/523 各一条：前两次失败第三次成功，**断言请求次数 == 3**（不只断言最终成功，否则外层出图循环碰巧成功也算过）
- 520/524/500/502/503 各一条：**断言请求次数 == 1**、直接抛 —— 这组是防止后来者一刀切的守卫
- 持续 522：报错文本里同时有状态码与重试次数
- 退避不超过上限
- 直接钉住可重试集合本身，改集合的人不用先读懂 `_post` 就会红

**变异测试验证过测试真的咬得住**（脚本 + `try/finally` + 结束校验 sha256，未用 `git checkout` 还原）：

| 变异体 | 结果 |
|---|---|
| 集合改成空（等于没做这个功能） | 6 项 FAIL |
| 集合改成全部 5xx（把重复扣费的洞开回来） | 6 项 FAIL |
| 集合里悄悄加进 524 | 2 项 FAIL |

三个方向都挡得住，还原后 sha256 一致。
