### PR TITLE
fix(quick-start): 使用可读项目名称

### DIFF
--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -5,7 +5,7 @@ export { createUserApis, userApis } from './user'
 export type { AuthTokens, CreateUserApisOptions, SendCodePurpose, User, UserApis } from './user'
 
 /* 项目 —— 全局约束：视角、朝向、精灵尺寸、画风 */
-export { CHARACTER_PERSPECTIVE, DIRECTIONAL_MOVEMENT } from './project'
+export { CHARACTER_PERSPECTIVE, DIRECTIONAL_MOVEMENT, ProjectNameConflictError } from './project'
 export { projectApis } from './project'
 export type {
   CharacterPerspective,

--- a/frontend/src/entities/project/index.test.ts
+++ b/frontend/src/entities/project/index.test.ts
@@ -23,7 +23,7 @@ afterEach(() => {
 async function loadProjectApis(fetchFn: typeof fetch) {
   vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
   vi.stubGlobal('fetch', fetchFn)
-  return (await import('./index')).projectApis
+  return import('./index')
 }
 
 function jsonResponse(data: unknown) {
@@ -35,7 +35,7 @@ function jsonResponse(data: unknown) {
 describe('projectApis', () => {
   it('maps the paged Project response and pagination query', async () => {
     let request: Request | undefined
-    const projectApis = await loadProjectApis(async (input, init) => {
+    const { projectApis } = await loadProjectApis(async (input, init) => {
       request = new Request(input, init)
       return new Response(
         JSON.stringify({
@@ -74,7 +74,7 @@ describe('projectApis', () => {
 
   it('serializes CreateProjectInput to the backend request body', async () => {
     let request: Request | undefined
-    const projectApis = await loadProjectApis(async (input, init) => {
+    const { projectApis } = await loadProjectApis(async (input, init) => {
       request = new Request(input, init)
       return jsonResponse(projectDto)
     })
@@ -105,7 +105,7 @@ describe('projectApis', () => {
 
   it('requests one Project by its backend resource path', async () => {
     let requestUrl = ''
-    const projectApis = await loadProjectApis(async (input) => {
+    const { projectApis } = await loadProjectApis(async (input) => {
       requestUrl = String(input)
       return jsonResponse(projectDto)
     })
@@ -117,7 +117,7 @@ describe('projectApis', () => {
 
   it('uses the access-token provider registered at the shared HTTP boundary', async () => {
     let authorization: string | null = null
-    const projectApis = await loadProjectApis(async (input, init) => {
+    const { projectApis } = await loadProjectApis(async (input, init) => {
       authorization = new Request(input, init).headers.get('authorization')
       return jsonResponse(projectDto)
     })
@@ -132,7 +132,7 @@ describe('projectApis', () => {
 
   it('deletes one Project through the backend resource path', async () => {
     let request: Request | undefined
-    const projectApis = await loadProjectApis(async (input, init) => {
+    const { projectApis } = await loadProjectApis(async (input, init) => {
       request = new Request(input, init)
       return jsonResponse(null)
     })
@@ -140,5 +140,23 @@ describe('projectApis', () => {
     await expect(projectApis.remove('42')).resolves.toBeUndefined()
     expect(request?.url).toBe('https://api.windup.test/projects/42')
     expect(request?.method).toBe('DELETE')
+  })
+
+  it('maps the backend project-name conflict contract to a stable domain error', async () => {
+    const { ProjectNameConflictError, projectApis } = await loadProjectApis(
+      async () =>
+        new Response(JSON.stringify({ code: 400, message: '项目名称已存在', data: null }), {
+          headers: { 'content-type': 'application/json' },
+        }),
+    )
+
+    await expect(
+      projectApis.create({
+        name: '点灯人',
+        perspective: 'side',
+        directionalMovement: 'single',
+        spriteSize: { width: 256, height: 256 },
+      }),
+    ).rejects.toBeInstanceOf(ProjectNameConflictError)
   })
 })

--- a/frontend/src/entities/project/index.ts
+++ b/frontend/src/entities/project/index.ts
@@ -31,6 +31,18 @@ export interface CreateProjectInput {
 
 export type ProjectPageQuery = PageQuery
 
+/** 项目名称违反后端的用户内唯一约束。 */
+export class ProjectNameConflictError extends ApiError {
+  constructor(options?: { cause?: unknown }) {
+    super('项目名称已存在', {
+      kind: 'business',
+      code: 400,
+      cause: options?.cause,
+    })
+    this.name = 'ProjectNameConflictError'
+  }
+}
+
 /** 后端 character_perspective: 1 横版 / 2 俯视 / 3 2.5D。 */
 export type CharacterPerspective = 'side' | 'top-down' | 'isometric'
 
@@ -155,25 +167,39 @@ export const projectApis: ProjectApis = {
   },
 
   async create(input) {
-    const dto = await getApiClient().request<ProjectDto>('/projects', {
-      method: 'POST',
-      json: {
-        workflow_id:
-          input.workflowId === undefined
-            ? undefined
-            : input.workflowId === null
-              ? null
-              : toBackendId(input.workflowId, 'workflowId'),
-        project_name: input.name,
-        character_perspective: perspectiveToDto[input.perspective],
-        directional_movement: movementToDto[input.directionalMovement],
-        sprite_width: input.spriteSize.width,
-        sprite_height: input.spriteSize.height,
-        game_style: input.gameStyle,
-        sprite_sample_url: input.sampleImageUrl,
-      },
-    })
-    return mapProject(dto)
+    try {
+      const dto = await getApiClient().request<ProjectDto>('/projects', {
+        method: 'POST',
+        json: {
+          workflow_id:
+            input.workflowId === undefined
+              ? undefined
+              : input.workflowId === null
+                ? null
+                : toBackendId(input.workflowId, 'workflowId'),
+          project_name: input.name,
+          character_perspective: perspectiveToDto[input.perspective],
+          directional_movement: movementToDto[input.directionalMovement],
+          sprite_width: input.spriteSize.width,
+          sprite_height: input.spriteSize.height,
+          game_style: input.gameStyle,
+          sprite_sample_url: input.sampleImageUrl,
+        },
+      })
+      return mapProject(dto)
+    } catch (error) {
+      // 后端目前只返回通用 BAD_REQUEST；中文 message 是项目重名的唯一可辨识契约。
+      // 文案映射仅留在 HTTP 适配器，业务用例只依赖稳定的前端错误类型。
+      if (
+        error instanceof ApiError &&
+        error.kind === 'business' &&
+        error.code === 400 &&
+        error.message === '项目名称已存在'
+      ) {
+        throw new ProjectNameConflictError({ cause: error })
+      }
+      throw error
+    }
   },
 
   async remove(id) {

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -16,6 +16,7 @@ import {
   createRealQuickStartService,
   type QuickStartMediaApis,
 } from './service'
+import { ProjectNameConflictError } from '@/entities'
 import { registerApiAccessTokenProvider } from '@/shared/api'
 
 function createWorkflowRunApis(initialRuns: readonly WorkflowRun[] = []): WorkflowRunApis {
@@ -270,7 +271,7 @@ describe('createQuickStartService', () => {
   it('uses a readable number when the generated project name already exists', async () => {
     const create = vi
       .fn()
-      .mockRejectedValueOnce(new Error('项目名称已存在'))
+      .mockRejectedValueOnce(new ProjectNameConflictError())
       .mockResolvedValueOnce({
         id: 'project-2',
         name: '会挥剑的像素骑士 2',
@@ -311,13 +312,46 @@ describe('createQuickStartService', () => {
     expect(create).toHaveBeenCalledTimes(1)
   })
 
-  it('stops retrying after exhausting the readable project name sequence', async () => {
-    const conflict = new Error('项目名称已存在')
+  it('does not infer a project-name conflict from an arbitrary error message', async () => {
+    const unrelatedError = new Error('项目名称已存在')
+    const create = vi.fn().mockRejectedValue(unrelatedError)
+    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
+
+    await expect(prepare('像素骑士')).rejects.toBe(unrelatedError)
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps long numbered project names readable within the backend limit', async () => {
+    const create = vi
+      .fn()
+      .mockRejectedValueOnce(new ProjectNameConflictError())
+      .mockResolvedValueOnce({
+        id: 'project-long-2',
+        name: '一位名字特别长的像素角色设定用于验… 2',
+        spriteSize: { width: 256, height: 256 },
+      })
+    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
+
+    await prepare('一位名字特别长的像素角色设定用于验证截断继续')
+
+    expect(create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ name: '一位名字特别长的像素角色设定用于验证截…' }),
+    )
+    expect(create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ name: '一位名字特别长的像素角色设定用于验… 2' }),
+    )
+    expect(Array.from(create.mock.calls[1]?.[0].name ?? '')).toHaveLength(20)
+  })
+
+  it('stops after five conflicting project names to avoid excessive write requests', async () => {
+    const conflict = new ProjectNameConflictError()
     const create = vi.fn().mockRejectedValue(conflict)
     const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
 
     await expect(prepare('像素骑士')).rejects.toBe(conflict)
-    expect(create).toHaveBeenCalledTimes(100)
+    expect(create).toHaveBeenCalledTimes(5)
   })
 
   it('creates one persisted node graph and starts the character image task', async () => {

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -289,6 +289,37 @@ describe('createQuickStartService', () => {
     )
   })
 
+  it('uses a readable fallback for an empty project prompt', async () => {
+    const create = vi.fn(async (input) => ({
+      id: 'project-fallback',
+      ...input,
+      spriteSize: { width: 256, height: 256 },
+    }))
+    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
+
+    await prepare('   ')
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ name: '未命名项目' }))
+  })
+
+  it('does not retry project creation errors other than name conflicts', async () => {
+    const networkError = new Error('网络请求失败')
+    const create = vi.fn().mockRejectedValue(networkError)
+    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
+
+    await expect(prepare('像素骑士')).rejects.toBe(networkError)
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops retrying after exhausting the readable project name sequence', async () => {
+    const conflict = new Error('项目名称已存在')
+    const create = vi.fn().mockRejectedValue(conflict)
+    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
+
+    await expect(prepare('像素骑士')).rejects.toBe(conflict)
+    expect(create).toHaveBeenCalledTimes(100)
+  })
+
   it('creates one persisted node graph and starts the character image task', async () => {
     const generationApis: GenerationApis = {
       create: vi.fn(async () => ({

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -242,9 +242,7 @@ describe('createQuickStartService', () => {
     await expect(service.open('missing')).rejects.toThrow('not found')
   })
 
-  it('creates a bounded default project name and returns the persisted sprite size', async () => {
-    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
-    vi.spyOn(Math, 'random').mockReturnValue(0.25)
+  it('creates a readable bounded project name without a hash suffix', async () => {
     const create = vi.fn(async (input) => ({
       id: 'project-1',
       ...input,
@@ -254,7 +252,7 @@ describe('createQuickStartService', () => {
     }))
     const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
 
-    await expect(prepare('一位名字特别长的像素角色设定用于验证截断')).resolves.toEqual({
+    await expect(prepare('  一位名字特别长的像素角色设定用于验证截断继续  ')).resolves.toEqual({
       id: 'project-1',
       spriteSize: { width: 256, height: 256 },
     })
@@ -262,12 +260,33 @@ describe('createQuickStartService', () => {
     expect(Array.from(createdName ?? '')).toHaveLength(20)
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: expect.stringMatching(/^一位名字特别长的像…-/u),
+        name: '一位名字特别长的像素角色设定用于验证截…',
         perspective: 'side',
         directionalMovement: 'single',
       }),
     )
-    vi.restoreAllMocks()
+  })
+
+  it('uses a readable number when the generated project name already exists', async () => {
+    const create = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('项目名称已存在'))
+      .mockResolvedValueOnce({
+        id: 'project-2',
+        name: '会挥剑的像素骑士 2',
+        spriteSize: { width: 256, height: 256 },
+      })
+    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
+
+    await expect(prepare('会挥剑的像素骑士')).resolves.toEqual({
+      id: 'project-2',
+      spriteSize: { width: 256, height: 256 },
+    })
+    expect(create).toHaveBeenNthCalledWith(1, expect.objectContaining({ name: '会挥剑的像素骑士' }))
+    expect(create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ name: '会挥剑的像素骑士 2' }),
+    )
   })
 
   it('creates one persisted node graph and starts the character image task', async () => {

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -602,23 +602,33 @@ export function createQuickStartService({
 
 export function createAutoPrepareProject(projectApis: ProjectApis): PrepareQuickStartProject {
   return async (prompt) => {
-    const timestamp = Date.now().toString(36).slice(-6).padStart(6, '0')
-    const nonce = Math.random().toString(36).slice(2, 5).padEnd(3, '0')
-    const suffix = `${timestamp}${nonce}`
-    const maxBaseLength = 20 - suffix.length - 1
-    const promptCharacters = Array.from(prompt)
-    const base =
-      promptCharacters.length > maxBaseLength
-        ? `${promptCharacters.slice(0, maxBaseLength - 1).join('')}…`
-        : promptCharacters.join('')
-    const name = `${base}-${suffix}`
-    const project = await projectApis.create({
-      name,
-      perspective: 'side',
-      directionalMovement: 'single',
-      spriteSize: { width: 256, height: 256 },
-    })
-    return { id: project.id, spriteSize: project.spriteSize }
+    const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
+    let lastConflict: unknown
+
+    for (let sequence = 1; sequence <= 100; sequence += 1) {
+      const suffix = sequence === 1 ? '' : ` ${sequence}`
+      const maxBaseLength = 20 - Array.from(suffix).length
+      const promptCharacters = Array.from(normalizedPrompt)
+      const base =
+        promptCharacters.length > maxBaseLength
+          ? `${promptCharacters.slice(0, maxBaseLength - 1).join('')}…`
+          : promptCharacters.join('')
+
+      try {
+        const project = await projectApis.create({
+          name: `${base}${suffix}`,
+          perspective: 'side',
+          directionalMovement: 'single',
+          spriteSize: { width: 256, height: 256 },
+        })
+        return { id: project.id, spriteSize: project.spriteSize }
+      } catch (error) {
+        if (!(error instanceof Error) || error.message !== '项目名称已存在') throw error
+        lastConflict = error
+      }
+    }
+
+    throw lastConflict
   }
 }
 

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -3,6 +3,7 @@ import {
   createGenerationApis,
   createMediaApis,
   projectApis,
+  ProjectNameConflictError,
   workflowRunApis,
   type Action,
   type Character,
@@ -605,7 +606,8 @@ export function createAutoPrepareProject(projectApis: ProjectApis): PrepareQuick
     const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
     let lastConflict: unknown
 
-    for (let sequence = 1; sequence <= 100; sequence += 1) {
+    for (let sequence = 1; sequence <= 5; sequence += 1) {
+      // 首次名称不预留编号空间；只有重名时才缩短前缀，为可读编号让出 20 字上限。
       const suffix = sequence === 1 ? '' : ` ${sequence}`
       const maxBaseLength = 20 - Array.from(suffix).length
       const promptCharacters = Array.from(normalizedPrompt)
@@ -623,7 +625,7 @@ export function createAutoPrepareProject(projectApis: ProjectApis): PrepareQuick
         })
         return { id: project.id, spriteSize: project.spriteSize }
       } catch (error) {
-        if (!(error instanceof Error) || error.message !== '项目名称已存在') throw error
+        if (!(error instanceof ProjectNameConflictError)) throw error
         lastConflict = error
       }
     }


### PR DESCRIPTION
## 改动内容

- Quick Start 自动创建项目时，直接使用整理后的角色描述作为项目名
- 项目名超过后端 20 字限制时进行可读截断
- 项目名称重复时使用 `项目名 2`、`项目名 3` 这样的可读编号
- 删除时间戳和随机字符串组成的哈希式后缀
- 将后端项目重名响应在 `entities/project` 适配器中转换为稳定的 `ProjectNameConflictError`
- 将连续重名时的创建尝试限制为最多 5 次，避免大量串行写请求

## 问题原因

原实现为了满足后端“同一用户项目名称唯一”的约束，始终给项目名追加时间戳和随机串，导致用户在项目列表中看到难以理解的哈希式名称。

后端当前对项目重名只提供通用 `BAD_REQUEST=400`，没有重名专属业务码。中文契约文案的识别现已收口在 Project HTTP 适配器，Quick Start 只依赖稳定错误类型，不再直接匹配后端文案。

## 用户影响

Quick Start 创建的项目现在具有可识别、可复述的名称；重复创建相同描述时仍能正常创建。普通业务错误不会被误判为重名并重复请求。

长名称首次创建会尽量保留更多内容；发生重名后才缩短前缀，为可读编号让出后端 20 字限制。

## 验证

- 5 个改动文件格式检查通过
- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage`（41 个测试文件、448 项测试通过）
- `npm run build`