### PR TITLE
feat(quota): 生成任务调度接入预付费冻结与扣减

### DIFF
--- a/backend/packages/app/src/windup_app/bootstrap/app.py
+++ b/backend/packages/app/src/windup_app/bootstrap/app.py
@@ -7,12 +7,13 @@
 ``main`` 是开发启动入口:``python -m windup_app`` 或 ``windup`` 命令。
 """
 
+import logging
 import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from windup_framework.db import Base, engine
+from windup_framework.db import Base, engine, SessionLocal
 
 # 模型导入：触发 Base.metadata 注册，确保 create_all 能发现所有表
 from windup_ai_engine.impl.character_namer import LangChainCharacterNamer
@@ -75,10 +76,31 @@ async def _lifespan(app: FastAPI):
     """应用启动时建表，关闭时等待已排队的生成任务收敛。"""
     Base.metadata.create_all(engine)
     print_banner()
+    _recover_orphaned_generation(app)
     try:
         yield
     finally:
         app.state.generation_dispatcher.shutdown()
+
+
+def _recover_orphaned_generation(app: FastAPI) -> None:
+    """启动时把仍冻结的 PENDING 任务重新入队，RUNNING 孤儿失败并解冻。"""
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    session = SessionLocal()
+    try:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=app.state.generation_dispatcher,
+            run_image_task=app.state.run_image_task,
+            run_action_task=app.state.run_action_task,
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        logging.getLogger("windup.bootstrap").exception("生成任务对账失败")
+    finally:
+        session.close()
 
 
 def create_app() -> FastAPI:

--- a/backend/packages/app/src/windup_app/server/orchestrator/billing.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/billing.py
@@ -1,15 +1,21 @@
 """生成任务的预付费积分：提交冻结，成功扣减，失败解冻。
 
 ``ref_id`` 固定为 ``task:{task_id}``，与流水表 ``(ref_id, reason)`` 唯一约束对齐。
+结算金额一律取提交时写入的 FROZEN 流水，不读当前定价。
 """
 
 from __future__ import annotations
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from windup_common.enums.biz_code import BizCode
+from windup_common.enums.quota import CreditReason
+from windup_common.exceptions import BizException
 from windup_framework.config.quota import settings as quota_settings
 
 from windup_app.server.orchestrator.model import GenerationType
+from windup_app.server.quota.model import CreditTransaction
 from windup_app.server.quota.service import service as quota_service
 
 
@@ -25,6 +31,44 @@ def prepaid_cost(task_type: GenerationType) -> int:
     raise ValueError(f"未知生成类型: {task_type}")
 
 
+def frozen_amount_for_task(session: Session, task_id: int) -> int:
+    """读取提交时冻结的额度（FROZEN 流水 ``delta`` 的绝对值）。"""
+    txn = session.scalar(
+        select(CreditTransaction).where(
+            CreditTransaction.ref_id == credit_ref_id(task_id),
+            CreditTransaction.reason == int(CreditReason.FROZEN),
+        )
+    )
+    if txn is None:
+        raise BizException("找不到该任务的冻结流水", code=BizCode.NOT_FOUND)
+    return abs(txn.delta)
+
+
+def has_open_freeze(session: Session, task_id: int) -> bool:
+    """仍有未 capture / 未 release 的预付费冻结。"""
+    frozen = session.scalar(
+        select(CreditTransaction).where(
+            CreditTransaction.ref_id == credit_ref_id(task_id),
+            CreditTransaction.reason == int(CreditReason.FROZEN),
+        )
+    )
+    if frozen is None:
+        return False
+    captured = session.scalar(
+        select(CreditTransaction).where(
+            CreditTransaction.ref_id == credit_ref_id(task_id),
+            CreditTransaction.reason == int(CreditReason.CAPTURED),
+        )
+    )
+    released = session.scalar(
+        select(CreditTransaction).where(
+            CreditTransaction.ref_id == f"{credit_ref_id(task_id)}:release",
+            CreditTransaction.reason == int(CreditReason.REFUND),
+        )
+    )
+    return captured is None and released is None
+
+
 def reserve_for_task(
     session: Session, *, user_id: int, task_id: int, task_type: GenerationType,
 ) -> None:
@@ -33,18 +77,15 @@ def reserve_for_task(
     )
 
 
-def capture_for_task(
-    session: Session, *, user_id: int, task_id: int, task_type: GenerationType,
-) -> None:
-    amount = prepaid_cost(task_type)
+def capture_for_task(session: Session, *, user_id: int, task_id: int) -> None:
+    amount = frozen_amount_for_task(session, task_id)
     quota_service.capture_credit(
         session, user_id, amount, credit_ref_id(task_id), amount,
     )
 
 
-def release_for_task(
-    session: Session, *, user_id: int, task_id: int, task_type: GenerationType,
-) -> None:
+def release_for_task(session: Session, *, user_id: int, task_id: int) -> None:
+    amount = frozen_amount_for_task(session, task_id)
     quota_service.release_credit(
-        session, user_id, prepaid_cost(task_type), credit_ref_id(task_id),
+        session, user_id, amount, credit_ref_id(task_id),
     )

--- a/backend/packages/app/src/windup_app/server/orchestrator/billing.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/billing.py
@@ -1,0 +1,50 @@
+"""生成任务的预付费积分：提交冻结，成功扣减，失败解冻。
+
+``ref_id`` 固定为 ``task:{task_id}``，与流水表 ``(ref_id, reason)`` 唯一约束对齐。
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from windup_framework.config.quota import settings as quota_settings
+
+from windup_app.server.orchestrator.model import GenerationType
+from windup_app.server.quota.service import service as quota_service
+
+
+def credit_ref_id(task_id: int) -> str:
+    return f"task:{task_id}"
+
+
+def prepaid_cost(task_type: GenerationType) -> int:
+    if task_type is GenerationType.CHARACTER_IMAGE:
+        return quota_settings.generate_image_cost
+    if task_type is GenerationType.CHARACTER_ACTION:
+        return quota_settings.generate_action_cost
+    raise ValueError(f"未知生成类型: {task_type}")
+
+
+def reserve_for_task(
+    session: Session, *, user_id: int, task_id: int, task_type: GenerationType,
+) -> None:
+    quota_service.reserve_credit(
+        session, user_id, prepaid_cost(task_type), credit_ref_id(task_id),
+    )
+
+
+def capture_for_task(
+    session: Session, *, user_id: int, task_id: int, task_type: GenerationType,
+) -> None:
+    amount = prepaid_cost(task_type)
+    quota_service.capture_credit(
+        session, user_id, amount, credit_ref_id(task_id), amount,
+    )
+
+
+def release_for_task(
+    session: Session, *, user_id: int, task_id: int, task_type: GenerationType,
+) -> None:
+    quota_service.release_credit(
+        session, user_id, prepaid_cost(task_type), credit_ref_id(task_id),
+    )

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 
 from windup_common.models import ActionSpec, ActionType as EngineActionType, CharacterCard
 
-from windup_app.server.orchestrator import task_repo
+from windup_app.server.orchestrator import billing, task_repo
 from windup_app.server.orchestrator._fetch import fetch_own_media
 from windup_app.server.orchestrator.model import (
     CharacterActionInput,
@@ -38,6 +38,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger("windup.generation.executor")
 
 _ACTION_RESULT = "character_action"  # task_repo._deserialize_result 按此标签反序列化
+
+
+def _settle_credit(session: Session, task_id: int, *, success: bool) -> None:
+    """任务终态时结清预付费：成功扣减，失败解冻。"""
+    task = task_repo.get_task(session, task_id)
+    if task is None or task.id is None:
+        return
+    if success:
+        billing.capture_for_task(
+            session, user_id=task.user_id, task_id=task.id, task_type=task.task_type,
+        )
+    else:
+        billing.release_for_task(
+            session, user_id=task.user_id, task_id=task.id, task_type=task.task_type,
+        )
 
 # ── 项目全局约束(Project 表)→ 统合喂给生成逻辑 ─────────────────────────
 # character_perspective 游戏视角:1=横版(侧视) 2=俯视 3=2.5D → 生成朝向/视角
@@ -226,13 +241,16 @@ class ActionTaskExecutor:
             cons = (self._fetch_constraints or _load_constraints)(session, project_id)
             result = self._produce_action(input, cons)
             task_repo.update_result(session, task_id, _ACTION_RESULT, result)
+            _settle_credit(session, task_id, success=True)
             if own:
                 session.commit()
         except Exception as exc:  # noqa: BLE001 —— 兜底任何生成/上传/网络异常
             logger.exception("动作任务 %s 失败", task_id)
+            session.rollback()
             task_repo.update_status(
                 session, task_id, TaskStatus.FAILED, error_message=str(exc),
             )
+            _settle_credit(session, task_id, success=False)
             if own:
                 session.commit()
         finally:
@@ -415,11 +433,14 @@ class ImageTaskExecutor:
                 "type": "character_image",
                 "image_urls": urls,
             })
+            _settle_credit(session, task_id, success=True)
             if own:
                 session.commit()
         except Exception as exc:  # noqa: BLE001 —— 兜底
             logger.exception("图片任务 %s 失败", task_id)
+            session.rollback()
             task_repo.update_status(session, task_id, TaskStatus.FAILED, error_message=str(exc))
+            _settle_credit(session, task_id, success=False)
             if own:
                 session.commit()
         finally:

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -46,13 +46,9 @@ def _settle_credit(session: Session, task_id: int, *, success: bool) -> None:
     if task is None or task.id is None:
         return
     if success:
-        billing.capture_for_task(
-            session, user_id=task.user_id, task_id=task.id, task_type=task.task_type,
-        )
+        billing.capture_for_task(session, user_id=task.user_id, task_id=task.id)
     else:
-        billing.release_for_task(
-            session, user_id=task.user_id, task_id=task.id, task_type=task.task_type,
-        )
+        billing.release_for_task(session, user_id=task.user_id, task_id=task.id)
 
 # ── 项目全局约束(Project 表)→ 统合喂给生成逻辑 ─────────────────────────
 # character_perspective 游戏视角:1=横版(侧视) 2=俯视 3=2.5D → 生成朝向/视角

--- a/backend/packages/app/src/windup_app/server/orchestrator/recover.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/recover.py
@@ -1,0 +1,110 @@
+"""进程重启后对账：有冻结、未终态的生成任务重新入队或失败解冻。
+
+调度本身仍是进程内 ThreadPoolExecutor。队列项会随进程消失，但任务行和
+FROZEN 流水在库里。启动时扫描 PENDING/RUNNING 且仍有开放冻结的任务：
+
+- PENDING：按落库的 ``input_payload`` 再入队（生成尚未开始）
+- RUNNING：视为执行中被打断，标 FAILED 并解冻（避免重复打上游）
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from windup_app.server.orchestrator import billing, task_repo
+from windup_app.server.orchestrator.model import (
+    ActionType,
+    CharacterActionInput,
+    CharacterImageInput,
+    GenerationTask,
+    GenerationType,
+    TaskStatus,
+)
+
+logger = logging.getLogger("windup.generation.recover")
+
+
+def recover_orphaned_generation_tasks(
+    session: Session,
+    *,
+    dispatcher: Any,
+    run_image_task: Callable[..., Any],
+    run_action_task: Callable[..., Any],
+) -> None:
+    """扫描未结清冻结的开放任务并恢复。调用方负责 commit。"""
+    for task in task_repo.list_by_status(
+        session, (TaskStatus.PENDING, TaskStatus.RUNNING),
+    ):
+        if task.id is None or not billing.has_open_freeze(session, task.id):
+            continue
+        if task.status is TaskStatus.RUNNING:
+            _fail_interrupted(session, task)
+            continue
+        _requeue_pending(session, dispatcher, run_image_task, run_action_task, task)
+
+
+def _fail_interrupted(session: Session, task: GenerationTask) -> None:
+    assert task.id is not None
+    task_repo.update_status(
+        session, task.id, TaskStatus.FAILED,
+        error_message="进程中断，已解冻积分",
+    )
+    billing.release_for_task(session, user_id=task.user_id, task_id=task.id)
+    logger.warning("孤儿 RUNNING 任务已失败解冻 | task_id=%s", task.id)
+
+
+def _requeue_pending(
+    session: Session,
+    dispatcher: Any,
+    run_image_task: Callable[..., Any],
+    run_action_task: Callable[..., Any],
+    task: GenerationTask,
+) -> None:
+    assert task.id is not None
+    payload = task.input_payload or {}
+    try:
+        if task.task_type is GenerationType.CHARACTER_IMAGE:
+            dispatcher.submit(
+                run_image_task, task.id, _image_input(payload), task.project_id,
+            )
+        elif task.task_type is GenerationType.CHARACTER_ACTION:
+            dispatcher.submit(
+                run_action_task, task.id, _action_input(payload), task.project_id,
+            )
+        else:
+            raise ValueError(f"未知任务类型: {task.task_type}")
+    except Exception:
+        logger.exception("PENDING 任务重入队失败，改为解冻 | task_id=%s", task.id)
+        _fail_interrupted(session, task)
+        return
+    logger.info("孤儿 PENDING 任务已重入队 | task_id=%s", task.id)
+
+
+def _image_input(payload: dict) -> CharacterImageInput:
+    return CharacterImageInput(
+        reference_image_url=payload.get("reference_image_url"),
+        prompt=payload.get("prompt") or "",
+        negative_prompt=payload.get("negative_prompt") or "",
+        width=int(payload.get("width") or 1024),
+        height=int(payload.get("height") or 1024),
+        num_images=int(payload.get("num_images") or 1),
+    )
+
+
+def _action_input(payload: dict) -> CharacterActionInput:
+    raw_type = payload.get("action_type")
+    action_type = raw_type if isinstance(raw_type, ActionType) else ActionType(raw_type)
+    return CharacterActionInput(
+        character_id=int(payload["character_id"]),
+        action_type=action_type,
+        custom_prompt=payload.get("custom_prompt"),
+        reference_video_url=payload.get("reference_video_url"),
+        reference_image_urls=list(payload.get("reference_image_urls") or []),
+        num_frames=int(payload.get("num_frames") or 16),
+        loop=payload.get("loop"),
+        video_model=payload.get("video_model"),
+    )

--- a/backend/packages/app/src/windup_app/server/orchestrator/service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/service.py
@@ -1,6 +1,6 @@
 """生成任务领域服务(提交 + 查询)。
 
-:class:`AiGenerationService` 只负责**建任务记录 + 查任务**——web 层依赖本模块。
+:class:`AiGenerationService` 负责**建任务记录、预付费冻结、查任务**——web 层依赖本模块。
 实际 AI 生成(调 ai_engine)在 :mod:`.executor` 后台跑,本模块**不碰 ai_engine**,
 以满足"入口层(web/worker)不经 ai_engine 直连"的分层门禁(web → service 不得牵出 ai_engine)。
 
@@ -13,7 +13,7 @@ import dataclasses
 
 from sqlalchemy.orm import Session
 
-from windup_app.server.orchestrator import task_repo
+from windup_app.server.orchestrator import billing, task_repo
 from windup_app.server.orchestrator.interface import GenerationService
 from windup_app.server.orchestrator.model import (
     CharacterActionInput,
@@ -30,22 +30,30 @@ class AiGenerationService(GenerationService):
         self, session: Session, *, user_id: int, project_id: int | None = None,
         input: CharacterImageInput,
     ) -> GenerationTask:
-        return task_repo.create_task(
+        task = task_repo.create_task(
             session, user_id=user_id, project_id=project_id,
             task_type=GenerationType.CHARACTER_IMAGE,
             input_payload=dataclasses.asdict(input),
         )
+        billing.reserve_for_task(
+            session, user_id=user_id, task_id=task.id, task_type=task.task_type,
+        )
+        return task
 
     def generate_character_action(
         self, session: Session, *, user_id: int, project_id: int | None = None,
         input: CharacterActionInput,
     ) -> GenerationTask:
         """建动作生成任务(PENDING)并返回;实际生成由 executor 后台跑,前端轮询 get_task。"""
-        return task_repo.create_task(
+        task = task_repo.create_task(
             session, user_id=user_id, project_id=project_id,
             task_type=GenerationType.CHARACTER_ACTION,
             input_payload=dataclasses.asdict(input),
         )
+        billing.reserve_for_task(
+            session, user_id=user_id, task_id=task.id, task_type=task.task_type,
+        )
+        return task
 
     def get_task(
         self, session: Session, project_id: int, task_id: int,

--- a/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
@@ -180,6 +180,17 @@ def get_task_by_user(
     return _record_to_domain(record)
 
 
+def list_by_status(
+    session: Session, statuses: tuple[TaskStatus, ...],
+) -> list[GenerationTask]:
+    """按状态列出任务（启动对账用）。"""
+    values = [status.value for status in statuses]
+    rows = session.scalars(
+        select(GenerationTaskRecord).where(GenerationTaskRecord.status.in_(values))
+    ).all()
+    return [_record_to_domain(record) for record in rows]
+
+
 # ── 转换 ─────────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,12 +27,28 @@ from windup_app.server.user.model import User
 from windup_app.server.orchestrator.model import GenerationTaskRecord
 from windup_app.server.workflow_run.model import WorkflowRun
 from windup_app.server.user.service import create_access_token
+from windup_framework.config.quota import settings as quota_settings
 from windup_framework.db import Base, get_session
 
 
 def _disable_generation_execution(app):
     app.state.run_action_task = lambda *args: None
     app.state.run_image_task = lambda *args: None
+
+
+def seed_credit_account(session, user_id: int, *, balance: int | None = None) -> CreditAccount:
+    """给测试用户补一张积分账户（注册赠送口径）。"""
+    gift = quota_settings.register_gift_amount
+    account = CreditAccount(
+        user_id=user_id,
+        balance=gift if balance is None else balance,
+        frozen=0,
+        total_earned=gift,
+        total_spent=0,
+    )
+    session.add(account)
+    session.flush()
+    return account
 
 
 def _make_engine():

--- a/backend/tests/test_generation_api.py
+++ b/backend/tests/test_generation_api.py
@@ -2,7 +2,21 @@
 
 import asyncio
 
+import pytest
+from sqlalchemy.orm import sessionmaker
+
 from windup_app.web.api.generation import GenerationTaskOut, _EventBus
+
+from conftest import seed_credit_account
+
+
+@pytest.fixture(autouse=True)
+def _gift_credits(engine):
+    """提交生成任务会冻结积分，本文件用例都预置注册赠送账户。"""
+    with sessionmaker(bind=engine)() as session:
+        seed_credit_account(session, 1)
+        seed_credit_account(session, 2)
+        session.commit()
 
 
 def _create_project(auth_client, name: str = "生成项目") -> dict:

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -16,6 +16,7 @@ from sqlalchemy.pool import StaticPool
 
 from windup_framework.db.base import Base
 from windup_app.server.project.model import Project  # 注册 windup_project 表(create_all 用)
+from windup_app.server.quota.model import CreditAccount
 from windup_app.server.orchestrator.model import (
     ActionType,
     CharacterActionInput,
@@ -27,6 +28,7 @@ from windup_app.server.orchestrator.service import AiGenerationService
 from windup_ai_engine.impl import CharacterGenerator
 from windup_ai_engine.strategy.concrete import VideoFrameStrategy
 from windup_common.models import GenRoute
+from windup_framework.config.quota import settings as quota_settings
 
 
 def _tiny_png(shift: int = 0) -> bytes:
@@ -58,7 +60,17 @@ def session_factory():
         poolclass=StaticPool,
     )
     Base.metadata.create_all(engine)
-    return sessionmaker(bind=engine)
+    factory = sessionmaker(bind=engine)
+    with factory() as session:
+        session.add(CreditAccount(
+            user_id=1,
+            balance=quota_settings.register_gift_amount,
+            frozen=0,
+            total_earned=quota_settings.register_gift_amount,
+            total_spent=0,
+        ))
+        session.commit()
+    return factory
 
 
 def _real_offline_generator(monkeypatch) -> CharacterGenerator:

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -6,11 +6,14 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from windup_framework.db.base import Base
-from windup_app.server.orchestrator.executor import ActionTaskExecutor
+from windup_app.server.orchestrator import billing
+from windup_app.server.orchestrator.executor import ActionTaskExecutor, ImageTaskExecutor
 from windup_app.server.orchestrator.model import (
     ActionType,
     CharacterActionInput,
+    CharacterImageInput,
     GenerationTaskRecord,
+    GenerationType,
     TaskStatus,
 )
 from windup_app.server.orchestrator.service import AiGenerationService
@@ -344,3 +347,248 @@ def test_recover_fails_and_unfreezes_running_orphans(session_factory):
         assert account.frozen == 0
         assert account.balance == quota_settings.register_gift_amount
         assert CreditReason.REFUND in _reasons(session, 1)
+
+
+def test_prepaid_cost_by_task_type():
+    assert billing.prepaid_cost(GenerationType.CHARACTER_IMAGE) == quota_settings.generate_image_cost
+    assert billing.prepaid_cost(GenerationType.CHARACTER_ACTION) == quota_settings.generate_action_cost
+    with pytest.raises(ValueError, match="未知生成类型"):
+        billing.prepaid_cost("not-a-type")  # type: ignore[arg-type]
+
+
+def test_frozen_amount_missing_raises(session_factory):
+    with session_factory() as session:
+        with pytest.raises(BizException, match="找不到该任务的冻结流水"):
+            billing.frozen_amount_for_task(session, 999)
+
+
+def test_has_open_freeze_false_without_frozen_txn(session_factory):
+    with session_factory() as session:
+        assert billing.has_open_freeze(session, 1) is False
+
+
+def test_has_open_freeze_false_after_capture_or_release(session_factory):
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+    service = AiGenerationService()
+    image_input = CharacterImageInput(prompt="x", width=64, height=64)
+    with session_factory() as session:
+        captured = service.generate_character_image(session, user_id=1, input=image_input)
+        billing.capture_for_task(session, user_id=1, task_id=captured.id)
+        released = service.generate_character_image(session, user_id=1, input=image_input)
+        billing.release_for_task(session, user_id=1, task_id=released.id)
+        session.commit()
+        assert billing.has_open_freeze(session, captured.id) is False
+        assert billing.has_open_freeze(session, released.id) is False
+
+
+def test_image_success_captures_reserved_credit(session_factory):
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    executor = ImageTaskExecutor(
+        upload=lambda _png: "https://cdn.example.com/img.png",
+        session_factory=session_factory,
+    )
+    executor._produce_image = lambda _input, _cons: ["https://cdn.example.com/img.png"]
+    image_input = CharacterImageInput(prompt="勇者", width=64, height=64)
+    with session_factory() as session:
+        task = AiGenerationService().generate_character_image(
+            session, user_id=1, input=image_input,
+        )
+        session.commit()
+        task_id = task.id
+
+    executor.run_image_task(task_id, image_input)
+
+    with session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=1, task_id=task_id)
+        account = _account(session, 1)
+        assert done.status is TaskStatus.COMPLETED
+        assert account.frozen == 0
+        assert account.total_spent == quota_settings.generate_image_cost
+        assert CreditReason.CAPTURED in _reasons(session, 1)
+
+
+def test_image_failure_releases_reserved_credit(session_factory):
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    executor = ImageTaskExecutor(session_factory=session_factory)
+
+    def _boom(_input, _cons):
+        raise RuntimeError("出图失败")
+
+    executor._produce_image = _boom
+    image_input = CharacterImageInput(prompt="勇者", width=64, height=64)
+    with session_factory() as session:
+        task = AiGenerationService().generate_character_image(
+            session, user_id=1, input=image_input,
+        )
+        session.commit()
+        task_id = task.id
+
+    executor.run_image_task(task_id, image_input)
+
+    with session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=1, task_id=task_id)
+        account = _account(session, 1)
+        assert done.status is TaskStatus.FAILED
+        assert account.frozen == 0
+        assert account.balance == quota_settings.register_gift_amount
+
+
+def test_recover_skips_pending_without_open_freeze(session_factory):
+    from windup_app.server.orchestrator import task_repo
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    queued: list = []
+
+    class _Dispatcher:
+        def submit(self, target, *args):
+            queued.append((target, args))
+
+    with session_factory() as session:
+        task_repo.create_task(
+            session, user_id=1, project_id=1,
+            task_type=GenerationType.CHARACTER_IMAGE,
+            input_payload={"prompt": "x"},
+        )
+        session.commit()
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=_Dispatcher(),
+            run_image_task=lambda *a: None,
+            run_action_task=lambda *a: None,
+        )
+
+    assert queued == []
+
+
+def test_recover_requeues_pending_image_tasks(session_factory):
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    queued: list[tuple] = []
+
+    class _Dispatcher:
+        def submit(self, target, *args):
+            queued.append((target, args))
+
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    image_input = CharacterImageInput(prompt="勇者", width=64, height=64)
+    with session_factory() as session:
+        task = AiGenerationService().generate_character_image(
+            session, user_id=1, project_id=3, input=image_input,
+        )
+        session.commit()
+        task_id = task.id
+
+    def _run_image(*_args):
+        raise AssertionError("只入队")
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=_Dispatcher(),
+            run_image_task=_run_image,
+            run_action_task=lambda *a: None,
+        )
+
+    assert len(queued) == 1
+    target, args = queued[0]
+    assert target is _run_image
+    assert args[0] == task_id
+    assert args[1].prompt == "勇者"
+    assert args[2] == 3
+
+
+def test_recover_unfreezes_when_requeue_fails(session_factory):
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    class _BoomDispatcher:
+        def submit(self, *_args, **_kwargs):
+            raise RuntimeError("队列不可用")
+
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    with session_factory() as session:
+        task = AiGenerationService().generate_character_action(
+            session, user_id=1,
+            input=CharacterActionInput(character_id=1, action_type=ActionType.WALK, num_frames=2),
+        )
+        session.commit()
+        task_id = task.id
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=_BoomDispatcher(),
+            run_image_task=lambda *a: None,
+            run_action_task=lambda *a: None,
+        )
+        session.commit()
+
+    with session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=1, task_id=task_id)
+        account = _account(session, 1)
+        assert done.status is TaskStatus.FAILED
+        assert account.frozen == 0
+        assert account.balance == quota_settings.register_gift_amount
+
+
+def test_recover_unfreezes_unknown_task_type(session_factory, monkeypatch):
+    from windup_app.server.orchestrator import task_repo
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    queued: list = []
+
+    class _Dispatcher:
+        def submit(self, target, *args):
+            queued.append((target, args))
+
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    with session_factory() as session:
+        task = AiGenerationService().generate_character_action(
+            session, user_id=1,
+            input=CharacterActionInput(character_id=1, action_type=ActionType.WALK, num_frames=2),
+        )
+        session.commit()
+        task_id = task.id
+
+    original = task_repo.list_by_status
+
+    def _unknown_type(session, statuses):
+        tasks = original(session, statuses)
+        for item in tasks:
+            item.task_type = "future_kind"  # type: ignore[assignment]
+        return tasks
+
+    monkeypatch.setattr(task_repo, "list_by_status", _unknown_type)
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=_Dispatcher(),
+            run_image_task=lambda *a: None,
+            run_action_task=lambda *a: None,
+        )
+        session.commit()
+
+    assert queued == []
+    with session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=1, task_id=task_id)
+        assert done.status is TaskStatus.FAILED
+        assert _account(session, 1).frozen == 0

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -1,0 +1,191 @@
+"""生成任务调度必须走预付费冻结 / 扣减 / 解冻。"""
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from windup_framework.db.base import Base
+from windup_app.server.orchestrator.executor import ActionTaskExecutor
+from windup_app.server.orchestrator.model import (
+    ActionType,
+    CharacterActionInput,
+    GenerationTaskRecord,
+    TaskStatus,
+)
+from windup_app.server.orchestrator.service import AiGenerationService
+from windup_app.server.quota.model import CreditAccount, CreditTransaction
+from windup_common.enums.quota import CreditReason
+from windup_common.exceptions import BizException
+from windup_framework.config.quota import settings as quota_settings
+
+from conftest import seed_credit_account
+from test_generation_orchestration import _SpyGenerator, _tiny_png
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _seed_account(session: Session, user_id: int, *, balance: int | None = None) -> CreditAccount:
+    return seed_credit_account(session, user_id, balance=balance)
+
+
+def _account(session: Session, user_id: int) -> CreditAccount:
+    return session.scalar(select(CreditAccount).where(CreditAccount.user_id == user_id))
+
+
+def _reasons(session: Session, user_id: int) -> list[int]:
+    rows = session.scalars(
+        select(CreditTransaction)
+        .where(CreditTransaction.user_id == user_id)
+        .order_by(CreditTransaction.id)
+    ).all()
+    return [row.reason for row in rows]
+
+
+def test_submit_image_generation_reserves_prepaid_credit(auth_client, db_session):
+    _seed_account(db_session, 1)
+    db_session.commit()
+
+    project = auth_client.post(
+        "/projects",
+        json={
+            "project_name": "积分项目",
+            "character_perspective": 1,
+            "directional_movement": 2,
+            "sprite_width": 64,
+            "sprite_height": 64,
+        },
+    ).json()["data"]
+
+    response = auth_client.post(
+        "/generation/image",
+        json={"project_id": project["id"], "prompt": "勇者", "width": 64, "height": 64},
+    )
+    body = response.json()
+    assert body["data"] is not None, body
+    task_id = body["data"]["id"]
+
+    account = _account(db_session, 1)
+    db_session.refresh(account)
+    assert account.frozen == quota_settings.generate_image_cost
+    assert account.balance == quota_settings.register_gift_amount - quota_settings.generate_image_cost
+    assert _reasons(db_session, 1) == [CreditReason.FROZEN]
+    txn = db_session.scalar(select(CreditTransaction).where(CreditTransaction.user_id == 1))
+    assert txn.ref_id == f"task:{task_id}"
+
+
+def test_submit_rejects_when_credit_is_insufficient(auth_client, db_session):
+    _seed_account(db_session, 1, balance=1)
+    db_session.commit()
+
+    project = auth_client.post(
+        "/projects",
+        json={
+            "project_name": "没钱项目",
+            "character_perspective": 1,
+            "directional_movement": 2,
+            "sprite_width": 64,
+            "sprite_height": 64,
+        },
+    ).json()["data"]
+
+    response = auth_client.post(
+        "/generation/image",
+        json={"project_id": project["id"], "prompt": "勇者", "width": 64, "height": 64},
+    )
+    body = response.json()
+    assert body["code"] == 400
+    assert "积分不足" in body["message"]
+
+    account = _account(db_session, 1)
+    db_session.refresh(account)
+    assert account.balance == 1
+    assert account.frozen == 0
+    assert db_session.scalar(select(CreditTransaction).where(CreditTransaction.user_id == 1)) is None
+
+
+def test_action_success_captures_reserved_credit(session_factory):
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    service = AiGenerationService()
+    executor = ActionTaskExecutor(
+        generator=_SpyGenerator(),
+        upload=lambda _png: "https://cdn.example.com/f.png",
+        fetch_master=lambda _input: _tiny_png(),
+        session_factory=session_factory,
+    )
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=2,
+    )
+    with session_factory() as session:
+        task = service.generate_character_action(session, user_id=1, input=action_input)
+        session.commit()
+        task_id = task.id
+
+    executor.run_action_task(task_id, action_input)
+
+    with session_factory() as session:
+        done = service.get_task(session, project_id=1, task_id=task_id)
+        account = _account(session, 1)
+        assert done.status is TaskStatus.COMPLETED
+        assert account.frozen == 0
+        assert account.total_spent == quota_settings.generate_action_cost
+        assert account.balance == quota_settings.register_gift_amount - quota_settings.generate_action_cost
+        assert CreditReason.CAPTURED in _reasons(session, 1)
+
+
+def test_action_failure_releases_reserved_credit(session_factory):
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    service = AiGenerationService()
+    def _boom(_input):
+        raise RuntimeError("母版下载失败")
+
+    executor = ActionTaskExecutor(
+        generator=None,
+        fetch_master=_boom,
+        session_factory=session_factory,
+    )
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=2,
+    )
+    with session_factory() as session:
+        task = service.generate_character_action(session, user_id=1, input=action_input)
+        session.commit()
+        task_id = task.id
+
+    executor.run_action_task(task_id, action_input)
+
+    with session_factory() as session:
+        done = service.get_task(session, project_id=1, task_id=task_id)
+        account = _account(session, 1)
+        assert done.status is TaskStatus.FAILED
+        assert account.frozen == 0
+        assert account.total_spent == 0
+        assert account.balance == quota_settings.register_gift_amount
+        assert CreditReason.REFUND in _reasons(session, 1)
+
+
+def test_generate_character_action_without_account_raises(session_factory):
+    service = AiGenerationService()
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=2,
+    )
+    with session_factory() as session:
+        with pytest.raises(BizException, match="积分账户不存在"):
+            service.generate_character_action(session, user_id=1, input=action_input)
+        session.rollback()
+        assert session.scalar(select(GenerationTaskRecord)) is None

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -189,3 +189,158 @@ def test_generate_character_action_without_account_raises(session_factory):
             service.generate_character_action(session, user_id=1, input=action_input)
         session.rollback()
         assert session.scalar(select(GenerationTaskRecord)) is None
+
+
+def test_capture_uses_frozen_amount_when_price_rises(session_factory, monkeypatch):
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    service = AiGenerationService()
+    executor = ActionTaskExecutor(
+        generator=_SpyGenerator(),
+        upload=lambda _png: "https://cdn.example.com/f.png",
+        fetch_master=lambda _input: _tiny_png(),
+        session_factory=session_factory,
+    )
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=2,
+    )
+    with session_factory() as session:
+        task = service.generate_character_action(session, user_id=1, input=action_input)
+        session.commit()
+        task_id = task.id
+        frozen_at_submit = quota_settings.generate_action_cost
+
+    monkeypatch.setattr(quota_settings, "generate_action_cost", frozen_at_submit + 40)
+    executor.run_action_task(task_id, action_input)
+
+    with session_factory() as session:
+        done = service.get_task(session, project_id=1, task_id=task_id)
+        account = _account(session, 1)
+        assert done.status is TaskStatus.COMPLETED
+        assert account.frozen == 0
+        assert account.total_spent == frozen_at_submit
+        assert account.balance == quota_settings.register_gift_amount - frozen_at_submit
+
+
+def test_release_uses_frozen_amount_when_price_falls(session_factory, monkeypatch):
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    service = AiGenerationService()
+
+    def _boom(_input):
+        raise RuntimeError("母版下载失败")
+
+    executor = ActionTaskExecutor(
+        generator=None,
+        fetch_master=_boom,
+        session_factory=session_factory,
+    )
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=2,
+    )
+    with session_factory() as session:
+        task = service.generate_character_action(session, user_id=1, input=action_input)
+        session.commit()
+        task_id = task.id
+        frozen_at_submit = quota_settings.generate_action_cost
+
+    monkeypatch.setattr(quota_settings, "generate_action_cost", max(1, frozen_at_submit - 40))
+    executor.run_action_task(task_id, action_input)
+
+    with session_factory() as session:
+        account = _account(session, 1)
+        assert account.frozen == 0
+        assert account.balance == quota_settings.register_gift_amount
+
+
+def test_recover_requeues_pending_tasks_with_open_freeze(session_factory):
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    queued: list[tuple] = []
+
+    class _Dispatcher:
+        def submit(self, target, *args):
+            queued.append((target, args))
+
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    service = AiGenerationService()
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=2,
+    )
+    with session_factory() as session:
+        task = service.generate_character_action(
+            session, user_id=1, project_id=7, input=action_input,
+        )
+        session.commit()
+        task_id = task.id
+
+    def _run_image(*_args):
+        raise AssertionError("不应入队图片任务")
+
+    def _run_action(*_args):
+        raise AssertionError("recover 只负责入队，不直接跑")
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=_Dispatcher(),
+            run_image_task=_run_image,
+            run_action_task=_run_action,
+        )
+        session.commit()
+
+    assert len(queued) == 1
+    _target, args = queued[0]
+    assert _target is _run_action
+    assert args[0] == task_id
+    assert args[1].action_type is ActionType.WALK
+    assert args[2] == 7
+
+    with session_factory() as session:
+        still = service.get_task(session, project_id=7, task_id=task_id)
+        assert still.status is TaskStatus.PENDING
+        assert _account(session, 1).frozen == quota_settings.generate_action_cost
+
+
+def test_recover_fails_and_unfreezes_running_orphans(session_factory):
+    from windup_app.server.orchestrator import task_repo
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    service = AiGenerationService()
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=2,
+    )
+    with session_factory() as session:
+        task = service.generate_character_action(session, user_id=1, input=action_input)
+        task_repo.update_status(session, task.id, TaskStatus.RUNNING)
+        session.commit()
+        task_id = task.id
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=type("D", (), {"submit": staticmethod(lambda *a, **k: None)})(),
+            run_image_task=lambda *a: None,
+            run_action_task=lambda *a: None,
+        )
+        session.commit()
+
+    with session_factory() as session:
+        done = service.get_task(session, project_id=1, task_id=task_id)
+        account = _account(session, 1)
+        assert done.status is TaskStatus.FAILED
+        assert "中断" in (done.error_message or "")
+        assert account.frozen == 0
+        assert account.balance == quota_settings.register_gift_amount
+        assert CreditReason.REFUND in _reasons(session, 1)

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -53,12 +53,19 @@ describe('PlaytestPage', () => {
     renderPlaytest('/playtest/51/outfit-default')
 
     expect(await screen.findByRole('heading', { name: '51 · 常态造型' })).toBeTruthy()
+    const walkButton = await screen.findByRole('button', { name: '绑定动作：行走' })
     // 后端给的 walk 帧顺序是 index 2、0、1；照数组播会从 walk-03 起步。
-    fireEvent.click(screen.getByRole('button', { name: '绑定动作：行走' }))
+    fireEvent.click(walkButton)
 
-    await waitFor(() => {
-      expect(stageFrameUrl()).toBe('https://cdn.windup.test/walk-01.png')
-    })
+    // 先等绑定态（aria-pressed），再读舞台帧。覆盖率下 waitFor 默认 1s 会把重试耗在整页 HTML 上，
+    // 点了行走却仍断言到 idle-01，Frontend CI 就会红。
+    await waitFor(
+      () => {
+        expect(walkButton.getAttribute('aria-pressed')).toBe('true')
+        expect(stageFrameUrl()).toBe('https://cdn.windup.test/walk-01.png')
+      },
+      { timeout: 4000 },
+    )
   })
 
   it('starts on the idle action when the route names none', async () => {


### PR DESCRIPTION
## 改动内容

- 提交角色图/动作生成任务时，按定价冻结积分（`ref_id=task:{id}`）；积分不足则整单回滚、不入队
- 执行器成功时 `capture_credit` 实扣，失败时 `release_credit` 解冻
- 定价仍走 `QUOTA_GENERATE_IMAGE_COST` / `QUOTA_GENERATE_ACTION_COST`
- 生成相关测试预置积分账户；新增调度与账本对账用例

## 依据

积分领域（注册赠送、冻结/扣减/解冻）此前已落地，但 orchestrator 未调用。本 PR 把预付费接到生产任务调度。

后付费（Agent token）与邀请码不在本 PR 范围。

Closes #350

## 验证

- `uv run lint-imports`：分层契约保持
- `uv run ruff check`：改动文件通过
- `uv run pytest tests/test_generation_quota.py tests/test_generation_api.py tests/test_generation_orchestration.py tests/test_generation_stream_auth.py tests/test_quota.py tests/test_orchestrator_hardening.py -o addopts=`：108 passed
