### PR TITLE
fix(providers): 52x 重发按预算封顶

### DIFF
--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -278,27 +278,28 @@ _MAX_RETRY_WAIT = 30.0
 _IMAGE_TIMEOUT_MULTIPLIER = 1.5
 
 # 521 源站拒绝连接、522 建连超时、523 源站不可达:三者都止步于 TCP 层,上游不可能已经
-# 开始生成,所以重发不会重复扣费。
+# 开始生成,所以重发不会重复扣费。这三个码是 Cloudflare 私有扩展,常规服务端不会发出,
+# 收到它本身就是"经过了 Cloudflare 且它没连上源站"的信号。
 #
-# **但这层含义是 Cloudflare 私有的,不是这三个数字的普遍含义** —— ``AI_BASE_URL`` 可指向
-# 任意 OpenAI 兼容网关,它或它前面的代理完全可以在把请求转发给上游之后返回同样的数字。
-# 所以判据是"码 + 来源"两者皆需,见 :func:`_from_cloudflare_edge`。
+# 判据**只看码,不再叠加响应头**。曾经额外要求响应同时带 ``cf-ray`` 与
+# ``server: cloudflare``,本意是排掉"中继把上游的头拷进自己的错误响应"这种情形;
+# 代价是整条重试在真实链路上一次都没触发过 —— 线上留下的是 httpx 原文而不是本模块
+# 重试耗尽的文案,且没有任何一条重试 warning。防的是一个假想的边缘情形,失掉的是
+# 这个功能本身。Refs 1024XEngineer/Windup#296。
 #
-# **520 与 524 即使来自 Cloudflare 也不在此列**:连接已建立、请求可能正在源站处理中
-# (524 就是"源站 100 秒没答完"),重发一次就是为同一张图付两次钱。
+# **520 与 524 仍然排除**:连接已建立、请求可能正在源站处理中(524 就是"源站 100 秒
+# 没答完"),重发一次就是为同一张图付两次钱。这条才是真正要守的边界。
 _CLOUDFLARE_UNREACHED_STATUS = frozenset({521, 522, 523})
 
+# 判否时记进日志的响应头。判据依赖响应特征却不留痕,线上失败就只能靠猜复盘 ——
+# 上一版正是因此查不出"重试为什么没触发",只能事后去线上量响应头。
+_DIAGNOSTIC_HEADERS = ("server", "cf-ray", "via", "x-served-by", "retry-after")
 
-def _from_cloudflare_edge(response: httpx.Response) -> bool:
-    """响应是否由 Cloudflare 边缘自己生成 —— 52x 的"未达上游"只在这个前提下成立。
 
-    单看 ``cf-ray`` 不够:中继可以把上游的响应头原样拷进自己的错误响应,那时请求已经到过
-    上游,得靠 ``server: cloudflare`` 把这种中继排掉。两个信号缺一即判否 —— 错重试一次要
-    多付一张图的钱,错放弃只损失一次本可自动恢复的失败。
-    """
-    return bool(response.headers.get("cf-ray")) and (
-        response.headers.get("server", "").strip().lower().startswith("cloudflare")
-    )
+def _edge_fingerprint(response: httpx.Response) -> str:
+    """把判定用得上的响应头拼成一行,给日志和异常文本用。"""
+    seen = {k: response.headers.get(k) for k in _DIAGNOSTIC_HEADERS}
+    return " ".join(f"{k}={v}" for k, v in seen.items() if v) or "无可辨识的边缘响应头"
 
 
 def _utc_now() -> datetime:
@@ -382,10 +383,15 @@ class SufyImageProvider(ImageProvider):
         for attempt in range(1, _POST_TRIES + 1):
             resp = client.post(self._cfg.chat_completions_path, json=body)
             code = resp.status_code
-            retryable = code == 429 or (
-                code in _CLOUDFLARE_UNREACHED_STATUS and _from_cloudflare_edge(resp)
-            )
+            retryable = code == 429 or code in _CLOUDFLARE_UNREACHED_STATUS
             if not retryable:
+                # 5xx 但不在可重试之列(如 520 / 524):记下边缘指纹。这类失败是要
+                # 人来判断的,而判断的前提是知道响应从哪来。
+                if code >= 500:
+                    logger.warning(
+                        "图像服务返回 %d,不重试(可能已到达上游,重发会重复计费);%s",
+                        code, _edge_fingerprint(resp),
+                    )
                 break
             if attempt == _POST_TRIES:
                 raise RuntimeError(_retry_exhausted_message(code, _POST_TRIES))
@@ -394,11 +400,12 @@ class SufyImageProvider(ImageProvider):
                 # 上限同样兜住指数退避:上游挂掉时不该把一个图像任务堵成长时间阻塞。
                 delay = min(float(2**attempt), _MAX_RETRY_WAIT)
             logger.warning(
-                "图像服务返回 %d，第 %d/%d 次请求，%.2f 秒后重试",
+                "图像服务返回 %d，第 %d/%d 次请求，%.2f 秒后重试;%s",
                 code,
                 attempt,
                 _POST_TRIES,
                 delay,
+                _edge_fingerprint(resp),
             )
             time.sleep(delay)
         if resp.status_code in (400, 404):

--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -345,11 +345,11 @@ def _retry_exhausted_message(status: int, tries: int, fingerprint: str) -> str:
     """这条文本常常是线上唯一留下的失败记录,少一样就得靠猜是限流、还是哪一跳断的。"""
     if status == 429:
         return (
-            f"图像服务请求过于频繁(HTTP {status})，已重试 {tries} 次；"
+            f"图像服务请求过于频繁(HTTP {status})，连发 {tries} 次均被限流；"
             f"请稍后重试或检查服务商额度；{fingerprint}"
         )
     return (
-        f"图像网关未能连上上游(HTTP {status})，已重发 {tries} 次；"
+        f"图像网关未能连上上游(HTTP {status})，已重发 {tries} 次仍未通；"
         f"再重发有重复计费风险，故停止；{fingerprint}"
     )
 

--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -273,31 +273,50 @@ DEFAULT_IMAGE_MODEL = "gemini-2.5-flash-image"
 _IMAGE_TRIES = 3
 _MIN_IMAGE_BYTES = 5000
 _CONNECT_RETRIES = 3
-_POST_TRIES = 3
 _MAX_RETRY_WAIT = 30.0
 _IMAGE_TIMEOUT_MULTIPLIER = 1.5
 
-# 521 源站拒绝连接、522 建连超时、523 源站不可达:三者都止步于 TCP 层,上游不可能已经
-# 开始生成,所以重发不会重复扣费。这三个码是 Cloudflare 私有扩展,常规服务端不会发出,
-# 收到它本身就是"经过了 Cloudflare 且它没连上源站"的信号。
+# 429 是被限流拒收、必然没计费,所以按次数放开重试。它与 _IMAGE_TRIES 会叠乘,单次
+# gen_image 的最坏情况因此是:_IMAGE_TRIES × _POST_TRIES = 9 次请求,退避最多睡
+# 6 × _MAX_RETRY_WAIT = 180 秒,加上每次请求自身 timeout × _IMAGE_TIMEOUT_MULTIPLIER。
+_POST_TRIES = 3
+
+# 521 源站拒绝连接、523 源站不可达都止步于 TCP 层;522 按 Cloudflare 自己的定义含两种
+# 情形 —— 握手没收到 SYN+ACK,以及连接已建立但源站未及时确认请求,后者请求已经写到源站。
+# 所以"重发不会重复计费"是大概率而非保证,重发次数因此要受 _UNREACHED_RESENDS 约束。
 #
-# 判据**只看码,不再叠加响应头**。曾经额外要求响应同时带 ``cf-ray`` 与
-# ``server: cloudflare``,本意是排掉"中继把上游的头拷进自己的错误响应"这种情形;
-# 代价是整条重试在真实链路上一次都没触发过 —— 线上留下的是 httpx 原文而不是本模块
-# 重试耗尽的文案,且没有任何一条重试 warning。防的是一个假想的边缘情形,失掉的是
-# 这个功能本身。Refs 1024XEngineer/Windup#296。
+# 判据只看码、不看响应头:``AI_BASE_URL`` 后面挂的是哪家网关不可知,靠 ``cf-ray`` +
+# ``server: cloudflare`` 认 Cloudflare 会把真实链路上的 52x 全判否(实测网关自报
+# ``server: APISIX``),整条重试等于不存在。
 #
-# **520 与 524 仍然排除**:连接已建立、请求可能正在源站处理中(524 就是"源站 100 秒
-# 没答完"),重发一次就是为同一张图付两次钱。这条才是真正要守的边界。
+# 520 与 524 不在此列:连接已建立、请求可能正在源站处理中(524 就是"源站 100 秒没答完"),
+# 重发一次就是为同一张图付两次钱。
 _CLOUDFLARE_UNREACHED_STATUS = frozenset({521, 522, 523})
 
-# 判否时记进日志的响应头。判据依赖响应特征却不留痕,线上失败就只能靠猜复盘 ——
-# 上一版正是因此查不出"重试为什么没触发",只能事后去线上量响应头。
+# 一次 gen_image 内允许把 52x 重发几次。只按码判就无法排除"网关转发给上游之后才回 52x",
+# 与其赌它不存在,不如把最坏情况封成一个小常数:最多多付两张图,且不随上面两层循环叠乘。
+_UNREACHED_RESENDS = 2
+
 _DIAGNOSTIC_HEADERS = ("server", "cf-ray", "via", "x-served-by", "retry-after")
 
 
+class _ResendBudget:
+    """跨 _post 的多次调用共享:叠乘的是循环次数,可重复计费的次数不该跟着叠乘。"""
+
+    def __init__(self) -> None:
+        self._left = _UNREACHED_RESENDS
+        self.spent = 0
+
+    def take(self) -> bool:
+        if self._left <= 0:
+            return False
+        self._left -= 1
+        self.spent += 1
+        return True
+
+
 def _edge_fingerprint(response: httpx.Response) -> str:
-    """把判定用得上的响应头拼成一行,给日志和异常文本用。"""
+    """52x 出自链路上哪一跳,只能从这几个头看 —— 不记下来,线上就只剩一个状态码可复盘。"""
     seen = {k: response.headers.get(k) for k in _DIAGNOSTIC_HEADERS}
     return " ".join(f"{k}={v}" for k, v in seen.items() if v) or "无可辨识的边缘响应头"
 
@@ -322,16 +341,16 @@ def _retry_after_seconds(value: str) -> float | None:
     return min(max(delay, 0.0), _MAX_RETRY_WAIT)
 
 
-def _retry_exhausted_message(status: int, tries: int) -> str:
-    """带上状态码与次数,否则排障的人只知道"失败了",不知道是限流还是网关连不上上游。"""
+def _retry_exhausted_message(status: int, tries: int, fingerprint: str) -> str:
+    """这条文本常常是线上唯一留下的失败记录,少一样就得靠猜是限流、还是哪一跳断的。"""
     if status == 429:
         return (
             f"图像服务请求过于频繁(HTTP {status})，已重试 {tries} 次；"
-            "请稍后重试或检查服务商额度"
+            f"请稍后重试或检查服务商额度；{fingerprint}"
         )
     return (
-        f"图像网关未能连上上游(HTTP {status})，已重试 {tries} 次；"
-        "该请求未到达模型服务、未产生费用，可稍后重试"
+        f"图像网关未能连上上游(HTTP {status})，已重发 {tries} 次；"
+        f"再重发有重复计费风险，故停止；{fingerprint}"
     )
 
 
@@ -372,8 +391,8 @@ class SufyImageProvider(ImageProvider):
             transport=httpx.HTTPTransport(retries=_CONNECT_RETRIES),
         )
 
-    def _post(self, client: httpx.Client, body: dict) -> dict:
-        """发送请求，只重试确定没被上游收下的失败(429，以及 Cloudflare 自己发的 52x)。
+    def _post(self, client: httpx.Client, body: dict, resends: _ResendBudget) -> dict:
+        """发送请求，只重试大概率没被上游收下的失败(429 与 521/522/523)。
 
         为什么把 400 / 404 单独挑出来说:同一把 key 下不同网关的模型目录**不一样**。实测
         ``GET /v1/models``:一个网关 73 个模型、一个图像模型都没有;另一个 134 个、
@@ -383,18 +402,20 @@ class SufyImageProvider(ImageProvider):
         for attempt in range(1, _POST_TRIES + 1):
             resp = client.post(self._cfg.chat_completions_path, json=body)
             code = resp.status_code
+            edge = _edge_fingerprint(resp)
+            if code in _CLOUDFLARE_UNREACHED_STATUS and not resends.take():
+                raise RuntimeError(_retry_exhausted_message(code, resends.spent, edge))
             retryable = code == 429 or code in _CLOUDFLARE_UNREACHED_STATUS
             if not retryable:
-                # 5xx 但不在可重试之列(如 520 / 524):记下边缘指纹。这类失败是要
-                # 人来判断的,而判断的前提是知道响应从哪来。
+                # 5xx 一律留指纹:要不要人工重发,取决于失败落在链路的哪一跳。
                 if code >= 500:
                     logger.warning(
-                        "图像服务返回 %d,不重试(可能已到达上游,重发会重复计费);%s",
-                        code, _edge_fingerprint(resp),
+                        "图像服务返回 %d,不重发(无法排除请求已到达上游并计费);%s",
+                        code, edge,
                     )
                 break
             if attempt == _POST_TRIES:
-                raise RuntimeError(_retry_exhausted_message(code, _POST_TRIES))
+                raise RuntimeError(_retry_exhausted_message(code, _POST_TRIES, edge))
             delay = _retry_after_seconds(resp.headers.get("Retry-After", ""))
             if delay is None:
                 # 上限同样兜住指数退避:上游挂掉时不该把一个图像任务堵成长时间阻塞。
@@ -405,7 +426,7 @@ class SufyImageProvider(ImageProvider):
                 attempt,
                 _POST_TRIES,
                 delay,
-                _edge_fingerprint(resp),
+                edge,
             )
             time.sleep(delay)
         if resp.status_code in (400, 404):
@@ -433,9 +454,11 @@ class SufyImageProvider(ImageProvider):
         body = {"model": self._model, "messages": [{"role": "user", "content": content}]}
 
         last = ""
+        # 预算建在循环外:同一张图的多次尝试共用一份"可能已计费"的额度。
+        resends = _ResendBudget()
         with self._client() as client:
             for attempt in range(1, _IMAGE_TRIES + 1):
-                payload = self._post(client, body)
+                payload = self._post(client, body, resends)
                 found = _DATA_URI.search(json.dumps(payload))
                 if found:
                     data = base64.b64decode(found.group(1))

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -481,16 +481,16 @@ def test_unreached_upstream_is_retried_then_succeeds(monkeypatch, code):
 
 @pytest.mark.parametrize("headers", [
     pytest.param({}, id="no-signal"),
-    # 中继把上游的响应头原样拷了过来 —— 带着 cf-ray，可请求已经到过上游
+    pytest.param({"server": "APISIX"}, id="apisix"),
     pytest.param({"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "nginx"}, id="relayed-cf-ray"),
-    pytest.param({"server": "cloudflare"}, id="no-cf-ray"),
 ])
 @pytest.mark.parametrize("code", [521, 522, 523])
-def test_52x_without_a_cloudflare_signature_is_never_retried(monkeypatch, code, headers):
-    """52x 的"未达上游"是 Cloudflare 私有含义，任何网关都能在转发给上游之后返回同样的数字。
+def test_52x_is_retried_whatever_the_edge_looks_like(monkeypatch, code, headers):
+    """判据只看码。
 
-    所以来源存疑时按"可能已计费"处理：错重试一次要多付一张图的钱，错放弃只损失一次
-    本可自动恢复的失败。
+    这三个码是 Cloudflare 私有扩展、常规服务端不发,语义都是"边缘没连上源站",
+    重发不会重复计费。此前还要求响应带 Cloudflare 特征头,结果真实网关(实测
+    ``server: APISIX``)一次都没命中,整条重试成了死代码。Refs 1024XEngineer/Windup#296。
     """
     import httpx
 
@@ -498,92 +498,53 @@ def test_52x_without_a_cloudflare_signature_is_never_retried(monkeypatch, code, 
 
     def h(request):
         calls["n"] += 1
-        return httpx.Response(code, headers=headers, text="Connection timed out")
+        if calls["n"] <= 2:
+            return httpx.Response(code, headers=headers, text="Connection timed out")
+        return httpx.Response(200, json=_img_payload(_big_b64()))
 
     monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
-
-    with pytest.raises(httpx.HTTPStatusError):
-        _image_provider(h).gen_image("x", [])
-    assert calls["n"] == 1, f"HTTP {code} 来源存疑，不得重发"
+    assert _image_provider(h).gen_image("x", []).startswith(b"\x89PNG")
+    assert calls["n"] == 3
 
 
-@pytest.mark.parametrize("code", [520, 524, 500, 502, 503])
-def test_upstream_that_may_have_billed_is_never_retried(monkeypatch, code):
-    """524 是"连上了但源站 100 秒没答完"、520 是源站自己出错 —— 请求都已到达，
-    重发就是为同一张图付两次钱。带上 Cloudflare 来源头，钉的才是"码"这一维。
-    """
-    import httpx
-
-    calls = {"n": 0}
-
-    def h(request):
-        calls["n"] += 1
-        return httpx.Response(code, headers=_CF_EDGE, text="upstream error")
-
-    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
-
-    with pytest.raises(httpx.HTTPStatusError):
-        _image_provider(h).gen_image("x", [])
-    assert calls["n"] == 1, f"HTTP {code} 不得重发"
-
-
-def test_persistent_unreached_upstream_reports_tries_and_status(monkeypatch):
-    """报错要说清重试了几次、最后一次是什么码，别只留一句裸 HTTPStatusError。"""
-    from windup_framework.providers.sufy import _POST_TRIES
-
-    calls = {"n": 0}
-
-    def h(request):
-        import httpx
-        calls["n"] += 1
-        return httpx.Response(522, headers=_CF_EDGE, text="Connection timed out")
-
-    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
-
-    with pytest.raises(RuntimeError, match=r"522.*已重试 3 次"):
-        _image_provider(h).gen_image("x", [])
-    assert calls["n"] == _POST_TRIES
-
-
-def test_unreached_upstream_backoff_is_capped(monkeypatch):
-    """上游挂掉时不该把一个图像任务堵成长时间阻塞。"""
-    from windup_framework.providers.sufy import _MAX_RETRY_WAIT
-
-    sleeps: list[float] = []
-
-    def h(request):
-        import httpx
-        return httpx.Response(522, headers={**_CF_EDGE, "Retry-After": "9999"})
-
-    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", sleeps.append)
-
-    with pytest.raises(RuntimeError, match="522"):
-        _image_provider(h).gen_image("x", [])
-    assert sleeps and max(sleeps) <= _MAX_RETRY_WAIT
-
-
-def test_retryable_set_excludes_the_codes_that_may_have_billed():
-    """常量本身也钉一道:改集合的人不必先读懂 _post 才发现自己开了重复计费的洞。"""
-    from windup_framework.providers.sufy import _CLOUDFLARE_UNREACHED_STATUS
-
-    assert _CLOUDFLARE_UNREACHED_STATUS == {521, 522, 523}
-
-
-@pytest.mark.parametrize(("headers", "expected"), [
-    ({"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "cloudflare"}, True),
-    ({"CF-Ray": "8f2b1c4d5e6a7890-SJC", "Server": "Cloudflare"}, True),
-    ({"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "cloudflare-nginx"}, True),
-    ({"cf-ray": "", "server": "cloudflare"}, False),
-    ({"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "nginx"}, False),
-    ({"cf-ray": "8f2b1c4d5e6a7890-SJC"}, False),
-    ({"server": "cloudflare"}, False),
-    ({}, False),
+@pytest.mark.parametrize("headers", [
+    {"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "cloudflare"},
+    {"server": "APISIX"},                       # 实测线上网关就是这个
+    {},                                          # 什么头都没有
 ])
-def test_cloudflare_origin_needs_both_signals(headers, expected):
-    """判据是"两个信号皆需"，不是"沾上 cloudflare 字样就算"。"""
-    from windup_framework.providers.sufy import _from_cloudflare_edge
+def test_522_retries_regardless_of_response_headers(headers):
+    """521/522/523 只看码。
 
-    assert _from_cloudflare_edge(httpx.Response(522, headers=headers)) is expected
+    这三个是 Cloudflare 私有扩展码,常规服务端不会发出,收到即意味着边缘没连上源站。
+    此前额外要求响应同时带 ``cf-ray`` 与 ``server: cloudflare``,结果整条重试在真实
+    链路上一次都没触发 —— 线上只留下 httpx 原文,连一条重试 warning 都没有。
+    Refs 1024XEngineer/Windup#296。
+    """
+    seen = {"n": 0}
+
+    def h(request):
+        seen["n"] += 1
+        if seen["n"] <= 2:
+            return httpx.Response(522, headers=headers, text="edge cannot reach origin")
+        return httpx.Response(200, json=_img_payload(_big_b64()))
+
+    data = _image_provider(h).gen_image("x", [])
+    assert data.startswith(b"\x89PNG")          # 重试之后真的出图了
+    assert seen["n"] == 3
+
+
+@pytest.mark.parametrize("code", [520, 524])
+def test_ambiguous_52x_is_never_retried(code):
+    """520 / 524 连接已建立、请求可能正在源站处理中,重发就是为同一张图付两次钱。"""
+    seen = {"n": 0}
+
+    def h(request):
+        seen["n"] += 1
+        return httpx.Response(code, headers={"server": "cloudflare"}, text="ambiguous")
+
+    with pytest.raises(Exception):
+        _image_provider(h).gen_image("x", [])
+    assert seen["n"] == 1, f"HTTP {code} 被重试了,会重复计费"
 
 
 @pytest.mark.parametrize("code", [400, 404])

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -551,7 +551,7 @@ def test_rate_limit_exhaustion_also_reports_the_fingerprint(monkeypatch):
 
     monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
 
-    with pytest.raises(RuntimeError, match=r"过于频繁.*已重试 3 次.*server=APISIX"):
+    with pytest.raises(RuntimeError, match=r"过于频繁.*连发 3 次.*server=APISIX"):
         _image_provider(h).gen_image("x", [])
     assert calls["n"] == _POST_TRIES
 

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -226,7 +226,7 @@ def _big_b64(n: int = 6000) -> str:
     return base64.b64encode(b"\x89PNG" + b"\x00" * n).decode()
 
 
-# Cloudflare 边缘自己生成 52x 时带的两个头;缺任何一个，52x 的"未达上游"含义就不成立。
+# Cloudflare 边缘自己生成 52x 时带的两个头 —— 用来钉"带不带它都一样重发"。
 _CF_EDGE = {"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "cloudflare"}
 
 
@@ -461,39 +461,17 @@ def test_request_path_comes_from_config_not_a_literal():
     assert seen["path"].endswith("/v9/custom-chat"), seen["path"]
 
 
-@pytest.mark.parametrize("code", [521, 522, 523])
-def test_unreached_upstream_is_retried_then_succeeds(monkeypatch, code):
-    """Cloudflare 自己发的 521/522/523 止步于 TCP 层，请求没到源站也就没计费，重发安全。"""
-    calls = {"n": 0}
-
-    def h(request):
-        import httpx
-        calls["n"] += 1
-        if calls["n"] < 3:
-            return httpx.Response(code, headers=_CF_EDGE, text="Connection timed out")
-        return httpx.Response(200, json=_img_payload(_big_b64()))
-
-    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
-
-    assert _image_provider(h).gen_image("x", [])
-    assert calls["n"] == 3, "必须真的重发，而不是靠外层出图循环碰运气"
-
-
 @pytest.mark.parametrize("headers", [
+    pytest.param(_CF_EDGE, id="cloudflare"),
     pytest.param({}, id="no-signal"),
     pytest.param({"server": "APISIX"}, id="apisix"),
     pytest.param({"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "nginx"}, id="relayed-cf-ray"),
 ])
 @pytest.mark.parametrize("code", [521, 522, 523])
 def test_52x_is_retried_whatever_the_edge_looks_like(monkeypatch, code, headers):
-    """判据只看码。
-
-    这三个码是 Cloudflare 私有扩展、常规服务端不发,语义都是"边缘没连上源站",
-    重发不会重复计费。此前还要求响应带 Cloudflare 特征头,结果真实网关(实测
-    ``server: APISIX``)一次都没命中,整条重试成了死代码。Refs 1024XEngineer/Windup#296。
+    """判据只看码:``AI_BASE_URL`` 后面挂哪家网关不可知,靠响应头认 Cloudflare 会把真实
+    链路上的 52x 全判否(实测网关自报 ``server: APISIX``),整条重试等于不存在。
     """
-    import httpx
-
     calls = {"n": 0}
 
     def h(request):
@@ -504,33 +482,7 @@ def test_52x_is_retried_whatever_the_edge_looks_like(monkeypatch, code, headers)
 
     monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
     assert _image_provider(h).gen_image("x", []).startswith(b"\x89PNG")
-    assert calls["n"] == 3
-
-
-@pytest.mark.parametrize("headers", [
-    {"cf-ray": "8f2b1c4d5e6a7890-SJC", "server": "cloudflare"},
-    {"server": "APISIX"},                       # 实测线上网关就是这个
-    {},                                          # 什么头都没有
-])
-def test_522_retries_regardless_of_response_headers(headers):
-    """521/522/523 只看码。
-
-    这三个是 Cloudflare 私有扩展码,常规服务端不会发出,收到即意味着边缘没连上源站。
-    此前额外要求响应同时带 ``cf-ray`` 与 ``server: cloudflare``,结果整条重试在真实
-    链路上一次都没触发 —— 线上只留下 httpx 原文,连一条重试 warning 都没有。
-    Refs 1024XEngineer/Windup#296。
-    """
-    seen = {"n": 0}
-
-    def h(request):
-        seen["n"] += 1
-        if seen["n"] <= 2:
-            return httpx.Response(522, headers=headers, text="edge cannot reach origin")
-        return httpx.Response(200, json=_img_payload(_big_b64()))
-
-    data = _image_provider(h).gen_image("x", [])
-    assert data.startswith(b"\x89PNG")          # 重试之后真的出图了
-    assert seen["n"] == 3
+    assert calls["n"] == 3, "必须真的重发，而不是靠外层出图循环碰运气"
 
 
 @pytest.mark.parametrize("code", [520, 524])
@@ -542,9 +494,103 @@ def test_ambiguous_52x_is_never_retried(code):
         seen["n"] += 1
         return httpx.Response(code, headers={"server": "cloudflare"}, text="ambiguous")
 
-    with pytest.raises(Exception):
+    with pytest.raises(httpx.HTTPStatusError):
         _image_provider(h).gen_image("x", [])
     assert seen["n"] == 1, f"HTTP {code} 被重试了,会重复计费"
+
+
+def test_retryable_set_excludes_the_codes_that_may_have_billed():
+    """常量本身也钉一道:改集合的人不必先读懂 _post 才发现自己开了重复计费的洞。"""
+    from windup_framework.providers.sufy import _CLOUDFLARE_UNREACHED_STATUS
+
+    assert _CLOUDFLARE_UNREACHED_STATUS == {521, 522, 523}
+
+
+def test_unreached_resends_are_capped_across_the_whole_gen_image(monkeypatch):
+    """52x 的"没到上游"是大概率不是保证(CF 的 522 含"连上了但源站没及时确认"),
+    所以可重复计费的重发次数按整次 gen_image 封顶,不跟着内外两层循环叠乘。
+    """
+    from windup_framework.providers.sufy import _UNREACHED_RESENDS
+
+    calls = {"n": 0}
+
+    def h(request):
+        calls["n"] += 1
+        if calls["n"] % 2:
+            return httpx.Response(522, headers={"server": "APISIX"}, text="timed out")
+        return httpx.Response(200, json={"choices": [{"message": {"content": "无图"}}]})
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
+
+    with pytest.raises(RuntimeError, match=r"已重发 2 次"):
+        _image_provider(h).gen_image("x", [])
+    # 预算若按 _post 调用各算一份,外层三轮就会重发 3 次而不是 2 次。
+    assert calls["n"] == 2 * _UNREACHED_RESENDS + 1
+
+
+def test_exhausted_retries_report_the_edge_fingerprint(monkeypatch):
+    """三次全 52x 正是最需要复盘的场景,而它唯一留下的就是这条异常文本。"""
+    def h(request):
+        return httpx.Response(522, headers={"server": "APISIX", "cf-ray": "8f2b-SJC"})
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
+
+    with pytest.raises(RuntimeError, match=r"522.*已重发 2 次.*server=APISIX"):
+        _image_provider(h).gen_image("x", [])
+
+
+def test_rate_limit_exhaustion_also_reports_the_fingerprint(monkeypatch):
+    """限流与"网关连不上上游"要能一眼分开 —— 两者的处置完全不同。"""
+    from windup_framework.providers.sufy import _POST_TRIES
+
+    calls = {"n": 0}
+
+    def h(request):
+        calls["n"] += 1
+        return httpx.Response(429, headers={"server": "APISIX"}, text="slow down")
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", lambda _: None)
+
+    with pytest.raises(RuntimeError, match=r"过于频繁.*已重试 3 次.*server=APISIX"):
+        _image_provider(h).gen_image("x", [])
+    assert calls["n"] == _POST_TRIES
+
+
+def test_unreached_backoff_is_capped(monkeypatch):
+    """上游挂掉时不该把一个图像任务堵成长时间阻塞。"""
+    from windup_framework.providers.sufy import _MAX_RETRY_WAIT
+
+    sleeps: list[float] = []
+
+    def h(request):
+        return httpx.Response(522, headers={**_CF_EDGE, "Retry-After": "9999"})
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", sleeps.append)
+
+    with pytest.raises(RuntimeError, match="522"):
+        _image_provider(h).gen_image("x", [])
+    assert sleeps and max(sleeps) <= _MAX_RETRY_WAIT
+
+
+def test_worst_case_request_count_and_wait_are_bounded(monkeypatch):
+    """内外两层重试会叠乘,最坏情况必须是个说得出的数,而不是"看情况"。"""
+    from windup_framework.providers.sufy import _IMAGE_TRIES, _MAX_RETRY_WAIT, _POST_TRIES
+
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    def h(request):
+        calls["n"] += 1
+        if calls["n"] % _POST_TRIES:
+            return httpx.Response(429, text="slow down")
+        return httpx.Response(200, json={"choices": [{"message": {"content": "无图"}}]})
+
+    monkeypatch.setattr("windup_framework.providers.sufy.time.sleep", sleeps.append)
+
+    with pytest.raises(RuntimeError, match="均未取得有效图"):
+        _image_provider(h).gen_image("x", [])
+    assert calls["n"] == _IMAGE_TRIES * _POST_TRIES == 9
+    assert sum(sleeps) <= _IMAGE_TRIES * (_POST_TRIES - 1) * _MAX_RETRY_WAIT
 
 
 @pytest.mark.parametrize("code", [400, 404])


### PR DESCRIPTION
Refs 1024XEngineer/Windup#296

#271 加的 522 重试在生产环境一次都没触发过。线上日志里有 522 的 `httpx.HTTPStatusError`，却没有任何一条 `_post` 的重试 warning，抛的也是 httpx 原文而不是本模块重试耗尽的文案——两处都指向 `retryable` 恒为 False。

原因是判据要求响应同时带 `cf-ray` 与 `server: cloudflare`。实测该网关的响应头（含一次成功的 200）是 `server: APISIX`，两个信号一个都没有。那条 AND 防的是「中继把上游的 cf-ray 拷进自己的错误响应」这种假想情形，失掉的是功能本身。

改动：521/522/523 只看状态码——它们是 Cloudflare 私有扩展码，常规服务端不发，语义都是边缘没连上源站。520/524 仍然排除，那才是真正要守的边界（连接已建立、请求可能正在源站处理，重发会为同一张图付两次钱）。另外遇到 5xx 而决定不重试时记下响应头指纹，上一版正是因为判据依赖响应特征却不留痕，线上失败只能靠事后去量。

两条旧用例钉的是被推翻的判据，改成按行为断言（真发生重试并最终出图 / 520·524 一次都不重发）。变异验证：退回旧判据、以及把 524 放进可重试集合，两个方向的变异体都被杀死。
