### PR TITLE
fix(frontend): 保留生成恢复时的结果预期

### DIFF
--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -883,6 +883,52 @@ describe('WorkflowController', () => {
     expect(controller.getWorkflow().nodes[1].phase).toBe('selecting')
   })
 
+  it('首帧订阅后的补偿查询沿用节点的图片结果预期', async () => {
+    const run = createRun([...completedCharacterNodes(), ...actionNodes()])
+    const workflow = createWorkflowApis(run)
+    const terminalGeneration: Generation = {
+      id: 'task-terminal',
+      projectId: '1',
+      type: 'first_frame',
+      status: 'completed',
+      result: {
+        type: 'first_frame',
+        images: [
+          { url: 'https://img/walk-1.png' },
+          { url: 'https://img/walk-2.png' },
+          { url: 'https://img/walk-3.png' },
+        ],
+      },
+      error: null,
+    }
+    const generationApis: GenerationApis = {
+      create: vi.fn(async () => ({
+        ...terminalGeneration,
+        status: 'pending',
+        result: null,
+      })) as GenerationApis['create'],
+      get: vi.fn(async () => terminalGeneration),
+      subscribe: vi.fn(() => () => undefined) as GenerationApis['subscribe'],
+    }
+    const controller = createWorkflowController({
+      workflow: run,
+      workflowRunApis: workflow.apis,
+      generationApis,
+      onAsyncError: vi.fn(),
+    })
+
+    await controller.generateFirstFrame('action-walk', { spriteWidth: 64, spriteHeight: 96 })
+
+    expect(generationApis.get).toHaveBeenCalledWith('1', 'task-terminal', {
+      type: 'first_frame',
+      actionType: 'walk',
+    })
+    expect(controller.getWorkflow().nodes[2]).toMatchObject({
+      status: 'active',
+      phase: 'selecting',
+    })
+  })
+
   it('从母版节点重做会清空下游任务，旧事件不能覆盖新执行线', async () => {
     const run = createRun([
       setupNode({ status: 'passed', phase: 'completed' }),
@@ -1585,7 +1631,10 @@ describe('WorkflowController', () => {
     await controller.resume()
 
     expect(generation.apis.get).toHaveBeenCalledTimes(1)
-    expect(generation.apis.get).toHaveBeenCalledWith('1', 'task-animation')
+    expect(generation.apis.get).toHaveBeenCalledWith('1', 'task-animation', {
+      type: 'complete_animation',
+      actionType: 'walk',
+    })
     expect(controller.getWorkflow().nodes[4].phase).toBe('generating')
   })
 })

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -756,7 +756,7 @@ export function createWorkflowController({
       else stop()
 
       // 先订阅再查询，关闭“GET 看到运行中，订阅前任务已结束”的丢事件窗口。
-      const latest = await generationApis.get(requireWorkflow().projectId, taskId)
+      const latest = await generationApis.get(requireWorkflow().projectId, taskId, expectation)
       if (latest.status === 'completed' || latest.status === 'failed') {
         await settleGeneration(nodeId, taskId, latest)
       }


### PR DESCRIPTION
## 问题
PR #290 合并后，WorkflowController 在订阅后的补偿查询中未传递节点的 GenerationExpectation。首帧任务若恰好在订阅建立与补偿查询之间完成，会被按 character_template 解释并错误失败。

## 修改
- 补偿 GET 沿用当前节点 expectation。
- 恢复查询断言同步要求 complete_animation expectation。
- 增加首帧在订阅窗口完成的回归测试。

## 验证
- lint 通过
- typecheck 通过
- Controller 测试 45/45 通过
- 全量前端测试 46 个文件、502/502 通过
- 生产构建通过