### PR TITLE
fix(workflow_run): PATCH 用乐观锁校验 version

### DIFF
--- a/backend/packages/app/src/windup_app/server/workflow_run/interface.py
+++ b/backend/packages/app/src/windup_app/server/workflow_run/interface.py
@@ -60,12 +60,15 @@ class WorkflowRunService(ABC):
         session: Session,
         run_id: int,
         *,
+        expected_version: int,
         nodes: list | None = None,
         status: RunStatus | None = None,
     ) -> WorkflowRun | None:
         """更新执行记录。
 
         前端维护节点树后，通过此接口全量写回。
+        ``expected_version`` 必须等于库中当前版本，否则乐观锁冲突。
+        无字段变更时不递增 version。
         返回更新后的记录；不存在时返回 None。
         """
 

--- a/backend/packages/app/src/windup_app/server/workflow_run/interface.py
+++ b/backend/packages/app/src/windup_app/server/workflow_run/interface.py
@@ -68,10 +68,11 @@ class WorkflowRunService(ABC):
 
         前端维护节点树后，通过此接口全量写回。
         ``expected_version`` 必须等于库中当前版本，否则乐观锁冲突。
-        无字段变更时不递增 version。
+        无字段变更时不递增 version，但仍校验版本。
+        只写入请求明确提供且确有变化的列。
         返回更新后的记录；不存在时返回 None。
         """
 
     @abstractmethod
     def delete_run(self, session: Session, run_id: int) -> bool:
-        """软删除执行记录。返回是否找到。"""
+        """软删除执行记录。命中时递增 version，与 PATCH 共用乐观锁。返回是否找到。"""

--- a/backend/packages/app/src/windup_app/server/workflow_run/schema.py
+++ b/backend/packages/app/src/windup_app/server/workflow_run/schema.py
@@ -30,10 +30,12 @@ class WorkflowRunUpdateRequest(BaseModel):
     """全量更新执行记录。
 
     前端维护节点树后，通过此接口全量写回。
+    ``version`` 必须等于当前记录版本，否则乐观锁冲突。
     """
 
-    nodes: list = Field(
-        default_factory=list,
+    version: int = Field(ge=1, description="客户端读到的当前版本号")
+    nodes: list | None = Field(
+        default=None,
         description="节点树（前端自定义结构，后端不校验）",
     )
     status: str | None = Field(
@@ -51,4 +53,4 @@ class WorkflowRunOut(BaseModel):
     project_id: int
     nodes: list = Field(default_factory=list, description="节点树（前端自定义结构）")
     status: str = Field(description="active / soft_deleted")
-    version: int = Field(description="版本号，从 1 递增")
+    version: int = Field(description="乐观锁版本号，从 1 递增")

--- a/backend/packages/app/src/windup_app/server/workflow_run/service.py
+++ b/backend/packages/app/src/windup_app/server/workflow_run/service.py
@@ -8,8 +8,11 @@ SQLAlchemy session 落库。无状态：``session`` 由调用方按请求传入�
 rollback，故本实现只 ``flush``（把变更发到当前事务、取回生成的主键），不 commit。
 """
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
+
+from windup_common.enums.biz_code import BizCode
+from windup_common.exceptions import BizException
 
 from windup_app.server.workflow_run.interface import WorkflowRunService
 from windup_app.server.workflow_run.model import RunStatus, WorkflowRun
@@ -72,18 +75,38 @@ class SqlAlchemyWorkflowRunService(WorkflowRunService):
         session: Session,
         run_id: int,
         *,
+        expected_version: int,
         nodes: list | None = None,
         status: RunStatus | None = None,
     ) -> WorkflowRun | None:
         run = session.get(WorkflowRun, run_id)
         if run is None:
             return None
-        if nodes is not None:
-            run.nodes = nodes
-        if status is not None:
-            run.status = status.value
-        run.version += 1
-        session.flush()
+
+        new_nodes = run.nodes if nodes is None else nodes
+        new_status = run.status if status is None else status.value
+        if new_nodes == run.nodes and new_status == run.status:
+            return run
+
+        result = session.execute(
+            update(WorkflowRun)
+            .where(
+                WorkflowRun.id == run_id,
+                WorkflowRun.version == expected_version,
+            )
+            .values(
+                nodes=new_nodes,
+                status=new_status,
+                version=expected_version + 1,
+            )
+            .execution_options(synchronize_session="fetch")
+        )
+        if result.rowcount == 0:
+            raise BizException(
+                "执行记录版本冲突，请刷新后重试",
+                code=BizCode.CONFLICT,
+            )
+        session.refresh(run)
         return run
 
     def delete_run(self, session: Session, run_id: int) -> bool:

--- a/backend/packages/app/src/windup_app/server/workflow_run/service.py
+++ b/backend/packages/app/src/windup_app/server/workflow_run/service.py
@@ -18,6 +18,13 @@ from windup_app.server.workflow_run.interface import WorkflowRunService
 from windup_app.server.workflow_run.model import RunStatus, WorkflowRun
 
 
+def _version_conflict() -> None:
+    raise BizException(
+        "执行记录版本冲突，请刷新后重试",
+        code=BizCode.CONFLICT,
+    )
+
+
 class SqlAlchemyWorkflowRunService(WorkflowRunService):
     """基于 SQLAlchemy session 的执行记录 CRUD 实现。"""
 
@@ -83,29 +90,29 @@ class SqlAlchemyWorkflowRunService(WorkflowRunService):
         if run is None:
             return None
 
-        new_nodes = run.nodes if nodes is None else nodes
-        new_status = run.status if status is None else status.value
-        if new_nodes == run.nodes and new_status == run.status:
+        values: dict[str, object] = {}
+        if nodes is not None and nodes != run.nodes:
+            values["nodes"] = nodes
+        if status is not None and status.value != run.status:
+            values["status"] = status.value
+
+        if not values:
+            if run.version != expected_version:
+                _version_conflict()
             return run
 
+        values["version"] = expected_version + 1
         result = session.execute(
             update(WorkflowRun)
             .where(
                 WorkflowRun.id == run_id,
                 WorkflowRun.version == expected_version,
             )
-            .values(
-                nodes=new_nodes,
-                status=new_status,
-                version=expected_version + 1,
-            )
+            .values(**values)
             .execution_options(synchronize_session="fetch")
         )
         if result.rowcount == 0:
-            raise BizException(
-                "执行记录版本冲突，请刷新后重试",
-                code=BizCode.CONFLICT,
-            )
+            _version_conflict()
         session.refresh(run)
         return run
 
@@ -113,9 +120,18 @@ class SqlAlchemyWorkflowRunService(WorkflowRunService):
         run = session.get(WorkflowRun, run_id)
         if run is None:
             return False
-        run.status = RunStatus.SOFT_DELETED.value
-        session.flush()
-        return True
+        if run.status == RunStatus.SOFT_DELETED.value:
+            return True
+        result = session.execute(
+            update(WorkflowRun)
+            .where(WorkflowRun.id == run_id)
+            .values(
+                status=RunStatus.SOFT_DELETED.value,
+                version=WorkflowRun.version + 1,
+            )
+            .execution_options(synchronize_session="fetch")
+        )
+        return result.rowcount > 0
 
 
 service = SqlAlchemyWorkflowRunService()

--- a/backend/packages/app/src/windup_app/web/api/workflow_run.py
+++ b/backend/packages/app/src/windup_app/web/api/workflow_run.py
@@ -52,6 +52,7 @@ class WorkflowRunCreate(BaseModel):
 class WorkflowRunUpdate(BaseModel):
     """全量更新执行记录。"""
 
+    version: int = Field(ge=1, description="客户端读到的当前版本号")
     nodes: list | None = Field(
         default=None,
         description="节点树（前端自定义结构，后端不校验）",
@@ -171,7 +172,13 @@ def update_run(
                 code=BizCode.BAD_REQUEST,
             ) from None
 
-    run = service.update_run(session, run_id, nodes=body.nodes, status=status)
+    run = service.update_run(
+        session,
+        run_id,
+        expected_version=body.version,
+        nodes=body.nodes,
+        status=status,
+    )
     return Response.success(WorkflowRunOut.model_validate(run), message="更新成功")
 
 

--- a/backend/packages/common/src/windup_common/enums/biz_code.py
+++ b/backend/packages/common/src/windup_common/enums/biz_code.py
@@ -22,6 +22,7 @@ class BizCode(int, Enum):
     BAD_REQUEST = 400          # 请求参数校验失败
     UNAUTHORIZED = 401         # 未登录 / token 无效
     NOT_FOUND = 404            # 资源不存在
+    CONFLICT = 409             # 乐观锁 / 资源版本冲突
     TOO_MANY_REQUESTS = 429    # 请求过于频繁
     INTERNAL_ERROR = 500       # 服务器内部错误 / 兜底
     MODEL_UNAVAILABLE = 503    # 模型服务不可用

--- a/backend/tests/test_workflow_run_api.py
+++ b/backend/tests/test_workflow_run_api.py
@@ -157,7 +157,8 @@ def test_update_nodes(auth_client):
 
     new_nodes = [{"id": "n1", "type": "action"}]
     resp = auth_client.patch(
-        f"/workflow-runs/{created['id']}", json={"nodes": new_nodes},
+        f"/workflow-runs/{created['id']}",
+        json={"nodes": new_nodes, "version": created["version"]},
     )
 
     assert resp.json()["code"] == 200
@@ -172,7 +173,8 @@ def test_update_status(auth_client):
     ).json()["data"]
 
     resp = auth_client.patch(
-        f"/workflow-runs/{created['id']}", json={"status": "soft_deleted"},
+        f"/workflow-runs/{created['id']}",
+        json={"status": "soft_deleted", "version": created["version"]},
     )
 
     assert resp.json()["code"] == 200
@@ -186,7 +188,8 @@ def test_update_invalid_status_returns_400(auth_client):
     ).json()["data"]
 
     resp = auth_client.patch(
-        f"/workflow-runs/{created['id']}", json={"status": "bogus"},
+        f"/workflow-runs/{created['id']}",
+        json={"status": "bogus", "version": created["version"]},
     )
 
     assert resp.json()["code"] == 400
@@ -200,10 +203,58 @@ def test_update_other_users_run_returns_404(auth_client, auth_client_b):
     ).json()["data"]
 
     resp = auth_client_b.patch(
-        f"/workflow-runs/{created['id']}", json={"nodes": []},
+        f"/workflow-runs/{created['id']}",
+        json={"nodes": [], "version": created["version"]},
     )
 
     assert resp.json()["code"] == 404
+
+
+def test_update_requires_version(auth_client):
+    project = _create_project(auth_client)
+    created = auth_client.post(
+        "/workflow-runs", json=_payload(project["id"]),
+    ).json()["data"]
+
+    resp = auth_client.patch(
+        f"/workflow-runs/{created['id']}", json={"nodes": []},
+    )
+
+    assert resp.json()["code"] == 400
+
+
+def test_update_noop_does_not_increment_version(auth_client):
+    project = _create_project(auth_client)
+    created = auth_client.post(
+        "/workflow-runs", json=_payload(project["id"]),
+    ).json()["data"]
+
+    resp = auth_client.patch(
+        f"/workflow-runs/{created['id']}", json={"version": created["version"]},
+    )
+
+    assert resp.json()["code"] == 200
+    assert resp.json()["data"]["version"] == created["version"]
+
+
+def test_update_stale_version_returns_409(auth_client):
+    project = _create_project(auth_client)
+    created = auth_client.post(
+        "/workflow-runs", json=_payload(project["id"]),
+    ).json()["data"]
+
+    auth_client.patch(
+        f"/workflow-runs/{created['id']}",
+        json={"nodes": [{"id": "n1"}], "version": created["version"]},
+    )
+
+    resp = auth_client.patch(
+        f"/workflow-runs/{created['id']}",
+        json={"nodes": [{"id": "n2"}], "version": created["version"]},
+    )
+
+    assert resp.json()["code"] == 409
+    assert "冲突" in resp.json()["message"]
 
 
 # -- DELETE /workflow-runs/{id} ------------------------------------------------

--- a/backend/tests/test_workflow_run_api.py
+++ b/backend/tests/test_workflow_run_api.py
@@ -237,6 +237,25 @@ def test_update_noop_does_not_increment_version(auth_client):
     assert resp.json()["data"]["version"] == created["version"]
 
 
+def test_update_noop_stale_version_returns_409(auth_client):
+    project = _create_project(auth_client)
+    created = auth_client.post(
+        "/workflow-runs", json=_payload(project["id"]),
+    ).json()["data"]
+
+    auth_client.patch(
+        f"/workflow-runs/{created['id']}",
+        json={"nodes": [{"id": "n1"}], "version": created["version"]},
+    )
+
+    resp = auth_client.patch(
+        f"/workflow-runs/{created['id']}", json={"version": created["version"]},
+    )
+
+    assert resp.json()["code"] == 409
+    assert "冲突" in resp.json()["message"]
+
+
 def test_update_stale_version_returns_409(auth_client):
     project = _create_project(auth_client)
     created = auth_client.post(
@@ -276,6 +295,26 @@ def test_delete_success(auth_client):
         "/workflow-runs", params={"project_id": project["id"]},
     )
     assert resp.json()["total"] == 0
+
+
+def test_patch_after_delete_does_not_restore_run(auth_client):
+    project = _create_project(auth_client)
+    created = auth_client.post(
+        "/workflow-runs", json=_payload(project["id"]),
+    ).json()["data"]
+
+    auth_client.delete(f"/workflow-runs/{created['id']}")
+
+    resp = auth_client.patch(
+        f"/workflow-runs/{created['id']}",
+        json={"nodes": [{"id": "n1"}], "version": created["version"]},
+    )
+
+    assert resp.json()["code"] == 409
+    got = auth_client.get(f"/workflow-runs/{created['id']}").json()["data"]
+    assert got["status"] == "soft_deleted"
+    assert got["nodes"] == []
+    assert got["version"] == created["version"] + 1
 
 
 def test_delete_not_found_returns_404(auth_client):

--- a/openapi.json
+++ b/openapi.json
@@ -1987,8 +1987,17 @@
             ],
             "description": "状态：active / soft_deleted",
             "title": "Status"
+          },
+          "version": {
+            "description": "客户端读到的当前版本号",
+            "minimum": 1.0,
+            "title": "Version",
+            "type": "integer"
           }
         },
+        "required": [
+          "version"
+        ],
         "title": "WorkflowRunUpdate",
         "type": "object"
       }


### PR DESCRIPTION
Closes #203

## Summary
- `PATCH /workflow-runs/{id}` 必须携带客户端读到的 `version`；无字段变更不递增版本。
- 实际写入使用 `UPDATE ... WHERE id = ? AND version = ?`，不匹配时返回业务码 409（HTTP 仍为 200）。
- 前端 PATCH 带 `version` 见 #205，本 PR 不含前端改动。

## Test plan
- [x] `uv run pytest tests/test_workflow_run_api.py`（含缺 version → 400、无变更不递增、过期 version → 409）
- [x] 前端合入 #205 后联调：正常保存 version +1；并发/过期保存提示冲突


Made with [Cursor](https://cursor.com)