### PR TITLE
fix(config): 部署模板改用生效的 AI_ 前缀模型键

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,13 +18,6 @@ REDIS_URL=redis://localhost:6379/0
 # 数据持久化目录（默认 ./data/redis）
 REDIS_DATA_DIR=./data/redis
 
-# ── LLM 配置 ──
-LLM_API_KEY=your-api-key-here
-LLM_MODEL_ID=doubao-seed-2.0-mini
-LLM_BASE_URL=https://api.qnaigc.com/v1
-LLM_IMAGE_MODEL_ID=gemini-3.0-pro-image-preview
-LLM_VIDEO_MODEL_ID=
-
 # ── 搜索 API ──
 SERPAPI_API_KEY=your-serpapi-key
 
@@ -37,8 +30,13 @@ QINIU_BUCKET_DOMAIN=https://cdn.example.com
 QINIU_PRIVATE_SPACE=false
 
 # ── AI Provider ──
+# 键名前缀必须是 AI_，由 framework/config/provider.py 的 env_prefix 决定。
 AI_BASE_URL=https://api.qnaigc.com/v1
 AI_API_KEY=your-ai-api-key
+# 各能力分开配型号：三条能力同时在用不同模型，共用一个字段会换一个连带换全部。
+# 取值即默认值——不写这两行时跑的就是它们。
+AI_IMAGE_MODEL=gemini-2.5-flash-image
+AI_VIDEO_MODEL=kling-v2-5-turbo
 
 # ── 积分定价 ──
 QUOTA_REGISTER_GIFT_AMOUNT=100

--- a/backend/tests/test_env_example_keys_are_live.py
+++ b/backend/tests/test_env_example_keys_are_live.py
@@ -1,0 +1,76 @@
+"""`.env.example` 里的键必须真的被读到。
+
+填了、不报错、也不生效的配置键是本仓反复清理的那一类问题(``ActionSpec.fps`` /
+``CharacterCard.palette``)。区别在于配置模板错了会**每个新部署重犯一次**,而且只有
+去问运行中的进程才发现 —— 照模板填 ``LLM_IMAGE_MODEL_ID=gemini-3.0-pro-image-preview``
+的部署,实际跑的是 ``AIProviderSettings.image_model`` 的默认值。Refs 1024XEngineer/Windup#288。
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+_ENV_EXAMPLE = pathlib.Path(__file__).resolve().parents[2] / ".env.example"
+
+# 非 pydantic-settings 消费的键:由 docker-compose / 部署脚本直接读,不走配置类。
+_INFRA_KEYS = frozenset({
+    "WINDUP_HOST", "WINDUP_PORT", "WINDUP_CORS_ORIGINS", "WINDUP_CORS_ORIGIN_REGEX",
+    "POSTGRES_DATA_DIR", "REDIS_DATA_DIR", "POSTGRES_EXTERNAL_PORT",
+    "SERPAPI_API_KEY", "VITE_API_BASE_URL",
+})
+
+
+def _example_keys() -> set[str]:
+    if not _ENV_EXAMPLE.is_file():
+        pytest.skip(f"没有 {_ENV_EXAMPLE}")
+    return {
+        m.group(1)
+        for line in _ENV_EXAMPLE.read_text(encoding="utf-8").splitlines()
+        if (m := re.match(r"^([A-Z][A-Z0-9_]*)=", line.strip()))
+    }
+
+
+def _settings_classes():
+    """遍历 config 包的每个子模块 —— 包的 __init__ 未必把配置类都再导出一遍。"""
+    import importlib
+    import pkgutil
+
+    from pydantic_settings import BaseSettings
+
+    import windup_framework.config as cfg
+
+    out = []
+    for mod in pkgutil.iter_modules(cfg.__path__):
+        m = importlib.import_module(f"{cfg.__name__}.{mod.name}")
+        for name in dir(m):
+            obj = getattr(m, name)
+            if (isinstance(obj, type) and issubclass(obj, BaseSettings)
+                    and obj is not BaseSettings and obj not in out):
+                out.append(obj)
+    return out
+
+
+def _live_keys() -> set[str]:
+    """所有配置类按各自 env_prefix 展开出来的、真正会被读的环境变量名。"""
+    keys = set()
+    for cls in _settings_classes():
+        prefix = cls.model_config.get("env_prefix", "")
+        keys |= {f"{prefix}{f}".upper() for f in cls.model_fields}
+    return keys
+
+
+def test_settings_classes_are_discoverable():
+    """先验仪器:一个配置类都没找到的话,下面那条会空跑成绿的。"""
+    assert len(_settings_classes()) >= 5
+
+
+def test_every_example_key_is_actually_read():
+    live = _live_keys()
+    dead = sorted(k for k in _example_keys() if k not in live and k not in _INFRA_KEYS)
+    assert not dead, (
+        f"这些键在 .env.example 里,但没有任何配置类会读:{dead}。"
+        "填了不生效比不填更糟——部署方以为配置生效了。"
+        "确认前缀与对应 BaseSettings 的 env_prefix 一致。"
+    )


### PR DESCRIPTION
Refs 1024XEngineer/Windup#288

`.env.example` 的「LLM 配置」一节五个键全部零消费方，其中 `LLM_IMAGE_MODEL_ID` 还填了 `gemini-3.0-pro-image-preview`。照模板部署的人以为生图走 3.0-pro，实际跑的是 `AIProviderSettings.image_model` 的默认值 `gemini-2.5-flash-image`。

真正的开关前缀是 `AI_`。仓里七个配置类的前缀是 `QUOTA_ / POSTGRES_ / JWT_ / AI_ / QINIU_ / RESEND_ / REDIS_`，没有一个用 `LLM_`。

改动：模板里换成 `AI_IMAGE_MODEL` / `AI_VIDEO_MODEL`，取值即当前默认值，所以**行为零变化**。另加一条测试，遍历各 `BaseSettings` 的 `env_prefix` 展开出真正会被读的键名，比对模板里的键，发现不生效的就报出来。

测试有做变异验证：把 `LLM_IMAGE_MODEL_ID` 加回模板，该用例失败并点名该键。测试里另有一条仪器自检，防止配置类发现不全时整条断言空跑成绿的（第一版就栽在这，只发现 3 个类而非 7 个）。
