### PR TITLE
fix(user): 落库接口改为 session-per-call，去掉 NotImplementedError stub

### DIFF
--- a/backend/packages/app/src/windup_app/server/user/interface.py
+++ b/backend/packages/app/src/windup_app/server/user/interface.py
@@ -1,9 +1,14 @@
 """用户领域服务抽象接口。
 
 API 层只依赖本模块定义的抽象，不感知具体实现（ORM / Redis / Resend）。
+
+约定为 session-per-call：需要落库的方法由调用方传入 ``session``（FastAPI 的
+``get_session`` 依赖），实现保持无状态，可作为模块级单例。
 """
 
 from abc import ABC, abstractmethod
+
+from sqlalchemy.orm import Session
 
 from windup_app.server.user.model import (
     ChangePasswordInput,
@@ -21,7 +26,7 @@ class UserService(ABC):
     # -- 注册 ------------------------------------------------------------
 
     @abstractmethod
-    def register_by_email(self, input: RegisterInput) -> LoginResult:
+    def register_by_email(self, session: Session, input: RegisterInput) -> LoginResult:
         """邮箱+密码注册，注册成功即登录。
 
         :raises windup_common.exceptions.BizException: 邮箱已注册。
@@ -30,7 +35,9 @@ class UserService(ABC):
     # -- 登录 ------------------------------------------------------------
 
     @abstractmethod
-    def login_by_password(self, input: LoginByPasswordInput) -> LoginResult:
+    def login_by_password(
+        self, session: Session, input: LoginByPasswordInput
+    ) -> LoginResult:
         """邮箱+密码登录。
 
         :raises windup_common.exceptions.BizException: 邮箱不存在 / 密码错误 / 账号已封禁。
@@ -45,7 +52,7 @@ class UserService(ABC):
         """
 
     @abstractmethod
-    def login_by_code(self, input: LoginByCodeInput) -> LoginResult:
+    def login_by_code(self, session: Session, input: LoginByCodeInput) -> LoginResult:
         """邮箱+验证码登录。内测期间不自动建号。
 
         :raises windup_common.exceptions.BizException: 验证码错误 / 已过期 / 账号不存在 / 账号已封禁。
@@ -73,7 +80,9 @@ class UserService(ABC):
     # -- 密码 ------------------------------------------------------------
 
     @abstractmethod
-    def change_password(self, user_id: int, input: ChangePasswordInput) -> None:
+    def change_password(
+        self, session: Session, user_id: int, input: ChangePasswordInput
+    ) -> None:
         """修改密码（需验证旧密码）。
 
         :raises windup_common.exceptions.BizException: 旧密码错误。
@@ -82,9 +91,9 @@ class UserService(ABC):
     # -- 查询 ------------------------------------------------------------
 
     @abstractmethod
-    def get_by_id(self, user_id: int) -> UserView | None:
+    def get_by_id(self, session: Session, user_id: int) -> UserView | None:
         """按 ID 查询用户。"""
 
     @abstractmethod
-    def get_by_email(self, email: str) -> UserView | None:
+    def get_by_email(self, session: Session, email: str) -> UserView | None:
         """按邮箱查询用户。"""

--- a/backend/packages/app/src/windup_app/server/user/service.py
+++ b/backend/packages/app/src/windup_app/server/user/service.py
@@ -166,17 +166,10 @@ class SqlAlchemyUserService(UserService):
 
     # -- 注册 ------------------------------------------------------------
 
-    def register_by_email(self, input: RegisterInput) -> LoginResult:
-        # 检查邮箱是否已注册（通过全局 session，这里需要外部传入）
-        # 由于接口签名不含 session，改为类级持有或工厂注入
-        # 但当前项目模式是 service 单例 + session 由调用方传入
-        # 此处需要重构：register 不走 session 查询，直接用内部方法
-        raise NotImplementedError("请通过 API 层调用带 session 的版本")
-
-    def register_by_email_with_session(
+    def register_by_email(
         self, session: Session, input: RegisterInput
     ) -> LoginResult:
-        """邮箱+验证码+密码注册（带 session）。"""
+        """邮箱+验证码+密码注册。"""
         # 校验验证码
         self._verify_code(input.email, input.code, "register")
 
@@ -236,13 +229,10 @@ class SqlAlchemyUserService(UserService):
 
     # -- 登录 ------------------------------------------------------------
 
-    def login_by_password(self, input: LoginByPasswordInput) -> LoginResult:
-        raise NotImplementedError("请通过 API 层调用带 session 的版本")
-
-    def login_by_password_with_session(
+    def login_by_password(
         self, session: Session, input: LoginByPasswordInput
     ) -> LoginResult:
-        """邮箱+密码登录（带 session）。"""
+        """邮箱+密码登录。"""
         # 检查账号锁定
         self._check_login_lock(input.email)
 
@@ -312,13 +302,10 @@ class SqlAlchemyUserService(UserService):
         # 验证通过，删除验证码
         self.redis.delete(code_key)
 
-    def login_by_code(self, input: LoginByCodeInput) -> LoginResult:
-        raise NotImplementedError("请通过 API 层调用带 session 的版本")
-
-    def login_by_code_with_session(
+    def login_by_code(
         self, session: Session, input: LoginByCodeInput
     ) -> LoginResult:
-        """邮箱+验证码登录（带 session）。内测期间不自动建号。"""
+        """邮箱+验证码登录。内测期间不自动建号。"""
         # 校验验证码
         self._verify_code(input.email, input.code, "login")
 
@@ -438,13 +425,10 @@ class SqlAlchemyUserService(UserService):
 
     # -- 密码 ------------------------------------------------------------
 
-    def change_password(self, user_id: int, input: ChangePasswordInput) -> None:
-        raise NotImplementedError("请通过 API 层调用带 session 的版本")
-
-    def change_password_with_session(
+    def change_password(
         self, session: Session, user_id: int, input: ChangePasswordInput
     ) -> None:
-        """修改密码（带 session）。"""
+        """修改密码。"""
         user = session.get(User, user_id)
         if user is None:
             raise BizException("用户不存在", code=BizCode.NOT_FOUND)
@@ -459,7 +443,7 @@ class SqlAlchemyUserService(UserService):
         self._revoke_all_user_tokens(user_id)
         logger.info("[WINDUP] 密码已修改 | user_id=%s", user_id)
 
-    def reset_password_with_session(
+    def reset_password(
         self, session: Session, input: ResetPasswordInput
     ) -> None:
         """邮箱+验证码重置密码（忘记密码场景）。"""
@@ -482,10 +466,10 @@ class SqlAlchemyUserService(UserService):
 
     # -- 昵称 ------------------------------------------------------------
 
-    def update_nickname_with_session(
+    def update_nickname(
         self, session: Session, user_id: int, input: UpdateNicknameInput
     ) -> UserView:
-        """修改昵称（带 session）。"""
+        """修改昵称。"""
         user = session.get(User, user_id)
         if user is None:
             raise BizException("用户不存在", code=BizCode.NOT_FOUND)
@@ -498,18 +482,11 @@ class SqlAlchemyUserService(UserService):
 
     # -- 查询 ------------------------------------------------------------
 
-    def get_by_id(self, user_id: int) -> UserView | None:
-        # 需要 session，由 API 层直接查 ORM
-        raise NotImplementedError("请通过 API 层直接查询 ORM")
-
-    def get_by_email(self, email: str) -> UserView | None:
-        raise NotImplementedError("请通过 API 层直接查询 ORM")
-
-    def get_by_id_with_session(self, session: Session, user_id: int) -> UserView | None:
+    def get_by_id(self, session: Session, user_id: int) -> UserView | None:
         user = session.get(User, user_id)
         return _to_view(user) if user else None
 
-    def get_by_email_with_session(self, session: Session, email: str) -> UserView | None:
+    def get_by_email(self, session: Session, email: str) -> UserView | None:
         user = session.scalar(select(User).where(User.email == email))
         return _to_view(user) if user else None
 

--- a/backend/packages/app/src/windup_app/web/api/auth.py
+++ b/backend/packages/app/src/windup_app/web/api/auth.py
@@ -125,7 +125,7 @@ def register(body: RegisterRequest, session: Session = Depends(get_session)):
 @router.post("/login", response_model=Response[TokenResponse])
 def login(body: LoginRequest, session: Session = Depends(get_session)):
     """邮箱+密码+验证码登录。"""
-    result = service.login_by_password_with_session(
+    result = service.login_by_password(
         session,
         type("LoginByPasswordInput", (), {"email": body.email, "password": body.password})(),
     )
@@ -149,7 +149,7 @@ def send_code(body: SendCodeRequest):
 @router.post("/login-by-code", response_model=Response[TokenResponse])
 def login_by_code(body: LoginByCodeRequest, session: Session = Depends(get_session)):
     """验证码登录。内测期间不自动注册。"""
-    result = service.login_by_code_with_session(
+    result = service.login_by_code(
         session,
         type("LoginByCodeInput", (), {"email": body.email, "code": body.code})(),
     )
@@ -207,7 +207,7 @@ def get_me(request: Request, session: Session = Depends(get_session)):
 def change_password(body: ChangePasswordRequest, request: Request, session: Session = Depends(get_session)):
     """修改密码。"""
     current_user = request.state.current_user
-    service.change_password_with_session(
+    service.change_password(
         session,
         current_user.id,
         type("ChangePasswordInput", (), {"old_password": body.old_password, "new_password": body.new_password})(),
@@ -218,7 +218,7 @@ def change_password(body: ChangePasswordRequest, request: Request, session: Sess
 @router.post("/reset-password", response_model=Response[None])
 def reset_password(body: ResetPasswordRequest, session: Session = Depends(get_session)):
     """邮箱+验证码重置密码（忘记密码）。"""
-    service.reset_password_with_session(
+    service.reset_password(
         session,
         ResetPasswordInput(email=body.email, code=body.code, new_password=body.new_password),
     )
@@ -229,7 +229,7 @@ def reset_password(body: ResetPasswordRequest, session: Session = Depends(get_se
 def update_nickname(body: UpdateNicknameRequest, request: Request, session: Session = Depends(get_session)):
     """修改当前用户昵称。"""
     current_user = request.state.current_user
-    user_view = service.update_nickname_with_session(
+    user_view = service.update_nickname(
         session, current_user.id, UpdateNicknameInput(nickname=body.nickname)
     )
     return Response.success(

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,0 +1,101 @@
+"""认证 API：覆盖 login / 验证码登录 / 改密 / 重置密码 / 改昵称调用链。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from windup_app.server.user.model import User
+from windup_app.server.user.service import _hash_password, service
+
+
+@pytest.fixture()
+def mock_user_redis():
+    """把模块级 user service 的 Redis 换成 mock，避免打到真实实例。"""
+    redis_mock = MagicMock()
+    redis_mock.get.return_value = None
+    redis_mock.setex.return_value = True
+    redis_mock.delete.return_value = True
+    redis_mock.scan_iter.return_value = iter([])
+    previous = service._redis
+    service._redis = redis_mock
+    yield redis_mock
+    service._redis = previous
+
+
+@pytest.fixture()
+def seeded_user(db_session):
+    """与 auth_client token 对齐的用户（id=1）。"""
+    user = User(
+        id=1,
+        email="test@example.com",
+        password_hash=_hash_password("password123"),
+        nickname="旧昵称",
+    )
+    db_session.add(user)
+    db_session.flush()
+    return user
+
+
+def test_login_by_password_endpoint(client, seeded_user, mock_user_redis):
+    resp = client.post(
+        "/auth/login",
+        json={"email": "test@example.com", "password": "password123"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 200
+    assert body["message"] == "登录成功"
+    assert body["data"]["user"]["email"] == "test@example.com"
+    assert body["data"]["access_token"]
+    assert body["data"]["refresh_token"]
+
+
+def test_login_by_code_endpoint(client, seeded_user, mock_user_redis):
+    mock_user_redis.get.return_value = "123456"
+    resp = client.post(
+        "/auth/login-by-code",
+        json={"email": "test@example.com", "code": "123456"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 200
+    assert body["message"] == "登录成功"
+    assert body["data"]["user"]["email"] == "test@example.com"
+    assert body["data"]["access_token"]
+
+
+def test_change_password_endpoint(auth_client, seeded_user, mock_user_redis):
+    resp = auth_client.post(
+        "/auth/change-password",
+        json={"old_password": "password123", "new_password": "newpass123"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 200
+    assert body["message"] == "密码修改成功"
+
+
+def test_reset_password_endpoint(auth_client, seeded_user, mock_user_redis):
+    mock_user_redis.get.return_value = "654321"
+    resp = auth_client.post(
+        "/auth/reset-password",
+        json={
+            "email": "test@example.com",
+            "code": "654321",
+            "new_password": "resetpass1",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 200
+    assert body["message"] == "密码重置成功"
+
+
+def test_update_nickname_endpoint(auth_client, seeded_user, mock_user_redis):
+    resp = auth_client.patch("/auth/profile", json={"nickname": "新昵称"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 200
+    assert body["message"] == "昵称修改成功"
+    assert body["data"]["nickname"] == "新昵称"
+    assert body["data"]["email"] == "test@example.com"

--- a/backend/tests/test_user_service.py
+++ b/backend/tests/test_user_service.py
@@ -131,12 +131,51 @@ def test_register_success(db_session, service, mock_email):
         code="123456",
     )
 
-    result = service.register_by_email_with_session(db_session, input_data)
+    result = service.register_by_email(db_session, input_data)
 
     assert result.user.email == "new@example.com"
     assert result.access_token is not None
     assert result.refresh_token is not None
     assert result.user.email_verified_at is not None  # 注册即验证
+
+
+def test_public_methods_accept_session(db_session, service, mock_email):
+    """公开接口走 session-per-call，不再抛 NotImplementedError。"""
+    service._redis.get.return_value = "123456"
+    registered = service.register_by_email(
+        db_session,
+        RegisterInput(
+            email="public@example.com",
+            password="password123",
+            code="123456",
+        ),
+    )
+
+    by_id = service.get_by_id(db_session, registered.user.id)
+    by_email = service.get_by_email(db_session, "public@example.com")
+    assert by_id is not None
+    assert by_email is not None
+    assert by_id.email == by_email.email == "public@example.com"
+
+    service._redis.get.return_value = None  # 未锁定
+    login = service.login_by_password(
+        db_session,
+        LoginByPasswordInput(email="public@example.com", password="password123"),
+    )
+    assert login.user.id == registered.user.id
+
+    service.change_password(
+        db_session,
+        registered.user.id,
+        ChangePasswordInput(old_password="password123", new_password="newpass123"),
+    )
+
+    service._redis.get.return_value = "654321"
+    code_login = service.login_by_code(
+        db_session,
+        LoginByCodeInput(email="public@example.com", code="654321"),
+    )
+    assert code_login.user.id == registered.user.id
 
 
 def test_register_creates_credit_account(db_session, service, mock_email):
@@ -154,7 +193,7 @@ def test_register_creates_credit_account(db_session, service, mock_email):
         code="123456",
     )
 
-    result = service.register_by_email_with_session(db_session, input_data)
+    result = service.register_by_email(db_session, input_data)
     user_id = result.user.id
 
     # 验证积分账户已创建
@@ -184,11 +223,11 @@ def test_register_duplicate_email(db_session, service):
     # 先注册一个用户
     service._redis.get.return_value = "123456"
     input_data = RegisterInput(email="dup@example.com", password="pass123", code="123456")
-    service.register_by_email_with_session(db_session, input_data)
+    service.register_by_email(db_session, input_data)
 
     # 尝试重复注册
     with pytest.raises(BizException, match="邮箱已注册"):
-        service.register_by_email_with_session(db_session, input_data)
+        service.register_by_email(db_session, input_data)
 
 
 def test_register_wrong_code(db_session, service):
@@ -201,7 +240,7 @@ def test_register_wrong_code(db_session, service):
     )
 
     with pytest.raises(BizException, match="验证码错误"):
-        service.register_by_email_with_session(db_session, input_data)
+        service.register_by_email(db_session, input_data)
 
 
 def test_register_expired_code(db_session, service):
@@ -214,7 +253,7 @@ def test_register_expired_code(db_session, service):
     )
 
     with pytest.raises(BizException, match="验证码已过期"):
-        service.register_by_email_with_session(db_session, input_data)
+        service.register_by_email(db_session, input_data)
 
 
 # -- 登录测试 ------------------------------------------------------------
@@ -224,12 +263,12 @@ def test_login_success(db_session, service, mock_email):
     # 先注册
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="login@example.com", password="pass123", code="123456")
-    service.register_by_email_with_session(db_session, register_input)
+    service.register_by_email(db_session, register_input)
 
     # 登录（不需要验证码）
     service._redis.get.return_value = None  # 未锁定
     login_input = LoginByPasswordInput(email="login@example.com", password="pass123")
-    result = service.login_by_password_with_session(db_session, login_input)
+    result = service.login_by_password(db_session, login_input)
 
     assert result.user.email == "login@example.com"
     assert result.access_token is not None
@@ -239,7 +278,7 @@ def test_login_wrong_password(db_session, service, mock_email):
     # 先注册
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="login@example.com", password="pass123", code="123456")
-    service.register_by_email_with_session(db_session, register_input)
+    service.register_by_email(db_session, register_input)
 
     # 密码错误
     service._redis.get.return_value = None  # 未锁定
@@ -247,7 +286,7 @@ def test_login_wrong_password(db_session, service, mock_email):
     login_input = LoginByPasswordInput(email="login@example.com", password="wrong")
 
     with pytest.raises(BizException, match="邮箱或密码错误"):
-        service.login_by_password_with_session(db_session, login_input)
+        service.login_by_password(db_session, login_input)
 
 
 def test_login_nonexistent_user(db_session, service):
@@ -256,14 +295,14 @@ def test_login_nonexistent_user(db_session, service):
     login_input = LoginByPasswordInput(email="no@example.com", password="pass123")
 
     with pytest.raises(BizException, match="邮箱或密码错误"):
-        service.login_by_password_with_session(db_session, login_input)
+        service.login_by_password(db_session, login_input)
 
 
 def test_login_banned_user(db_session, service, mock_email):
     # 先注册
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="banned@example.com", password="pass123", code="123456")
-    service.register_by_email_with_session(db_session, register_input)
+    service.register_by_email(db_session, register_input)
 
     # 封禁用户
     from sqlalchemy import select
@@ -276,7 +315,7 @@ def test_login_banned_user(db_session, service, mock_email):
     login_input = LoginByPasswordInput(email="banned@example.com", password="pass123")
 
     with pytest.raises(BizException, match="账号已被封禁"):
-        service.login_by_password_with_session(db_session, login_input)
+        service.login_by_password(db_session, login_input)
 
 
 # -- 验证码登录测试 ------------------------------------------------------
@@ -290,7 +329,7 @@ def test_login_by_code_unknown_email_does_not_create_user(db_session, service, m
     input_data = LoginByCodeInput(email="code@example.com", code="123456")
 
     with pytest.raises(BizException, match="账号不存在") as exc:
-        service.login_by_code_with_session(db_session, input_data)
+        service.login_by_code(db_session, input_data)
 
     from windup_common.enums.biz_code import BizCode
 
@@ -311,7 +350,7 @@ def test_login_by_code_banned_user(db_session, service, mock_email):
     from sqlalchemy import select
 
     service._redis.get.return_value = "123456"
-    service.register_by_email_with_session(
+    service.register_by_email(
         db_session,
         RegisterInput(email="banned-code@example.com", password="pass123", code="123456"),
     )
@@ -321,7 +360,7 @@ def test_login_by_code_banned_user(db_session, service, mock_email):
 
     service._redis.get.return_value = "654321"
     with pytest.raises(BizException, match="账号已被封禁"):
-        service.login_by_code_with_session(
+        service.login_by_code(
             db_session,
             LoginByCodeInput(email="banned-code@example.com", code="654321"),
         )
@@ -333,7 +372,7 @@ def test_login_by_code_marks_unverified_email(db_session, service):
     db_session.flush()
 
     service._redis.get.return_value = "123456"
-    result = service.login_by_code_with_session(
+    result = service.login_by_code(
         db_session,
         LoginByCodeInput(email="unverified@example.com", code="123456"),
     )
@@ -346,12 +385,12 @@ def test_login_by_code_existing_user(db_session, service, mock_email):
     # 先注册
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="exist@example.com", password="pass123", code="123456")
-    service.register_by_email_with_session(db_session, register_input)
+    service.register_by_email(db_session, register_input)
 
     # 验证码登录
     service._redis.get.return_value = "654321"
     input_data = LoginByCodeInput(email="exist@example.com", code="654321")
-    result = service.login_by_code_with_session(db_session, input_data)
+    result = service.login_by_code(db_session, input_data)
 
     assert result.user.email == "exist@example.com"
 
@@ -362,7 +401,7 @@ def test_login_by_code_wrong_code(db_session, service):
     input_data = LoginByCodeInput(email="code@example.com", code="999999")
 
     with pytest.raises(BizException, match="验证码错误"):
-        service.login_by_code_with_session(db_session, input_data)
+        service.login_by_code(db_session, input_data)
 
 
 # -- 发送验证码测试 ------------------------------------------------------
@@ -452,16 +491,16 @@ def test_change_password(db_session, service, mock_email):
     # 先注册
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="change@example.com", password="oldpass123", code="123456")
-    result = service.register_by_email_with_session(db_session, register_input)
+    result = service.register_by_email(db_session, register_input)
 
     # 修改密码
     change_input = ChangePasswordInput(old_password="oldpass123", new_password="newpass123")
-    service.change_password_with_session(db_session, result.user.id, change_input)
+    service.change_password(db_session, result.user.id, change_input)
 
     # 用新密码登录
     service._redis.get.return_value = None
     login_input = LoginByPasswordInput(email="change@example.com", password="newpass123")
-    login_result = service.login_by_password_with_session(db_session, login_input)
+    login_result = service.login_by_password(db_session, login_input)
 
     assert login_result.user.email == "change@example.com"
 
@@ -470,13 +509,13 @@ def test_change_password_wrong_old(db_session, service, mock_email):
     # 先注册
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="change@example.com", password="oldpass123", code="123456")
-    result = service.register_by_email_with_session(db_session, register_input)
+    result = service.register_by_email(db_session, register_input)
 
     # 旧密码错误
     change_input = ChangePasswordInput(old_password="wrong", new_password="newpass123")
 
     with pytest.raises(BizException, match="旧密码错误"):
-        service.change_password_with_session(db_session, result.user.id, change_input)
+        service.change_password(db_session, result.user.id, change_input)
 
 
 # -- 昵称修改测试 --------------------------------------------------------
@@ -486,10 +525,10 @@ def test_update_nickname(db_session, service, mock_email):
     """修改昵称后立即生效。"""
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="nick@example.com", password="pass1234", code="123456", nickname="旧昵称")
-    result = service.register_by_email_with_session(db_session, register_input)
+    result = service.register_by_email(db_session, register_input)
 
     update_input = UpdateNicknameInput(nickname="新昵称")
-    user_view = service.update_nickname_with_session(db_session, result.user.id, update_input)
+    user_view = service.update_nickname(db_session, result.user.id, update_input)
 
     assert user_view.nickname == "新昵称"
     assert user_view.id == result.user.id
@@ -499,11 +538,11 @@ def test_update_nickname_max_length(db_session, service, mock_email):
     """昵称长度上限 50。"""
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="nick2@example.com", password="pass1234", code="123456")
-    result = service.register_by_email_with_session(db_session, register_input)
+    result = service.register_by_email(db_session, register_input)
 
     long_nickname = "a" * 50
     update_input = UpdateNicknameInput(nickname=long_nickname)
-    user_view = service.update_nickname_with_session(db_session, result.user.id, update_input)
+    user_view = service.update_nickname(db_session, result.user.id, update_input)
 
     assert user_view.nickname == long_nickname
 
@@ -513,7 +552,7 @@ def test_update_nickname_user_not_found(db_session, service):
     update_input = UpdateNicknameInput(nickname="test")
 
     with pytest.raises(BizException, match="用户不存在"):
-        service.update_nickname_with_session(db_session, 999999, update_input)
+        service.update_nickname(db_session, 999999, update_input)
 
 
 # -- 重置密码测试 --------------------------------------------------------
@@ -524,17 +563,17 @@ def test_reset_password(db_session, service, mock_email):
     # 先注册
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="reset@example.com", password="oldpass123", code="123456")
-    service.register_by_email_with_session(db_session, register_input)
+    service.register_by_email(db_session, register_input)
 
     # 重置密码（验证码 purpose 为 reset_password）
     service._redis.get.return_value = "654321"
     reset_input = ResetPasswordInput(email="reset@example.com", code="654321", new_password="newpass123")
-    service.reset_password_with_session(db_session, reset_input)
+    service.reset_password(db_session, reset_input)
 
     # 用新密码登录
     service._redis.get.return_value = None
     login_input = LoginByPasswordInput(email="reset@example.com", password="newpass123")
-    login_result = service.login_by_password_with_session(db_session, login_input)
+    login_result = service.login_by_password(db_session, login_input)
 
     assert login_result.user.email == "reset@example.com"
 
@@ -543,14 +582,14 @@ def test_reset_password_wrong_code(db_session, service, mock_email):
     """验证码错误时拒绝重置。"""
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="reset2@example.com", password="oldpass123", code="123456")
-    service.register_by_email_with_session(db_session, register_input)
+    service.register_by_email(db_session, register_input)
 
     # 验证码错误
     service._redis.get.return_value = None  # 验证码过期
     reset_input = ResetPasswordInput(email="reset2@example.com", code="000000", new_password="newpass123")
 
     with pytest.raises(BizException, match="验证码已过期"):
-        service.reset_password_with_session(db_session, reset_input)
+        service.reset_password(db_session, reset_input)
 
 
 def test_reset_password_user_not_found(db_session, service):
@@ -559,7 +598,7 @@ def test_reset_password_user_not_found(db_session, service):
     reset_input = ResetPasswordInput(email="noexist@example.com", code="654321", new_password="newpass123")
 
     with pytest.raises(BizException, match="用户不存在"):
-        service.reset_password_with_session(db_session, reset_input)
+        service.reset_password(db_session, reset_input)
 
 
 # -- 登录限流测试 --------------------------------------------------------
@@ -570,14 +609,14 @@ def test_login_account_locked(db_session, service, mock_email):
     # 先注册
     service._redis.get.return_value = "123456"
     register_input = RegisterInput(email="lock@example.com", password="pass123", code="123456")
-    service.register_by_email_with_session(db_session, register_input)
+    service.register_by_email(db_session, register_input)
 
     # 模拟账号锁定
     service._redis.get.return_value = "1"  # lock key 存在
     login_input = LoginByPasswordInput(email="lock@example.com", password="pass123")
 
     with pytest.raises(BizException, match="邮箱或密码错误"):
-        service.login_by_password_with_session(db_session, login_input)
+        service.login_by_password(db_session, login_input)
 
 
 def test_login_failure_records_count(service, mock_redis):


### PR DESCRIPTION
## Summary
- 修复 [#204](https://github.com/1024XEngineer/Windup/issues/204)：`UserService` 公开方法不再 `raise NotImplementedError`。
- 与 project / workflow_run 对齐，落库方法改为 session-per-call：调用方传入 `session`，去掉 `_with_session` 双接口。
- 更新 auth API 与 user service 测试。

Fixes #204

## Test plan
- [x] `uv run pytest tests/test_user_service.py tests/test_auth_middleware.py`（47 passed）
- [x] `uv run ruff check` 变更文件
- [x] 走一遍登录 / 改密 / 验证码登录，确认 API 行为不变
