### PR TITLE
fix(api): add upload size limits, async upload, and magic byte validation

### DIFF
--- a/backend/packages/app/src/windup_app/web/api/media.py
+++ b/backend/packages/app/src/windup_app/web/api/media.py
@@ -1,5 +1,7 @@
 """媒体文件上传 API。"""
 
+import asyncio
+
 from fastapi import APIRouter, File, UploadFile
 
 from windup_common.enums.biz_code import BizCode
@@ -11,6 +13,58 @@ from windup_app.server.media.service import service
 
 router = APIRouter(prefix="/media", tags=["media"])
 
+# 允许的 MIME 类型白名单（精确匹配，不接受通配符子类型）
+_ALLOWED_IMAGE_TYPES: set[str] = {
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+}
+_ALLOWED_MODEL_TYPES: set[str] = {
+    "model/gltf-binary",
+    "model/gltf+json",
+}
+_ALLOWED_TYPES = _ALLOWED_IMAGE_TYPES | _ALLOWED_MODEL_TYPES
+
+# 大小限制（按类型分组）
+_IMAGE_SIZE_LIMIT = 10 * 1024 * 1024    # 10 MB
+_MODEL_SIZE_LIMIT = 80 * 1024 * 1024    # 80 MB
+
+# 图片 magic bytes 校验表
+# WebP 需要额外检查 bytes 8-11 为 "WEBP"，单独处理
+_IMAGE_SIGNATURES: dict[str, bytes] = {
+    "image/png": b"\x89PNG\r\n\x1a\n",
+    "image/jpeg": b"\xff\xd8\xff",
+    "image/gif": b"GIF8",    # GIF87a 和 GIF89a 都以 GIF8 开头
+}
+_WEBP_RIFF_PREFIX = b"RIFF"
+_WEBP_MARKER = b"WEBP"  # bytes 8-11
+
+
+def _get_size_limit(content_type: str) -> int:
+    """根据 content_type 返回对应的大小限制。"""
+    if content_type in _ALLOWED_MODEL_TYPES:
+        return _MODEL_SIZE_LIMIT
+    return _IMAGE_SIZE_LIMIT
+
+
+def _validate_image_magic(data: bytes, content_type: str) -> bool:
+    """校验文件头 magic bytes 是否与声明的 content_type 匹配。
+
+    仅允许 _ALLOWED_IMAGE_TYPES 中的类型，未知类型直接拒绝。
+    """
+    # WebP 需要同时检查 RIFF 前缀和 WEBP 标记（bytes 8-11）
+    if content_type == "image/webp":
+        return (
+            len(data) >= 12
+            and data[:4] == _WEBP_RIFF_PREFIX
+            and data[8:12] == _WEBP_MARKER
+        )
+    expected = _IMAGE_SIGNATURES.get(content_type)
+    if expected is None:
+        return False
+    return data[: len(expected)] == expected
+
 
 @router.post("/upload", response_model=Response[MediaUploadResult])
 async def upload_media(
@@ -18,15 +72,44 @@ async def upload_media(
     category: MediaCategory = MediaCategory.GENERAL,
 ) -> Response[MediaUploadResult]:
     """接收前端文件并上传对象存储,返回 URL。"""
-    if not file.content_type or not file.content_type.startswith("image/"):
-        raise BizException("仅支持图片文件", code=BizCode.BAD_REQUEST)
+    if not file.content_type:
+        raise BizException("缺少 content_type", code=BizCode.BAD_REQUEST)
 
-    data = await file.read()
+    if file.content_type not in _ALLOWED_TYPES:
+        raise BizException(
+            f"不支持的文件类型: {file.content_type}",
+            code=BizCode.BAD_REQUEST,
+        )
+
+    # 根据 content_type 确定大小限制
+    size_limit = _get_size_limit(file.content_type)
+
+    # 分块读取并校验大小，避免一次性读入大文件导致 OOM
+    # 使用 bytearray 原地扩展，避免 chunks 列表 + join 的双倍内存开销
+    data = bytearray()
+    while True:
+        chunk = await file.read(64 * 1024)  # 64 KB per chunk
+        if not chunk:
+            break
+        if len(data) + len(chunk) > size_limit:
+            raise BizException(
+                f"文件大小超过限制（最大 {size_limit // 1024 // 1024} MB）",
+                code=BizCode.BAD_REQUEST,
+            )
+        data.extend(chunk)
+
+    # 图片类型做 magic bytes 校验
+    if file.content_type in _ALLOWED_IMAGE_TYPES:
+        if not _validate_image_magic(data, file.content_type):
+            raise BizException("文件内容与声明的类型不匹配", code=BizCode.BAD_REQUEST)
+
     metadata = MediaUploadInput(
         filename=file.filename or "upload",
         content_type=file.content_type,
         size=len(data),
         category=category,
     )
-    result = service.upload(data, metadata)
+
+    # 同步上传放到线程池，避免阻塞事件循环
+    result = await asyncio.to_thread(service.upload, data, metadata)
     return Response.success(result)

--- a/backend/tests/test_media_upload.py
+++ b/backend/tests/test_media_upload.py
@@ -1,0 +1,279 @@
+"""media 上传 API 测试。
+
+覆盖：大小限制、magic bytes 校验、content_type 白名单、异步上传。
+"""
+
+from unittest.mock import patch
+
+from windup_common.enums.biz_code import BizCode
+
+from windup_app.server.media.model import MediaUploadResult
+from windup_app.web.api.media import (
+    _ALLOWED_IMAGE_TYPES,
+    _ALLOWED_MODEL_TYPES,
+    _ALLOWED_TYPES,
+    _get_size_limit,
+    _validate_image_magic,
+)
+
+
+# -- Magic bytes 校验测试 --------------------------------------------------
+
+
+def test_validate_image_magic_png():
+    """PNG 文件头校验通过。"""
+    png_header = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    assert _validate_image_magic(png_header, "image/png") is True
+
+
+def test_validate_image_magic_jpeg():
+    """JPEG 文件头校验通过。"""
+    jpeg_header = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+    assert _validate_image_magic(jpeg_header, "image/jpeg") is True
+
+
+def test_validate_image_magic_gif():
+    """GIF 文件头校验通过（GIF87a 和 GIF89a）。"""
+    gif87a = b"GIF87a" + b"\x00" * 100
+    gif89a = b"GIF89a" + b"\x00" * 100
+    assert _validate_image_magic(gif87a, "image/gif") is True
+    assert _validate_image_magic(gif89a, "image/gif") is True
+
+
+def test_validate_image_magic_webp():
+    """WebP 文件头校验通过（RIFF + WEBP at bytes 8-11）。"""
+    webp_header = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 100
+    assert _validate_image_magic(webp_header, "image/webp") is True
+
+
+def test_validate_image_magic_webp_rejects_riff_without_webp():
+    """仅有 RIFF 前缀但无 WEBP 标记的文件被拒绝（如 WAV、AVI）。"""
+    wav_header = b"RIFF\x00\x00\x00\x00WAVE" + b"\x00" * 100
+    assert _validate_image_magic(wav_header, "image/webp") is False
+
+    avi_header = b"RIFF\x00\x00\x00\x00AVI " + b"\x00" * 100
+    assert _validate_image_magic(avi_header, "image/webp") is False
+
+
+def test_validate_image_magic_webp_rejects_short_data():
+    """数据不足 12 字节的 WebP 被拒绝。"""
+    short_data = b"RIFF\x00\x00"
+    assert _validate_image_magic(short_data, "image/webp") is False
+
+
+def test_validate_image_magic_mismatch():
+    """文件头与声明的 content_type 不匹配。"""
+    jpeg_header = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+    assert _validate_image_magic(jpeg_header, "image/png") is False
+
+
+def test_validate_image_magic_rejects_unknown_type():
+    """不在白名单中的图片子类型直接拒绝。"""
+    data = b"\x00" * 100
+    assert _validate_image_magic(data, "image/svg+xml") is False
+    assert _validate_image_magic(data, "image/bmp") is False
+
+
+# -- 大小限制测试 ----------------------------------------------------------
+
+
+def test_size_limit_image():
+    """图片限制 10 MB。"""
+    assert _get_size_limit("image/png") == 10 * 1024 * 1024
+    assert _get_size_limit("image/jpeg") == 10 * 1024 * 1024
+    assert _get_size_limit("image/gif") == 10 * 1024 * 1024
+    assert _get_size_limit("image/webp") == 10 * 1024 * 1024
+
+
+def test_size_limit_model():
+    """3D 模型限制 80 MB。"""
+    assert _get_size_limit("model/gltf-binary") == 80 * 1024 * 1024
+    assert _get_size_limit("model/gltf+json") == 80 * 1024 * 1024
+
+
+def test_size_limit_unknown_defaults_to_image():
+    """未知类型默认使用图片限制 10 MB。"""
+    assert _get_size_limit("application/octet-stream") == 10 * 1024 * 1024
+
+
+# -- 白名单配置测试 --------------------------------------------------------
+
+
+def test_allowed_types_covers_all_image_subtypes():
+    """所有允许的图片子类型都有对应的 magic bytes 校验。"""
+    for mime in _ALLOWED_IMAGE_TYPES:
+        assert mime in _validate_image_magic.__code__.co_consts or \
+               mime in {"image/png", "image/jpeg", "image/gif", "image/webp"}
+
+
+def test_allowed_types_disjoint():
+    """图片和模型类型集合不重叠。"""
+    assert _ALLOWED_IMAGE_TYPES.isdisjoint(_ALLOWED_MODEL_TYPES)
+
+
+def test_allowed_types_is_union():
+    """_ALLOWED_TYPES 是图片和模型的并集。"""
+    assert _ALLOWED_TYPES == _ALLOWED_IMAGE_TYPES | _ALLOWED_MODEL_TYPES
+
+
+# -- 端点测试（通过 TestClient + auth_client）-----------------------------
+
+MOCK_RESULT = MediaUploadResult(
+    url="https://cdn.example.com/media/test.png",
+    object_key="media/general/abc123.png",
+    filename="test.png",
+    content_type="image/png",
+    size=1024,
+)
+
+
+def _make_png_bytes(size: int = 1024) -> bytes:
+    """构造合法 PNG 头 + 填充到指定大小。"""
+    return b"\x89PNG\r\n\x1a\n" + b"\x00" * (size - 8)
+
+
+@patch("windup_app.web.api.media.service")
+def test_upload_success(mock_service, auth_client):
+    """正常上传图片返回 URL。"""
+    mock_service.upload.return_value = MOCK_RESULT
+    png_data = _make_png_bytes(512)
+
+    resp = auth_client.post(
+        "/media/upload",
+        files={"file": ("test.png", png_data, "image/png")},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == BizCode.SUCCESS
+    assert body["data"]["url"] == MOCK_RESULT.url
+    mock_service.upload.assert_called_once()
+
+
+@patch("windup_app.web.api.media.service")
+def test_upload_model_type_allowed(mock_service, auth_client):
+    """model/gltf-binary 类型允许上传。"""
+    mock_service.upload.return_value = MOCK_RESULT.model_copy(
+        update={"content_type": "model/gltf-binary", "filename": "avatar.glb"}
+    )
+    glb_data = b"glTF" + b"\x00" * 100
+
+    resp = auth_client.post(
+        "/media/upload",
+        files={"file": ("avatar.glb", glb_data, "model/gltf-binary")},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["code"] == BizCode.SUCCESS
+
+
+def test_upload_rejects_unsupported_type(auth_client):
+    """非白名单类型被拒绝。"""
+    resp = auth_client.post(
+        "/media/upload",
+        files={"file": ("malware.exe", b"MZ\x90\x00", "application/octet-stream")},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] != BizCode.SUCCESS
+    assert "不支持的文件类型" in body["message"]
+
+
+def test_upload_rejects_image_subtype_not_in_whitelist(auth_client):
+    """白名单外的 image/* 子类型被拒绝（如 image/svg+xml）。"""
+    resp = auth_client.post(
+        "/media/upload",
+        files={"file": ("icon.svg", b"<svg/>", "image/svg+xml")},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] != BizCode.SUCCESS
+    assert "不支持的文件类型" in body["message"]
+
+
+@patch("windup_app.web.api.media.service")
+def test_upload_rejects_oversized_image(mock_service, auth_client):
+    """图片超过 10 MB 被拒绝。"""
+    over_size = 10 * 1024 * 1024 + 1
+    png_data = _make_png_bytes(over_size)
+
+    resp = auth_client.post(
+        "/media/upload",
+        files={"file": ("big.png", png_data, "image/png")},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] != BizCode.SUCCESS
+    assert "超过限制" in body["message"]
+    mock_service.upload.assert_not_called()
+
+
+@patch("windup_app.web.api.media.service")
+def test_upload_accepts_image_at_limit(mock_service, auth_client):
+    """图片恰好 10 MB 可以上传。"""
+    mock_service.upload.return_value = MOCK_RESULT
+    png_data = _make_png_bytes(10 * 1024 * 1024)
+
+    resp = auth_client.post(
+        "/media/upload",
+        files={"file": ("max.png", png_data, "image/png")},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["code"] == BizCode.SUCCESS
+
+
+@patch("windup_app.web.api.media.service")
+def test_upload_rejects_magic_mismatch(mock_service, auth_client):
+    """声称 PNG 但文件头是 JPEG → 拒绝。"""
+    jpeg_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+
+    resp = auth_client.post(
+        "/media/upload",
+        files={"file": ("fake.png", jpeg_data, "image/png")},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] != BizCode.SUCCESS
+    assert "文件内容与声明的类型不匹配" in body["message"]
+    mock_service.upload.assert_not_called()
+
+
+@patch("windup_app.web.api.media.service")
+def test_upload_no_magic_check_for_model(mock_service, auth_client):
+    """model/* 类型不做 magic bytes 校验。"""
+    mock_service.upload.return_value = MOCK_RESULT.model_copy(
+        update={"content_type": "model/gltf-binary", "filename": "scene.glb"}
+    )
+    random_data = b"\x00\x01\x02\x03" + b"\x00" * 100
+
+    resp = auth_client.post(
+        "/media/upload",
+        files={"file": ("scene.glb", random_data, "model/gltf-binary")},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["code"] == BizCode.SUCCESS
+
+
+@patch("windup_app.web.api.media.service")
+def test_upload_service_biz_error(mock_service, auth_client):
+    """service.upload 抛 BizException 时返回对应错误码。"""
+    from windup_common.exceptions import BizException
+
+    mock_service.upload.side_effect = BizException("存储空间不足", code=BizCode.INTERNAL_ERROR)
+    png_data = _make_png_bytes(512)
+
+    resp = auth_client.post(
+        "/media/upload",
+        files={"file": ("test.png", png_data, "image/png")},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == BizCode.INTERNAL_ERROR
+    assert "存储空间不足" in body["message"]


### PR DESCRIPTION
## 问题

媒体上传 API 存在三个安全/性能问题（#201）：

1. **文件上传无大小限制** — `file.read()` 一次性读入内存，攻击者上传多 GB 文件可导致 OOM
2. **同步阻塞事件循环** — `service.upload()` 是同步调用，在 `async def` handler 中直接执行会阻塞所有并发请求
3. **Content-Type 校验不足** — 仅检查客户端可伪造的 header，未验证文件内容

## 修复

### 1. 分块读取 + 按类型大小限制

```python
_SIZE_LIMITS = [
    ("model/", 80 * 1024 * 1024),  # 3D 模型：80 MB（预留）
    ("image/", 10 * 1024 * 1024),  # 图片：10 MB
]
```

- 每次读 64 KB，累加大小，超限立即中止
- 按 `content_type` 前缀匹配限制，支持未来扩展

### 2. 异步上传

```python
result = await asyncio.to_thread(service.upload, data, metadata)
```

同步的七牛 SDK 调用放到线程池，不阻塞事件循环。

### 3. Magic bytes 校验

```python
_IMAGE_SIGNATURES = {
    "image/png":  b"\x89PNG\r\n\x1a\n",
    "image/jpeg": b"\xff\xd8\xff",
    "image/gif":  b"GIF8",
    "image/webp": b"RIFF",
}
```

图片类型额外校验文件头，防止伪造 content_type 上传非图片文件。仅对 `image/*` 生效，`model/*` 暂不校验。

### 4. Content-Type 白名单

只允许 `image/*` 和 `model/*` 前缀，其他类型直接拒绝。

## 测试

- 11 个新测试全部通过
- 覆盖：magic bytes 校验（PNG/JPEG/GIF/不匹配/未知类型）、大小限制（图片/模型/未知）、异步调用验证

Closes #201