### PR TITLE
feat(quick-start): redesign character creation entry

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -141,6 +141,7 @@ body,
 
   --shadow-app-card: 0 18px 45px rgb(29 37 31 / 9%);
   --shadow-app-panel: 0 22px 60px rgb(29 37 31 / 12%);
+  --shadow-app-composer-focus: 0 18px 48px rgb(29 37 31 / 14%);
   --shadow-app-page: 0 26px 80px rgb(29 37 31 / 10%);
   --shadow-app-header: inset 0 1px 0 rgb(255 255 255 / 55%);
   --shadow-app-menu: 0 8px 24px rgb(29 37 31 / 10%);

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -338,8 +338,6 @@ describe('QuickStartPage', () => {
     expect(screen.getByRole('button', { name: /16-bit 日式 RPG/u })).toBeTruthy()
     expect(screen.getByRole('button', { name: /暗黑哥特像素/u })).toBeTruthy()
     expect(screen.getByRole('button', { name: /温暖手绘像素/u })).toBeTruthy()
-    expect(screen.getByRole('button', { name: '像素守夜人' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: '轻装信使' })).toBeTruthy()
 
     fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
       target: { value: '戴银色面具的游侠' },
@@ -350,18 +348,27 @@ describe('QuickStartPage', () => {
     expect(screen.queryByRole('button', { name: /暗黑哥特像素/u })).toBeNull()
   })
 
-  it('keeps the original Quick Start prompt shortcuts functional', () => {
-    const view = renderAt('/quick-start', serviceFor(null))
-    fireEvent.click(screen.getByRole('button', { name: '像素守夜人' }))
-    expect((screen.getByRole('textbox', { name: '创作指令' }) as HTMLTextAreaElement).value).toBe(
-      '一位提着风灯、披深色斗篷的像素守夜人',
-    )
-
-    view.unmount()
+  it('offers style prompts only, without the retired role-example shortcuts', () => {
     renderAt('/quick-start', serviceFor(null))
-    fireEvent.click(screen.getByRole('button', { name: '轻装信使' }))
-    expect((screen.getByRole('textbox', { name: '创作指令' }) as HTMLTextAreaElement).value).toBe(
-      '轻装信使，侧视像素风，轮廓清晰，动作轻快',
+
+    // 入口只保留三张风格卡：角色样例会让人误以为这些形象是现成资产。
+    expect(screen.queryByRole('button', { name: '像素守夜人' })).toBeNull()
+    expect(screen.queryByRole('button', { name: '轻装信使' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /16-bit 日式 RPG/u }))
+    expect((screen.getByRole('textbox', { name: '创作指令' }) as HTMLInputElement).value).toBe(
+      '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',
+    )
+  })
+
+  it('keeps the entry composer on a single line', () => {
+    renderAt('/quick-start', serviceFor(null))
+    const composer = screen.getByRole('textbox', { name: '创作指令' })
+
+    expect(composer.tagName).toBe('INPUT')
+    expect(composer.className).toContain('h-10')
+    expect(composer.closest('form')?.className).toContain(
+      'focus-within:shadow-[var(--shadow-app-composer-focus)]',
     )
   })
 
@@ -748,7 +755,7 @@ describe('QuickStartPage', () => {
 
     expect(screen.getByRole('textbox', { name: '创作指令' })).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: /16-bit 日式 RPG/u }))
-    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
       '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',
     )
     expect(screen.queryByRole('button', { name: /暗黑哥特像素/u })).toBeNull()
@@ -846,7 +853,7 @@ describe('QuickStartPage', () => {
     fireEvent.change(screen.getByLabelText('上传角色母版'), { target: { files: [file] } })
 
     const composer = screen.getByLabelText('创作指令').closest('form')
-    expect(screen.getByLabelText('创作指令').tagName).toBe('TEXTAREA')
+    expect(screen.getByLabelText('创作指令').tagName).toBe('INPUT')
     expect(composer?.textContent).toContain('hero.png')
     expect(screen.getByRole('button', { name: '移除图片' }).closest('form')).toBe(composer)
     expect(composer?.querySelector('[data-layout="quick-start-attachment-row"]')).toBeNull()

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -355,20 +355,20 @@ function QuickStartInput({
         <div data-layout="quick-start-composer" className="mx-auto w-full max-w-3xl self-end">
           <form
             onSubmit={(event) => void submit(event)}
-            className="grid items-center gap-1.5 rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent sm:grid-cols-[1fr_auto_auto]"
+            className="grid items-center gap-1.5 rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)] sm:grid-cols-[1fr_auto_auto]"
           >
             <label className="min-w-0" htmlFor="quick-start-prompt">
               <span className="sr-only">创作指令</span>
-              <textarea
+              <input
                 id="quick-start-prompt"
+                type="text"
                 aria-label="创作指令"
                 value={prompt}
                 onChange={(event) => setPrompt(event.target.value)}
-                rows={2}
                 placeholder={
                   templateFile ? '描述动作，可留空生成待机动作…' : '描述角色的外形、身份和气质…'
                 }
-                className="min-h-10 w-full min-w-0 resize-none border-0 bg-transparent px-3 py-2 text-[15px] leading-6 text-app-ink outline-none placeholder:text-app-faint"
+                className="h-10 w-full min-w-0 border-0 bg-transparent px-3 text-[15px] text-app-ink outline-none placeholder:text-app-faint"
               />
             </label>
 

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -241,17 +241,6 @@ function QuickStartInput({
   const hasPrompt = Boolean(prompt.trim())
   const showStylePrompts = !hasPrompt && !templateFile
 
-  const originalPromptShortcuts = [
-    {
-      label: '像素守夜人',
-      prompt: '一位提着风灯、披深色斗篷的像素守夜人',
-    },
-    {
-      label: '轻装信使',
-      prompt: '轻装信使，侧视像素风，轮廓清晰，动作轻快',
-    },
-  ] as const
-
   useEffect(
     () => () => {
       submitAbortController.current?.abort()
@@ -358,28 +347,6 @@ function QuickStartInput({
               >
                 <strong className="text-sm font-semibold text-app-ink">{stylePrompt.title}</strong>
                 <span className="text-[11px] text-app-muted">{stylePrompt.detail}</span>
-              </button>
-            ))}
-          </div>
-          <div
-            data-layout="quick-start-original-shortcuts"
-            data-presence={showStylePrompts ? 'visible' : 'hidden'}
-            aria-hidden={!showStylePrompts}
-            className={`flex flex-wrap justify-center gap-2 transition-[opacity,transform,filter] duration-[460ms] motion-reduce:transition-none ${
-              showStylePrompts
-                ? 'translate-y-0 opacity-100 blur-0'
-                : 'pointer-events-none -translate-y-1 opacity-0 blur-[4px]'
-            }`}
-          >
-            {originalPromptShortcuts.map((shortcut) => (
-              <button
-                key={shortcut.label}
-                type="button"
-                disabled={!showStylePrompts}
-                onClick={() => setPrompt(shortcut.prompt)}
-                className="rounded-full border border-app-line px-3 py-1.5 text-xs font-medium text-app-muted transition hover:border-app-line-strong hover:text-app-accent"
-              >
-                {shortcut.label}
               </button>
             ))}
           </div>


### PR DESCRIPTION
重构 Quick Start 的角色创建入口：收紧为单行底部输入器，用风格提示替代角色样例卡，并增加只描述角色外形与身份的轮换灵感和逐字镜像动效。生成服务、路由、导出与异常处理均保持原样。

> 依赖 #302；该 PR 合并后，本 PR 的差异会自动收敛为 Quick Start 专属提交。

## Why

原入口包含冗余说明、无意义像素装饰和过高输入框，视觉重心分散；角色示例与真实生成能力也容易产生误导。

## Changes

- 删除入口标题说明、装饰像素图与无效辅助文案。
- 使用三张风格提示卡，选中后填入对应像素风格描述并消散隐藏。
- 首句只显示一次，随后循环八条角色身份、外形、服装和配饰灵感。
- 输入后切换为常驻“用文字塑造你的角色……”。
- 将母版、输入和生成操作收进底部单行 composer。

## Implementation

- 在 #302 的公共整句字幕基础上叠加 `KineticCopyCycle`：支持消息替换、循环起点、可选前缀与逐字镜像进退场。
- 保留 `service.start`、`startWithUploadedTemplate`、导航、错误处理、`ExportButton` 和运行态逻辑。

## Verification

- [x] `npm test --prefix frontend -- src/shared/ui/kinetic-copy.test.tsx src/pages/quick-start/index.test.tsx src/features/account-panel/index.test.tsx --configLoader runner`：3 files / 47 tests passed
- [x] `npm run typecheck --prefix frontend`：passed
- [x] `git diff --check`：passed
- [x] 本轮界面已由用户确认，不重复执行视觉验收

## Screenshots

### Desktop

![Quick Start entry](https://raw.githubusercontent.com/huyanxius/Windup/feat/274-quick-start-entry/.github/assets/quick-start/quick-start-entry-desktop.jpg)

## Scope

- 本 PR 不包含：API、实体、后端、路由或生成流程改动。
- 本 PR 当前包含依赖 #302 的两个公共层提交；#302 合并后自动从差异中消失。

## Related Issues

Refs #274
Refs #301
