### PR TITLE
fix(web): 校验失败的 message 给出可读原因

### DIFF
--- a/backend/packages/app/src/windup_app/web/handler/exception_handlers.py
+++ b/backend/packages/app/src/windup_app/web/handler/exception_handlers.py
@@ -36,16 +36,35 @@ def handle_request_validation_error(
 ) -> JSONResponse:
     """请求参数校验失败(FastAPI 默认 422)-> ``code=BizCode.BAD_REQUEST``,data 带校验明细。
 
+    ``message`` 取第一条校验错误的原文而不是一句笼统的"请求参数校验失败":前端展示的是
+    ``message``,把原因只放进 ``data`` 等于用户永远看不到——实测用户看到的是读不懂的
+    "请求参数校验失败",而真正的原因("custom 动作必须提供 custom_prompt")就在 data 里躺着。
+
     ``exc.errors()`` 的 ``ctx`` 可能含不可 JSON 序列化的对象(如 ``ValueError``),
     过一道 ``jsonable_encoder`` 保险。
     """
+    detail = jsonable_encoder(exc.errors())
     return _jsonify(
         Response.fail(
-            "请求参数校验失败",
+            _first_validation_message(detail),
             code=BizCode.BAD_REQUEST,
-            data=jsonable_encoder(exc.errors()),
+            data=detail,
         )
     )
+
+
+# pydantic 把自定义 ValueError 的原文前缀成 "Value error, xxx",对用户是噪声。
+_VALUE_ERROR_PREFIX = "Value error, "
+
+
+def _first_validation_message(errors: object) -> str:
+    """取第一条校验错误的可读原文;取不到就退回笼统文案(总比抛在处理器里强)。"""
+    if isinstance(errors, list):
+        for e in errors:
+            msg = (e or {}).get("msg") if isinstance(e, dict) else None
+            if isinstance(msg, str) and msg:
+                return msg.removeprefix(_VALUE_ERROR_PREFIX)
+    return "请求参数校验失败"
 
 
 def handle_http_exception(request: Request, exc: HTTPException) -> JSONResponse:

--- a/backend/tests/test_generation_api.py
+++ b/backend/tests/test_generation_api.py
@@ -227,3 +227,22 @@ def test_response_conversion_path_is_live(auth_client):
     for k in ("id", "status", "task_type"):
         assert k in data, f"缺字段 {k}：{data}"
     assert "user_id" not in data, "响应不该暴露 user_id"
+
+
+def test_validation_error_message_tells_the_user_what_is_wrong(auth_client):
+    """校验失败的 message 必须是可读原因,不是一句笼统的"请求参数校验失败"。
+
+    前端展示的是 message;把原因只塞进 data 等于用户永远看不到 —— 实测用户看到的是
+    读不懂的"请求参数校验失败",而"custom 动作必须提供 custom_prompt"就在 data 里躺着。
+    """
+    project = _create_project(auth_client)
+    r = auth_client.post("/generation/action", json={
+        "project_id": project["id"], "character_id": 1,
+        "action_type": "custom", "custom_prompt": "",
+        "num_frames": 32, "reference_image_urls": ["https://media.windup.xin/x.png"],
+    })
+    body = r.json()
+    assert body["code"] == 400
+    assert body["message"] != "请求参数校验失败", "还是笼统文案,用户看不懂"
+    assert "custom_prompt" in body["message"] or "动作" in body["message"]
+    assert not body["message"].startswith("Value error,"), "pydantic 前缀是噪声,该剥掉"


### PR DESCRIPTION
## Summary

请求参数校验失败时，`message` 恒为「请求参数校验失败」，真实原因只在 `data` 里。前端展示的是 `message`，所以用户看到的是一句读不懂的通用文案，无法据此改正输入。

改为取第一条校验错误的 `msg` 原文，取不到时退回原文案。`data` 不变。

pydantic 会给自定义 `ValueError` 的原文加上 `Value error, ` 前缀，对用户是噪声，剥掉后再返回。

以自定义动作为例：提交空 `custom_prompt` 时，原来返回「请求参数校验失败」，现在返回「custom 动作必须提供 custom_prompt」。

Closes #336

## Test plan

- [x] `uv run ruff check .` → All checks passed
- [x] `uv run lint-imports` → 2 kept, 0 broken
- [x] `uv run python -m scripts.export_openapi && git diff --exit-code -- ../openapi.json` → 无漂移
- [x] `uv run pytest -q` → 718 passed, 14 skipped
- [x] 新增用例断言 message 不等于原文案、含具体原因、且不以 `Value error, ` 开头