### PR TITLE
feat(frontend): 在账号中心展示积分余额与流水

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -309,6 +309,9 @@ describe('AppHeader', () => {
     resolveBalance(creditAccount)
     expect(await screen.findByText('90')).toBeTruthy()
     expect(screen.getByText('积分')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: '打开账号菜单' }))
+    expect(screen.getByText('90')).toBeTruthy()
   })
 
   it('积分查询失败时保留账号菜单的其他操作', async () => {

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 
-import type { AuthTokens, UserApis } from '@/entities'
+import type { AuthTokens, CreditAccount, QuotaApis, UserApis } from '@/entities'
 import { AuthSessionProvider } from '@/features/auth-session'
 import { AppHeader } from './app-header'
 
@@ -33,6 +33,21 @@ function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn
   }
 }
 
+const creditAccount: CreditAccount = {
+  id: '11',
+  userId: '7',
+  balance: 90,
+  frozen: 10,
+  totalEarned: 150,
+  totalSpent: 50,
+  createdAt: '2026-08-12T01:02:03Z',
+  updatedAt: '2026-08-17T01:02:03Z',
+}
+
+function createQuotaMock(): QuotaApis & { getBalance: ReturnType<typeof vi.fn> } {
+  return { getBalance: vi.fn(async () => creditAccount) }
+}
+
 function LocationProbe() {
   const location = useLocation()
   return (
@@ -40,9 +55,15 @@ function LocationProbe() {
   )
 }
 
-function renderHeader(entry = '/', apis = createApis(), previousEntry?: string) {
+function renderHeader(
+  entry = '/',
+  apis = createApis(),
+  previousEntry?: string,
+  quota = createQuotaMock(),
+) {
   return {
     apis,
+    quota,
     ...render(
       <AuthSessionProvider apis={apis}>
         <MemoryRouter
@@ -54,7 +75,7 @@ function renderHeader(entry = '/', apis = createApis(), previousEntry?: string) 
               path="*"
               element={
                 <>
-                  <AppHeader />
+                  <AppHeader quotaApis={quota} />
                   <LocationProbe />
                 </>
               }
@@ -260,6 +281,41 @@ describe('AppHeader', () => {
 
     await waitFor(() => expect(menuSurface.getAttribute('data-state')).toBe('closed'))
     expect(menuSurface.classList.contains('invisible')).toBe(true)
+  })
+
+  it('打开账号菜单时查询并展示最新可用积分', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    let resolveBalance: (account: CreditAccount) => void = () => undefined
+    const quota = createQuotaMock()
+    quota.getBalance.mockReturnValue(
+      new Promise<CreditAccount>((resolve) => {
+        resolveBalance = resolve
+      }),
+    )
+    renderHeader('/workspace', createApis(), undefined, quota)
+
+    fireEvent.click(await screen.findByRole('button', { name: '打开账号菜单' }))
+
+    expect(quota.getBalance).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('可用积分')).toBeTruthy()
+    expect(screen.getByText('查询中…')).toBeTruthy()
+
+    resolveBalance(creditAccount)
+    expect(await screen.findByText('90')).toBeTruthy()
+    expect(screen.getByText('积分')).toBeTruthy()
+  })
+
+  it('积分查询失败时保留账号菜单的其他操作', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    const quota = createQuotaMock()
+    quota.getBalance.mockRejectedValue(new Error('积分接口不可用'))
+    renderHeader('/workspace', createApis(), undefined, quota)
+
+    fireEvent.click(await screen.findByRole('button', { name: '打开账号菜单' }))
+
+    expect(await screen.findByText('积分暂不可用')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '打开账号中心' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '退出登录' })).toBeTruthy()
   })
 
   it('使用贴顶毛玻璃栏承载品牌、产品导航与账号入口', async () => {

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -44,8 +44,14 @@ const creditAccount: CreditAccount = {
   updatedAt: '2026-08-17T01:02:03Z',
 }
 
-function createQuotaMock(): QuotaApis & { getBalance: ReturnType<typeof vi.fn> } {
-  return { getBalance: vi.fn(async () => creditAccount) }
+function createQuotaMock(): QuotaApis & {
+  getBalance: ReturnType<typeof vi.fn>
+  listTransactions: ReturnType<typeof vi.fn>
+} {
+  return {
+    getBalance: vi.fn(async () => creditAccount),
+    listTransactions: vi.fn(async () => ({ items: [], total: 0, page: 1, pageSize: 20 })),
+  }
 }
 
 function LocationProbe() {
@@ -296,7 +302,7 @@ describe('AppHeader', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: '打开账号菜单' }))
 
-    expect(quota.getBalance).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(quota.getBalance).toHaveBeenCalledTimes(1))
     expect(screen.getByText('可用积分')).toBeTruthy()
     expect(screen.getByText('查询中…')).toBeTruthy()
 

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation, useNavigate } from 'react-router'
 import { quotaApis as defaultQuotaApis } from '@/entities'
 import type { QuotaApis } from '@/entities'
 import { useAuthSession } from '@/features/auth-session'
+import { useQuotaBalance } from '@/features/quota'
 import { PageBackButton } from './page-back-button'
 
 interface ProductNavigationItem {
@@ -15,10 +16,6 @@ interface ProductNavigationItem {
 }
 
 type AccountMenuState = 'closed' | 'open' | 'closing'
-type CreditBalanceState =
-  | { status: 'idle' | 'loading'; balance: null }
-  | { status: 'loaded'; balance: number }
-  | { status: 'error'; balance: null }
 
 export interface AppHeaderProps {
   quotaApis?: QuotaApis
@@ -83,10 +80,10 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
   const session = useAuthSession()
   const [accountMenuState, setAccountMenuState] = useState<AccountMenuState>('closed')
   const accountMenuOpen = accountMenuState === 'open'
-  const [creditBalance, setCreditBalance] = useState<CreditBalanceState>({
-    status: 'idle',
-    balance: null,
-  })
+  const creditBalance = useQuotaBalance(
+    accountMenuOpen && session.state.status === 'authenticated',
+    quotaApis,
+  )
   const [wave, setWave] = useState({ entry: '', playId: 0 })
   const accountEntry = `/?${new URLSearchParams({
     account: 'login',
@@ -101,24 +98,6 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
     const timer = window.setTimeout(() => setAccountMenuState('closed'), accountMenuExitDurationMs)
     return () => window.clearTimeout(timer)
   }, [accountMenuState])
-
-  useEffect(() => {
-    if (!accountMenuOpen || session.state.status !== 'authenticated') return
-
-    let active = true
-    setCreditBalance({ status: 'loading', balance: null })
-    void quotaApis.getBalance().then(
-      (account) => {
-        if (active) setCreditBalance({ status: 'loaded', balance: account.balance })
-      },
-      () => {
-        if (active) setCreditBalance({ status: 'error', balance: null })
-      },
-    )
-    return () => {
-      active = false
-    }
-  }, [accountMenuOpen, quotaApis, session.state.status])
 
   function signOut() {
     const returnHome = () => navigate('/', { replace: true })
@@ -282,9 +261,9 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
                 >
                   <span className="text-app-muted">可用积分</span>
                   <output aria-live="polite" className="font-mono font-semibold text-app-accent">
-                    {creditBalance.status === 'loaded' ? (
+                    {creditBalance.status === 'ready' ? (
                       <>
-                        {creditBalance.balance}
+                        {creditBalance.account.balance}
                         <span className="ml-1 font-sans text-[11px] font-normal text-app-faint">
                           积分
                         </span>

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 
+import { quotaApis as defaultQuotaApis } from '@/entities'
+import type { QuotaApis } from '@/entities'
 import { useAuthSession } from '@/features/auth-session'
 import { PageBackButton } from './page-back-button'
 
@@ -13,6 +15,14 @@ interface ProductNavigationItem {
 }
 
 type AccountMenuState = 'closed' | 'open' | 'closing'
+type CreditBalanceState =
+  | { status: 'idle' | 'loading'; balance: null }
+  | { status: 'loaded'; balance: number }
+  | { status: 'error'; balance: null }
+
+export interface AppHeaderProps {
+  quotaApis?: QuotaApis
+}
 
 const accountMenuExitDurationMs = 260
 
@@ -67,12 +77,16 @@ function WaveText({ playId, text }: { playId: number; text: string }) {
  * 跨页面顶栏知道产品路由，因此属于 app 外壳，不下沉到 shared/ui。
  * 品牌、主导航和账号共用一个平面，避免三个功能层被误读成彼此独立的卡片。
  */
-export function AppHeader() {
+export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {}) {
   const { pathname, search, hash } = useLocation()
   const navigate = useNavigate()
   const session = useAuthSession()
   const [accountMenuState, setAccountMenuState] = useState<AccountMenuState>('closed')
   const accountMenuOpen = accountMenuState === 'open'
+  const [creditBalance, setCreditBalance] = useState<CreditBalanceState>({
+    status: 'idle',
+    balance: null,
+  })
   const [wave, setWave] = useState({ entry: '', playId: 0 })
   const accountEntry = `/?${new URLSearchParams({
     account: 'login',
@@ -87,6 +101,24 @@ export function AppHeader() {
     const timer = window.setTimeout(() => setAccountMenuState('closed'), accountMenuExitDurationMs)
     return () => window.clearTimeout(timer)
   }, [accountMenuState])
+
+  useEffect(() => {
+    if (!accountMenuOpen || session.state.status !== 'authenticated') return
+
+    let active = true
+    setCreditBalance({ status: 'loading', balance: null })
+    void quotaApis.getBalance().then(
+      (account) => {
+        if (active) setCreditBalance({ status: 'loaded', balance: account.balance })
+      },
+      () => {
+        if (active) setCreditBalance({ status: 'error', balance: null })
+      },
+    )
+    return () => {
+      active = false
+    }
+  }, [accountMenuOpen, quotaApis, session.state.status])
 
   function signOut() {
     const returnHome = () => navigate('/', { replace: true })
@@ -244,6 +276,30 @@ export function AppHeader() {
                       : 'invisible pointer-events-none -translate-y-2 scale-[0.82] opacity-0'
                 }`}
               >
+                <div
+                  aria-label="积分余额"
+                  className="flex min-h-11 items-center justify-between gap-4 border-b border-app-ink/10 px-3 pb-1 text-[13px]"
+                >
+                  <span className="text-app-muted">可用积分</span>
+                  <output aria-live="polite" className="font-mono font-semibold text-app-accent">
+                    {creditBalance.status === 'loaded' ? (
+                      <>
+                        {creditBalance.balance}
+                        <span className="ml-1 font-sans text-[11px] font-normal text-app-faint">
+                          积分
+                        </span>
+                      </>
+                    ) : creditBalance.status === 'error' ? (
+                      <span className="font-sans text-[12px] font-normal text-app-faint">
+                        积分暂不可用
+                      </span>
+                    ) : (
+                      <span className="font-sans text-[12px] font-normal text-app-faint">
+                        查询中…
+                      </span>
+                    )}
+                  </output>
+                </div>
                 <Link
                   to="/account"
                   aria-label="打开账号中心"

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -81,7 +81,7 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
   const [accountMenuState, setAccountMenuState] = useState<AccountMenuState>('closed')
   const accountMenuOpen = accountMenuState === 'open'
   const creditBalance = useQuotaBalance(
-    accountMenuOpen && session.state.status === 'authenticated',
+    accountMenuState !== 'closed' && session.state.status === 'authenticated',
     quotaApis,
   )
   const [wave, setWave] = useState({ entry: '', playId: 0 })

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -4,6 +4,10 @@
 export { createUserApis, userApis } from './user'
 export type { AuthTokens, CreateUserApisOptions, SendCodePurpose, User, UserApis } from './user'
 
+/* 积分 —— 读取当前用户的可用余额与账本汇总 */
+export { createQuotaApis, quotaApis } from './quota'
+export type { CreateQuotaApisOptions, CreditAccount, QuotaApis } from './quota'
+
 /* 项目 —— 全局约束：视角、朝向、精灵尺寸、画风 */
 export { CHARACTER_PERSPECTIVE, DIRECTIONAL_MOVEMENT, ProjectNameConflictError } from './project'
 export { projectApis } from './project'

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -6,7 +6,13 @@ export type { AuthTokens, CreateUserApisOptions, SendCodePurpose, User, UserApis
 
 /* 积分 —— 读取当前用户的可用余额与账本汇总 */
 export { createQuotaApis, quotaApis } from './quota'
-export type { CreateQuotaApisOptions, CreditAccount, QuotaApis } from './quota'
+export type {
+  CreateQuotaApisOptions,
+  CreditAccount,
+  CreditTransaction,
+  QuotaApis,
+  QuotaTransactionPageQuery,
+} from './quota'
 
 /* 项目 —— 全局约束：视角、朝向、精灵尺寸、画风 */
 export { CHARACTER_PERSPECTIVE, DIRECTIONAL_MOVEMENT, ProjectNameConflictError } from './project'

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -52,4 +52,39 @@ describe('createQuotaApis', () => {
       message: '积分账户响应格式无效',
     })
   })
+
+  it('默认适配器读取环境地址并携带当前登录凭证', async () => {
+    vi.resetModules()
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ code: 200, message: 'ok', data: accountResponse }), {
+          status: 200,
+        }),
+      ),
+    )
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+    vi.stubGlobal('fetch', fetchFn)
+    const [{ registerApiAccessTokenProvider }, { quotaApis }] = await Promise.all([
+      import('@/shared/api'),
+      import('./api'),
+    ])
+    const unregister = registerApiAccessTokenProvider(() => 'access-token')
+
+    try {
+      await expect(quotaApis.getBalance()).resolves.toMatchObject({ balance: 90 })
+      expect(fetchFn).toHaveBeenCalledWith(
+        'https://api.windup.test/quota/balance',
+        expect.objectContaining({
+          headers: expect.objectContaining({}),
+        }),
+      )
+      const request = fetchFn.mock.calls[0]?.[1]
+      expect(new Headers(request?.headers).get('authorization')).toBe('Bearer access-token')
+    } finally {
+      unregister()
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    }
+  })
 })

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -90,13 +90,20 @@ describe('createQuotaApis', () => {
 
   it('默认适配器读取环境地址并携带当前登录凭证', async () => {
     vi.resetModules()
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      Promise.resolve(
-        new Response(JSON.stringify({ code: 200, message: 'ok', data: accountResponse }), {
-          status: 200,
-        }),
-      ),
-    )
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const url = String(input)
+      const body = url.includes('/quota/transactions')
+        ? {
+            code: 200,
+            message: 'ok',
+            data: [],
+            total: 0,
+            page: 1,
+            page_size: 20,
+          }
+        : { code: 200, message: 'ok', data: accountResponse }
+      return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
+    })
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
     vi.stubGlobal('fetch', fetchFn)
     const [{ registerApiAccessTokenProvider }, { quotaApis }] = await Promise.all([
@@ -107,6 +114,10 @@ describe('createQuotaApis', () => {
 
     try {
       await expect(quotaApis.getBalance()).resolves.toMatchObject({ balance: 90 })
+      await expect(quotaApis.listTransactions({ page: 1, pageSize: 20 })).resolves.toMatchObject({
+        items: [],
+        total: 0,
+      })
       expect(fetchFn).toHaveBeenCalledWith(
         'https://api.windup.test/quota/balance',
         expect.objectContaining({
@@ -115,6 +126,9 @@ describe('createQuotaApis', () => {
       )
       const request = fetchFn.mock.calls[0]?.[1]
       expect(new Headers(request?.headers).get('authorization')).toBe('Bearer access-token')
+      expect(fetchFn.mock.calls[1]?.[0]).toBe(
+        'https://api.windup.test/quota/transactions?page=1&page_size=20',
+      )
     } finally {
       unregister()
       vi.unstubAllGlobals()

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ApiClient } from '@/shared/api'
+
+import { createQuotaApis } from './api'
+
+const accountResponse = {
+  id: 11,
+  user_id: 7,
+  balance: 90,
+  frozen: 10,
+  total_earned: 150,
+  total_spent: 50,
+  create_at: '2026-08-12T01:02:03Z',
+  update_at: '2026-08-17T01:02:03Z',
+}
+
+describe('createQuotaApis', () => {
+  let request: ReturnType<typeof vi.fn>
+  let client: ApiClient
+
+  beforeEach(() => {
+    request = vi.fn()
+    client = {
+      request: request as unknown as ApiClient['request'],
+      requestList: vi.fn() as unknown as ApiClient['requestList'],
+    }
+  })
+
+  it('从后端积分余额接口读取并映射账户', async () => {
+    request.mockResolvedValue(accountResponse)
+
+    await expect(createQuotaApis({ client }).getBalance()).resolves.toEqual({
+      id: '11',
+      userId: '7',
+      balance: 90,
+      frozen: 10,
+      totalEarned: 150,
+      totalSpent: 50,
+      createdAt: '2026-08-12T01:02:03Z',
+      updatedAt: '2026-08-17T01:02:03Z',
+    })
+    expect(request).toHaveBeenCalledWith('/quota/balance')
+  })
+
+  it('拒绝缺字段或负数积分的响应', async () => {
+    request.mockResolvedValue({ ...accountResponse, balance: -1 })
+
+    await expect(createQuotaApis({ client }).getBalance()).rejects.toMatchObject({
+      name: 'ApiError',
+      kind: 'invalid-response',
+      message: '积分账户响应格式无效',
+    })
+  })
+})

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -17,13 +17,15 @@ const accountResponse = {
 
 describe('createQuotaApis', () => {
   let request: ReturnType<typeof vi.fn>
+  let requestList: ReturnType<typeof vi.fn>
   let client: ApiClient
 
   beforeEach(() => {
     request = vi.fn()
+    requestList = vi.fn()
     client = {
       request: request as unknown as ApiClient['request'],
-      requestList: vi.fn() as unknown as ApiClient['requestList'],
+      requestList: requestList as unknown as ApiClient['requestList'],
     }
   })
 
@@ -43,13 +45,46 @@ describe('createQuotaApis', () => {
     expect(request).toHaveBeenCalledWith('/quota/balance')
   })
 
-  it('拒绝缺字段或负数积分的响应', async () => {
-    request.mockResolvedValue({ ...accountResponse, balance: -1 })
+  it('分页读取积分流水并保留后端原因码', async () => {
+    requestList.mockResolvedValue({
+      items: [
+        {
+          id: 21,
+          user_id: 7,
+          delta: -12,
+          reason: 8,
+          billing_mode: 0,
+          ref_id: 'generation-42',
+          balance_after: 78,
+          create_at: '2026-08-17T02:03:04Z',
+        },
+      ],
+      total: 41,
+      page: 2,
+      pageSize: 20,
+    })
 
-    await expect(createQuotaApis({ client }).getBalance()).rejects.toMatchObject({
-      name: 'ApiError',
-      kind: 'invalid-response',
-      message: '积分账户响应格式无效',
+    await expect(
+      createQuotaApis({ client }).listTransactions({ page: 2, pageSize: 20 }),
+    ).resolves.toEqual({
+      items: [
+        {
+          id: '21',
+          userId: '7',
+          delta: -12,
+          reason: 8,
+          billingMode: 0,
+          refId: 'generation-42',
+          balanceAfter: 78,
+          createdAt: '2026-08-17T02:03:04Z',
+        },
+      ],
+      total: 41,
+      page: 2,
+      pageSize: 20,
+    })
+    expect(requestList).toHaveBeenCalledWith('/quota/transactions', {
+      query: { page: 2, page_size: 20 },
     })
   })
 

--- a/frontend/src/entities/quota/api.ts
+++ b/frontend/src/entities/quota/api.ts
@@ -1,6 +1,11 @@
-import type { CreditAccount, QuotaApis } from '.'
+import type {
+  CreditAccount,
+  CreditTransaction,
+  QuotaApis,
+  QuotaTransactionPageQuery,
+} from './types'
 
-import { ApiError, createApiClient, getApiAccessToken } from '@/shared/api'
+import { createApiClient, getApiAccessToken } from '@/shared/api'
 import type { ApiClient, ApiClientOptions } from '@/shared/api'
 
 interface CreditAccountDto {
@@ -14,44 +19,22 @@ interface CreditAccountDto {
   update_at: string
 }
 
+interface CreditTransactionDto {
+  id: number
+  user_id: number
+  delta: number
+  reason: number
+  billing_mode: number
+  ref_id: string | null
+  balance_after: number
+  create_at: string
+}
+
 export interface CreateQuotaApisOptions extends ApiClientOptions {
   client?: ApiClient
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function isPositiveInteger(value: unknown): value is number {
-  return Number.isSafeInteger(value) && (value as number) > 0
-}
-
-function isNonNegativeInteger(value: unknown): value is number {
-  return Number.isSafeInteger(value) && (value as number) >= 0
-}
-
-function invalidResponse(data: unknown): never {
-  throw new ApiError('积分账户响应格式无效', { kind: 'invalid-response', data })
-}
-
-function toCreditAccount(value: unknown): CreditAccount {
-  if (
-    !isRecord(value) ||
-    !isPositiveInteger(value.id) ||
-    !isPositiveInteger(value.user_id) ||
-    !isNonNegativeInteger(value.balance) ||
-    !isNonNegativeInteger(value.frozen) ||
-    !isNonNegativeInteger(value.total_earned) ||
-    !isNonNegativeInteger(value.total_spent) ||
-    typeof value.create_at !== 'string' ||
-    value.create_at.length === 0 ||
-    typeof value.update_at !== 'string' ||
-    value.update_at.length === 0
-  ) {
-    return invalidResponse(value)
-  }
-
-  const dto = value as unknown as CreditAccountDto
+function toCreditAccount(dto: CreditAccountDto): CreditAccount {
   return {
     id: String(dto.id),
     userId: String(dto.user_id),
@@ -61,6 +44,19 @@ function toCreditAccount(value: unknown): CreditAccount {
     totalSpent: dto.total_spent,
     createdAt: dto.create_at,
     updatedAt: dto.update_at,
+  }
+}
+
+function toCreditTransaction(dto: CreditTransactionDto): CreditTransaction {
+  return {
+    id: String(dto.id),
+    userId: String(dto.user_id),
+    delta: dto.delta,
+    reason: dto.reason,
+    billingMode: dto.billing_mode,
+    refId: dto.ref_id,
+    balanceAfter: dto.balance_after,
+    createdAt: dto.create_at,
   }
 }
 
@@ -77,6 +73,15 @@ export function createQuotaApis(options: CreateQuotaApisOptions = {}): QuotaApis
     async getBalance() {
       return toCreditAccount(await protectedClient.request<CreditAccountDto>('/quota/balance'))
     },
+    async listTransactions(query: QuotaTransactionPageQuery = {}) {
+      const result = await protectedClient.requestList<CreditTransactionDto>(
+        '/quota/transactions',
+        {
+          query: { page: query.page, page_size: query.pageSize },
+        },
+      )
+      return { ...result, items: result.items.map(toCreditTransaction) }
+    },
   }
 }
 
@@ -90,4 +95,5 @@ function getDefaultApis(): QuotaApis {
 /** 默认适配器延迟初始化，避免仅导入 entities 时强制要求 API 地址。 */
 export const quotaApis: QuotaApis = {
   getBalance: () => getDefaultApis().getBalance(),
+  listTransactions: (query) => getDefaultApis().listTransactions(query),
 }

--- a/frontend/src/entities/quota/api.ts
+++ b/frontend/src/entities/quota/api.ts
@@ -1,0 +1,93 @@
+import type { CreditAccount, QuotaApis } from '.'
+
+import { ApiError, createApiClient, getApiAccessToken } from '@/shared/api'
+import type { ApiClient, ApiClientOptions } from '@/shared/api'
+
+interface CreditAccountDto {
+  id: number
+  user_id: number
+  balance: number
+  frozen: number
+  total_earned: number
+  total_spent: number
+  create_at: string
+  update_at: string
+}
+
+export interface CreateQuotaApisOptions extends ApiClientOptions {
+  client?: ApiClient
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+function invalidResponse(data: unknown): never {
+  throw new ApiError('积分账户响应格式无效', { kind: 'invalid-response', data })
+}
+
+function toCreditAccount(value: unknown): CreditAccount {
+  if (
+    !isRecord(value) ||
+    !isPositiveInteger(value.id) ||
+    !isPositiveInteger(value.user_id) ||
+    !isNonNegativeInteger(value.balance) ||
+    !isNonNegativeInteger(value.frozen) ||
+    !isNonNegativeInteger(value.total_earned) ||
+    !isNonNegativeInteger(value.total_spent) ||
+    typeof value.create_at !== 'string' ||
+    value.create_at.length === 0 ||
+    typeof value.update_at !== 'string' ||
+    value.update_at.length === 0
+  ) {
+    return invalidResponse(value)
+  }
+
+  const dto = value as unknown as CreditAccountDto
+  return {
+    id: String(dto.id),
+    userId: String(dto.user_id),
+    balance: dto.balance,
+    frozen: dto.frozen,
+    totalEarned: dto.total_earned,
+    totalSpent: dto.total_spent,
+    createdAt: dto.create_at,
+    updatedAt: dto.update_at,
+  }
+}
+
+export function createQuotaApis(options: CreateQuotaApisOptions = {}): QuotaApis {
+  const { client, ...clientOptions } = options
+  const protectedClient =
+    client ??
+    createApiClient({
+      ...clientOptions,
+      getAccessToken: clientOptions.getAccessToken ?? getApiAccessToken,
+    })
+
+  return {
+    async getBalance() {
+      return toCreditAccount(await protectedClient.request<CreditAccountDto>('/quota/balance'))
+    },
+  }
+}
+
+let defaultApis: QuotaApis | undefined
+
+function getDefaultApis(): QuotaApis {
+  defaultApis ??= createQuotaApis()
+  return defaultApis
+}
+
+/** 默认适配器延迟初始化，避免仅导入 entities 时强制要求 API 地址。 */
+export const quotaApis: QuotaApis = {
+  getBalance: () => getDefaultApis().getBalance(),
+}

--- a/frontend/src/entities/quota/index.ts
+++ b/frontend/src/entities/quota/index.ts
@@ -1,18 +1,8 @@
-/** 当前登录用户的积分账户；数值均由后端账本汇总。 */
-export interface CreditAccount {
-  id: string
-  userId: string
-  balance: number
-  frozen: number
-  totalEarned: number
-  totalSpent: number
-  createdAt: string
-  updatedAt: string
-}
-
-export interface QuotaApis {
-  getBalance(): Promise<CreditAccount>
-}
-
 export { createQuotaApis, quotaApis } from './api'
 export type { CreateQuotaApisOptions } from './api'
+export type {
+  CreditAccount,
+  CreditTransaction,
+  QuotaApis,
+  QuotaTransactionPageQuery,
+} from './types'

--- a/frontend/src/entities/quota/index.ts
+++ b/frontend/src/entities/quota/index.ts
@@ -1,0 +1,18 @@
+/** 当前登录用户的积分账户；数值均由后端账本汇总。 */
+export interface CreditAccount {
+  id: string
+  userId: string
+  balance: number
+  frozen: number
+  totalEarned: number
+  totalSpent: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface QuotaApis {
+  getBalance(): Promise<CreditAccount>
+}
+
+export { createQuotaApis, quotaApis } from './api'
+export type { CreateQuotaApisOptions } from './api'

--- a/frontend/src/entities/quota/types.ts
+++ b/frontend/src/entities/quota/types.ts
@@ -1,0 +1,32 @@
+import type { Paged, PageQuery } from '@/shared/pagination'
+
+/** 当前登录用户的积分账户；数值均由后端账本汇总。 */
+export interface CreditAccount {
+  id: string
+  userId: string
+  balance: number
+  frozen: number
+  totalEarned: number
+  totalSpent: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** 一次积分余额变动；原因与计费模式保留后端数字码，兼容后端新增枚举值。 */
+export interface CreditTransaction {
+  id: string
+  userId: string
+  delta: number
+  reason: number
+  billingMode: number
+  refId: string | null
+  balanceAfter: number
+  createdAt: string
+}
+
+export type QuotaTransactionPageQuery = PageQuery
+
+export interface QuotaApis {
+  getBalance(): Promise<CreditAccount>
+  listTransactions(query?: QuotaTransactionPageQuery): Promise<Paged<CreditTransaction>>
+}

--- a/frontend/src/features/quota/index.test.ts
+++ b/frontend/src/features/quota/index.test.ts
@@ -4,7 +4,12 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { CreditAccount, QuotaApis } from '@/entities'
 
-import { useQuotaBalance, useQuotaTransactions } from '.'
+import {
+  formatCreditDateTime,
+  getCreditReasonLabel,
+  useQuotaBalance,
+  useQuotaTransactions,
+} from '.'
 
 const account: CreditAccount = {
   id: '11',
@@ -87,6 +92,35 @@ describe('quota queries', () => {
       expect(apis.listTransactions).toHaveBeenLastCalledWith({ page: 2, pageSize: 20 }),
     )
     await waitFor(() => expect(result.current.page).toBe(2))
+  })
+
+  it('禁用时不读取流水', () => {
+    const apis = createQuotaApis()
+    const { result } = renderHook(() => useQuotaTransactions(false, apis))
+
+    expect(result.current).toMatchObject({ status: 'idle', transactions: [], page: 1 })
+    expect(apis.listTransactions).not.toHaveBeenCalled()
+  })
+
+  it('流水失败后允许重新加载', async () => {
+    const apis = createQuotaApis()
+    apis.listTransactions
+      .mockRejectedValueOnce(new Error('流水服务不可用'))
+      .mockResolvedValueOnce({ items: [], total: 0, page: 1, pageSize: 20 })
+    const { result } = renderHook(() => useQuotaTransactions(true, apis))
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    expect(result.current.error).toBe('流水服务不可用')
+
+    act(() => result.current.reload())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(apis.listTransactions).toHaveBeenCalledTimes(2)
+  })
+
+  it('为已知和未知原因码提供文案，并处理无效时间', () => {
+    expect(getCreditReasonLabel(4)).toBe('生成角色动作')
+    expect(getCreditReasonLabel(99)).toBe('积分变动（原因码 99）')
+    expect(formatCreditDateTime('not-a-date')).toBe('时间未知')
   })
 
   it('组件卸载后忽略迟到的余额结果', async () => {

--- a/frontend/src/features/quota/index.test.ts
+++ b/frontend/src/features/quota/index.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { CreditAccount, QuotaApis } from '@/entities'
+
+import { useQuotaBalance, useQuotaTransactions } from '.'
+
+const account: CreditAccount = {
+  id: '11',
+  userId: '7',
+  balance: 90,
+  frozen: 10,
+  totalEarned: 150,
+  totalSpent: 50,
+  createdAt: '2026-08-12T01:02:03Z',
+  updatedAt: '2026-08-17T01:02:03Z',
+}
+
+function createQuotaApis(): QuotaApis & {
+  getBalance: ReturnType<typeof vi.fn>
+  listTransactions: ReturnType<typeof vi.fn>
+} {
+  return {
+    getBalance: vi.fn(async () => account),
+    listTransactions: vi.fn(async ({ page = 1, pageSize = 20 } = {}) => ({
+      items: [
+        {
+          id: '21',
+          userId: '7',
+          delta: -12,
+          reason: 8,
+          billingMode: 0,
+          refId: 'generation-42',
+          balanceAfter: 78,
+          createdAt: '2026-08-17T02:03:04Z',
+        },
+      ],
+      total: 41,
+      page,
+      pageSize,
+    })),
+  }
+}
+
+describe('quota queries', () => {
+  it('只在启用时查询余额并保留判别状态', async () => {
+    const apis = createQuotaApis()
+    const { result, rerender } = renderHook(({ enabled }) => useQuotaBalance(enabled, apis), {
+      initialProps: { enabled: false },
+    })
+
+    expect(result.current).toMatchObject({ status: 'idle', account: null })
+    expect(apis.getBalance).not.toHaveBeenCalled()
+
+    rerender({ enabled: true })
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    if (result.current.status !== 'ready') throw new Error('余额状态未进入 ready')
+    expect(result.current.account.balance).toBe(90)
+  })
+
+  it('余额失败后允许用户重试', async () => {
+    const apis = createQuotaApis()
+    apis.getBalance
+      .mockRejectedValueOnce(new Error('积分服务不可用'))
+      .mockResolvedValueOnce(account)
+    const { result } = renderHook(() => useQuotaBalance(true, apis))
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+    if (result.current.status !== 'error') throw new Error('余额状态未进入 error')
+    expect(result.current.error).toBe('积分服务不可用')
+
+    act(() => result.current.reload())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(apis.getBalance).toHaveBeenCalledTimes(2)
+  })
+
+  it('切换页码后读取对应的积分流水', async () => {
+    const apis = createQuotaApis()
+    const { result } = renderHook(() => useQuotaTransactions(true, apis))
+
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    expect(apis.listTransactions).toHaveBeenLastCalledWith({ page: 1, pageSize: 20 })
+
+    act(() => result.current.loadPage(2))
+    await waitFor(() =>
+      expect(apis.listTransactions).toHaveBeenLastCalledWith({ page: 2, pageSize: 20 }),
+    )
+    await waitFor(() => expect(result.current.page).toBe(2))
+  })
+
+  it('组件卸载后忽略迟到的余额结果', async () => {
+    const apis = createQuotaApis()
+    let resolveBalance!: (value: CreditAccount) => void
+    apis.getBalance.mockReturnValue(
+      new Promise<CreditAccount>((resolve) => {
+        resolveBalance = resolve
+      }),
+    )
+    const { result, unmount } = renderHook(() => useQuotaBalance(true, apis))
+
+    await waitFor(() => expect(result.current.status).toBe('loading'))
+    unmount()
+    resolveBalance(account)
+    await Promise.resolve()
+
+    expect(apis.getBalance).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/features/quota/index.ts
+++ b/frontend/src/features/quota/index.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { quotaApis as defaultQuotaApis } from '@/entities'
+import type { CreditAccount, CreditTransaction, QuotaApis } from '@/entities'
+
+const TRANSACTIONS_PAGE_SIZE = 20
+
+type BalanceResult =
+  | { status: 'idle' | 'loading'; account: null; error: null }
+  | { status: 'ready'; account: CreditAccount; error: null }
+  | { status: 'error'; account: null; error: string }
+
+export type QuotaBalanceState = BalanceResult & { reload(): void }
+
+type TransactionsResult = {
+  status: 'idle' | 'loading' | 'ready' | 'error'
+  transactions: CreditTransaction[]
+  total: number
+  page: number
+  pageSize: number
+  error: string | null
+}
+
+export type QuotaTransactionsState = TransactionsResult & {
+  loadPage(page: number): void
+  reload(): void
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : '积分加载失败，请稍后重试'
+}
+
+export function useQuotaBalance(
+  enabled: boolean,
+  apis: QuotaApis = defaultQuotaApis,
+): QuotaBalanceState {
+  const [attempt, setAttempt] = useState(0)
+  const [result, setResult] = useState<BalanceResult>({
+    status: 'idle',
+    account: null,
+    error: null,
+  })
+
+  useEffect(() => {
+    if (!enabled) {
+      setResult({ status: 'idle', account: null, error: null })
+      return
+    }
+
+    let active = true
+    setResult({ status: 'loading', account: null, error: null })
+    void Promise.resolve()
+      .then(() => apis.getBalance())
+      .then(
+        (account) => {
+          if (active) setResult({ status: 'ready', account, error: null })
+        },
+        (error: unknown) => {
+          if (active) setResult({ status: 'error', account: null, error: errorMessage(error) })
+        },
+      )
+
+    return () => {
+      active = false
+    }
+  }, [apis, attempt, enabled])
+
+  const reload = useCallback(() => setAttempt((current) => current + 1), [])
+  return { ...result, reload }
+}
+
+const initialTransactions: TransactionsResult = {
+  status: 'idle',
+  transactions: [],
+  total: 0,
+  page: 1,
+  pageSize: TRANSACTIONS_PAGE_SIZE,
+  error: null,
+}
+
+export function useQuotaTransactions(
+  enabled: boolean,
+  apis: QuotaApis = defaultQuotaApis,
+): QuotaTransactionsState {
+  const [attempt, setAttempt] = useState(0)
+  const [requestedPage, setRequestedPage] = useState(1)
+  const [result, setResult] = useState<TransactionsResult>(initialTransactions)
+
+  useEffect(() => {
+    if (!enabled) {
+      setResult(initialTransactions)
+      return
+    }
+
+    let active = true
+    setResult((current) => ({ ...current, status: 'loading', error: null }))
+    void Promise.resolve()
+      .then(() => apis.listTransactions({ page: requestedPage, pageSize: TRANSACTIONS_PAGE_SIZE }))
+      .then(
+        (page) => {
+          if (!active) return
+          setResult({
+            status: 'ready',
+            transactions: page.items,
+            total: page.total,
+            page: page.page,
+            pageSize: page.pageSize,
+            error: null,
+          })
+        },
+        (error: unknown) => {
+          if (active) {
+            setResult((current) => ({
+              ...current,
+              status: 'error',
+              error: errorMessage(error),
+            }))
+          }
+        },
+      )
+
+    return () => {
+      active = false
+    }
+  }, [apis, attempt, enabled, requestedPage])
+
+  const loadPage = useCallback((page: number) => setRequestedPage(Math.max(1, page)), [])
+  const reload = useCallback(() => setAttempt((current) => current + 1), [])
+  return { ...result, loadPage, reload }
+}
+
+const reasonLabels: Readonly<Record<number, string>> = {
+  1: '注册赠送',
+  2: '邀请奖励',
+  3: '生成角色参考图',
+  4: '生成角色动作',
+  5: '管理员调整',
+  6: '退款 / 回退',
+  7: '积分冻结',
+  8: '实际扣减',
+}
+
+export function getCreditReasonLabel(reason: number): string {
+  return reasonLabels[reason] ?? `积分变动（原因码 ${reason}）`
+}
+
+const creditDateTimeFormatter = new Intl.DateTimeFormat('zh-CN', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+})
+
+export function formatCreditDateTime(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? '时间未知' : creditDateTimeFormatter.format(date)
+}

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, useLocation } from 'react-router'
 
+import { quotaApis } from '@/entities'
 import type { AuthTokens, User, UserApis } from '@/entities'
 import { AuthSessionProvider } from '@/features/auth-session'
 import { AppRoutes } from '@/app/app'
@@ -68,6 +69,7 @@ function renderAccount(apis = createApis()) {
 afterEach(() => {
   cleanup()
   window.localStorage.clear()
+  vi.restoreAllMocks()
 })
 
 describe('AccountPage', () => {
@@ -147,6 +149,44 @@ describe('AccountPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '登录安全' }))
     expect((screen.getByLabelText('当前密码') as HTMLInputElement).value).toBe('')
     expect((screen.getByLabelText('新密码') as HTMLInputElement).value).toBe('')
+  })
+
+  it('在账号中心展示积分汇总、流水与未知原因码', async () => {
+    vi.spyOn(quotaApis, 'getBalance').mockResolvedValue({
+      id: '11',
+      userId: '7',
+      balance: 90,
+      frozen: 10,
+      totalEarned: 150,
+      totalSpent: 50,
+      createdAt: '2026-08-12T01:02:03Z',
+      updatedAt: '2026-08-17T01:02:03Z',
+    })
+    vi.spyOn(quotaApis, 'listTransactions').mockResolvedValue({
+      items: [
+        {
+          id: '21',
+          userId: '7',
+          delta: -12,
+          reason: 99,
+          billingMode: 0,
+          refId: 'generation-42',
+          balanceAfter: 78,
+          createdAt: '2026-08-17T02:03:04Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    })
+
+    renderAccount()
+    fireEvent.click(await screen.findByRole('button', { name: '积分账户' }))
+
+    expect(await screen.findByRole('heading', { name: '积分账户' })).toBeTruthy()
+    expect(await screen.findByText('90')).toBeTruthy()
+    expect(screen.getByText('积分变动（原因码 99）')).toBeTruthy()
+    expect(screen.getByText('-12')).toBeTruthy()
   })
 
   it('reports a profile refresh failure without claiming the data is synchronized', async () => {

--- a/frontend/src/pages/account/index.tsx
+++ b/frontend/src/pages/account/index.tsx
@@ -3,6 +3,13 @@ import { useEffect, useId, useReducer, useRef, useState, type FormEvent } from '
 import accountBadgeArtwork from '@/assets/account/illustrations/account-badge.webp'
 import type { User } from '@/entities'
 import { useAuthSession } from '@/features/auth-session'
+import {
+  formatCreditDateTime,
+  getCreditReasonLabel,
+  useQuotaBalance,
+  useQuotaTransactions,
+} from '@/features/quota'
+import { Pagination } from '@/shared/ui'
 
 import './account.css'
 import { createProfileState, initialSecurityState, profileReducer, securityReducer } from './state'
@@ -25,6 +32,115 @@ function formatVerificationTime(value: string): string {
   }).format(date)
 }
 
+function formatCredits(value: number): string {
+  return value.toLocaleString('zh-CN')
+}
+
+function QuotaSection() {
+  const balance = useQuotaBalance(true)
+  const transactions = useQuotaTransactions(true)
+  const account = balance.status === 'ready' ? balance.account : null
+  const summaryRows: Array<[string, string]> = [
+    ['可用积分', account ? formatCredits(account.balance) : '—'],
+    ['冻结积分', account ? formatCredits(account.frozen) : '—'],
+    ['累计获得', account ? formatCredits(account.totalEarned) : '—'],
+    ['累计使用', account ? formatCredits(account.totalSpent) : '—'],
+  ]
+
+  return (
+    <div>
+      <header>
+        <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">积分账户</h2>
+        <p className="mt-1.5 text-sm text-app-muted">查看当前余额与最近的积分变动记录。</p>
+      </header>
+
+      <dl className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {summaryRows.map(([label, value]) => (
+          <div
+            key={label}
+            className="rounded-xl border border-app-line bg-app-surface-muted px-4 py-3"
+          >
+            <dt className="text-xs text-app-faint">{label}</dt>
+            <dd className="mt-1 font-mono text-2xl font-semibold text-app-ink">{value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {balance.status === 'loading' && (
+        <p role="status" className="mt-3 text-sm text-app-muted">
+          正在加载积分余额…
+        </p>
+      )}
+      {balance.status === 'error' && (
+        <div className="mt-3 flex flex-wrap items-center gap-3 rounded-lg bg-app-danger-soft px-3 py-2.5 text-sm text-app-danger">
+          <p role="alert">{balance.error}</p>
+          <button type="button" onClick={balance.reload} className="font-semibold underline">
+            重新加载
+          </button>
+        </div>
+      )}
+
+      <section className="mt-7" aria-labelledby="credit-transactions-title">
+        <div className="flex items-center justify-between gap-4">
+          <h3 id="credit-transactions-title" className="text-sm font-semibold text-app-ink-soft">
+            积分流水
+          </h3>
+          {transactions.status === 'ready' && (
+            <span className="text-xs text-app-faint">共 {transactions.total} 条</span>
+          )}
+        </div>
+
+        {transactions.status === 'loading' ? (
+          <p role="status" className="mt-3 text-sm text-app-muted">
+            正在加载积分流水…
+          </p>
+        ) : transactions.status === 'error' ? (
+          <div className="mt-3 flex flex-wrap items-center gap-3 rounded-lg bg-app-danger-soft px-3 py-2.5 text-sm text-app-danger">
+            <p role="alert">{transactions.error}</p>
+            <button type="button" onClick={transactions.reload} className="font-semibold underline">
+              重新加载
+            </button>
+          </div>
+        ) : transactions.status === 'ready' && transactions.transactions.length === 0 ? (
+          <p className="mt-3 text-sm text-app-muted">还没有积分流水。</p>
+        ) : transactions.status === 'ready' ? (
+          <ul className="mt-3 divide-y divide-app-line overflow-hidden rounded-xl border border-app-line bg-app-surface-muted">
+            {transactions.transactions.map((transaction) => (
+              <li key={transaction.id} className="flex items-center gap-4 px-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-app-ink-soft">
+                    {getCreditReasonLabel(transaction.reason)}
+                  </p>
+                  <p className="mt-0.5 text-xs text-app-faint">
+                    {formatCreditDateTime(transaction.createdAt)} · 余额{' '}
+                    {formatCredits(transaction.balanceAfter)}
+                  </p>
+                </div>
+                <span
+                  className={`shrink-0 font-mono text-sm font-semibold ${
+                    transaction.delta >= 0 ? 'text-app-accent' : 'text-app-danger'
+                  }`}
+                >
+                  {transaction.delta > 0 ? '+' : ''}
+                  {formatCredits(transaction.delta)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        <Pagination
+          page={transactions.page}
+          pageSize={transactions.pageSize}
+          total={transactions.total}
+          disabled={transactions.status === 'loading'}
+          onPageChange={transactions.loadPage}
+        />
+      </section>
+    </div>
+  )
+}
+
 /** 账号页以 /auth/me 为事实来源；会话层负责把刷新和编辑结果同步给 Header。 */
 export function AccountPage() {
   const session = useAuthSession()
@@ -42,7 +158,7 @@ export function AccountPage() {
     createProfileState,
   )
   const [security, dispatchSecurity] = useReducer(securityReducer, initialSecurityState)
-  const [activeSection, setActiveSection] = useState<'profile' | 'security'>('profile')
+  const [activeSection, setActiveSection] = useState<'profile' | 'security' | 'quota'>('profile')
   const nicknameId = useId()
   const oldPasswordId = useId()
   const newPasswordId = useId()
@@ -114,7 +230,7 @@ export function AccountPage() {
     void logout().catch(() => undefined)
   }
 
-  function selectSection(section: 'profile' | 'security') {
+  function selectSection(section: 'profile' | 'security' | 'quota') {
     setActiveSection(section)
     dispatchProfile({ type: 'sectionChanged' })
     dispatchSecurity({ type: 'sectionChanged' })
@@ -175,6 +291,7 @@ export function AccountPage() {
                 [
                   ['profile', '个人资料'],
                   ['security', '登录安全'],
+                  ['quota', '积分账户'],
                 ] as const
               ).map(([section, label]) => (
                 <button
@@ -298,7 +415,7 @@ export function AccountPage() {
                   </div>
                 </form>
               </div>
-            ) : (
+            ) : activeSection === 'security' ? (
               <div>
                 <header>
                   <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">
@@ -371,6 +488,8 @@ export function AccountPage() {
                   </button>
                 </form>
               </div>
+            ) : (
+              <QuotaSection />
             )}
           </section>
         </div>


### PR DESCRIPTION
## 改动内容

- 复用后端 `GET /quota/balance`，在账号菜单按需展示最新可用积分
- 接入 `GET /quota/transactions`，在账号中心新增积分汇总与分页流水
- 将积分契约移入 `entities/quota/types.ts`，消除 `api.ts` 对公开入口的反向导入
- 去除重复的逐字段运行时校验，由公共 API 客户端校验响应壳，实体适配器只负责字段映射
- 保留后端数字原因码，并为未来新增原因码提供可读兜底文案
- 抽取可复用查询 Hook，覆盖加载、失败、重试、分页与卸载后的迟到响应

## 评审意见处理

- 已在账号中心增加积分页签，不再只显示在 Header
- 已解决 `entities/quota/api.ts` 反向导入
- 已删除可读性差且重复的手写防御式字段校验
- 参考 #337 的页面方向，但未照搬其反向依赖和未知枚举直接报错行为
- 迁移自 #341；旧 PR 的评审上下文保留在原讨论中

## 依据

复用已合并 PR #230 提供的积分账户接口，不修改后端契约，不引入 Zod 或全局 API 重构。

Closes #342

## 验证

- `npm run lint`
- 11 个改动文件 `oxfmt --check`
- `npm test`：51 个测试文件，524 条通过，4 条按仓库配置跳过
- `npm run build`
- 代码审查：无阻塞问题；关闭动画期间余额闪烁问题已补充修复与回归测试