### PR TITLE
feat(frontend): 积分余额与流水查询展示

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -1,11 +1,23 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 
-import type { AuthTokens, UserApis } from '@/entities'
+import type { AuthTokens, CreditAccount, UserApis } from '@/entities'
+import { quotaApis } from '@/entities'
 import { AuthSessionProvider } from '@/features/auth-session'
 import { AppHeader } from './app-header'
+
+const quotaAccount: CreditAccount = {
+  id: '1',
+  userId: '7',
+  balance: 128,
+  frozen: 10,
+  totalEarned: 200,
+  totalSpent: 72,
+  createdAt: '2026-08-01T01:02:03Z',
+  updatedAt: '2026-08-07T01:02:03Z',
+}
 
 const user = {
   id: '7',
@@ -70,6 +82,11 @@ afterEach(() => {
   cleanup()
   window.localStorage.clear()
   window.history.replaceState({ idx: 0 }, '')
+  vi.restoreAllMocks()
+})
+
+beforeEach(() => {
+  vi.spyOn(quotaApis, 'getBalance').mockResolvedValue(quotaAccount)
 })
 
 describe('AppHeader', () => {
@@ -295,5 +312,31 @@ describe('AppHeader', () => {
     expect(
       screen.getByRole('link', { name: '项目资产' }).querySelectorAll('.app-header-wave-glyph'),
     ).toHaveLength('项目资产项目'.length)
+  })
+
+  it('在账号菜单里展示当前积分余额', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    renderHeader('/workspace')
+
+    const accountMenu = await screen.findByRole('button', { name: '打开账号菜单' })
+    await waitFor(() => expect(quotaApis.getBalance).toHaveBeenCalled())
+
+    fireEvent.click(accountMenu)
+    const balance = screen.getByLabelText('积分余额')
+    expect(balance.textContent).toContain('128')
+
+    fireEvent.click(screen.getByRole('button', { name: '退出登录' }))
+    await waitFor(() => expect(screen.queryByLabelText('积分余额')).toBeNull())
+  })
+
+  it('积分余额查询失败时在菜单里给出可读反馈', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    vi.spyOn(quotaApis, 'getBalance').mockRejectedValueOnce(new Error('积分服务不可用'))
+    renderHeader('/workspace')
+
+    const accountMenu = await screen.findByRole('button', { name: '打开账号菜单' })
+    fireEvent.click(accountMenu)
+
+    await waitFor(() => expect(screen.getByLabelText('积分余额').textContent).toContain('加载失败'))
   })
 })

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 
 import { useAuthSession } from '@/features/auth-session'
+import { useQuotaBalance } from '@/features/quota'
 import { PageBackButton } from './page-back-button'
 
 interface ProductNavigationItem {
@@ -60,6 +61,35 @@ function WaveText({ playId, text }: { playId: number; text: string }) {
         </span>
       ))}
     </span>
+  )
+}
+
+/**
+ * 账号菜单里的积分余额。挂载点本身已限定在登录态分支，因此始终 enabled。
+ * 只展示余额这一条轻量信息，流水明细交给账号中心页。
+ */
+function QuotaBalanceRow() {
+  const { status, account, error } = useQuotaBalance(true)
+  return (
+    <div
+      aria-label="积分余额"
+      className="mb-1 grid min-h-10 items-center rounded-md border-b border-app-ink/8 px-3 py-2"
+    >
+      <span className="text-[11px] leading-4 text-app-faint">积分余额</span>
+      {status === 'loading' ? (
+        <span className="text-[13px] leading-5 text-app-muted">正在查询…</span>
+      ) : status === 'error' ? (
+        <span className="text-[12px] leading-5 text-app-danger" title={error ?? undefined}>
+          加载失败
+        </span>
+      ) : account ? (
+        <span className="font-mono text-[15px] leading-6 font-semibold text-app-ink">
+          {account.balance.toLocaleString('zh-CN')}
+        </span>
+      ) : (
+        <span className="text-[13px] leading-5 text-app-muted">—</span>
+      )}
+    </div>
   )
 }
 
@@ -243,6 +273,7 @@ export function AppHeader() {
                       : 'invisible pointer-events-none -translate-y-2 scale-[0.82] opacity-0'
                 }`}
               >
+                <QuotaBalanceRow />
                 <Link
                   to="/account"
                   aria-label="打开账号中心"

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -66,6 +66,19 @@ export type { GenerationApiConfig, GenerationTransport } from './generation/api'
 export { createMediaApis } from './media/api'
 export type { MediaApis, MediaCategory, MediaReference } from './media'
 
+/* 积分 —— 账户余额与流水查询 */
+export { createQuotaApis, quotaApis } from './quota'
+export type {
+  BillingMode,
+  CreateQuotaApisOptions,
+  CreditAccount,
+  CreditReason,
+  CreditTransaction,
+  QuotaApis,
+  QuotaTransactionPageQuery,
+} from './quota'
+export { BILLING_MODE_LABELS, CREDIT_REASON_LABELS } from './quota'
+
 /* 工作流 —— 前端管理节点，后端只持久化完整 nodes 文档 */
 export { workflowRunApis } from './workflow-run'
 export type {

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ApiClient } from '@/shared/api'
+
+import { createQuotaApis } from './api'
+
+const balanceResponse = {
+  id: 1,
+  user_id: 7,
+  balance: 128,
+  frozen: 10,
+  total_earned: 200,
+  total_spent: 72,
+  create_at: '2026-08-01T01:02:03Z',
+  update_at: '2026-08-07T01:02:03Z',
+}
+
+const transactionResponse = {
+  id: 11,
+  user_id: 7,
+  delta: -12,
+  reason: 8,
+  billing_mode: 0,
+  ref_id: 'gen-42',
+  balance_after: 116,
+  create_at: '2026-08-07T01:02:03Z',
+}
+
+describe('createQuotaApis', () => {
+  let request: ReturnType<typeof vi.fn>
+  let requestList: ReturnType<typeof vi.fn>
+  let client: ApiClient
+
+  beforeEach(() => {
+    request = vi.fn()
+    requestList = vi.fn()
+    client = {
+      request: request as unknown as ApiClient['request'],
+      requestList: requestList as unknown as ApiClient['requestList'],
+    }
+  })
+
+  it('maps the balance command to /quota/balance and converts the account payload', async () => {
+    request.mockResolvedValue(balanceResponse)
+    const apis = createQuotaApis({ client })
+
+    await expect(apis.getBalance()).resolves.toEqual({
+      id: '1',
+      userId: '7',
+      balance: 128,
+      frozen: 10,
+      totalEarned: 200,
+      totalSpent: 72,
+      createdAt: '2026-08-01T01:02:03Z',
+      updatedAt: '2026-08-07T01:02:03Z',
+    })
+    expect(request).toHaveBeenCalledWith('/quota/balance')
+  })
+
+  it('maps the transactions command to /quota/transactions with pagination and converts rows', async () => {
+    requestList.mockResolvedValue({
+      items: [transactionResponse],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    })
+    const apis = createQuotaApis({ client })
+
+    await expect(apis.listTransactions({ page: 2, pageSize: 20 })).resolves.toEqual({
+      items: [
+        {
+          id: '11',
+          userId: '7',
+          delta: -12,
+          reason: 'captured',
+          billingMode: 'prepaid',
+          refId: 'gen-42',
+          balanceAfter: 116,
+          createdAt: '2026-08-07T01:02:03Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    })
+    expect(requestList).toHaveBeenCalledWith('/quota/transactions', {
+      query: { page: 2, page_size: 20 },
+    })
+  })
+
+  it.each([
+    ['missing id', { ...balanceResponse, id: null }],
+    ['missing balance', { ...balanceResponse, balance: '128' }],
+  ])('rejects a successful balance response with %s', async (_label, response) => {
+    request.mockResolvedValue(response)
+    const apis = createQuotaApis({ client })
+
+    await expect(apis.getBalance()).rejects.toMatchObject({
+      name: 'ApiError',
+      kind: 'invalid-response',
+    })
+  })
+
+  it.each([
+    ['unknown reason', { ...transactionResponse, reason: 99 }],
+    ['missing delta', { ...transactionResponse, delta: null }],
+  ])('rejects a successful transaction row with %s', async (_label, response) => {
+    requestList.mockResolvedValue({
+      items: [response],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    })
+    const apis = createQuotaApis({ client })
+
+    await expect(apis.listTransactions()).rejects.toMatchObject({
+      name: 'ApiError',
+      kind: 'invalid-response',
+    })
+  })
+
+  it('recovers and replays protected quota requests after unauthorized', async () => {
+    const recover = vi.fn(async () => true)
+    const unregister = await import('@/shared/api').then(({ registerApiUnauthorizedRecovery }) =>
+      registerApiUnauthorizedRecovery(recover),
+    )
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 401, message: 'access token expired', data: null }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 200, message: 'ok', data: balanceResponse }), {
+          status: 200,
+        }),
+      )
+    const apis = createQuotaApis({ baseUrl: 'https://api.windup.test', fetchFn })
+
+    try {
+      await expect(apis.getBalance()).resolves.toMatchObject({ balance: 128 })
+      expect(recover).toHaveBeenCalledTimes(1)
+      expect(fetchFn).toHaveBeenCalledTimes(2)
+    } finally {
+      unregister()
+    }
+  })
+})

--- a/frontend/src/entities/quota/api.ts
+++ b/frontend/src/entities/quota/api.ts
@@ -1,0 +1,158 @@
+import type {
+  BillingMode,
+  CreditAccount,
+  CreditReason,
+  CreditTransaction,
+  QuotaApis,
+  QuotaTransactionPageQuery,
+} from '.'
+import { ApiError, createApiClient } from '@/shared/api'
+import type { ApiClient, ApiClientOptions } from '@/shared/api'
+
+interface CreditAccountDto {
+  id: number
+  user_id: number
+  balance: number
+  frozen: number
+  total_earned: number
+  total_spent: number
+  create_at: string
+  update_at: string
+}
+
+interface CreditTransactionDto {
+  id: number
+  user_id: number
+  delta: number
+  reason: number
+  billing_mode: number
+  ref_id: string | null
+  balance_after: number
+  create_at: string
+}
+
+export interface CreateQuotaApisOptions extends ApiClientOptions {
+  client?: ApiClient
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function invalidResponse(data: unknown): never {
+  throw new ApiError('积分响应格式无效', { kind: 'invalid-response', data })
+}
+
+const reasonFromDto: Record<number, CreditReason> = {
+  1: 'register-gift',
+  2: 'invite-reward',
+  3: 'generate-image',
+  4: 'generate-action',
+  5: 'admin-adjust',
+  6: 'refund',
+  7: 'frozen',
+  8: 'captured',
+}
+
+const billingModeFromDto: Record<number, BillingMode> = {
+  0: 'prepaid',
+}
+
+function mapCreditReason(value: number): CreditReason {
+  const reason = reasonFromDto[value]
+  if (reason !== undefined) return reason
+  return invalidResponse(value)
+}
+
+function mapBillingMode(value: number): BillingMode {
+  const mode = billingModeFromDto[value]
+  if (mode !== undefined) return mode
+  return invalidResponse(value)
+}
+
+function mapCreditAccount(dto: CreditAccountDto): CreditAccount {
+  if (
+    !isRecord(dto) ||
+    !Number.isInteger(dto.id) ||
+    dto.id <= 0 ||
+    !Number.isInteger(dto.user_id) ||
+    dto.user_id <= 0 ||
+    !Number.isInteger(dto.balance) ||
+    !Number.isInteger(dto.frozen) ||
+    !Number.isInteger(dto.total_earned) ||
+    !Number.isInteger(dto.total_spent) ||
+    typeof dto.create_at !== 'string' ||
+    typeof dto.update_at !== 'string'
+  ) {
+    return invalidResponse(dto)
+  }
+  return {
+    id: String(dto.id),
+    userId: String(dto.user_id),
+    balance: dto.balance,
+    frozen: dto.frozen,
+    totalEarned: dto.total_earned,
+    totalSpent: dto.total_spent,
+    createdAt: dto.create_at,
+    updatedAt: dto.update_at,
+  }
+}
+
+function mapCreditTransaction(dto: CreditTransactionDto): CreditTransaction {
+  if (
+    !isRecord(dto) ||
+    !Number.isInteger(dto.id) ||
+    dto.id <= 0 ||
+    !Number.isInteger(dto.user_id) ||
+    dto.user_id <= 0 ||
+    !Number.isInteger(dto.delta) ||
+    (typeof dto.ref_id !== 'string' && dto.ref_id !== null) ||
+    !Number.isInteger(dto.balance_after) ||
+    typeof dto.create_at !== 'string'
+  ) {
+    return invalidResponse(dto)
+  }
+  return {
+    id: String(dto.id),
+    userId: String(dto.user_id),
+    delta: dto.delta,
+    reason: mapCreditReason(dto.reason),
+    billingMode: mapBillingMode(dto.billing_mode),
+    refId: dto.ref_id,
+    balanceAfter: dto.balance_after,
+    createdAt: dto.create_at,
+  }
+}
+
+export function createQuotaApis(options: CreateQuotaApisOptions = {}): QuotaApis {
+  const { client, ...clientOptions } = options
+  const apiClient = client ?? createApiClient(clientOptions)
+
+  return {
+    async getBalance() {
+      return mapCreditAccount(await apiClient.request<CreditAccountDto>('/quota/balance'))
+    },
+    async listTransactions(query: QuotaTransactionPageQuery = {}) {
+      const result = await apiClient.requestList<CreditTransactionDto>('/quota/transactions', {
+        query: {
+          page: query.page,
+          page_size: query.pageSize,
+        },
+      })
+      return { ...result, items: result.items.map(mapCreditTransaction) }
+    },
+  }
+}
+
+let defaultApis: QuotaApis | undefined
+
+function getDefaultApis(): QuotaApis {
+  defaultApis ??= createQuotaApis()
+  return defaultApis
+}
+
+/** 延迟创建默认 client，避免仅导入 entities 时要求运行环境已经配置 API 地址。 */
+export const quotaApis: QuotaApis = {
+  getBalance: () => getDefaultApis().getBalance(),
+  listTransactions: (query) => getDefaultApis().listTransactions(query),
+}

--- a/frontend/src/entities/quota/index.ts
+++ b/frontend/src/entities/quota/index.ts
@@ -1,0 +1,65 @@
+import type { Paged, PageQuery } from '@/shared/pagination'
+
+/** 积分账户 —— 当前用户的积分余额与累计统计。 */
+export interface CreditAccount {
+  id: string
+  userId: string
+  balance: number
+  frozen: number
+  totalEarned: number
+  totalSpent: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** 积分变动原因（对应后端 CreditReason）。 */
+export type CreditReason =
+  | 'register-gift'
+  | 'invite-reward'
+  | 'generate-image'
+  | 'generate-action'
+  | 'admin-adjust'
+  | 'refund'
+  | 'frozen'
+  | 'captured'
+
+export const CREDIT_REASON_LABELS: Record<CreditReason, string> = {
+  'register-gift': '注册赠送',
+  'invite-reward': '邀请奖励',
+  'generate-image': '生成角色参考图',
+  'generate-action': '生成角色动作',
+  'admin-adjust': '管理员调整',
+  refund: '退款 / 回退',
+  frozen: '冻结',
+  captured: '扣减',
+}
+
+/** 计费模式（对应后端 BillingMode）；后端目前只有预付费。 */
+export type BillingMode = 'prepaid'
+
+export const BILLING_MODE_LABELS: Record<BillingMode, string> = {
+  prepaid: '预付费',
+}
+
+/** 积分流水 —— 一次余额变动。 */
+export interface CreditTransaction {
+  id: string
+  userId: string
+  delta: number
+  reason: CreditReason
+  billingMode: BillingMode
+  refId: string | null
+  balanceAfter: number
+  createdAt: string
+}
+
+export type QuotaTransactionPageQuery = PageQuery
+
+/** 积分模块对应的一组后端接口。 */
+export interface QuotaApis {
+  getBalance(): Promise<CreditAccount>
+  listTransactions(query?: QuotaTransactionPageQuery): Promise<Paged<CreditTransaction>>
+}
+
+export { createQuotaApis, quotaApis } from './api'
+export type { CreateQuotaApisOptions } from './api'

--- a/frontend/src/features/quota/index.test.ts
+++ b/frontend/src/features/quota/index.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { act } from 'react'
+
+import type { CreditAccount, CreditTransaction, QuotaApis } from '@/entities'
+
+import { formatCreditDateTime, useQuotaBalance, useQuotaTransactions } from '.'
+
+const account: CreditAccount = {
+  id: '1',
+  userId: '7',
+  balance: 128,
+  frozen: 10,
+  totalEarned: 200,
+  totalSpent: 72,
+  createdAt: '2026-08-01T01:02:03Z',
+  updatedAt: '2026-08-07T01:02:03Z',
+}
+
+const transactions: CreditTransaction[] = [
+  {
+    id: '11',
+    userId: '7',
+    delta: -12,
+    reason: 'captured',
+    billingMode: 'prepaid',
+    refId: 'gen-42',
+    balanceAfter: 116,
+    createdAt: '2026-08-07T01:02:03Z',
+  },
+]
+
+function createApis() {
+  return {
+    getBalance: vi.fn(async () => account),
+    listTransactions: vi.fn(async () => ({
+      items: transactions,
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    })),
+  } satisfies QuotaApis
+}
+
+describe('useQuotaBalance', () => {
+  it('loads the balance when enabled and exposes it as ready', async () => {
+    const apis = createApis()
+    const { result } = renderHook(() => useQuotaBalance(true, apis))
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.account).toEqual(account)
+    expect(result.current.error).toBeNull()
+    expect(apis.getBalance).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not issue a request while disabled', () => {
+    const apis = createApis()
+    const { result } = renderHook(() => useQuotaBalance(false, apis))
+
+    expect(result.current.status).toBe('loading')
+    expect(apis.getBalance).not.toHaveBeenCalled()
+  })
+
+  it('reports a readable error instead of throwing when the request fails', async () => {
+    const apis = createApis()
+    apis.getBalance.mockRejectedValue(new Error('积分服务不可用'))
+    const { result } = renderHook(() => useQuotaBalance(true, apis))
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.account).toBeNull()
+    expect(result.current.error).toBe('积分服务不可用')
+  })
+
+  it('treats a synchronous failure as an error state too', async () => {
+    const apis = createApis()
+    apis.getBalance.mockImplementation(() => {
+      throw new Error('API 地址未配置')
+    })
+    const { result } = renderHook(() => useQuotaBalance(true, apis))
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error).toBe('API 地址未配置')
+  })
+
+  it('refetches after reload', async () => {
+    const apis = createApis()
+    const { result } = renderHook(() => useQuotaBalance(true, apis))
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    act(() => result.current.reload())
+
+    await waitFor(() => expect(apis.getBalance).toHaveBeenCalledTimes(2))
+    expect(result.current.status).toBe('ready')
+  })
+})
+
+describe('useQuotaTransactions', () => {
+  it('loads the first page of transactions when enabled', async () => {
+    const apis = createApis()
+    const { result } = renderHook(() => useQuotaTransactions(true, apis))
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(result.current.transactions).toEqual(transactions)
+    expect(result.current.total).toBe(1)
+    expect(apis.listTransactions).toHaveBeenCalledWith({ page: 1, pageSize: 20 })
+  })
+
+  it('loads a requested page', async () => {
+    const apis = createApis()
+    const { result } = renderHook(() => useQuotaTransactions(true, apis))
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    act(() => result.current.loadPage(3))
+
+    await waitFor(() =>
+      expect(apis.listTransactions).toHaveBeenLastCalledWith({ page: 3, pageSize: 20 }),
+    )
+  })
+
+  it('does not issue a request while disabled', () => {
+    const apis = createApis()
+    const { result } = renderHook(() => useQuotaTransactions(false, apis))
+
+    expect(result.current.status).toBe('loading')
+    expect(apis.listTransactions).not.toHaveBeenCalled()
+  })
+
+  it('reports a readable error when the request fails', async () => {
+    const apis = createApis()
+    apis.listTransactions.mockRejectedValue(new Error('流水读取失败'))
+    const { result } = renderHook(() => useQuotaTransactions(true, apis))
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error).toBe('流水读取失败')
+  })
+})
+
+describe('formatCreditDateTime', () => {
+  it('formats an ISO timestamp in zh-CN', () => {
+    const formatted = formatCreditDateTime('2026-08-07T01:02:03Z')
+    expect(formatted).toContain('2026')
+    expect(formatted).toContain('08')
+  })
+
+  it('returns a stable fallback for invalid values', () => {
+    expect(formatCreditDateTime('not-a-date')).toBe('时间未知')
+  })
+})

--- a/frontend/src/features/quota/index.ts
+++ b/frontend/src/features/quota/index.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type { CreditAccount, CreditTransaction, QuotaApis } from '@/entities'
+import { quotaApis } from '@/entities'
+
+const TRANSACTIONS_PAGE_SIZE = 20
+
+export type QuotaBalanceStatus = 'loading' | 'ready' | 'error'
+
+export interface QuotaBalanceState {
+  status: QuotaBalanceStatus
+  account: CreditAccount | null
+  error: string | null
+  reload(): void
+}
+
+type QuotaBalanceResult =
+  | { status: 'loading'; account: null; error: null }
+  | { status: 'ready'; account: CreditAccount; error: null }
+  | { status: 'error'; account: null; error: string }
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : '积分加载失败，请稍后重试'
+}
+
+/** 查询当前用户积分余额；enabled=false 时不发起请求，用于访客态。 */
+export function useQuotaBalance(enabled: boolean, apis: QuotaApis = quotaApis): QuotaBalanceState {
+  const [attempt, setAttempt] = useState(0)
+  const [result, setResult] = useState<QuotaBalanceResult>({
+    status: 'loading',
+    account: null,
+    error: null,
+  })
+
+  useEffect(() => {
+    if (!enabled) return
+    let active = true
+    setResult({ status: 'loading', account: null, error: null })
+    // createApiClient 可能在配置缺失时同步抛错，放进微任务再进入统一的错误分支。
+    void Promise.resolve()
+      .then(() => apis.getBalance())
+      .then(
+        (account) => {
+          if (active) setResult({ status: 'ready', account, error: null })
+        },
+        (error: unknown) => {
+          if (active) setResult({ status: 'error', account: null, error: errorMessage(error) })
+        },
+      )
+    return () => {
+      active = false
+    }
+  }, [apis, attempt, enabled])
+
+  const reload = useCallback(() => setAttempt((current) => current + 1), [])
+
+  return { ...result, reload }
+}
+
+export type QuotaTransactionsStatus = 'loading' | 'ready' | 'error'
+
+export interface QuotaTransactionsState {
+  status: QuotaTransactionsStatus
+  transactions: CreditTransaction[]
+  total: number
+  page: number
+  pageSize: number
+  error: string | null
+  loadPage(page: number): void
+  reload(): void
+}
+
+type QuotaTransactionsResult = {
+  status: QuotaTransactionsStatus
+  transactions: CreditTransaction[]
+  total: number
+  page: number
+  pageSize: number
+  error: string | null
+}
+
+const initialTransactionsResult: QuotaTransactionsResult = {
+  status: 'loading',
+  transactions: [],
+  total: 0,
+  page: 1,
+  pageSize: TRANSACTIONS_PAGE_SIZE,
+  error: null,
+}
+
+/** 分页查询当前用户积分流水；enabled=false 时不发起请求。 */
+export function useQuotaTransactions(
+  enabled: boolean,
+  apis: QuotaApis = quotaApis,
+): QuotaTransactionsState {
+  const [attempt, setAttempt] = useState(0)
+  const [page, setPage] = useState(1)
+  const [result, setResult] = useState<QuotaTransactionsResult>(initialTransactionsResult)
+
+  useEffect(() => {
+    if (!enabled) return
+    let active = true
+    setResult((current) => ({ ...current, status: 'loading', error: null }))
+    void Promise.resolve()
+      .then(() => apis.listTransactions({ page, pageSize: TRANSACTIONS_PAGE_SIZE }))
+      .then(
+        (paged) => {
+          if (active) {
+            setResult({
+              status: 'ready',
+              transactions: paged.items,
+              total: paged.total,
+              page: paged.page,
+              pageSize: paged.pageSize,
+              error: null,
+            })
+          }
+        },
+        (error: unknown) => {
+          if (active)
+            setResult((current) => ({ ...current, status: 'error', error: errorMessage(error) }))
+        },
+      )
+    return () => {
+      active = false
+    }
+  }, [apis, attempt, enabled, page])
+
+  const loadPage = useCallback((nextPage: number) => setPage(Math.max(1, nextPage)), [])
+  const reload = useCallback(() => {
+    setPage(1)
+    setAttempt((current) => current + 1)
+  }, [])
+
+  return { ...result, loadPage, reload }
+}
+
+const creditDateTimeFormatter = new Intl.DateTimeFormat('zh-CN', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+})
+
+/** 流水时间展示；无效值返回「时间未知」。 */
+export function formatCreditDateTime(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '时间未知'
+  return creditDateTimeFormatter.format(date)
+}

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, useLocation } from 'react-router'
 
-import type { AuthTokens, User, UserApis } from '@/entities'
+import type { AuthTokens, CreditAccount, CreditTransaction, User, UserApis } from '@/entities'
+import { quotaApis } from '@/entities'
 import { AuthSessionProvider } from '@/features/auth-session'
 import { AppRoutes } from '@/app/app'
 
@@ -13,6 +14,28 @@ const user: User = {
   nickname: 'Reader',
   emailVerifiedAt: '2026-08-07T01:02:03Z',
   statusCode: 0,
+}
+
+const quotaAccount: CreditAccount = {
+  id: '1',
+  userId: '7',
+  balance: 128,
+  frozen: 10,
+  totalEarned: 200,
+  totalSpent: 72,
+  createdAt: '2026-08-01T01:02:03Z',
+  updatedAt: '2026-08-07T01:02:03Z',
+}
+
+const quotaTransaction: CreditTransaction = {
+  id: '11',
+  userId: '7',
+  delta: -12,
+  reason: 'captured',
+  billingMode: 'prepaid',
+  refId: 'gen-42',
+  balanceAfter: 116,
+  createdAt: '2026-08-07T01:02:03Z',
 }
 
 function tokens(): AuthTokens {
@@ -68,6 +91,17 @@ function renderAccount(apis = createApis()) {
 afterEach(() => {
   cleanup()
   window.localStorage.clear()
+  vi.restoreAllMocks()
+})
+
+beforeEach(() => {
+  vi.spyOn(quotaApis, 'getBalance').mockResolvedValue(quotaAccount)
+  vi.spyOn(quotaApis, 'listTransactions').mockResolvedValue({
+    items: [quotaTransaction],
+    total: 1,
+    page: 1,
+    pageSize: 20,
+  })
 })
 
 describe('AccountPage', () => {
@@ -238,5 +272,37 @@ describe('AccountPage', () => {
 
     await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/'))
     expect(apis.logout).toHaveBeenCalledWith('rotated-refresh-token')
+  })
+
+  it('在积分页签展示余额概览与最近流水', async () => {
+    renderAccount()
+    fireEvent.click(await screen.findByRole('button', { name: '积分' }))
+
+    expect(await screen.findByRole('heading', { name: '积分' })).toBeTruthy()
+    await waitFor(() => expect(quotaApis.getBalance).toHaveBeenCalled())
+    expect(quotaApis.listTransactions).toHaveBeenCalledWith({ page: 1, pageSize: 20 })
+
+    expect(screen.getByText('当前余额')).toBeTruthy()
+    // Header 的积分行与积分页签概览都会展示余额，这里允许出现多次。
+    expect(screen.getAllByText('128').length).toBeGreaterThan(0)
+    expect(screen.getByText('冻结中')).toBeTruthy()
+    expect(screen.getByText('累计获得')).toBeTruthy()
+    expect(screen.getByText('累计消耗')).toBeTruthy()
+
+    expect(await screen.findByText('扣减')).toBeTruthy()
+    expect(screen.getByText('共 1 条')).toBeTruthy()
+    expect(screen.getByText('-12')).toBeTruthy()
+  })
+
+  it('积分查询失败时展示可读错误而不是崩溃', async () => {
+    // Header 的积分行会先消费一次查询，因此用持续拒绝而不是 Once，
+    // 保证切到积分页签时也能拿到失败结果。
+    vi.spyOn(quotaApis, 'getBalance').mockRejectedValue(new Error('积分服务不可用'))
+    vi.spyOn(quotaApis, 'listTransactions').mockRejectedValueOnce(new Error('流水读取失败'))
+    renderAccount()
+    fireEvent.click(await screen.findByRole('button', { name: '积分' }))
+
+    expect(await screen.findByText('积分服务不可用')).toBeTruthy()
+    expect(await screen.findByText('流水读取失败')).toBeTruthy()
   })
 })

--- a/frontend/src/pages/account/index.tsx
+++ b/frontend/src/pages/account/index.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useId, useReducer, useRef, useState, type FormEvent } from 'react'
 
 import accountBadgeArtwork from '@/assets/account/illustrations/account-badge.webp'
+import { CREDIT_REASON_LABELS } from '@/entities'
 import type { User } from '@/entities'
 import { useAuthSession } from '@/features/auth-session'
+import { formatCreditDateTime, useQuotaBalance, useQuotaTransactions } from '@/features/quota'
 
 import './account.css'
 import { createProfileState, initialSecurityState, profileReducer, securityReducer } from './state'
@@ -25,7 +27,125 @@ function formatVerificationTime(value: string): string {
   }).format(date)
 }
 
-/** 账号页以 /auth/me 为事实来源；会话层负责把刷新和编辑结果同步给 Header。 */
+function formatCredits(value: number): string {
+  return value.toLocaleString('zh-CN')
+}
+
+/** 积分页签：余额概览 + 最近流水。独立组件挂载即查询，切走再切回会刷新数据。 */
+function QuotaSection() {
+  const balance = useQuotaBalance(true)
+  const transactions = useQuotaTransactions(true)
+  const account = balance.account
+  const totalPages = Math.max(1, Math.ceil(transactions.total / transactions.pageSize))
+
+  const summaryRows: Array<[string, string]> = [
+    ['当前余额', account ? formatCredits(account.balance) : balance.status === 'error' ? '—' : '…'],
+    ['冻结中', account ? formatCredits(account.frozen) : '…'],
+    ['累计获得', account ? formatCredits(account.totalEarned) : '…'],
+    ['累计消耗', account ? formatCredits(account.totalSpent) : '…'],
+  ]
+
+  return (
+    <div>
+      <header>
+        <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">积分</h2>
+        <p className="mt-1.5 text-sm text-app-muted">查看你的积分余额与使用流水。</p>
+      </header>
+
+      <dl className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {summaryRows.map(([label, value]) => (
+          <div
+            key={label}
+            className="rounded-xl border border-app-line bg-app-surface-muted px-4 py-3"
+          >
+            <dt className="text-xs text-app-faint">{label}</dt>
+            <dd className="mt-1 font-mono text-2xl font-semibold text-app-ink">{value}</dd>
+          </div>
+        ))}
+      </dl>
+      {balance.status === 'error' && (
+        <p
+          role="alert"
+          className="mt-3 rounded-lg bg-app-danger-soft px-3 py-2.5 text-sm text-app-danger"
+        >
+          {balance.error}
+        </p>
+      )}
+
+      <div className="mt-6">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-app-ink-soft">最近流水</h3>
+          {transactions.status === 'ready' && (
+            <span className="text-xs text-app-faint">共 {transactions.total} 条</span>
+          )}
+        </div>
+
+        {transactions.status === 'loading' ? (
+          <p className="mt-3 text-sm text-app-muted">正在加载流水…</p>
+        ) : transactions.status === 'error' ? (
+          <p
+            role="alert"
+            className="mt-3 rounded-lg bg-app-danger-soft px-3 py-2.5 text-sm text-app-danger"
+          >
+            {transactions.error}
+          </p>
+        ) : transactions.transactions.length === 0 ? (
+          <p className="mt-3 text-sm text-app-muted">还没有积分流水。</p>
+        ) : (
+          <ul className="mt-3 divide-y divide-app-line overflow-hidden rounded-xl border border-app-line bg-app-surface-muted">
+            {transactions.transactions.map((transaction) => (
+              <li key={transaction.id} className="flex items-center gap-4 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-app-ink-soft">
+                    {CREDIT_REASON_LABELS[transaction.reason]}
+                  </p>
+                  <p className="mt-0.5 text-xs text-app-faint">
+                    {formatCreditDateTime(transaction.createdAt)} · 余额{' '}
+                    {formatCredits(transaction.balanceAfter)}
+                  </p>
+                </div>
+                <span
+                  className={`shrink-0 font-mono text-sm font-semibold ${
+                    transaction.delta >= 0 ? 'text-app-accent' : 'text-app-danger'
+                  }`}
+                >
+                  {transaction.delta > 0 ? '+' : ''}
+                  {formatCredits(transaction.delta)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {totalPages > 1 && (
+          <div className="mt-3 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              disabled={transactions.page <= 1}
+              onClick={() => transactions.loadPage(transactions.page - 1)}
+              className="rounded-md border border-app-line px-3 py-1.5 text-xs font-medium text-app-ink-soft transition-colors hover:bg-app-accent-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:text-app-faint"
+            >
+              上一页
+            </button>
+            <span className="text-xs text-app-faint">
+              {transactions.page} / {totalPages}
+            </span>
+            <button
+              type="button"
+              disabled={transactions.page >= totalPages}
+              onClick={() => transactions.loadPage(transactions.page + 1)}
+              className="rounded-md border border-app-line px-3 py-1.5 text-xs font-medium text-app-ink-soft transition-colors hover:bg-app-accent-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:text-app-faint"
+            >
+              下一页
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** 账号中心页以 /auth/me 为事实来源；会话层负责把刷新和编辑结果同步给 Header。 */
 export function AccountPage() {
   const session = useAuthSession()
   const {
@@ -42,7 +162,7 @@ export function AccountPage() {
     createProfileState,
   )
   const [security, dispatchSecurity] = useReducer(securityReducer, initialSecurityState)
-  const [activeSection, setActiveSection] = useState<'profile' | 'security'>('profile')
+  const [activeSection, setActiveSection] = useState<'profile' | 'security' | 'quota'>('profile')
   const nicknameId = useId()
   const oldPasswordId = useId()
   const newPasswordId = useId()
@@ -114,7 +234,7 @@ export function AccountPage() {
     void logout().catch(() => undefined)
   }
 
-  function selectSection(section: 'profile' | 'security') {
+  function selectSection(section: 'profile' | 'security' | 'quota') {
     setActiveSection(section)
     dispatchProfile({ type: 'sectionChanged' })
     dispatchSecurity({ type: 'sectionChanged' })
@@ -175,6 +295,7 @@ export function AccountPage() {
                 [
                   ['profile', '个人资料'],
                   ['security', '登录安全'],
+                  ['quota', '积分'],
                 ] as const
               ).map(([section, label]) => (
                 <button
@@ -298,7 +419,7 @@ export function AccountPage() {
                   </div>
                 </form>
               </div>
-            ) : (
+            ) : activeSection === 'security' ? (
               <div>
                 <header>
                   <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">
@@ -371,6 +492,8 @@ export function AccountPage() {
                   </button>
                 </form>
               </div>
+            ) : (
+              <QuotaSection />
             )}
           </section>
         </div>


### PR DESCRIPTION
## 概述

本 PR 在前端实现积分余额与流水的查询展示，对接已在 #230 合入后端 `/quota/balance` 与 `/quota/transactions` 接口。

## 改动内容

- **实体层** `frontend/src/entities/quota/`
  - 新增积分类型定义（`CreditAccount`、`CreditTransaction`、`CreditReason`、`BillingMode` 等）与标签映射
  - 新增 `createQuotaApis` API 客户端，封装余额查询与流水查询
  - `frontend/src/entities/index.ts` 导出积分模块
- **特性层** `frontend/src/features/quota/`
  - 新增 `useQuotaBalance` / `useQuotaTransactions` hooks，处理加载 / 成功 / 失败状态与分页
- **展示层**
  - 顶部账号菜单展示当前积分余额（`app-header.tsx`）
  - 账号中心新增「积分」页签，展示余额概览与最近流水（`pages/account/index.tsx`）
- **测试**：为 API 客户端、hooks、顶部菜单与账号中心页签补充单元测试

## 说明

- 仅包含积分功能必要代码，未触及 `main` 分支
- 需在登录态下查看；访客态不发起请求
