### PR TITLE
test(auth): stabilize expired-session route test

### DIFF
--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -235,11 +235,12 @@ describe('AppRoutes authentication boundary', () => {
 
     expect(await screen.findByRole('dialog', { name: '登录 Windup' })).toBeTruthy()
     vi.useFakeTimers()
-    fireEvent.keyDown(document, { key: 'Escape' })
-    await act(async () => vi.advanceTimersByTimeAsync(520))
+    fireEvent.click(screen.getByRole('button', { name: '关闭账号面板' }))
+    await act(async () => vi.runOnlyPendingTimersAsync())
     expect(screen.getByTestId('location').textContent).toBe(
       '/?returnTo=%2Fquick-start%3Fdraft%3D1%23setup',
     )
+    vi.useRealTimers()
 
     fireEvent.click(screen.getByRole('link', { name: '重新登录' }))
     expect(screen.getByTestId('location').textContent).toBe(


### PR DESCRIPTION
本 PR 让过期会话路由测试显式驱动登录面板的关闭动作与退出计时器，避免无关 PR 因测试运行时序随机触发前端 CI 失败。

## Why

登录面板加入退出动画后，路由测试在弹窗刚出现时立即发送 `Escape`，既可能早于文档级键盘监听器挂载，也需要等待真实的 520ms 定时器。CI 负载较高时，URL 未能在 `waitFor` 窗口内删除 `account=login`，使没有前端改动的 PR #271 被染红。

## Changes

- 通过面板的真实关闭按钮触发既有关闭逻辑，路由测试只负责验证 `returnTo` 在关闭和重新打开之间保持不变。
- 使用 Vitest 假时钟推进退出计时器，并在每条测试后恢复真实时钟。
- 保留生产环境的关闭动画；`AccountPanel` 组件测试继续覆盖 `Escape` 关闭行为。

## Verification

- [x] 目标用例连续运行 30 次：30/30 通过。
- [x] `npx vitest run src/app/app.test.tsx src/features/account-panel/index.test.tsx --reporter=verbose`：32 tests passed。
- [x] `npx oxfmt --check src/app/app.test.tsx`：通过。
- [x] `npx oxlint src/app/app.test.tsx`：通过。
- [x] `npm run typecheck`：通过。

## Scope

- 本 PR 不包含：生产代码、关闭动画、CI 配置或其他偶发测试的修改。
- 后续事项：workflow-editor 的独立偶发测试继续由 #272 跟进。

## Related Issues

Closes #285
Refs #271
Refs #272
