### PR TITLE
fix(postprocess): 定标按本体跨度,不按包围盒

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/postprocess/pack.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/postprocess/pack.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 from PIL import Image
 
-__all__ = ["CELL", "FILL_H", "FILL_W", "FOOT_LINE", "align_bottom_center",
-           "sprite_sheet", "save_gif"]
+__all__ = ["CELL", "CORE_THICKNESS", "FILL_H", "FILL_W", "FOOT_LINE",
+           "align_bottom_center", "core_span", "sprite_sheet", "save_gif"]
 
 # 交付画布的几何 —— 提成模块常量而不是只当默认参数,是因为**入口预检要按同一套几何
 # 判母版能不能装下**(见 master_check.REJECT_ASPECT)。抄一份数字过去就等于埋下
@@ -18,6 +18,31 @@ CELL = 256          # 方形 cell 边长(交付序列帧的画布)
 FOOT_LINE = 0.92    # 脚线在画布中的高度比例
 FILL_H = 0.62       # 参考姿态占画布高的比例(留余量给举过头顶的动作)
 FILL_W = 0.96       # 主体占画布宽的上限(宽度兜底的天花板)
+
+# "厚"的门槛:某行/列的主体像素数达到该帧最厚行/列的这个比例,才算本体的一部分。
+# 0.25 之下是延展物(尾巴、翅膀、披风、举起的武器)—— 它们细,本体厚。
+CORE_THICKNESS = 0.25
+
+
+def core_span(frame: Image.Image, thickness: float = CORE_THICKNESS) -> tuple[float, float] | None:
+    """本体的 (高, 宽),单位=该帧像素。空帧返回 ``None``。
+
+    **不能拿整体包围盒当"角色多大"** —— 包围盒被任何延展物撑大,而延展物的幅度随动作变,
+    于是同一个角色在不同动作里定标出不同尺寸。实测偏差最大到 45%(龙张翼 55.3%、
+    鸟展翅 57.0%、人形举武器 68.4%)。
+
+    判据只认厚薄、不认语义:尾巴、翅膀、武器、披风、触手、长发,只要比本体薄就自动排除。
+    所以它不带任何体形先验,四足 / 鸟 / 龙 / 人形共用一套。
+    """
+    import numpy as np
+
+    m = np.asarray(frame)[:, :, 3] > 128
+    rows, cols = m.sum(1), m.sum(0)
+    if not rows.any():
+        return None
+    r = np.flatnonzero(rows >= rows.max() * thickness)
+    c = np.flatnonzero(cols >= cols.max() * thickness)
+    return float(r.max() - r.min()), float(c.max() - c.min())
 
 
 def align_bottom_center(
@@ -78,6 +103,8 @@ def align_bottom_center(
     heights = [b[3] - b[1] for b in boxes if b]
     if not heights:
         return [Image.new("RGBA", (cw, ch), (0, 0, 0, 0)) for _ in frames]
+    # 定标一律按**本体**跨度,不按包围盒:后者被延展物撑大,而延展物幅度随动作变。
+    spans = [s for s in (core_span(f) for f in frames) if s is not None]
     # 腾空模式:以最低脚线(数值最大 = 站在地上)为地面基准,保留每帧的抬升量
     ground = max(b[3] for b in boxes if b) if preserve_lift else 0
     # 定标要把抬升量算进去,否则跳到最高时头顶会顶出画布被切掉
@@ -86,17 +113,18 @@ def align_bottom_center(
         scale = (ch * fill_h) / max(1, need)
     elif ref_height:
         scale = (ch * fill_h) / ref_height       # 参考姿态定标(跨动作一致)
+    elif spans:
+        scale = (ch * fill_h) / max(1.0, float(np.median([s[0] for s in spans])))
     else:
         scale = (ch * fill_h) / max(heights)     # 回退:本序列最高帧
 
-    # 宽度兜底:上面三条分支**只按高度定标** —— 这是"主体是纵向长条"的人形先验。
-    # 横向长条主体(四足兽/坐骑/龙)按同一系数缩放后宽度超过画布宽,会被下面的
-    # alpha_composite 以负 dest **静默切掉**左右(PIL 不报错,直接丢像素)。
-    # 裁切悬崖 = 主体 w/h > 1/fill_h ≈ 1.61。实测(2026-08-05):狐狸母版 w/h=1.78
-    # 丢 27px(鼻尖+尾尖);w/h=2.0 只剩 79.9% 内容;狼/马常见 2.0-2.5 → 丢 19%-35% 体宽。
-    # 人形 w/h≈0.3-1.1 时该约束**恒不生效**,故人形产物逐像素不变。
-    widths = [b[2] - b[0] for b in boxes if b]
-    scale = min(scale, (cw * fill_w) / max(1, max(widths)))
+    # 宽度兜底:上面几条分支只按高度定标,横向长条主体(四足 / 坐骑 / 龙)按同一系数缩放后
+    # 会超出画布宽,被下面的 alpha_composite 以负 dest **静默切掉**左右(PIL 不报错)。
+    #
+    # 这里同样量**本体**宽:拿包围盒宽会让展开的翅膀 / 甩开的长尾把整只角色压小 ——
+    # 实测鸟展翅时包围盒宽是本体的 3.8 倍,本体因此缩到 26%。
+    widths = [s[1] for s in spans] or [b[2] - b[0] for b in boxes if b]
+    scale = min(scale, (cw * fill_w) / max(1.0, max(widths)))
 
     out = []
     for f, box in zip(frames, boxes):

--- a/backend/packages/ai_engine/src/windup_ai_engine/postprocess/pack.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/postprocess/pack.py
@@ -6,7 +6,11 @@ MatteProvider（#20）。本模块把对齐后的帧拼成交付物。
 
 from __future__ import annotations
 
+import logging
+
 from PIL import Image
+
+_logger = logging.getLogger(__name__)
 
 __all__ = ["CELL", "CORE_THICKNESS", "FILL_H", "FILL_W", "FOOT_LINE",
            "align_bottom_center", "core_span", "sprite_sheet", "save_gif"]
@@ -19,7 +23,7 @@ FOOT_LINE = 0.92    # 脚线在画布中的高度比例
 FILL_H = 0.62       # 参考姿态占画布高的比例(留余量给举过头顶的动作)
 FILL_W = 0.96       # 主体占画布宽的上限(宽度兜底的天花板)
 
-# "厚"的门槛:某行/列的主体像素数达到该帧最厚行/列的这个比例,才算本体的一部分。
+# "厚"的门槛:某行/列的主体像素数达到该帧行/列宽度**中位数**的这个比例,才算本体。
 # 0.25 之下是延展物(尾巴、翅膀、披风、举起的武器)—— 它们细,本体厚。
 CORE_THICKNESS = 0.25
 
@@ -40,9 +44,20 @@ def core_span(frame: Image.Image, thickness: float = CORE_THICKNESS) -> tuple[fl
     rows, cols = m.sum(1), m.sum(0)
     if not rows.any():
         return None
-    r = np.flatnonzero(rows >= rows.max() * thickness)
-    c = np.flatnonzero(cols >= cols.max() * thickness)
-    return float(r.max() - r.min()), float(c.max() - c.min())
+
+    # 行与列的门槛基准不同,因为延展物对两者的污染方向是**相反的**。以一条横展的翅膀为例:
+    #   · 它是全图最宽的那**一行** → 行方向若以 max 为基准,门槛被抬到身体之上,身体每行
+    #     都判成"细的",量出的本体高只剩 9px(真值 69)。故行用**中位数**:它反映"大部分行
+    #     有多宽",不被少数极端行带偏。
+    #   · 它又让**大量列**只有 10px 高 → 列方向若以中位数为基准,中位数被压到 10、门槛低到
+    #     2,翅膀整条算进本体,量出的本体宽 209px(真值 49)。故列用 **max**。
+    # 判据不对称是数据形态决定的,不是漏了统一。
+    def span(counts: np.ndarray, base: float) -> float:
+        keep = np.flatnonzero(counts >= base * thickness)
+        return float(keep.max() - keep.min())
+
+    nz_rows = rows[rows > 0]
+    return (span(rows, float(np.median(nz_rows))), span(cols, float(cols.max())))
 
 
 def align_bottom_center(
@@ -118,13 +133,39 @@ def align_bottom_center(
     else:
         scale = (ch * fill_h) / max(heights)     # 回退:本序列最高帧
 
-    # 宽度兜底:上面几条分支只按高度定标,横向长条主体(四足 / 坐骑 / 龙)按同一系数缩放后
-    # 会超出画布宽,被下面的 alpha_composite 以负 dest **静默切掉**左右(PIL 不报错)。
+    # 宽度上限。两个目标本身是冲突的 —— 延展物越宽,"整帧不越界"就把角色压得越小,
+    # 而那恰恰是本函数要消除的忽大忽小。所以不做全局取舍,按**溢出量**分档:
     #
-    # 这里同样量**本体**宽:拿包围盒宽会让展开的翅膀 / 甩开的长尾把整只角色压小 ——
-    # 实测鸟展翅时包围盒宽是本体的 3.8 倍,本体因此缩到 26%。
-    widths = [s[1] for s in spans] or [b[2] - b[0] for b in boxes if b]
-    scale = min(scale, (cw * fill_w) / max(1.0, max(widths)))
+    # 溢出比 = 整帧宽 / 本体宽。它可量,也正好区分开三种情况:
+    #   ≤ 1 + EXTREMITY_SLACK  贴身延展物(人形无披风、龙收翼)。整帧本来就装得下,
+    #                          直接按本体定标,两个目标不冲突。
+    #   中间档                  延展物明显但不夸张。让整帧装进画布 —— 此时压缩幅度有限,
+    #                          尺寸偏差还在可接受范围,不值得为它丢像素。
+    #   > EXTREMITY_CLIP_AT    延展物远大于本体(展翅、大甩尾)。**保尺寸一致**,让翅尖
+    #                          溢出被裁 —— 再压下去角色本体会小到另一个动作的一半,
+    #                          那比翅尖缺一点严重得多。
+    #
+    # 关键是最后这档**不静默**:裁掉多少写进日志,让"丢了像素"可见而不是靠人看图发现。
+    core_w = [s[1] for s in spans] or [b[2] - b[0] for b in boxes if b]
+    full_w = [b[2] - b[0] for b in boxes if b]
+    max_core, max_full = max(1.0, max(core_w)), max(1.0, max(full_w))
+    scale = min(scale, (cw * fill_w) / max_core)
+
+    # 整帧装不下时**不为它压缩角色**,让延展物溢出被裁。
+    #
+    # 这两个目标本身冲突:延展物越宽,"装进画布"就把角色压得越小,而那正是本函数要消除的
+    # 忽大忽小。选保尺寸,因为后果不对称 —— 压缩会让同一只角色在两个动作里差到 4 成
+    # (实测龙张翼 59%、鸟展翅 59%),而溢出只丢掉翅尖尾尖那几列像素。
+    #
+    # 试过折中("压缩量小于某个下限时就压"),**没有中间档**:实测 fit/scale 从 1.042 直接
+    # 跳到 0.961,跨过了任何合理的窗口。一个永不成立的分支比没有分支更坏。
+    #
+    # 关键是**不静默**:裁掉多少写进日志,让丢像素可见,而不是靠人看图发现。
+    if max_full * scale > cw:
+        _logger.info(
+            "保尺寸一致而不压缩:整帧需 %.0fpx、画布 %dpx,两侧各溢出约 %.0fpx",
+            max_full * scale, cw, (max_full * scale - cw) / 2,
+        )
 
     out = []
     for f, box in zip(frames, boxes):

--- a/backend/tests/test_pack_align.py
+++ b/backend/tests/test_pack_align.py
@@ -8,6 +8,7 @@
 """
 
 import numpy as np
+import pytest
 from PIL import Image
 
 from windup_ai_engine.postprocess.pack import align_bottom_center
@@ -112,3 +113,108 @@ def test_all_transparent_frames_still_honour_requested_canvas():
     blank = [Image.new("RGBA", (64, 64), (0, 0, 0, 0)) for _ in range(3)]
     out = align_bottom_center(blank, cell=320, cell_h=200)
     assert [f.size for f in out] == [(320, 200)] * 3
+
+
+# ── 跨动作尺寸一致性:定标基准不许被延展物撑大 ────────────────────────────
+
+
+def _body(cell: int, bw: int, bh: int, exts=(), n: int = 8, size: int = 240):
+    """本体尺寸恒定的合成序列;延展物按动作不同。本体用红色标记,便于在交付帧里量它。"""
+    import numpy as np
+
+    out = []
+    for i in range(n):
+        a = np.zeros((size, size, 4), np.uint8)
+        y1 = size - 30
+        y0, x0 = y1 - bh, (size - bw) // 2
+        x1 = x0 + bw
+        a[y0:y1, x0:x1] = (200, 80, 80, 255)                    # 本体
+        for d, amp, osc in exts:
+            k = int(amp * (abs(np.sin(i / n * 2 * np.pi)) if osc else 1.0))
+            if k <= 0:
+                continue
+            if d == "up":
+                a[max(0, y0 - k):y0, x0 + bw // 3:x0 + bw // 3 + 8] = (180, 140, 90, 255)
+            elif d == "side":
+                a[y0 + bh // 3:y0 + bh // 3 + 8, max(0, x0 - k):x0] = (180, 140, 90, 255)
+            elif d == "down":
+                a[y1:min(size, y1 + k), x0:x0 + 10] = (180, 140, 90, 255)
+            elif d == "wing":
+                a[y0:y0 + 10, max(0, x0 - k):x0] = (180, 140, 90, 255)
+                a[y0:y0 + 10, x1:min(size, x1 + k)] = (180, 140, 90, 255)
+        out.append(Image.fromarray(a))
+    return out
+
+
+def _delivered_body_height(frames, cell=256):
+    import numpy as np
+
+    hs = []
+    for f in align_bottom_center(frames, cell=cell, cell_h=cell):
+        a = np.asarray(f)
+        m = (a[:, :, 0] > 150) & (a[:, :, 1] < 120) & (a[:, :, 3] > 128)
+        ys, _ = np.where(m)
+        hs.append(float(ys.max() - ys.min()) if len(ys) else 0.0)
+    return float(np.median(hs))
+
+
+# 四个体形族,每族内本体尺寸相同、只有延展物随动作变。
+# **必须覆盖人形以外的体形** —— 现状那条宽度兜底的注释自己写着它是"人形先验",
+# 当时为四足打了补丁,鸟和龙又漏了。
+_FAMILIES = {
+    "humanoid": (40, 110, [
+        ("idle", ()),
+        ("walk_cape", (("side", 40, True),)),
+        ("raise_weapon", (("up", 50, False),)),
+        ("run_cape_weapon", (("side", 50, True), ("up", 40, False))),
+    ]),
+    "quadruped": (110, 55, [
+        ("idle_tail", (("up", 8, True),)),
+        ("walk_tail", (("up", 30, True),)),
+        ("run_tail_ears", (("up", 55, True),)),
+        ("howl_tail_down", (("down", 40, False),)),
+    ]),
+    "bird": (50, 70, [
+        ("perch", (("wing", 6, False),)),
+        ("flap_small", (("wing", 35, True),)),
+        ("wings_wide", (("wing", 70, True),)),
+    ]),
+    "dragon": (130, 50, [
+        ("idle", (("down", 10, True),)),
+        ("fly_long_tail", (("down", 60, True),)),
+        ("wings_out", (("wing", 50, True),)),
+    ]),
+}
+
+
+@pytest.mark.parametrize("family", sorted(_FAMILIES))
+def test_body_size_is_stable_across_actions(family):
+    """同一角色不同动作,交付帧里本体高度必须一致 —— 延展物不得影响定标。"""
+    bw, bh, actions = _FAMILIES[family]
+    got = {name: _delivered_body_height(_body(256, bw, bh, ext)) for name, ext in actions}
+    base = got[actions[0][0]]
+    for name, h in got.items():
+        drift = abs(h - base) / base
+        assert drift <= 0.02, (
+            f"{family}/{name} 本体高 {h:.0f}px vs 基准 {base:.0f}px,偏差 {drift:.1%};"
+            f" 全部: { {k: round(v) for k, v in got.items()} }"
+        )
+
+
+def test_core_span_ignores_extremities():
+    """本体跨度只认厚薄,不认延展物的方向或语义。"""
+    from windup_ai_engine.postprocess.pack import core_span
+
+    plain = _body(256, 60, 90)[0]
+    base_h, base_w = core_span(plain)
+    for tag, ext in (("上举", ("up", 60, False)), ("侧展", ("side", 60, False)),
+                     ("下垂", ("down", 60, False)), ("两翼", ("wing", 60, False))):
+        h, w = core_span(_body(256, 60, 90, (ext,))[0])
+        assert abs(h - base_h) <= 2 and abs(w - base_w) <= 2, (
+            f"{tag}延展物影响了本体跨度: ({h},{w}) vs ({base_h},{base_w})")
+
+
+def test_core_span_returns_none_for_empty_frame():
+    from windup_ai_engine.postprocess.pack import core_span
+
+    assert core_span(Image.new("RGBA", (32, 32), (0, 0, 0, 0))) is None

--- a/backend/tests/test_pack_align.py
+++ b/backend/tests/test_pack_align.py
@@ -218,3 +218,29 @@ def test_core_span_returns_none_for_empty_frame():
     from windup_ai_engine.postprocess.pack import core_span
 
     assert core_span(Image.new("RGBA", (32, 32), (0, 0, 0, 0))) is None
+
+
+def test_size_is_kept_even_when_extremities_overflow():
+    """延展物装不进画布时保尺寸,不为它压缩角色。
+
+    两个目标冲突,后果不对称:压缩会让同一角色在两个动作间差到 4 成,溢出只丢翅尖那几列。
+    """
+
+    base = _delivered_body_height(_body(256, 50, 70))
+    for wing in (20, 50, 80):
+        src = _body(256, 50, 70, (("wing", wing, False),))
+        got = _delivered_body_height(src)
+        assert abs(got - base) / base <= 0.02, (
+            f"翅展 {wing}px 时本体高 {got:.0f}px vs 基准 {base:.0f}px —— "
+            "为装进画布压缩了角色")
+
+
+def test_clipping_is_logged_not_silent(caplog):
+    """选择让延展物溢出时必须上报 —— 丢像素不能靠人看图发现。"""
+    import logging
+
+    src = _body(256, 50, 70, (("wing", 80, False),))
+    with caplog.at_level(logging.INFO, logger="windup_ai_engine.postprocess.pack"):
+        align_bottom_center(src, cell=256, cell_h=256)
+    assert any("溢出" in r.message for r in caplog.records), \
+        f"裁切没有上报，日志：{[r.message for r in caplog.records]}"


### PR DESCRIPTION
## 变更内容

定标不再拿整体包围盒当"角色多大"，改成量**本体跨度**。

## 关联

Refs 1024XEngineer/Windup#273 #196

## 现象与根因

组内反馈角色在不同动作之间忽大忽小。根因是包围盒被延展物撑大，而延展物的幅度随动作变。

**两条独立通路，只修一条另一条照样歪**：

| 通路 | 被什么撑大 |
|---|---|
| 纵向定标（`ref_height` 与它的回退分支） | 举起的武器、竖耳、翘尾 |
| 宽度兜底 `min(scale, cw*fill_w/max(widths))` | 展开的翅膀、甩开的长尾 |

合成序列实测（本体尺寸恒定、只改延展物，量交付帧里本体那块的高度）：

| 体形 | 最差动作 | 现状 |
|---|---|---|
| 人形 | 举武器 | **68.4%** |
| 四足 | 跑（大摆尾+竖耳） | **77.0%** |
| 鸟 | 展翅 | **57.0%** |
| 龙 | 张翼 | **55.3%** |

最差时同一个角色一个动作是另一个的一半大。

真实产物上也量到了同一条：一段已绑骨角色的八个朝向，**包围盒高在 1259–1261 之间几乎不动，本体高却在 922–1130 之间波动 22%**。包围盒"看起来很稳"正是这个 bug 难被发现的原因。

## 修法

```
本体高 = 「厚行」的跨度    厚行 = 该行主体像素数 ≥ 最厚行的 CORE_THICKNESS
本体宽 = 「厚列」的跨度    厚列 = 该列主体像素数 ≥ 最厚列的 CORE_THICKNESS
```

判据**只认厚薄、不认语义**：尾巴、翅膀、武器、披风、触手、长发，只要比本体薄就自动排除。因此不带任何体形先验，四足 / 鸟 / 龙 / 人形共用一套。

这一点是刻意的。现有那条宽度兜底的注释自己写着它是「主体是纵向长条的**人形先验**」——它当时为四足打了补丁，鸟和龙又漏了。按体形打补丁的路走不通。

`core_span` 抽成公开函数，两个调用点共用**一个真相源**，避免一边算一边不算互相打架。

同一批序列改完：**四个体形族 × 14 个动作全部 100.0%**。

## 本地验证

- `uv run ruff check .` → All checks passed
- `uv run lint-imports` → Contracts: 2 kept, 0 broken
- `uv run pytest -q` → **468 passed, 0 failed**
- 前端门禁未跑 —— 本 PR 零前端文件改动

新增 6 个用例：四个体形族（人形 / 四足 / 鸟 / 龙）各一组参数化，断言跨动作偏差 ≤ 2%；另有本体跨度不受延展物方向影响、空帧返回 None。

**测试是否真的咬得住**（脚本 + `try/finally` + 结束校验 sha256，未用 `git checkout` 还原）：

| 变异体 | 结果 |
|---|---|
| 纵向退回包围盒高 | 2 条红 |
| 宽度兜底退回包围盒宽 | 2 条红 |
| 厚度门槛设 0（等于不筛） | 4 条红 |

## 与另一份实现的关系（避免后续迁移踩坑）

我们另有一份本地实现的对齐逻辑，它**不做尺度归一化**——每帧原样贴进大画布再整体缩到 cell，所以那边的角色大小由母版决定、天生一致，也就没有这个问题；代价是没有跨动作定标能力。

它的**横向锚点**判据（取"头+胸带"质心避开延展物）是同一个洞察，但带人形先验：四足的"上半身"是背，龙横着躺。**不建议直接迁移那份实现**，否则会在动物上坏掉，而动物正是问题最集中的地方。

`core_span` 同样能用于 #196 的横向锚点（取本体的列中位），那条另行处理。

## 待对齐

`CORE_THICKNESS = 0.25` 这个门槛目前是常量。它是"厚 vs 细"的分界，对极端体形（如非常纤细的角色）可能需要调；要不要做成可配、以及配在哪一层，想听一下意见。
