### PR TITLE
fix(backend): serialize generation and enforce HTTPS media

### DIFF
--- a/backend/packages/app/src/windup_app/bootstrap/app.py
+++ b/backend/packages/app/src/windup_app/bootstrap/app.py
@@ -16,6 +16,7 @@ from windup_framework.db import Base, engine
 
 # 模型导入：触发 Base.metadata 注册，确保 create_all 能发现所有表
 from windup_app.server.character.model import Character  # noqa: F401
+from windup_app.server.orchestrator.dispatcher import GenerationDispatcher
 from windup_app.server.project.model import Project  # noqa: F401
 from windup_app.server.quota.model import CreditAccount, CreditTransaction  # noqa: F401
 # InviteCode, InviteRecord, TokenUsage 暂不实现
@@ -70,14 +71,23 @@ def print_banner() -> None:
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
-    """应用启动时建表 + 打印 banner,关闭时无特殊处理。"""
+    """应用启动时建表，关闭时等待已排队的生成任务收敛。"""
     Base.metadata.create_all(engine)
     print_banner()
-    yield
+    try:
+        yield
+    finally:
+        app.state.generation_dispatcher.shutdown()
 
 
 def create_app() -> FastAPI:
     app = FastAPI(title="windup", version="0.1.0", lifespan=_lifespan)
+    app.state.generation_dispatcher = GenerationDispatcher()
+
+    @app.get("/health", include_in_schema=False)
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
     # 中间件（add_middleware 后加的先执行：请求先进 CORS → 再进 RateLimit → 再进 Auth → 最后到路由）
     app.add_middleware(AuthMiddleware)
     app.add_middleware(RateLimitMiddleware)

--- a/backend/packages/app/src/windup_app/server/orchestrator/dispatcher.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/dispatcher.py
@@ -1,0 +1,21 @@
+"""进程内生成任务调度器。"""
+
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
+
+
+class GenerationDispatcher:
+    """串行执行付费生成任务，避免并发触发上游限流。"""
+
+    def __init__(self) -> None:
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="windup-generation",
+        )
+
+    def submit(self, target: Callable[..., Any], *args: Any) -> Future[Any]:
+        return self._executor.submit(target, *args)
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=True)

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -17,7 +17,6 @@ import asyncio
 import dataclasses
 import json
 import logging
-import threading
 from collections import defaultdict
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -33,6 +32,7 @@ from windup_framework.db import get_session
 
 from windup_app.server.character.model import Character
 from windup_app.server.orchestrator import task_repo
+from windup_app.server.orchestrator.dispatcher import GenerationDispatcher
 from windup_app.server.orchestrator.service import service as generation_service
 from windup_app.server.orchestrator.model import (
     ActionType,
@@ -61,7 +61,7 @@ _TERMINAL_EVENTS = {"completed", "failed"}
 class _EventBus:
     """任务进度内存发布-订阅。
 
-    **publish 会被后台线程调用**(executor 在 daemon thread 里跑,经 task_repo 触发),
+    **publish 会被后台线程调用**(executor 在生成工作线程里跑,经 task_repo 触发),
     而队列属于处理 SSE 请求的那个 event loop。``asyncio.Queue`` 不是线程安全的:
     跨线程 ``put_nowait`` 能把元素放进去,但唤醒 waiter 用的是 loop 内部调度,
     从别的线程调不会唤醒 —— 订阅者可能一直挂在 ``get()`` 上,直到下一次同 loop 内的
@@ -105,7 +105,7 @@ class _EventBus:
     ) -> None:
         """跨线程安全地投递。
 
-        executor 在 daemon thread 里跑,而队列属于处理 SSE 请求的那个 event loop。
+        executor 在生成工作线程里跑,而队列属于处理 SSE 请求的那个 event loop。
         ``asyncio.Queue`` 不是线程安全的:跨线程 ``put_nowait`` 能把元素放进去,但唤醒
         waiter 用的是 loop 内部调度,从别的线程调不会唤醒 —— 订阅者可能一直挂在
         ``get()`` 上,直到下一次同 loop 内的操作偶然把它带起来。故订阅时记下所属 loop,
@@ -114,7 +114,7 @@ class _EventBus:
         try:
             here = asyncio.get_running_loop()
         except RuntimeError:
-            here = None                       # 从没有 loop 的线程调(executor daemon thread)
+            here = None                       # 从没有 loop 的生成工作线程调用
 
         for queue, loop in list(self._queues.get((project_id, task_id), [])):
             if loop is here:
@@ -253,15 +253,20 @@ def _validate_project_size(project: Project, width: int, height: int) -> None:
         )
 
 
-def _dispatch_after_commit(session: Session, target, *args) -> None:
-    """注册 after_commit 回调:session 提交成功后再启动后台线程。
+def _dispatch_after_commit(
+    session: Session,
+    dispatcher: GenerationDispatcher,
+    target,
+    *args,
+) -> None:
+    """注册 after_commit 回调:session 提交成功后再排入生成队列。
 
     解决竞态: create_task() 只 flush,session 在 handler 返回后才 commit。
-    若直接起线程,后台 session 可能读不到未提交的行,导致 update 静默跳过。
+    若直接排队,后台 session 可能读不到未提交的行,导致 update 静默跳过。
     """
     @event.listens_for(session, "after_commit", once=True)
     def _after_commit(session):
-        threading.Thread(target=target, args=args, daemon=True).start()
+        dispatcher.submit(target, *args)
 
 
 @router.post("/image", response_model=Response[GenerationTaskOut])
@@ -285,10 +290,15 @@ def submit_image_generation(
     task = generation_service.generate_character_image(
         session, user_id=user_id, project_id=body.project_id, input=input_data,
     )
-    # 后台线程要在 commit 之后再起:任务行未提交时线程用自己的 session 读不到它,
+    # 生成任务要在 commit 之后再入队:任务行未提交时工作线程用自己的 session 读不到它,
     # update 会静默跳过,表现为任务永远停在 PENDING。
     _dispatch_after_commit(
-        session, request.app.state.run_image_task, task.id, input_data, body.project_id,
+        session,
+        request.app.state.generation_dispatcher,
+        request.app.state.run_image_task,
+        task.id,
+        input_data,
+        body.project_id,
     )
     return Response.success(_task_to_out(task), message="任务已提交")
 
@@ -315,7 +325,12 @@ def submit_action_generation(
         session, user_id=user_id, project_id=body.project_id, input=input_data,
     )
     _dispatch_after_commit(
-        session, request.app.state.run_action_task, task.id, input_data, body.project_id,
+        session,
+        request.app.state.generation_dispatcher,
+        request.app.state.run_action_task,
+        task.id,
+        input_data,
+        body.project_id,
     )
     return Response.success(_task_to_out(task), message="任务已提交")
 

--- a/backend/packages/framework/src/windup_framework/config/storage.py
+++ b/backend/packages/framework/src/windup_framework/config/storage.py
@@ -36,7 +36,9 @@ class StorageSettings(BaseSettings):
     def download_base(self) -> str:
         """返回浏览器可访问的下载域名。"""
         domain = self.bucket_domain.rstrip("/")
-        if domain and not domain.startswith(("http://", "https://")):
+        if domain.startswith("http://"):
+            raise ValueError("QINIU_BUCKET_DOMAIN 必须使用 HTTPS 下载域名")
+        if domain and not domain.startswith("https://"):
             domain = f"https://{domain}"
         hostname = (urlsplit(domain).hostname or "").lower()
         labels = hostname.split(".")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,6 +22,11 @@ from windup_app.server.user.service import create_access_token
 from windup_framework.db import Base, get_session
 
 
+def _disable_generation_execution(app):
+    app.state.run_action_task = lambda *args: None
+    app.state.run_image_task = lambda *args: None
+
+
 def _make_engine():
     """单连接内存 SQLite;``check_same_thread=False`` 让 TestClient 线程可共用。"""
     return create_engine(
@@ -75,8 +80,10 @@ def client(engine):
             session.close()
 
     app = create_app()
+    _disable_generation_execution(app)
     app.dependency_overrides[get_session] = override_get_session
     yield TestClient(app)
+    app.state.generation_dispatcher.shutdown()
     app.dependency_overrides.clear()
 
 
@@ -100,6 +107,7 @@ def auth_client(engine):
             session.close()
 
     app = create_app()
+    _disable_generation_execution(app)
     app.dependency_overrides[get_session] = override_get_session
 
     # 生成测试用 token
@@ -107,6 +115,7 @@ def auth_client(engine):
     client = TestClient(app, headers={"Authorization": f"Bearer {token}"})
 
     yield client
+    app.state.generation_dispatcher.shutdown()
     app.dependency_overrides.clear()
 
 
@@ -127,10 +136,12 @@ def auth_client_b(engine):
             session.close()
 
     app = create_app()
+    _disable_generation_execution(app)
     app.dependency_overrides[get_session] = override_get_session
 
     token = create_access_token(2, "other@example.com")
     client = TestClient(app, headers={"Authorization": f"Bearer {token}"})
 
     yield client
+    app.state.generation_dispatcher.shutdown()
     app.dependency_overrides.clear()

--- a/backend/tests/test_orchestrator_hardening.py
+++ b/backend/tests/test_orchestrator_hardening.py
@@ -36,6 +36,49 @@ from windup_common.enums.media import MediaCategory
 from windup_framework.config.storage import StorageSettings
 
 
+def test_generation_dispatcher_serializes_provider_work():
+    from windup_app.server.orchestrator.dispatcher import GenerationDispatcher
+
+    dispatcher = GenerationDispatcher()
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+
+    def first_task():
+        first_started.set()
+        release_first.wait(timeout=5)
+
+    def second_task():
+        second_started.set()
+
+    try:
+        dispatcher.submit(first_task)
+        assert first_started.wait(timeout=3)
+
+        dispatcher.submit(second_task)
+        assert not second_started.wait(timeout=0.1)
+
+        release_first.set()
+        assert second_started.wait(timeout=3)
+    finally:
+        release_first.set()
+        dispatcher.shutdown()
+
+
+def test_generation_dispatch_starts_only_after_commit(db_session):
+    from windup_app.web.api.generation import _dispatch_after_commit
+
+    dispatcher = Mock()
+    target = Mock()
+
+    _dispatch_after_commit(db_session, dispatcher, target, 7, "payload")
+    dispatcher.submit.assert_not_called()
+
+    db_session.commit()
+
+    dispatcher.submit.assert_called_once_with(target, 7, "payload")
+
+
 @pytest.mark.parametrize(
     ("configured", "expected"),
     [
@@ -61,6 +104,11 @@ def test_storage_download_base_rejects_qiniu_s3_api_endpoint(configured):
         StorageSettings(bucket_domain=configured).download_base
 
 
+def test_storage_download_base_rejects_plain_http():
+    with pytest.raises(ValueError, match="HTTPS"):
+        StorageSettings(bucket_domain="http://cdn.example.com").download_base
+
+
 def test_media_upload_rejects_s3_endpoint_before_uploading(monkeypatch):
     import qiniu
     import windup_app.server.media.service as media_service_module
@@ -80,6 +128,30 @@ def test_media_upload_rejects_s3_endpoint_before_uploading(monkeypatch):
         category=MediaCategory.REFERENCE_IMAGE,
     )
     with pytest.raises(ValueError, match="S3 API"):
+        ObjectStorageMediaService().upload(b"png", metadata)
+
+    put_data.assert_not_called()
+
+
+def test_media_upload_rejects_plain_http_before_uploading(monkeypatch):
+    import qiniu
+    import windup_app.server.media.service as media_service_module
+
+    monkeypatch.setattr(
+        media_service_module.storage_settings,
+        "bucket_domain",
+        "http://cdn.example.com",
+    )
+    put_data = Mock()
+    monkeypatch.setattr(qiniu, "put_data", put_data)
+
+    metadata = MediaUploadInput(
+        filename="character.png",
+        content_type="image/png",
+        size=3,
+        category=MediaCategory.REFERENCE_IMAGE,
+    )
+    with pytest.raises(ValueError, match="HTTPS"):
         ObjectStorageMediaService().upload(b"png", metadata)
 
     put_data.assert_not_called()
@@ -318,7 +390,7 @@ def test_every_terminal_event_name_is_recognised_by_the_stream():
 
 
 def test_publish_from_another_thread_delivers():
-    """executor 在 daemon thread 里跑，队列属于处理 SSE 请求的那个 loop。
+    """executor 在独立工作线程里跑，队列属于处理 SSE 请求的那个 loop。
 
     诚实说明本用例的强度：它只证明跨线程发布**能到达**订阅者，**证不出**
     call_soon_threadsafe 是必需的 —— 实测在这个单队列场景里，裸 put_nowait

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -1,6 +1,34 @@
+from unittest.mock import Mock
+
+from fastapi.testclient import TestClient
+
 from windup_app.bootstrap.app import create_app
 
 
 def test_create_app():
     app = create_app()
     assert app.title == "windup"
+
+
+def test_health_endpoint_reports_ok_without_auth(client):
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_lifespan_shuts_down_generation_dispatcher(monkeypatch):
+    import windup_app.bootstrap.app as app_module
+
+    create_all = Mock()
+    monkeypatch.setattr(app_module.Base.metadata, "create_all", create_all)
+    app = create_app()
+    dispatcher = Mock()
+    app.state.generation_dispatcher = dispatcher
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        dispatcher.shutdown.assert_not_called()
+
+    create_all.assert_called_once_with(app_module.engine)
+    dispatcher.shutdown.assert_called_once_with()

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -55,7 +55,9 @@ describe('PlaytestPage', () => {
     // 后端给的 walk 帧顺序是 index 2、0、1；照数组播会从 walk-03 起步。
     fireEvent.click(screen.getByRole('button', { name: '绑定动作：行走' }))
 
-    expect(stageFrameUrl()).toBe('https://cdn.windup.test/walk-01.png')
+    await waitFor(() => {
+      expect(stageFrameUrl()).toBe('https://cdn.windup.test/walk-01.png')
+    })
   })
 
   it('starts on the idle action when the route names none', async () => {


### PR DESCRIPTION
## 说明

本 PR 迁移自 #275，代码提交保持不变；迁移目的是删除上游仓库中的个人工作分支，改为从个人 fork 发起 PR。旧 PR 的评论与检查历史仍保留在 #275。

## 修改内容

- 将图片与动作生成从“每次请求新起线程”改为共享串行队列，任务仍只在数据库提交成功后入队，避免并发触发上游 429/525。
- 强制媒体下载域名使用 HTTPS，并在上传前拒绝不安全配置，防止上传成功后才因浏览器不可访问而留下孤儿对象。
- 增加无需鉴权的 `/health` 健康检查，并在应用关闭时等待生成队列收敛。
- 隔离接口测试中的真实生成副作用，补充队列串行、提交顺序、HTTPS 校验及生命周期回归测试。
- 修正 Playtest 动作帧切换测试的异步等待方式。

## 验证

- `uv run ruff check packages tests`
- `uv run lint-imports`
- `uv run pytest -q`：468 passed，整体覆盖率 90%
- #275 原提交的 GitHub CI、Vercel 与 Codecov 均已通过

## 提交范围

保持 #275 的两个提交和 8 个文件不变，不包含环境文件、数据库备份、服务器地址或任何令牌。