### PR TITLE
fix(project): 有角色挂载时拒绝删除项目

### DIFF
--- a/backend/packages/app/src/windup_app/server/character/interface.py
+++ b/backend/packages/app/src/windup_app/server/character/interface.py
@@ -51,6 +51,10 @@ class CharacterService(ABC):
         """
 
     @abstractmethod
+    def project_has_characters(self, session: Session, project_id: int) -> bool:
+        """判断项目下是否仍挂载角色（草稿或已发布均算）。"""
+
+    @abstractmethod
     def update_character(self, session: Session, character_id: int, **fields) -> Character | None:
         """更新角色描述、参考图或 character_data 等字段。
 

--- a/backend/packages/app/src/windup_app/server/character/model.py
+++ b/backend/packages/app/src/windup_app/server/character/model.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import (
     BigInteger,
     DateTime,
+    ForeignKey,
     Integer,
     JSON,
     SmallInteger,
@@ -71,7 +72,15 @@ class Character(Base):
         autoincrement=True,
     )
 
-    project_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    project_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey(
+            "windup_project.id",
+            ondelete="RESTRICT",
+            name="fk_windup_character_project_id",
+        ),
+        nullable=False,
+    )
 
     workflow_run_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
 

--- a/backend/packages/app/src/windup_app/server/character/service.py
+++ b/backend/packages/app/src/windup_app/server/character/service.py
@@ -76,6 +76,14 @@ class SqlAlchemyCharacterService(CharacterService):
         items = list(session.scalars(stmt))
         return items, total
 
+    def project_has_characters(self, session: Session, project_id: int) -> bool:
+        stmt = (
+            select(Character.id)
+            .where(Character.project_id == project_id)
+            .limit(1)
+        )
+        return session.scalar(stmt) is not None
+
     def update_character(
         self, session: Session, character_id: int, **fields,
     ) -> Character | None:

--- a/backend/packages/app/src/windup_app/server/project/interface.py
+++ b/backend/packages/app/src/windup_app/server/project/interface.py
@@ -31,8 +31,14 @@ class ProjectService(ABC):
         """判断用户下的项目名称是否已存在。"""
 
     @abstractmethod
-    def get_project(self, session: Session, project_id: int) -> Project | None:
-        """按 ID 查询项目。"""
+    def get_project(
+        self, session: Session, project_id: int, *, for_update: bool = False
+    ) -> Project | None:
+        """按 ID 查询项目。
+
+        ``for_update`` 为真时对项目行加 ``SELECT ... FOR UPDATE``，供角色创建与
+        项目删除互斥，避免检查与写入之间插入角色。
+        """
 
     @abstractmethod
     def list_projects(

--- a/backend/packages/app/src/windup_app/server/project/service.py
+++ b/backend/packages/app/src/windup_app/server/project/service.py
@@ -32,8 +32,14 @@ class SqlAlchemyProjectService(ProjectService):
         )
         return session.scalar(stmt) is not None
 
-    def get_project(self, session: Session, project_id: int) -> Project | None:
-        return session.get(Project, project_id)
+    def get_project(
+        self, session: Session, project_id: int, *, for_update: bool = False
+    ) -> Project | None:
+        if not for_update:
+            return session.get(Project, project_id)
+        return session.scalar(
+            select(Project).where(Project.id == project_id).with_for_update()
+        )
 
     def list_projects(
         self, session: Session, *, page: int, page_size: int, user_id: int | None = None

--- a/backend/packages/app/src/windup_app/web/api/character.py
+++ b/backend/packages/app/src/windup_app/web/api/character.py
@@ -18,6 +18,7 @@ from windup_app.server.character.model import Character, CharacterData
 from windup_app.server.character.service import service as character_service
 from windup_app.server.media.service import service as media_service
 from windup_app.server.project.model import Project
+from windup_app.server.project.service import service as project_service
 
 logger = logging.getLogger("windup.character.api")
 
@@ -97,10 +98,13 @@ def _extract_object_keys(character: Character) -> list[str]:
 
 
 def _get_project_or_raise(
-    session: Session, project_id: int, user_id: int,
+    session: Session, project_id: int, user_id: int, *, for_update: bool = False,
 ) -> Project:
-    """校验项目存在且属于当前用户，否则抛 BizException。"""
-    project = session.get(Project, project_id)
+    """校验项目存在且属于当前用户，否则抛 BizException。
+
+    创建角色时 ``for_update=True``，与删除项目锁同一行，避免并发下留下无归属角色。
+    """
+    project = project_service.get_project(session, project_id, for_update=for_update)
     if project is None or project.user_id != user_id:
         raise BizException("项目不存在", code=BizCode.NOT_FOUND)
     return project
@@ -132,7 +136,7 @@ def create_character(
     session: Session = Depends(get_session),
 ) -> Response[CharacterOut]:
     user_id = request.state.current_user.id
-    _get_project_or_raise(session, body.project_id, user_id)
+    _get_project_or_raise(session, body.project_id, user_id, for_update=True)
     character_data = body.character_data.model_dump()
     status = CharacterStatus.from_character_data(character_data)
     try:
@@ -146,8 +150,11 @@ def create_character(
             character_data=character_data,
             status=status,
         )
-    except IntegrityError:
+    except IntegrityError as exc:
         session.rollback()
+        orig = str(getattr(exc, "orig", exc)).lower()
+        if "foreign key" in orig:
+            raise BizException("项目不存在", code=BizCode.NOT_FOUND) from None
         character = character_service.get_character_by_workflow_run(
             session,
             body.workflow_run_id,

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -118,10 +118,14 @@ def delete_project(
     request: Request,
     session: Session = Depends(get_session),
 ) -> Response[None]:
-    project = service.get_project(session, project_id)
+    project = service.get_project(session, project_id, for_update=True)
     if project is None or project.user_id != request.state.current_user.id:
         raise BizException("项目不存在", code=BizCode.NOT_FOUND)
     if character_service.project_has_characters(session, project_id):
         raise BizException("项目下仍有角色，无法删除", code=BizCode.BAD_REQUEST)
-    service.delete_project(session, project_id)
+    try:
+        service.delete_project(session, project_id)
+    except IntegrityError:
+        session.rollback()
+        raise BizException("项目下仍有角色，无法删除", code=BizCode.BAD_REQUEST) from None
     return Response.success(None, message="删除成功")

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -13,6 +13,7 @@ from windup_common.exceptions import BizException
 from windup_common.result import ListResponse, Response
 from windup_framework.db import get_session
 
+from windup_app.server.character.service import service as character_service
 from windup_app.server.project.service import service
 
 logger = logging.getLogger("windup.project.api")
@@ -120,5 +121,7 @@ def delete_project(
     project = service.get_project(session, project_id)
     if project is None or project.user_id != request.state.current_user.id:
         raise BizException("项目不存在", code=BizCode.NOT_FOUND)
+    if character_service.project_has_characters(session, project_id):
+        raise BizException("项目下仍有角色，无法删除", code=BizCode.BAD_REQUEST)
     service.delete_project(session, project_id)
     return Response.success(None, message="删除成功")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,7 +15,7 @@ os.environ.setdefault("POSTGRES_PASSWORD", "testpassword123")
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -30,6 +30,23 @@ from windup_app.server.user.service import create_access_token
 from windup_framework.db import Base, get_session
 
 
+def insert_project(session, **overrides) -> Project:
+    """写入一条合法项目，供需要 ``windup_character.project_id`` 外键的测试使用。"""
+    fields = {
+        "user_id": 1,
+        "project_name": "测试项目",
+        "character_perspective": 1,
+        "directional_movement": 2,
+        "sprite_width": 64,
+        "sprite_height": 64,
+    }
+    fields.update(overrides)
+    project = Project(**fields)
+    session.add(project)
+    session.flush()
+    return project
+
+
 def _disable_generation_execution(app):
     app.state.run_action_task = lambda *args: None
     app.state.run_image_task = lambda *args: None
@@ -37,11 +54,19 @@ def _disable_generation_execution(app):
 
 def _make_engine():
     """单连接内存 SQLite;``check_same_thread=False`` 让 TestClient 线程可共用。"""
-    return create_engine(
+    engine = create_engine(
         "sqlite:///:memory:",
         poolclass=StaticPool,
         connect_args={"check_same_thread": False},
     )
+
+    @event.listens_for(engine, "connect")
+    def _enable_sqlite_foreign_keys(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    return engine
 
 
 @pytest.fixture()

--- a/backend/tests/test_character_api.py
+++ b/backend/tests/test_character_api.py
@@ -72,7 +72,10 @@ def _payload_with_frames(project_id: int, **overrides):
 
 def test_character_model_defaults_to_draft(db_session):
     """非 API 写入也不得把尚无真实动作帧的角色默认为已发布。"""
-    character = Character(project_id=1, workflow_run_id=999, character_data={})
+    from conftest import insert_project
+
+    project = insert_project(db_session)
+    character = Character(project_id=project.id, workflow_run_id=999, character_data={})
     db_session.add(character)
     db_session.flush()
 

--- a/backend/tests/test_character_naming.py
+++ b/backend/tests/test_character_naming.py
@@ -62,13 +62,15 @@ def test_empty_namer_result_falls_back_to_description():
 
 
 def test_service_create_skips_namer_when_workflow_run_exists(db_session):
+    from conftest import insert_project
     from windup_app.server.character.service import SqlAlchemyCharacterService
 
+    project = insert_project(db_session)
     namer = _FakeNamer("第一次")
     service = SqlAlchemyCharacterService(namer=namer)
     first = service.create_character(
         db_session,
-        project_id=1,
+        project_id=project.id,
         workflow_run_id=77,
         name=None,
         description="红发少年",
@@ -77,7 +79,7 @@ def test_service_create_skips_namer_when_workflow_run_exists(db_session):
     namer.result = "第二次"
     second = service.create_character(
         db_session,
-        project_id=1,
+        project_id=project.id,
         workflow_run_id=77,
         name=None,
         description="红发少年",
@@ -92,13 +94,16 @@ def test_service_create_skips_namer_when_workflow_run_exists(db_session):
 def test_service_create_skips_namer_on_cross_project_workflow_run(db_session):
     from sqlalchemy.exc import IntegrityError
 
+    from conftest import insert_project
     from windup_app.server.character.service import SqlAlchemyCharacterService
 
+    first_project = insert_project(db_session, project_name="项目一")
+    second_project = insert_project(db_session, project_name="项目二")
     namer = _FakeNamer("第一次")
     service = SqlAlchemyCharacterService(namer=namer)
     service.create_character(
         db_session,
-        project_id=1,
+        project_id=first_project.id,
         workflow_run_id=88,
         name=None,
         description="红发少年",
@@ -108,7 +113,7 @@ def test_service_create_skips_namer_on_cross_project_workflow_run(db_session):
     with pytest.raises(IntegrityError):
         service.create_character(
             db_session,
-            project_id=2,
+            project_id=second_project.id,
             workflow_run_id=88,
             name=None,
             description="另一段描述",
@@ -119,12 +124,14 @@ def test_service_create_skips_namer_on_cross_project_workflow_run(db_session):
 
 
 def test_service_create_uses_namer_when_name_missing(db_session):
+    from conftest import insert_project
     from windup_app.server.character.service import SqlAlchemyCharacterService
 
+    project = insert_project(db_session)
     service = SqlAlchemyCharacterService(namer=_FakeNamer("雾港少年"))
     character = service.create_character(
         db_session,
-        project_id=1,
+        project_id=project.id,
         workflow_run_id=901,
         name=None,
         description="红发少年站在雾港码头",

--- a/backend/tests/test_project_api.py
+++ b/backend/tests/test_project_api.py
@@ -122,3 +122,29 @@ def test_delete_not_found_returns_404(auth_client):
     resp = auth_client.delete("/projects/99999")
 
     assert resp.json()["code"] == 404
+
+
+def test_delete_rejected_when_project_has_characters(auth_client):
+    created = auth_client.post("/projects", json=_payload(project_name="有角色")).json()[
+        "data"
+    ]
+    character = auth_client.post(
+        "/characters",
+        json={
+            "project_id": created["id"],
+            "workflow_run_id": 348,
+            "name": "挂载角色",
+            "description": "阻止删项目",
+        },
+    ).json()
+
+    assert character["code"] == 200
+
+    resp = auth_client.delete(f"/projects/{created['id']}")
+
+    body = resp.json()
+    assert body["code"] == 400
+    assert body["message"] == "项目下仍有角色，无法删除"
+    assert body["data"] is None
+    assert auth_client.get(f"/projects/{created['id']}").json()["code"] == 200
+    assert auth_client.get(f"/characters/{character['data']['id']}").json()["code"] == 200

--- a/backend/tests/test_project_api.py
+++ b/backend/tests/test_project_api.py
@@ -148,3 +148,33 @@ def test_delete_rejected_when_project_has_characters(auth_client):
     assert body["data"] is None
     assert auth_client.get(f"/projects/{created['id']}").json()["code"] == 200
     assert auth_client.get(f"/characters/{character['data']['id']}").json()["code"] == 200
+
+
+def test_delete_rejected_when_character_arrives_after_empty_check(auth_client, monkeypatch):
+    """模拟检查与删除之间插入角色：应用层已看见空项目，数据库仍应拦住删除。"""
+    created = auth_client.post("/projects", json=_payload(project_name="竞态")).json()[
+        "data"
+    ]
+    character = auth_client.post(
+        "/characters",
+        json={
+            "project_id": created["id"],
+            "workflow_run_id": 349,
+            "name": "后插入",
+            "description": "检查之后才出现",
+        },
+    ).json()
+    assert character["code"] == 200
+
+    monkeypatch.setattr(
+        "windup_app.web.api.project.character_service.project_has_characters",
+        lambda session, project_id: False,
+    )
+
+    resp = auth_client.delete(f"/projects/{created['id']}")
+
+    body = resp.json()
+    assert body["code"] == 400
+    assert body["message"] == "项目下仍有角色，无法删除"
+    assert auth_client.get(f"/projects/{created['id']}").json()["code"] == 200
+    assert auth_client.get(f"/characters/{character['data']['id']}").json()["code"] == 200

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -15,7 +15,12 @@ export type {
 } from './quota'
 
 /* 项目 —— 全局约束：视角、朝向、精灵尺寸、画风 */
-export { CHARACTER_PERSPECTIVE, DIRECTIONAL_MOVEMENT, ProjectHasCharactersError, ProjectNameConflictError } from './project'
+export {
+  CHARACTER_PERSPECTIVE,
+  DIRECTIONAL_MOVEMENT,
+  ProjectHasCharactersError,
+  ProjectNameConflictError,
+} from './project'
 export { projectApis } from './project'
 export type {
   CharacterPerspective,

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -15,7 +15,7 @@ export type {
 } from './quota'
 
 /* 项目 —— 全局约束：视角、朝向、精灵尺寸、画风 */
-export { CHARACTER_PERSPECTIVE, DIRECTIONAL_MOVEMENT, ProjectNameConflictError } from './project'
+export { CHARACTER_PERSPECTIVE, DIRECTIONAL_MOVEMENT, ProjectHasCharactersError, ProjectNameConflictError } from './project'
 export { projectApis } from './project'
 export type {
   CharacterPerspective,

--- a/frontend/src/entities/project/index.test.ts
+++ b/frontend/src/entities/project/index.test.ts
@@ -159,4 +159,16 @@ describe('projectApis', () => {
       }),
     ).rejects.toBeInstanceOf(ProjectNameConflictError)
   })
+
+  it('maps the backend in-use project contract to a stable domain error', async () => {
+    const { ProjectHasCharactersError, projectApis } = await loadProjectApis(
+      async () =>
+        new Response(
+          JSON.stringify({ code: 400, message: '项目下仍有角色，无法删除', data: null }),
+          { headers: { 'content-type': 'application/json' } },
+        ),
+    )
+
+    await expect(projectApis.remove('42')).rejects.toBeInstanceOf(ProjectHasCharactersError)
+  })
 })

--- a/frontend/src/entities/project/index.ts
+++ b/frontend/src/entities/project/index.ts
@@ -43,6 +43,18 @@ export class ProjectNameConflictError extends ApiError {
   }
 }
 
+/** 项目下仍挂载角色，后端拒绝删除。 */
+export class ProjectHasCharactersError extends ApiError {
+  constructor(options?: { cause?: unknown }) {
+    super('项目下仍有角色，无法删除', {
+      kind: 'business',
+      code: 400,
+      cause: options?.cause,
+    })
+    this.name = 'ProjectHasCharactersError'
+  }
+}
+
 /** 后端 character_perspective: 1 横版 / 2 俯视 / 3 2.5D。 */
 export type CharacterPerspective = 'side' | 'top-down' | 'isometric'
 
@@ -203,8 +215,20 @@ export const projectApis: ProjectApis = {
   },
 
   async remove(id) {
-    await getApiClient().request<null>(`/projects/${encodeURIComponent(id)}`, {
-      method: 'DELETE',
-    })
+    try {
+      await getApiClient().request<null>(`/projects/${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      })
+    } catch (error) {
+      if (
+        error instanceof ApiError &&
+        error.kind === 'business' &&
+        error.code === 400 &&
+        error.message === '项目下仍有角色，无法删除'
+      ) {
+        throw new ProjectHasCharactersError({ cause: error })
+      }
+      throw error
+    }
   },
 }

--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -112,6 +112,27 @@ describe('ProjectsPage', () => {
     ).toBe(true)
   })
 
+  it('keeps the project and shows why delete is blocked when characters remain', async () => {
+    installBackend()
+    const { ProjectHasCharactersError, projectApis } = await import('@/entities')
+    vi.spyOn(projectApis, 'remove').mockRejectedValue(new ProjectHasCharactersError())
+    render(
+      <AuthenticatedAuthSession>
+        <MemoryRouter initialEntries={['/projects']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </AuthenticatedAuthSession>,
+    )
+
+    expect(await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '删除项目 点灯人 · MVP' }))
+    fireEvent.click(screen.getByRole('button', { name: '确认删除项目' }))
+
+    expect(await screen.findByText('项目下仍有角色，无法删除')).toBeTruthy()
+    expect(screen.queryByRole('dialog', { name: '删除项目' })).toBeNull()
+    expect(screen.getByRole('link', { name: '打开项目 点灯人 · MVP' })).toBeTruthy()
+  })
+
   it('falls back through character preview sources without blocking the gallery', async () => {
     const backend = createProjectAssetsBackend({ projectCount: 3 })
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')

--- a/frontend/src/pages/projects/index.tsx
+++ b/frontend/src/pages/projects/index.tsx
@@ -2,7 +2,13 @@ import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import { Link } from 'react-router'
 
 import assetLibraryArtwork from '@/assets/workspace/asset-library.png'
-import { characterApis, projectApis, ProjectHasCharactersError, type Character, type Project } from '@/entities'
+import {
+  characterApis,
+  projectApis,
+  ProjectHasCharactersError,
+  type Character,
+  type Project,
+} from '@/entities'
 import type { Paged } from '@/shared/pagination'
 import { Pagination } from '@/shared/ui'
 
@@ -172,9 +178,7 @@ export function ProjectsPage() {
       }
       setDeleteTarget(null)
     } catch (error) {
-      setError(
-        error instanceof ProjectHasCharactersError ? error.message : '项目暂时无法删除',
-      )
+      setError(error instanceof ProjectHasCharactersError ? error.message : '项目暂时无法删除')
       setDeleteTarget(null)
     } finally {
       setDeleting(false)

--- a/frontend/src/pages/projects/index.tsx
+++ b/frontend/src/pages/projects/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import { Link } from 'react-router'
 
 import assetLibraryArtwork from '@/assets/workspace/asset-library.png'
-import { characterApis, projectApis, type Character, type Project } from '@/entities'
+import { characterApis, projectApis, ProjectHasCharactersError, type Character, type Project } from '@/entities'
 import type { Paged } from '@/shared/pagination'
 import { Pagination } from '@/shared/ui'
 
@@ -171,8 +171,11 @@ export function ProjectsPage() {
         )
       }
       setDeleteTarget(null)
-    } catch {
-      setError('项目暂时无法删除')
+    } catch (error) {
+      setError(
+        error instanceof ProjectHasCharactersError ? error.message : '项目暂时无法删除',
+      )
+      setDeleteTarget(null)
     } finally {
       setDeleting(false)
     }
@@ -200,9 +203,11 @@ export function ProjectsPage() {
           >
             {error}
           </p>
-        ) : projectsPage === null ? (
+        ) : null}
+        {projectsPage === null && !error ? (
           <p className="mt-6 text-sm text-app-muted">正在读取项目…</p>
-        ) : (
+        ) : null}
+        {projectsPage ? (
           <div className="mt-5">
             <ProjectCreateCard />
             {projectsPage.items.length > 0 ? (
@@ -214,7 +219,7 @@ export function ProjectsPage() {
               />
             ) : null}
           </div>
-        )}
+        ) : null}
         {projectsPage ? (
           <Pagination
             page={projectsPage.page}


### PR DESCRIPTION
## Summary
- 修复 [#348](https://github.com/1024XEngineer/Windup/issues/348)：`DELETE /projects/{id}` 在项目下仍有 character 时拒绝删除。
- 角色服务新增 `project_has_characters`；空项目仍可删，挂载角色时返回业务码 400「项目下仍有角色，无法删除」。
- 项目中心把该错误展示给用户，并在失败后保留列表。

Fixes #348

## Test plan
- [x] `cd backend && uv run pytest tests/test_project_api.py --no-cov`（10 passed）
- [x] `cd frontend && npm test -- src/entities/project/index.test.ts src/pages/projects/index.test.tsx`（14 passed）
- [x] `uv run ruff check` 变更文件 + `uv run lint-imports`
- [x] 项目中心：空项目可删；有角色的项目删除后提示「项目下仍有角色，无法删除」，项目仍在列表里