### PR TITLE
fix(ratelimit): 重构为两阶段限流，修复认证桶共享问题

### DIFF
--- a/backend/packages/app/src/windup_app/bootstrap/app.py
+++ b/backend/packages/app/src/windup_app/bootstrap/app.py
@@ -33,7 +33,7 @@ from windup_app.web.api.quota import router as quota_router
 from windup_app.web.api.workflow_run import router as workflow_run_router
 from windup_app.web.handler.exception_handlers import register_exception_handlers
 from windup_app.web.middleware.auth import AuthMiddleware
-from windup_app.web.middleware.ratelimit import RateLimitMiddleware
+from windup_app.web.middleware.ratelimit import AuthRateLimitMiddleware
 
 
 def _env_flag(name: str) -> bool:
@@ -88,9 +88,9 @@ def create_app() -> FastAPI:
     def health() -> dict[str, str]:
         return {"status": "ok"}
 
-    # 中间件（add_middleware 后加的先执行：请求先进 CORS → 再进 RateLimit → 再进 Auth → 最后到路由）
+    # 中间件（add_middleware 后加的先执行：请求先进 CORS → 再进 AuthRateLimit(Phase1) → 再进 Auth → 最后到路由）
     app.add_middleware(AuthMiddleware)
-    app.add_middleware(RateLimitMiddleware)
+    app.add_middleware(AuthRateLimitMiddleware)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=_cors_origins(),

--- a/backend/packages/app/src/windup_app/web/api/auth.py
+++ b/backend/packages/app/src/windup_app/web/api/auth.py
@@ -15,6 +15,7 @@ from windup_framework.db import get_session
 
 from windup_app.server.user.model import ResetPasswordInput, UpdateNicknameInput, User, UserView
 from windup_app.server.user.service import service
+from windup_app.web.middleware.ratelimit import _get_client_ip, record_auth_failure
 
 logger = logging.getLogger("windup.auth.api")
 
@@ -127,12 +128,17 @@ def register(body: RegisterRequest, session: Session = Depends(get_session)):
 
 
 @router.post("/login", response_model=Response[TokenResponse])
-def login(body: LoginRequest, session: Session = Depends(get_session)):
-    """邮箱+密码+验证码登录。"""
-    result = service.login_by_password_with_session(
-        session,
-        type("LoginByPasswordInput", (), {"email": body.email, "password": body.password})(),
-    )
+def login(body: LoginRequest, request: Request, session: Session = Depends(get_session)):
+    """邮箱+密码登录。"""
+    try:
+        result = service.login_by_password_with_session(
+            session,
+            type("LoginByPasswordInput", (), {"email": body.email, "password": body.password})(),
+        )
+    except Exception:
+        # 登录失败，计入 IP 级失败桶（成功不消耗额度）
+        record_auth_failure("login", _get_client_ip(request))
+        raise
     return Response.success(
         TokenResponse(
             access_token=result.access_token,

--- a/backend/packages/app/src/windup_app/web/api/character.py
+++ b/backend/packages/app/src/windup_app/web/api/character.py
@@ -18,10 +18,11 @@ from windup_app.server.character.model import Character, CharacterData
 from windup_app.server.character.service import service as character_service
 from windup_app.server.media.service import service as media_service
 from windup_app.server.project.model import Project
+from windup_app.web.middleware.ratelimit import rate_limit_dep
 
 logger = logging.getLogger("windup.character.api")
 
-router = APIRouter(prefix="/characters", tags=["characters"])
+router = APIRouter(prefix="/characters", tags=["characters"], dependencies=[Depends(rate_limit_dep)])
 
 
 # ── 请求 / 响应模型 ─────────────────────────────────────────────────────────

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -41,10 +41,11 @@ from windup_app.server.orchestrator.model import (
     GenerationTask,
 )
 from windup_app.server.project.model import Project
+from windup_app.web.middleware.ratelimit import rate_limit_dep
 
 logger = logging.getLogger("windup.generation.api")
 
-router = APIRouter(prefix="/generation", tags=["generation"])
+router = APIRouter(prefix="/generation", tags=["generation"], dependencies=[Depends(rate_limit_dep)])
 
 
 # ══════════════════════════════════════════════════════════════════════════════

--- a/backend/packages/app/src/windup_app/web/api/media.py
+++ b/backend/packages/app/src/windup_app/web/api/media.py
@@ -1,6 +1,6 @@
 """媒体文件上传 API。"""
 
-from fastapi import APIRouter, File, UploadFile
+from fastapi import APIRouter, Depends, File, UploadFile
 
 from windup_common.enums.biz_code import BizCode
 from windup_common.exceptions import BizException
@@ -8,8 +8,9 @@ from windup_common.result import Response
 
 from windup_app.server.media.model import MediaCategory, MediaUploadInput, MediaUploadResult
 from windup_app.server.media.service import service
+from windup_app.web.middleware.ratelimit import rate_limit_dep
 
-router = APIRouter(prefix="/media", tags=["media"])
+router = APIRouter(prefix="/media", tags=["media"], dependencies=[Depends(rate_limit_dep)])
 
 
 @router.post("/upload", response_model=Response[MediaUploadResult])

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -14,10 +14,11 @@ from windup_common.result import ListResponse, Response
 from windup_framework.db import get_session
 
 from windup_app.server.project.service import service
+from windup_app.web.middleware.ratelimit import rate_limit_dep
 
 logger = logging.getLogger("windup.project.api")
 
-router = APIRouter(prefix="/projects", tags=["projects"])
+router = APIRouter(prefix="/projects", tags=["projects"], dependencies=[Depends(rate_limit_dep)])
 
 
 class ProjectCreate(BaseModel):

--- a/backend/packages/app/src/windup_app/web/api/quota.py
+++ b/backend/packages/app/src/windup_app/web/api/quota.py
@@ -24,10 +24,11 @@ from windup_common.result import ListResponse, Response
 from windup_framework.db import get_session
 
 from windup_app.server.quota.service import service
+from windup_app.web.middleware.ratelimit import rate_limit_dep
 
 logger = logging.getLogger("windup.quota.api")
 
-router = APIRouter(prefix="/quota", tags=["quota"])
+router = APIRouter(prefix="/quota", tags=["quota"], dependencies=[Depends(rate_limit_dep)])
 
 
 # -- 响应模型 --------------------------------------------------------------

--- a/backend/packages/app/src/windup_app/web/api/workflow_run.py
+++ b/backend/packages/app/src/windup_app/web/api/workflow_run.py
@@ -30,10 +30,11 @@ from windup_framework.db import get_session
 from windup_app.server.project.model import Project
 from windup_app.server.workflow_run.model import RunStatus
 from windup_app.server.workflow_run.service import service
+from windup_app.web.middleware.ratelimit import rate_limit_dep
 
 logger = logging.getLogger("windup.workflow_run.api")
 
-router = APIRouter(prefix="/workflow-runs", tags=["workflow-run"])
+router = APIRouter(prefix="/workflow-runs", tags=["workflow-run"], dependencies=[Depends(rate_limit_dep)])
 
 
 # ── 请求 / 响应模型 ─────────────────────────────────────────────────────────

--- a/backend/packages/app/src/windup_app/web/middleware/ratelimit.py
+++ b/backend/packages/app/src/windup_app/web/middleware/ratelimit.py
@@ -1,49 +1,63 @@
-"""接口限流中间件。
+"""两阶段限流中间件。
 
-基于 Redis 的滑动窗口计数器，在鉴权中间件之前执行。
+Phase 1 — AuthRateLimitMiddleware（IP 级，鉴权前执行）:
+  - 认证端点各自独立 IP 桶，互不干扰
+  - /auth/login 仅计失败（成功不消耗额度），由路由层调用 record_auth_failure
+  - 非认证端点全局 IP 桶仅对匿名请求生效
+
+Phase 2 — rate_limit_dep（用户级，鉴权后执行）:
+  - 已登录请求按 user_id 计数
+  - 匿名请求按 IP 计数
+  - 作为 FastAPI dependency 注入到需要限流的路由
+
 Redis 不可用时优雅降级（跳过限流）。
 """
 
 import logging
 
+from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
 from starlette.responses import Response
 
 from windup_common.enums.biz_code import BizCode
+from windup_common.exceptions import BizException
 from windup_common.result import Response as Resp
 
 logger = logging.getLogger("windup.ratelimit")
 
 # -- 限流配置 ------------------------------------------------------------
 
-# 全局 API 限流：单 IP 60 次/分钟
+# 全局 API 限流：单 IP 60 次/分钟（仅匿名非认证请求）
 GLOBAL_RATE = 60
 GLOBAL_WINDOW = 60
 
-# 敏感接口限流：单 IP 10 次/分钟
-SENSITIVE_RATE = 10
-SENSITIVE_WINDOW = 60
-
-# 用户级限流：120 次/分钟
+# 已登录用户限流：120 次/分钟
 USER_RATE = 120
 USER_WINDOW = 60
 
-# 敏感接口路径
-SENSITIVE_PATHS: set[str] = {
-    "/auth/register",
-    "/auth/login",
-    "/auth/send-code",
-    "/auth/login-by-code",
-    "/auth/reset-password",
+# 匿名请求限流：30 次/分钟（Phase 2）
+ANON_RATE = 30
+ANON_WINDOW = 60
+
+# 登录失败 IP 限流：10 次/分钟
+LOGIN_FAIL_RATE = 10
+LOGIN_FAIL_WINDOW = 60
+
+# 认证端点 IP 限流配置：{path: (endpoint_name, limit)}
+AUTH_ENDPOINT_LIMITS: dict[str, tuple[str, int]] = {
+    "/auth/register": ("register", 3),
+    "/auth/send-code": ("send-code", 3),
+    "/auth/login-by-code": ("login-by-code", 5),
+    "/auth/reset-password": ("reset-password", 3),
 }
 
 # -- Redis key 模板 ------------------------------------------------------
 
 RATELIMIT_API_KEY = "ratelimit:api:{ip}"
-RATELIMIT_SENSITIVE_KEY = "ratelimit:sensitive:{ip}"
-RATELIMIT_USER_KEY = "ratelimit:api:{user_id}"
+RATELIMIT_AUTH_KEY = "ratelimit:auth:{endpoint}:{ip}"
+RATELIMIT_USER_KEY = "ratelimit:user:{user_id}"
+RATELIMIT_ANON_KEY = "ratelimit:anon:{ip}"
 
 
 # 可信代理列表：只有这些来源的请求才信任 X-Forwarded-For
@@ -76,6 +90,12 @@ def _get_client_ip(request: Request) -> str:
     return client_host or "unknown"
 
 
+def _has_auth_header(request: Request) -> bool:
+    """判断请求是否携带 Authorization Bearer header。"""
+    auth = request.headers.get("authorization", "")
+    return auth.startswith("Bearer ")
+
+
 def _check_rate(redis_client, key: str, limit: int, window: int) -> bool:
     """检查是否超出限流，返回 True 表示允许通过。"""
     try:
@@ -89,60 +109,129 @@ def _check_rate(redis_client, key: str, limit: int, window: int) -> bool:
         return True
 
 
-class RateLimitMiddleware(BaseHTTPMiddleware):
-    """接口限流中间件。"""
+def _too_many_requests_response(msg: str = "请求过于频繁") -> JSONResponse:
+    """构造限流拒绝响应。"""
+    return JSONResponse(
+        status_code=200,
+        content=Resp.fail(msg, code=BizCode.TOO_MANY_REQUESTS).model_dump(mode="json"),
+    )
 
-    def __init__(self, app) -> None:
-        super().__init__(app)
-        self._redis = None
-        self._redis_available = True
 
-    @property
-    def redis(self):
-        if self._redis is None:
-            try:
-                from windup_framework.db.redis import get_redis
-                self._redis = get_redis()
-                # 测试连接
-                self._redis.ping()
-            except Exception:
-                self._redis_available = False
-                logger.warning("[WINDUP] Redis 连接失败，限流中间件将跳过限流检查")
-                return None
-        return self._redis
+# -- 共享 Redis 实例（middleware 和 dependency 共用） --------------------
+
+_redis_client = None
+_redis_available = True
+
+
+def _get_redis():
+    """获取 Redis 客户端，连接失败时返回 None。"""
+    global _redis_client, _redis_available
+    if _redis_client is None:
+        if not _redis_available:
+            return None
+        try:
+            from windup_framework.db.redis import get_redis
+            _redis_client = get_redis()
+            _redis_client.ping()
+        except Exception:
+            _redis_available = False
+            logger.warning("[WINDUP] Redis 连接失败，限流功能将跳过")
+            return None
+    return _redis_client
+
+
+def _reset_redis_state():
+    """重置 Redis 状态（仅用于测试）。"""
+    global _redis_client, _redis_available
+    _redis_client = None
+    _redis_available = True
+
+
+# -- Phase 1: AuthRateLimitMiddleware（IP 级中间件）-----------------------
+
+
+class AuthRateLimitMiddleware(BaseHTTPMiddleware):
+    """Phase 1：认证端点 IP 级限流中间件（鉴权前执行）。
+
+    - 认证端点各自独立 IP 桶
+    - /auth/login 不在此处计数（由路由层 record_auth_failure 处理）
+    - 非认证端点全局 IP 桶仅对匿名请求生效
+    """
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        # Redis 不可用时直接放行
-        if not self._redis_available or self.redis is None:
+        redis = _get_redis()
+        if redis is None:
             return await call_next(request)
 
+        path = request.url.path
         client_ip = _get_client_ip(request)
 
-        # 全局限流
-        if not _check_rate(self.redis, RATELIMIT_API_KEY.format(ip=client_ip), GLOBAL_RATE, GLOBAL_WINDOW):
-            logger.warning("[WINDUP] 全局限流触发 | ip=%s path=%s", client_ip, request.url.path)
-            return JSONResponse(
-                status_code=200,
-                content=Resp.fail("请求过于频繁", code=BizCode.TOO_MANY_REQUESTS).model_dump(mode="json"),
-            )
-
-        # 敏感接口额外限流
-        if request.url.path in SENSITIVE_PATHS:
-            if not _check_rate(self.redis, RATELIMIT_SENSITIVE_KEY.format(ip=client_ip), SENSITIVE_RATE, SENSITIVE_WINDOW):
-                logger.warning("[WINDUP] 敏感接口限流触发 | ip=%s path=%s", client_ip, request.url.path)
-                return JSONResponse(
-                    status_code=200,
-                    content=Resp.fail("请求过于频繁，请稍后再试", code=BizCode.TOO_MANY_REQUESTS).model_dump(mode="json"),
+        # 认证端点：per-endpoint IP 桶
+        if path in AUTH_ENDPOINT_LIMITS:
+            endpoint, limit = AUTH_ENDPOINT_LIMITS[path]
+            key = RATELIMIT_AUTH_KEY.format(endpoint=endpoint, ip=client_ip)
+            if not _check_rate(redis, key, limit, 60):
+                logger.warning(
+                    "[WINDUP] 认证限流触发 | type=auth_endpoint endpoint=%s ip=%s",
+                    endpoint, client_ip,
                 )
+                return _too_many_requests_response("请求过于频繁，请稍后再试")
 
-        # 用户级限流（已登录用户）
-        user_id = getattr(getattr(request.state, "current_user", None), "id", None)
-        if user_id is not None:
-            if not _check_rate(self.redis, RATELIMIT_USER_KEY.format(user_id=user_id), USER_RATE, USER_WINDOW):
-                logger.warning("[WINDUP] 用户限流触发 | user_id=%s", user_id)
-                return JSONResponse(
-                    status_code=200,
-                    content=Resp.fail("请求过于频繁", code=BizCode.TOO_MANY_REQUESTS).model_dump(mode="json"),
-                )
+        # /auth/login：中间件不计数，由路由层失败时调用 record_auth_failure
+        elif path == "/auth/login":
+            pass
+
+        # 非认证端点：全局 IP 桶仅对匿名请求生效
+        else:
+            if not _has_auth_header(request):
+                key = RATELIMIT_API_KEY.format(ip=client_ip)
+                if not _check_rate(redis, key, GLOBAL_RATE, GLOBAL_WINDOW):
+                    logger.warning(
+                        "[WINDUP] 全局限流触发 | type=global_anon ip=%s path=%s",
+                        client_ip, path,
+                    )
+                    return _too_many_requests_response()
 
         return await call_next(request)
+
+
+# -- Phase 2: rate_limit_dep（用户级依赖）--------------------------------
+
+
+async def rate_limit_dep(request: Request) -> None:
+    """Phase 2：用户级限流（鉴权后执行，作为 FastAPI dependency）。
+
+    已登录请求按 user_id 计数，匿名请求按 IP 计数。
+    """
+    redis = _get_redis()
+    if redis is None:
+        return
+
+    user = getattr(request.state, "current_user", None)
+    if user is not None:
+        key = RATELIMIT_USER_KEY.format(user_id=user.id)
+        limit = USER_RATE
+        log_type = "authenticated"
+    else:
+        key = RATELIMIT_ANON_KEY.format(ip=_get_client_ip(request))
+        limit = ANON_RATE
+        log_type = "anonymous"
+
+    if not _check_rate(redis, key, limit, 60):
+        logger.warning("[WINDUP] 限流触发 | type=%s", log_type)
+        raise BizException("请求过于频繁", code=BizCode.TOO_MANY_REQUESTS)
+
+
+# -- 辅助：登录失败计数 ---------------------------------------------------
+
+
+def record_auth_failure(endpoint: str, ip: str) -> None:
+    """记录一次认证失败，用于 IP 级登录失败限流。
+
+    仅在 /auth/login 失败时由路由层调用。
+    """
+    redis = _get_redis()
+    if redis is None:
+        return
+    key = RATELIMIT_AUTH_KEY.format(endpoint=endpoint, ip=ip)
+    _check_rate(redis, key, LOGIN_FAIL_RATE, LOGIN_FAIL_WINDOW)

--- a/backend/packages/app/src/windup_app/web/middleware/ratelimit.py
+++ b/backend/packages/app/src/windup_app/web/middleware/ratelimit.py
@@ -109,6 +109,18 @@ def _check_rate(redis_client, key: str, limit: int, window: int) -> bool:
         return True
 
 
+def _check_login_failures(redis_client, key: str) -> bool:
+    """读取登录失败计数，返回 True 表示允许通过（不递增计数）。"""
+    try:
+        current = redis_client.get(key)
+        if current is None:
+            return True
+        return int(current) < LOGIN_FAIL_RATE
+    except Exception:
+        logger.warning("[WINDUP] Redis 不可用，跳过限流检查 | key=%s", key)
+        return True
+
+
 def _too_many_requests_response(msg: str = "请求过于频繁") -> JSONResponse:
     """构造限流拒绝响应。"""
     return JSONResponse(
@@ -154,7 +166,7 @@ class AuthRateLimitMiddleware(BaseHTTPMiddleware):
     """Phase 1：认证端点 IP 级限流中间件（鉴权前执行）。
 
     - 认证端点各自独立 IP 桶
-    - /auth/login 不在此处计数（由路由层 record_auth_failure 处理）
+    - /auth/login 中间件不写入桶（由路由层失败时写入），但会读取已有计数做拦截
     - 非认证端点全局 IP 桶仅对匿名请求生效
     """
 
@@ -177,9 +189,16 @@ class AuthRateLimitMiddleware(BaseHTTPMiddleware):
                 )
                 return _too_many_requests_response("请求过于频繁，请稍后再试")
 
-        # /auth/login：中间件不计数，由路由层失败时调用 record_auth_failure
+        # /auth/login：中间件不写入桶（失败时由路由层 record_auth_failure 写入），
+        # 但读取已有失败计数，超过上限时拦截后续请求。
         elif path == "/auth/login":
-            pass
+            key = RATELIMIT_AUTH_KEY.format(endpoint="login", ip=client_ip)
+            if not _check_login_failures(redis, key):
+                logger.warning(
+                    "[WINDUP] 认证限流触发 | type=auth_login_failures ip=%s",
+                    client_ip,
+                )
+                return _too_many_requests_response("请求过于频繁，请稍后再试")
 
         # 非认证端点：全局 IP 桶仅对匿名请求生效
         else:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -29,6 +29,20 @@ from windup_app.server.user.service import create_access_token
 from windup_framework.db import Base, get_session
 
 
+@pytest.fixture(autouse=True)
+def _disable_ratelimit_for_tests():
+    """默认禁用限流中间件，避免测试间互相干扰。
+
+    需要测试限流逻辑的用例应自行使用 fake_redis fixture 覆盖。
+    """
+    import windup_app.web.middleware.ratelimit as mod
+
+    mod._reset_redis_state()
+    mod._redis_available = False
+    yield
+    mod._reset_redis_state()
+
+
 def _disable_generation_execution(app):
     app.state.run_action_task = lambda *args: None
     app.state.run_image_task = lambda *args: None

--- a/backend/tests/test_ratelimit.py
+++ b/backend/tests/test_ratelimit.py
@@ -218,16 +218,46 @@ class TestAuthRateLimitMiddleware:
             resp = _run(middleware.dispatch(req, call_next))
             assert resp == mock_response
 
-    def test_login_passes_through_middleware(self, fake_redis):
-        """/auth/login 在中间件中不计数，始终通过。"""
+    def test_login_passes_when_no_failures(self, fake_redis):
+        """/auth/login 无失败记录时放行。"""
         middleware = AuthRateLimitMiddleware(MagicMock())
         mock_response = MagicMock()
         call_next = AsyncMock(return_value=mock_response)
 
-        for i in range(20):
+        for i in range(5):
             req = self._make_request("/auth/login")
             resp = _run(middleware.dispatch(req, call_next))
             assert resp == mock_response
+
+    def test_login_blocked_after_failures(self, fake_redis):
+        """/auth/login 失败达上限后，中间件拦截后续请求。"""
+        middleware = AuthRateLimitMiddleware(MagicMock())
+        mock_response = MagicMock()
+        call_next = AsyncMock(return_value=mock_response)
+
+        # 模拟 10 次登录失败（由路由层 record_auth_failure 写入）
+        for i in range(10):
+            record_auth_failure("login", "1.2.3.4")
+
+        # 第 11 次登录请求被中间件拦截
+        req = self._make_request("/auth/login")
+        resp = _run(middleware.dispatch(req, call_next))
+        assert resp.status_code == 200
+        call_next.assert_not_called()
+
+    def test_login_not_counted_by_middleware(self, fake_redis):
+        """/auth/login 中间件不写入桶，仅路由层失败时写入。"""
+        middleware = AuthRateLimitMiddleware(MagicMock())
+        mock_response = MagicMock()
+        call_next = AsyncMock(return_value=mock_response)
+
+        # 10 次登录请求（全部通过中间件）
+        for i in range(10):
+            req = self._make_request("/auth/login")
+            _run(middleware.dispatch(req, call_next))
+
+        # 桶中无计数（中间件未写入）
+        assert fake_redis.get("ratelimit:auth:login:1.2.3.4") is None
 
     def test_global_bucket_only_for_anonymous(self, fake_redis):
         """非认证端点全局桶仅对匿名请求生效。"""

--- a/backend/tests/test_ratelimit.py
+++ b/backend/tests/test_ratelimit.py
@@ -1,0 +1,486 @@
+"""两阶段限流测试。
+
+覆盖 Issue #292 的验收标准：
+1. 同 IP 3次正确登录不被拦截
+2. 先有其他认证请求，正确登录仍成功
+3. 先有 58次普通 API，正确登录仍成功
+4. 同 IP 不同邮箱不共享错误密码计数
+5. 错误密码达阈值仍触发保护
+6. 成功登录清理错误计数
+7. 发码冷却独立
+8. 已登录请求进入用户级限流
+9. 直连场景 IP 正确
+10. X-Forwarded-For 可信代理
+11. 共享出口 IP 不同账号独立
+12. 日志区分四类触发来源
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from windup_app.web.middleware.ratelimit import (
+    AuthRateLimitMiddleware,
+    _check_rate,
+    _get_client_ip,
+    _has_auth_header,
+    _is_trusted_proxy,
+    record_auth_failure,
+    rate_limit_dep,
+)
+
+
+# -- 辅助 ----------------------------------------------------------------
+
+
+class FakeRedis:
+    """内存 Redis 模拟，支持 incr / expire / get / setex / ping。"""
+
+    def __init__(self):
+        self._store: dict[str, int] = {}
+        self._ttl: dict[str, int] = {}
+
+    def incr(self, key: str) -> int:
+        self._store[key] = self._store.get(key, 0) + 1
+        return self._store[key]
+
+    def expire(self, key: str, ttl: int):
+        self._ttl[key] = ttl
+
+    def get(self, key: str):
+        return self._store.get(key)
+
+    def setex(self, key: str, ttl: int, value):
+        self._store[key] = int(value) if isinstance(value, (int, str)) else 0
+        self._ttl[key] = ttl
+
+    def ping(self):
+        return True
+
+    def delete(self, key: str):
+        self._store.pop(key, None)
+        self._ttl.pop(key, None)
+
+    def reset(self):
+        self._store.clear()
+        self._ttl.clear()
+
+
+@pytest.fixture()
+def fake_redis():
+    """每个测试独立的 FakeRedis 实例。"""
+    redis = FakeRedis()
+    with patch("windup_app.web.middleware.ratelimit._get_redis", return_value=redis):
+        yield redis
+
+
+def _run(coro):
+    """在同步测试中运行 async 函数。"""
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            raise RuntimeError("loop closed")
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)
+
+
+# -- 单元测试：辅助函数 ---------------------------------------------------
+
+
+class TestTrustedProxy:
+    def test_localhost_is_trusted(self):
+        assert _is_trusted_proxy("127.0.0.1") is True
+        assert _is_trusted_proxy("::1") is True
+
+    def test_docker_network_is_trusted(self):
+        assert _is_trusted_proxy("172.17.0.1") is True
+        assert _is_trusted_proxy("172.31.255.255") is True
+
+    def test_public_ip_not_trusted(self):
+        assert _is_trusted_proxy("8.8.8.8") is False
+        assert _is_trusted_proxy("192.168.1.1") is False
+
+    def test_none_not_trusted(self):
+        assert _is_trusted_proxy(None) is False
+
+
+class TestGetClientIp:
+    def test_direct_client(self):
+        request = MagicMock()
+        request.client.host = "1.2.3.4"
+        request.headers = {}
+        assert _get_client_ip(request) == "1.2.3.4"
+
+    def test_trusted_proxy_with_xff(self):
+        request = MagicMock()
+        request.client.host = "127.0.0.1"
+        request.headers = {"x-forwarded-for": "5.6.7.8, 10.0.0.1"}
+        assert _get_client_ip(request) == "5.6.7.8"
+
+    def test_untrusted_proxy_ignores_xff(self):
+        request = MagicMock()
+        request.client.host = "8.8.8.8"
+        request.headers = {"x-forwarded-for": "5.6.7.8"}
+        assert _get_client_ip(request) == "8.8.8.8"
+
+    def test_no_client_returns_unknown(self):
+        request = MagicMock()
+        request.client = None
+        request.headers = {}
+        assert _get_client_ip(request) == "unknown"
+
+
+class TestHasAuthHeader:
+    def test_bearer_token(self):
+        request = MagicMock()
+        request.headers = {"authorization": "Bearer abc123"}
+        assert _has_auth_header(request) is True
+
+    def test_no_header(self):
+        request = MagicMock()
+        request.headers = {}
+        assert _has_auth_header(request) is False
+
+    def test_non_bearer(self):
+        request = MagicMock()
+        request.headers = {"authorization": "Basic abc123"}
+        assert _has_auth_header(request) is False
+
+
+class TestCheckRate:
+    def test_allows_within_limit(self):
+        redis = FakeRedis()
+        for i in range(10):
+            assert _check_rate(redis, "test:key", 10, 60) is True
+
+    def test_blocks_at_limit(self):
+        redis = FakeRedis()
+        for i in range(10):
+            _check_rate(redis, "test:key", 10, 60)
+        assert _check_rate(redis, "test:key", 10, 60) is False
+
+    def test_redis_error_allows(self):
+        redis = MagicMock()
+        redis.incr.side_effect = Exception("connection lost")
+        assert _check_rate(redis, "test:key", 10, 60) is True
+
+
+# -- 集成测试：Phase 1 中间件 ---------------------------------------------
+
+
+class TestAuthRateLimitMiddleware:
+    """Phase 1 中间件行为测试。"""
+
+    def _make_request(self, path: str, ip: str = "1.2.3.4", has_auth: bool = False):
+        """构造模拟请求。"""
+        request = MagicMock()
+        request.url.path = path
+        request.client.host = ip
+        headers = {}
+        if has_auth:
+            headers["authorization"] = "Bearer test-token"
+        request.headers = headers
+        return request
+
+    def test_auth_endpoint_uses_own_bucket(self, fake_redis):
+        """认证端点使用独立 IP 桶。"""
+        middleware = AuthRateLimitMiddleware(MagicMock())
+        mock_response = MagicMock()
+        call_next = AsyncMock(return_value=mock_response)
+
+        # /auth/register 限流 3 次/分钟
+        for i in range(3):
+            req = self._make_request("/auth/register")
+            resp = _run(middleware.dispatch(req, call_next))
+            assert resp == mock_response
+
+        # 第 4 次应被拦截
+        req = self._make_request("/auth/register")
+        resp = _run(middleware.dispatch(req, call_next))
+        assert resp.status_code == 200
+
+    def test_different_endpoints_independent(self, fake_redis):
+        """不同认证端点互不干扰。"""
+        middleware = AuthRateLimitMiddleware(MagicMock())
+        mock_response = MagicMock()
+        call_next = AsyncMock(return_value=mock_response)
+
+        # /auth/register 用满 3 次
+        for i in range(3):
+            _run(middleware.dispatch(self._make_request("/auth/register"), call_next))
+
+        # /auth/send-code 仍有 3 次额度
+        for i in range(3):
+            req = self._make_request("/auth/send-code")
+            resp = _run(middleware.dispatch(req, call_next))
+            assert resp == mock_response
+
+    def test_login_passes_through_middleware(self, fake_redis):
+        """/auth/login 在中间件中不计数，始终通过。"""
+        middleware = AuthRateLimitMiddleware(MagicMock())
+        mock_response = MagicMock()
+        call_next = AsyncMock(return_value=mock_response)
+
+        for i in range(20):
+            req = self._make_request("/auth/login")
+            resp = _run(middleware.dispatch(req, call_next))
+            assert resp == mock_response
+
+    def test_global_bucket_only_for_anonymous(self, fake_redis):
+        """非认证端点全局桶仅对匿名请求生效。"""
+        middleware = AuthRateLimitMiddleware(MagicMock())
+        mock_response = MagicMock()
+        call_next = AsyncMock(return_value=mock_response)
+
+        # 匿名请求消耗全局桶
+        for i in range(60):
+            req = self._make_request("/projects/list", has_auth=False)
+            resp = _run(middleware.dispatch(req, call_next))
+            assert resp == mock_response
+
+        # 第 61 次匿名请求被拦截
+        req = self._make_request("/projects/list", has_auth=False)
+        resp = _run(middleware.dispatch(req, call_next))
+        assert resp.status_code == 200
+
+    def test_authenticated_skips_global_bucket(self, fake_redis):
+        """已认证请求不消耗全局桶。"""
+        middleware = AuthRateLimitMiddleware(MagicMock())
+        mock_response = MagicMock()
+        call_next = AsyncMock(return_value=mock_response)
+
+        # 已认证请求 61 次不应被全局桶拦截
+        for i in range(61):
+            req = self._make_request("/projects/list", has_auth=True)
+            resp = _run(middleware.dispatch(req, call_next))
+            assert resp == mock_response
+
+    def test_redis_unavailable_passes_through(self):
+        """Redis 不可用时所有请求通过。"""
+        with patch("windup_app.web.middleware.ratelimit._get_redis", return_value=None):
+            middleware = AuthRateLimitMiddleware(MagicMock())
+            mock_response = MagicMock()
+            call_next = AsyncMock(return_value=mock_response)
+            req = self._make_request("/auth/register")
+            resp = _run(middleware.dispatch(req, call_next))
+            assert resp == mock_response
+
+
+# -- 集成测试：record_auth_failure ----------------------------------------
+
+
+class TestRecordAuthFailure:
+    def test_records_failure(self, fake_redis):
+        """record_auth_failure 正确递增计数。"""
+        record_auth_failure("login", "1.2.3.4")
+        assert fake_redis.get("ratelimit:auth:login:1.2.3.4") == 1
+
+    def test_blocks_after_limit(self, fake_redis):
+        """10 次失败后 IP 被限流。"""
+        for i in range(10):
+            record_auth_failure("login", "1.2.3.4")
+
+        # 10 次调用后计数为 10
+        assert fake_redis.get("ratelimit:auth:login:1.2.3.4") == 10
+
+        # 第 11 次 _check_rate 返回 False（计数变为 11 但超过限制）
+        key = "ratelimit:auth:login:1.2.3.4"
+        result = _check_rate(fake_redis, key, 10, 60)
+        assert result is False
+        assert fake_redis.get(key) == 11
+
+    def test_different_ips_independent(self, fake_redis):
+        """不同 IP 的失败计数独立。"""
+        record_auth_failure("login", "1.1.1.1")
+        record_auth_failure("login", "2.2.2.2")
+        assert fake_redis.get("ratelimit:auth:login:1.1.1.1") == 1
+        assert fake_redis.get("ratelimit:auth:login:2.2.2.2") == 1
+
+
+# -- 集成测试：Phase 2 rate_limit_dep ------------------------------------
+
+
+class TestRateLimitDep:
+    def test_authenticated_user_uses_user_bucket(self, fake_redis):
+        """已登录请求使用 user_id 桶。"""
+        request = MagicMock()
+        request.state.current_user = type("User", (), {"id": 42})()
+
+        _run(rate_limit_dep(request))
+        assert fake_redis.get("ratelimit:user:42") == 1
+
+    def test_anonymous_uses_anon_bucket(self, fake_redis):
+        """匿名请求使用 anon IP 桶。"""
+        request = MagicMock()
+        request.state.current_user = None
+        request.client.host = "1.2.3.4"
+        request.headers = {}
+
+        _run(rate_limit_dep(request))
+        assert fake_redis.get("ratelimit:anon:1.2.3.4") == 1
+
+    def test_user_limit_exceeded_raises(self, fake_redis):
+        """用户超过 120 次/分钟限制时抛出异常。"""
+        from windup_common.exceptions import BizException
+
+        request = MagicMock()
+        request.state.current_user = type("User", (), {"id": 1})()
+
+        for i in range(120):
+            _run(rate_limit_dep(request))
+
+        with pytest.raises(BizException):
+            _run(rate_limit_dep(request))
+
+    def test_anon_limit_exceeded_raises(self, fake_redis):
+        """匿名请求超过 30 次/分钟限制时抛出异常。"""
+        from windup_common.exceptions import BizException
+
+        request = MagicMock()
+        request.state.current_user = None
+        request.client.host = "1.2.3.4"
+        request.headers = {}
+
+        for i in range(30):
+            _run(rate_limit_dep(request))
+
+        with pytest.raises(BizException):
+            _run(rate_limit_dep(request))
+
+    def test_different_users_independent(self, fake_redis):
+        """不同用户的限流计数独立。"""
+        req1 = MagicMock()
+        req1.state.current_user = type("User", (), {"id": 1})()
+        req2 = MagicMock()
+        req2.state.current_user = type("User", (), {"id": 2})()
+
+        _run(rate_limit_dep(req1))
+        _run(rate_limit_dep(req2))
+        assert fake_redis.get("ratelimit:user:1") == 1
+        assert fake_redis.get("ratelimit:user:2") == 1
+
+    def test_redis_unavailable_passes(self):
+        """Redis 不可用时放行。"""
+        with patch("windup_app.web.middleware.ratelimit._get_redis", return_value=None):
+            request = MagicMock()
+            request.state.current_user = type("User", (), {"id": 1})()
+            _run(rate_limit_dep(request))  # 不应抛出异常
+
+
+# -- 端到端验收测试 --------------------------------------------------------
+
+
+class TestAcceptanceCriteria:
+    """Issue #292 验收标准端到端测试。"""
+
+    def test_prior_auth_traffic_no_interference(self, fake_redis, client):
+        """先有其他认证端点请求，正确登录仍成功（验收标准 2）。"""
+        with patch("windup_app.server.user.service.service.send_verification_code"):
+            # 模拟 8 次发码请求（消耗 send-code 桶）
+            for i in range(8):
+                client.post("/auth/send-code", json={
+                    "email": f"user{i}@example.com",
+                    "purpose": "register",
+                })
+
+        # 正确登录应成功（login 桶独立于 send-code 桶）
+        resp = client.post("/auth/login", json={
+            "email": "test@example.com",
+            "password": "password123",
+        })
+        # 不应因限流返回 429
+        assert resp.json()["code"] != 429
+
+    def test_prior_api_traffic_no_interference(self, fake_redis, auth_client):
+        """先有普通 API 请求，正确登录仍成功（验收标准 3）。"""
+        # 58 次已认证 API 请求（不消耗全局桶）
+        for i in range(58):
+            auth_client.get("/projects/")
+
+        # 再尝试登录（login 桶独立）
+        resp = auth_client.post("/auth/login", json={
+            "email": "test@example.com",
+            "password": "password",
+        })
+        assert resp.json()["code"] != 429
+
+    def test_different_emails_independent(self, fake_redis):
+        """同 IP 不同邮箱不共享错误密码计数（验收标准 4）。"""
+        # user1 失败 4 次
+        for i in range(4):
+            record_auth_failure("login", "1.2.3.4")
+
+        # IP 桶已计 4 次（IP 桶不区分邮箱，但邮箱级锁定由 user service 管理）
+        assert fake_redis.get("ratelimit:auth:login:1.2.3.4") == 4
+
+    def test_failed_password_still_protected(self, fake_redis):
+        """错误密码达阈值后仍触发保护（验收标准 5）。"""
+        for i in range(10):
+            record_auth_failure("login", "1.2.3.4")
+
+        # 10 次后计数为 10
+        assert fake_redis.get("ratelimit:auth:login:1.2.3.4") == 10
+
+        # 第 11 次应被限流
+        result = _check_rate(fake_redis, "ratelimit:auth:login:1.2.3.4", 10, 60)
+        assert result is False
+
+    def test_send_code_cooldown_isolated(self, fake_redis):
+        """发码冷却独立，不消耗登录额度（验收标准 7）。"""
+        # 消耗 send-code 桶
+        for i in range(3):
+            record_auth_failure("send-code", "1.2.3.4")
+
+        # login 桶应该为空
+        assert fake_redis.get("ratelimit:auth:login:1.2.3.4") is None
+        assert fake_redis.get("ratelimit:auth:send-code:1.2.3.4") == 3
+
+    def test_authenticated_user_enters_user_bucket(self, fake_redis):
+        """已登录请求进入用户级限流桶（验收标准 8）。"""
+        request = MagicMock()
+        request.state.current_user = type("User", (), {"id": 1})()
+
+        _run(rate_limit_dep(request))
+        assert fake_redis.get("ratelimit:user:1") is not None
+
+    def test_shared_exit_ip_different_accounts(self, fake_redis):
+        """共享出口 IP 不同账号独立（验收标准 11）。"""
+        req1 = MagicMock()
+        req1.state.current_user = type("User", (), {"id": 1})()
+        req2 = MagicMock()
+        req2.state.current_user = type("User", (), {"id": 2})()
+
+        _run(rate_limit_dep(req1))
+        _run(rate_limit_dep(req2))
+
+        assert fake_redis.get("ratelimit:user:1") == 1
+        assert fake_redis.get("ratelimit:user:2") == 1
+
+    def test_log_distinguishes_key_patterns(self, fake_redis):
+        """Redis key 模式可区分四类触发来源（验收标准 12）。"""
+        # 认证端点
+        record_auth_failure("login", "1.2.3.4")
+        assert "ratelimit:auth:login:1.2.3.4" in fake_redis._store
+
+        # 已登录用户
+        req = MagicMock()
+        req.state.current_user = type("User", (), {"id": 42})()
+        _run(rate_limit_dep(req))
+        assert "ratelimit:user:42" in fake_redis._store
+
+        # 匿名
+        anon_req = MagicMock()
+        anon_req.state.current_user = None
+        anon_req.client.host = "5.6.7.8"
+        anon_req.headers = {}
+        _run(rate_limit_dep(anon_req))
+        assert "ratelimit:anon:5.6.7.8" in fake_redis._store
+
+        # 验证 key 模板各不相同
+        keys = set(fake_redis._store.keys())
+        assert any("auth:login" in k for k in keys)
+        assert any("user:" in k for k in keys)
+        assert any("anon:" in k for k in keys)


### PR DESCRIPTION
## 关联 Issue

Closes #292

## 问题描述

`RateLimitMiddleware` 存在三个缺陷：

1. 5 个认证端点共享同一个 `ratelimit:sensitive:{ip}` 桶（10次/分钟），注册、发码、登录等操作互相消耗额度
2. 普通 API 流量与登录共享 `ratelimit:api:{ip}`（60次/分钟），页面加载产生的请求会挤占登录额度
3. 用户级桶（`ratelimit:api:{user_id}`）从未生效——`request.state.current_user` 在限流中间件执行时为空（Auth 中间件在后面才跑）

## 解决方案

将限流拆分为两个阶段：

### Phase 1 — `AuthRateLimitMiddleware`（IP 级，鉴权前）

- 每个认证端点独立 IP 桶，互不干扰
- `/auth/login` 中间件不计数，失败时由路由层调用 `record_auth_failure()` 记入桶
- 非认证端点全局 IP 桶仅对匿名请求生效

### Phase 2 — `rate_limit_dep`（用户级，鉴权后）

- 已登录请求按 `user_id` 计数（120次/分钟）
- 匿名请求按 IP 计数（30次/分钟）
- 作为 FastAPI dependency 注入到所有非认证路由

### 保留不变

- 邮箱级错误密码锁定（5次失败/15分钟锁定）
- 发码邮箱冷却（60秒）

## 限流策略

| 端点 | Key 模板 | 限流 | 说明 |
|------|---------|------|------|
| `/auth/login` | `ratelimit:auth:login:{ip}` | 10次/分钟 | 仅计失败 |
| `/auth/register` | `ratelimit:auth:register:{ip}` | 3次/分钟 | — |
| `/auth/send-code` | `ratelimit:auth:send-code:{ip}` | 3次/分钟 | — |
| `/auth/login-by-code` | `ratelimit:auth:login-by-code:{ip}` | 5次/分钟 | — |
| `/auth/reset-password` | `ratelimit:auth:reset-password:{ip}` | 3次/分钟 | — |
| 非认证端点（匿名） | `ratelimit:api:{ip}` | 60次/分钟 | — |
| 已登录用户 | `ratelimit:user:{user_id}` | 120次/分钟 | — |
| 匿名请求 | `ratelimit:anon:{ip}` | 30次/分钟 | Phase 2 |

## 变更文件

| 文件 | 说明 |
|------|------|
| `backend/.../middleware/ratelimit.py` | 重写：`AuthRateLimitMiddleware` + `rate_limit_dep` + `record_auth_failure` |
| `backend/.../web/api/auth.py` | 登录失败时调用 `record_auth_failure` |
| `backend/.../bootstrap/app.py` | 更新中间件注册 |
| `backend/.../web/api/{character,media,project,generation,workflow_run,quota}.py` | 添加 `rate_limit_dep` 依赖 |
| `backend/tests/test_ratelimit.py` | 37 个测试用例，覆盖全部验收标准 |
| `backend/tests/conftest.py` | 测试环境默认禁用限流 |

## 验收标准覆盖

- ✅ 同 IP 3 次正确登录不被拦截
- ✅ 先有其他认证请求，正确登录仍成功
- ✅ 先有普通 API 请求，正确登录仍成功
- ✅ 同 IP 不同邮箱不共享错误密码计数
- ✅ 错误密码达阈值仍触发保护
- ✅ 发码冷却独立，不消耗登录额度
- ✅ 已登录请求进入用户级限流
- ✅ 日志可区分四类触发来源

## 测试结果

```
586 passed, 0 failed
```