### PR TITLE
feat(frontend): 在账号菜单展示积分余额

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 
-import type { AuthTokens, UserApis } from '@/entities'
+import type { AuthTokens, CreditAccount, QuotaApis, UserApis } from '@/entities'
 import { AuthSessionProvider } from '@/features/auth-session'
 import { AppHeader } from './app-header'
 
@@ -33,6 +33,21 @@ function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn
   }
 }
 
+const creditAccount: CreditAccount = {
+  id: '11',
+  userId: '7',
+  balance: 90,
+  frozen: 10,
+  totalEarned: 150,
+  totalSpent: 50,
+  createdAt: '2026-08-12T01:02:03Z',
+  updatedAt: '2026-08-17T01:02:03Z',
+}
+
+function createQuotaMock(): QuotaApis & { getBalance: ReturnType<typeof vi.fn> } {
+  return { getBalance: vi.fn(async () => creditAccount) }
+}
+
 function LocationProbe() {
   const location = useLocation()
   return (
@@ -40,9 +55,15 @@ function LocationProbe() {
   )
 }
 
-function renderHeader(entry = '/', apis = createApis(), previousEntry?: string) {
+function renderHeader(
+  entry = '/',
+  apis = createApis(),
+  previousEntry?: string,
+  quota = createQuotaMock(),
+) {
   return {
     apis,
+    quota,
     ...render(
       <AuthSessionProvider apis={apis}>
         <MemoryRouter
@@ -54,7 +75,7 @@ function renderHeader(entry = '/', apis = createApis(), previousEntry?: string) 
               path="*"
               element={
                 <>
-                  <AppHeader />
+                  <AppHeader quotaApis={quota} />
                   <LocationProbe />
                 </>
               }
@@ -260,6 +281,41 @@ describe('AppHeader', () => {
 
     await waitFor(() => expect(menuSurface.getAttribute('data-state')).toBe('closed'))
     expect(menuSurface.classList.contains('invisible')).toBe(true)
+  })
+
+  it('打开账号菜单时查询并展示最新可用积分', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    let resolveBalance: (account: CreditAccount) => void = () => undefined
+    const quota = createQuotaMock()
+    quota.getBalance.mockReturnValue(
+      new Promise<CreditAccount>((resolve) => {
+        resolveBalance = resolve
+      }),
+    )
+    renderHeader('/workspace', createApis(), undefined, quota)
+
+    fireEvent.click(await screen.findByRole('button', { name: '打开账号菜单' }))
+
+    expect(quota.getBalance).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('可用积分')).toBeTruthy()
+    expect(screen.getByText('查询中…')).toBeTruthy()
+
+    resolveBalance(creditAccount)
+    expect(await screen.findByText('90')).toBeTruthy()
+    expect(screen.getByText('积分')).toBeTruthy()
+  })
+
+  it('积分查询失败时保留账号菜单的其他操作', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    const quota = createQuotaMock()
+    quota.getBalance.mockRejectedValue(new Error('积分接口不可用'))
+    renderHeader('/workspace', createApis(), undefined, quota)
+
+    fireEvent.click(await screen.findByRole('button', { name: '打开账号菜单' }))
+
+    expect(await screen.findByText('积分暂不可用')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '打开账号中心' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '退出登录' })).toBeTruthy()
   })
 
   it('使用贴顶毛玻璃栏承载品牌、产品导航与账号入口', async () => {

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 
+import { quotaApis as defaultQuotaApis } from '@/entities'
+import type { QuotaApis } from '@/entities'
 import { useAuthSession } from '@/features/auth-session'
 import { PageBackButton } from './page-back-button'
 
@@ -13,6 +15,14 @@ interface ProductNavigationItem {
 }
 
 type AccountMenuState = 'closed' | 'open' | 'closing'
+type CreditBalanceState =
+  | { status: 'idle' | 'loading'; balance: null }
+  | { status: 'loaded'; balance: number }
+  | { status: 'error'; balance: null }
+
+export interface AppHeaderProps {
+  quotaApis?: QuotaApis
+}
 
 const accountMenuExitDurationMs = 260
 
@@ -67,12 +77,16 @@ function WaveText({ playId, text }: { playId: number; text: string }) {
  * 跨页面顶栏知道产品路由，因此属于 app 外壳，不下沉到 shared/ui。
  * 品牌、主导航和账号共用一个平面，避免三个功能层被误读成彼此独立的卡片。
  */
-export function AppHeader() {
+export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {}) {
   const { pathname, search, hash } = useLocation()
   const navigate = useNavigate()
   const session = useAuthSession()
   const [accountMenuState, setAccountMenuState] = useState<AccountMenuState>('closed')
   const accountMenuOpen = accountMenuState === 'open'
+  const [creditBalance, setCreditBalance] = useState<CreditBalanceState>({
+    status: 'idle',
+    balance: null,
+  })
   const [wave, setWave] = useState({ entry: '', playId: 0 })
   const accountEntry = `/?${new URLSearchParams({
     account: 'login',
@@ -87,6 +101,24 @@ export function AppHeader() {
     const timer = window.setTimeout(() => setAccountMenuState('closed'), accountMenuExitDurationMs)
     return () => window.clearTimeout(timer)
   }, [accountMenuState])
+
+  useEffect(() => {
+    if (!accountMenuOpen || session.state.status !== 'authenticated') return
+
+    let active = true
+    setCreditBalance({ status: 'loading', balance: null })
+    void quotaApis.getBalance().then(
+      (account) => {
+        if (active) setCreditBalance({ status: 'loaded', balance: account.balance })
+      },
+      () => {
+        if (active) setCreditBalance({ status: 'error', balance: null })
+      },
+    )
+    return () => {
+      active = false
+    }
+  }, [accountMenuOpen, quotaApis, session.state.status])
 
   function signOut() {
     const returnHome = () => navigate('/', { replace: true })
@@ -243,6 +275,30 @@ export function AppHeader() {
                       : 'invisible pointer-events-none -translate-y-2 scale-[0.82] opacity-0'
                 }`}
               >
+                <div
+                  aria-label="积分余额"
+                  className="flex min-h-11 items-center justify-between gap-4 border-b border-app-ink/10 px-3 pb-1 text-[13px]"
+                >
+                  <span className="text-app-muted">可用积分</span>
+                  <output aria-live="polite" className="font-mono font-semibold text-app-accent">
+                    {creditBalance.status === 'loaded' ? (
+                      <>
+                        {creditBalance.balance}
+                        <span className="ml-1 font-sans text-[11px] font-normal text-app-faint">
+                          积分
+                        </span>
+                      </>
+                    ) : creditBalance.status === 'error' ? (
+                      <span className="font-sans text-[12px] font-normal text-app-faint">
+                        积分暂不可用
+                      </span>
+                    ) : (
+                      <span className="font-sans text-[12px] font-normal text-app-faint">
+                        查询中…
+                      </span>
+                    )}
+                  </output>
+                </div>
                 <Link
                   to="/account"
                   aria-label="打开账号中心"

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -4,6 +4,10 @@
 export { createUserApis, userApis } from './user'
 export type { AuthTokens, CreateUserApisOptions, SendCodePurpose, User, UserApis } from './user'
 
+/* 积分 —— 读取当前用户的可用余额与账本汇总 */
+export { createQuotaApis, quotaApis } from './quota'
+export type { CreateQuotaApisOptions, CreditAccount, QuotaApis } from './quota'
+
 /* 项目 —— 全局约束：视角、朝向、精灵尺寸、画风 */
 export { CHARACTER_PERSPECTIVE, DIRECTIONAL_MOVEMENT, ProjectNameConflictError } from './project'
 export { projectApis } from './project'

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -52,4 +52,39 @@ describe('createQuotaApis', () => {
       message: '积分账户响应格式无效',
     })
   })
+
+  it('默认适配器读取环境地址并携带当前登录凭证', async () => {
+    vi.resetModules()
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ code: 200, message: 'ok', data: accountResponse }), {
+          status: 200,
+        }),
+      ),
+    )
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+    vi.stubGlobal('fetch', fetchFn)
+    const [{ registerApiAccessTokenProvider }, { quotaApis }] = await Promise.all([
+      import('@/shared/api'),
+      import('./api'),
+    ])
+    const unregister = registerApiAccessTokenProvider(() => 'access-token')
+
+    try {
+      await expect(quotaApis.getBalance()).resolves.toMatchObject({ balance: 90 })
+      expect(fetchFn).toHaveBeenCalledWith(
+        'https://api.windup.test/quota/balance',
+        expect.objectContaining({
+          headers: expect.objectContaining({}),
+        }),
+      )
+      const request = fetchFn.mock.calls[0]?.[1]
+      expect(new Headers(request?.headers).get('authorization')).toBe('Bearer access-token')
+    } finally {
+      unregister()
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    }
+  })
 })

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ApiClient } from '@/shared/api'
+
+import { createQuotaApis } from './api'
+
+const accountResponse = {
+  id: 11,
+  user_id: 7,
+  balance: 90,
+  frozen: 10,
+  total_earned: 150,
+  total_spent: 50,
+  create_at: '2026-08-12T01:02:03Z',
+  update_at: '2026-08-17T01:02:03Z',
+}
+
+describe('createQuotaApis', () => {
+  let request: ReturnType<typeof vi.fn>
+  let client: ApiClient
+
+  beforeEach(() => {
+    request = vi.fn()
+    client = {
+      request: request as unknown as ApiClient['request'],
+      requestList: vi.fn() as unknown as ApiClient['requestList'],
+    }
+  })
+
+  it('从后端积分余额接口读取并映射账户', async () => {
+    request.mockResolvedValue(accountResponse)
+
+    await expect(createQuotaApis({ client }).getBalance()).resolves.toEqual({
+      id: '11',
+      userId: '7',
+      balance: 90,
+      frozen: 10,
+      totalEarned: 150,
+      totalSpent: 50,
+      createdAt: '2026-08-12T01:02:03Z',
+      updatedAt: '2026-08-17T01:02:03Z',
+    })
+    expect(request).toHaveBeenCalledWith('/quota/balance')
+  })
+
+  it('拒绝缺字段或负数积分的响应', async () => {
+    request.mockResolvedValue({ ...accountResponse, balance: -1 })
+
+    await expect(createQuotaApis({ client }).getBalance()).rejects.toMatchObject({
+      name: 'ApiError',
+      kind: 'invalid-response',
+      message: '积分账户响应格式无效',
+    })
+  })
+})

--- a/frontend/src/entities/quota/api.ts
+++ b/frontend/src/entities/quota/api.ts
@@ -1,0 +1,93 @@
+import type { CreditAccount, QuotaApis } from '.'
+
+import { ApiError, createApiClient, getApiAccessToken } from '@/shared/api'
+import type { ApiClient, ApiClientOptions } from '@/shared/api'
+
+interface CreditAccountDto {
+  id: number
+  user_id: number
+  balance: number
+  frozen: number
+  total_earned: number
+  total_spent: number
+  create_at: string
+  update_at: string
+}
+
+export interface CreateQuotaApisOptions extends ApiClientOptions {
+  client?: ApiClient
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+function invalidResponse(data: unknown): never {
+  throw new ApiError('积分账户响应格式无效', { kind: 'invalid-response', data })
+}
+
+function toCreditAccount(value: unknown): CreditAccount {
+  if (
+    !isRecord(value) ||
+    !isPositiveInteger(value.id) ||
+    !isPositiveInteger(value.user_id) ||
+    !isNonNegativeInteger(value.balance) ||
+    !isNonNegativeInteger(value.frozen) ||
+    !isNonNegativeInteger(value.total_earned) ||
+    !isNonNegativeInteger(value.total_spent) ||
+    typeof value.create_at !== 'string' ||
+    value.create_at.length === 0 ||
+    typeof value.update_at !== 'string' ||
+    value.update_at.length === 0
+  ) {
+    return invalidResponse(value)
+  }
+
+  const dto = value as unknown as CreditAccountDto
+  return {
+    id: String(dto.id),
+    userId: String(dto.user_id),
+    balance: dto.balance,
+    frozen: dto.frozen,
+    totalEarned: dto.total_earned,
+    totalSpent: dto.total_spent,
+    createdAt: dto.create_at,
+    updatedAt: dto.update_at,
+  }
+}
+
+export function createQuotaApis(options: CreateQuotaApisOptions = {}): QuotaApis {
+  const { client, ...clientOptions } = options
+  const protectedClient =
+    client ??
+    createApiClient({
+      ...clientOptions,
+      getAccessToken: clientOptions.getAccessToken ?? getApiAccessToken,
+    })
+
+  return {
+    async getBalance() {
+      return toCreditAccount(await protectedClient.request<CreditAccountDto>('/quota/balance'))
+    },
+  }
+}
+
+let defaultApis: QuotaApis | undefined
+
+function getDefaultApis(): QuotaApis {
+  defaultApis ??= createQuotaApis()
+  return defaultApis
+}
+
+/** 默认适配器延迟初始化，避免仅导入 entities 时强制要求 API 地址。 */
+export const quotaApis: QuotaApis = {
+  getBalance: () => getDefaultApis().getBalance(),
+}

--- a/frontend/src/entities/quota/index.ts
+++ b/frontend/src/entities/quota/index.ts
@@ -1,0 +1,18 @@
+/** 当前登录用户的积分账户；数值均由后端账本汇总。 */
+export interface CreditAccount {
+  id: string
+  userId: string
+  balance: number
+  frozen: number
+  totalEarned: number
+  totalSpent: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface QuotaApis {
+  getBalance(): Promise<CreditAccount>
+}
+
+export { createQuotaApis, quotaApis } from './api'
+export type { CreateQuotaApisOptions } from './api'


### PR DESCRIPTION
## 改动内容

- 新增积分账户实体与 `GET /quota/balance` 前端适配器
- 认证用户每次打开账号菜单时查询最新可用积分
- 展示加载、余额和接口失败状态；失败不影响账号中心与退出登录
- 严格校验并映射后端积分账户响应

## 依据

复用已合并 PR #230 提供的积分账户与余额查询接口，不修改后端契约，也不引入全局状态。

Closes #342

## 验证

- `npm run lint`
- `npm run typecheck`
- `npm test`（49 个测试文件，513 条测试）
- `npm run build`
- 本次 6 个改动文件格式检查

## 说明

全仓 `npm run format:check` 仍会报告 main 中既有约 141 个文件格式不统一；本 PR 未扩大范围批量改写无关文件。