### PR TITLE
fix(frontend): 处理 WorkflowRun 乐观锁与跨资源冲突对账

### DIFF
--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -82,7 +82,7 @@ export { createMediaApis } from './media/api'
 export type { MediaApis, MediaCategory, MediaReference } from './media'
 
 /* 工作流 —— 前端管理节点，后端只持久化完整 nodes 文档 */
-export { workflowRunApis } from './workflow-run'
+export { WorkflowRunConflictError, workflowRunApis } from './workflow-run'
 export type {
   ActionFirstFrameWorkflowNode,
   ActionFullFrameWorkflowNode,

--- a/frontend/src/entities/workflow-run/api.test.ts
+++ b/frontend/src/entities/workflow-run/api.test.ts
@@ -239,6 +239,25 @@ describe('workflowRunApis', () => {
     })
   })
 
+  it('preserves non-conflict API errors from an update', async () => {
+    const apis = await loadWorkflowRunApis(
+      async () =>
+        new Response(JSON.stringify({ code: 500, message: '保存失败', data: null }), {
+          headers: { 'content-type': 'application/json' },
+        }),
+    )
+
+    await expect(
+      apis.update({
+        id: '17',
+        projectId: '42',
+        version: 3,
+        storageStatus: 'active',
+        nodes,
+      }),
+    ).rejects.toMatchObject({ name: 'ApiError', code: 500, message: '保存失败' })
+  })
+
   it('soft deletes through the backend DELETE endpoint', async () => {
     let request: Request | undefined
     const apis = await loadWorkflowRunApis(async (input, init) => {

--- a/frontend/src/entities/workflow-run/api.test.ts
+++ b/frontend/src/entities/workflow-run/api.test.ts
@@ -212,8 +212,31 @@ describe('workflowRunApis', () => {
       nodes,
     })
     expect(request?.method).toBe('PATCH')
-    await expect(request?.json()).resolves.toEqual({ nodes, status: 'active' })
+    await expect(request?.json()).resolves.toEqual({ nodes, status: 'active', version: 3 })
     expect(updated.version).toBe(4)
+  })
+
+  it('exposes a version conflict as a workflow-run domain error', async () => {
+    const apis = await loadWorkflowRunApis(
+      async () =>
+        new Response(
+          JSON.stringify({ code: 409, message: '执行记录版本冲突，请刷新后重试', data: null }),
+          { headers: { 'content-type': 'application/json' } },
+        ),
+    )
+
+    await expect(
+      apis.update({
+        id: '17',
+        projectId: '42',
+        version: 3,
+        storageStatus: 'active',
+        nodes,
+      }),
+    ).rejects.toMatchObject({
+      name: 'WorkflowRunConflictError',
+      message: '执行记录版本冲突，请刷新后重试',
+    })
   })
 
   it('soft deletes through the backend DELETE endpoint', async () => {

--- a/frontend/src/entities/workflow-run/api.ts
+++ b/frontend/src/entities/workflow-run/api.ts
@@ -17,6 +17,14 @@ import {
   WORKFLOW_RUN_STORAGE_STATUSES,
 } from './constants'
 
+/** 当前 WorkflowRun 已被其他请求更新，调用方需要重新读取后再继续修改。 */
+export class WorkflowRunConflictError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'WorkflowRunConflictError'
+  }
+}
+
 interface WorkflowRunDto {
   id: number
   project_id: number
@@ -299,12 +307,22 @@ export const workflowRunApis: WorkflowRunApis & Required<Pick<WorkflowRunApis, '
     )
   },
   async update(run) {
-    return mapWorkflowRun(
-      await getApiClient().request<WorkflowRunDto>(`/workflow-runs/${encodeURIComponent(run.id)}`, {
-        method: 'PATCH',
-        json: { nodes: run.nodes, status: run.storageStatus },
-      }),
-    )
+    try {
+      return mapWorkflowRun(
+        await getApiClient().request<WorkflowRunDto>(
+          `/workflow-runs/${encodeURIComponent(run.id)}`,
+          {
+            method: 'PATCH',
+            json: { nodes: run.nodes, status: run.storageStatus, version: run.version },
+          },
+        ),
+      )
+    } catch (cause) {
+      if (cause instanceof ApiError && cause.kind === 'business' && cause.code === 409) {
+        throw new WorkflowRunConflictError(cause.message, { cause })
+      }
+      throw cause
+    }
   },
   async remove(id) {
     await getApiClient().request<null>(`/workflow-runs/${encodeURIComponent(id)}`, {

--- a/frontend/src/entities/workflow-run/index.ts
+++ b/frontend/src/entities/workflow-run/index.ts
@@ -121,7 +121,7 @@ export type WorkflowNode =
 export interface WorkflowRun {
   id: string
   projectId: string
-  /** 后端更新序号；当前仅随 PATCH 递增，不承担并发冲突检测。 */
+  /** 后端乐观锁版本；更新时原样回传，保存成功后使用响应中的新版本。 */
   version: number
   /** 后端资源状态，仅表示正常或软删除。 */
   storageStatus: WorkflowRunStorageStatus
@@ -143,4 +143,4 @@ export interface WorkflowRunApis {
   remove(id: WorkflowRun['id']): Promise<void>
 }
 
-export { workflowRunApis } from './api'
+export { WorkflowRunConflictError, workflowRunApis } from './api'

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -15,6 +15,7 @@ import type {
   WorkflowRun,
   WorkflowRunApis,
 } from '@/entities'
+import { WorkflowRunConflictError } from '@/entities'
 import { createWorkflowController } from '.'
 
 function setupNode(
@@ -255,20 +256,6 @@ async function flushAsyncWork() {
 }
 
 describe('WorkflowController', () => {
-  it('绑定角色后拒绝把同一条 WorkflowRun 改绑到另一角色', async () => {
-    const { controller } = createController()
-
-    await controller.bindCharacter('setup-1', 'character-1')
-
-    expect(controller.getWorkflow().nodes[0]).toMatchObject({
-      type: 'character-setup',
-      input: { characterId: 'character-1' },
-    })
-    await expect(controller.bindCharacter('setup-1', 'character-2')).rejects.toThrow(
-      'WorkflowRun 已绑定到另一角色，不能改绑',
-    )
-  })
-
   it('只在角色设定节点仍处于配置阶段时更新提示词和参考媒体', async () => {
     const { controller } = createController()
 
@@ -288,10 +275,19 @@ describe('WorkflowController', () => {
   it('接受上传母版时完成角色设定和母版节点', async () => {
     const { controller } = createController()
 
-    await controller.acceptUploadedCharacterTemplate('setup-1', 'https://img/uploaded-template.png')
+    await controller.acceptUploadedCharacterTemplate(
+      'setup-1',
+      'https://img/uploaded-template.png',
+      'character-1',
+    )
 
     expect(controller.getWorkflow().nodes).toMatchObject([
-      { type: 'character-setup', status: 'passed', phase: 'completed' },
+      {
+        type: 'character-setup',
+        status: 'passed',
+        phase: 'completed',
+        input: { characterId: 'character-1' },
+      },
       {
         type: 'character-template',
         status: 'passed',
@@ -299,6 +295,64 @@ describe('WorkflowController', () => {
         selectedImageUrl: 'https://img/uploaded-template.png',
       },
     ])
+  })
+
+  it('母版确认和上传都拒绝错误节点状态与角色改绑', async () => {
+    const { controller: lockedController } = createController()
+    await expect(
+      lockedController.confirmCharacterTemplate(
+        'template-1',
+        'https://img/knight.png',
+        'character-1',
+      ),
+    ).rejects.toThrow('角色母版节点当前不能确认候选图')
+    await expect(
+      lockedController.confirmCharacterTemplate(
+        'setup-1' as never,
+        'https://img/knight.png',
+        'character-1',
+      ),
+    ).rejects.toThrow('目标节点不是角色母版')
+
+    const boundRun = createRun([
+      setupNode({
+        status: 'passed',
+        phase: 'completed',
+        input: {
+          prompt: '像素骑士',
+          referenceMedia: [],
+          characterId: 'character-existing',
+        },
+      }),
+      templateNode({ status: 'active', phase: 'selecting' }),
+    ])
+    const { controller: boundController } = createController(boundRun)
+    await expect(
+      boundController.confirmCharacterTemplate(
+        'template-1',
+        'https://img/knight.png',
+        'character-other',
+      ),
+    ).rejects.toThrow('WorkflowRun 已绑定到另一角色，不能改绑')
+
+    const uploadRun = createRun([
+      setupNode({
+        input: {
+          prompt: '像素骑士',
+          referenceMedia: [],
+          characterId: 'character-existing',
+        },
+      }),
+      templateNode(),
+    ])
+    const { controller: uploadController } = createController(uploadRun)
+    await expect(
+      uploadController.acceptUploadedCharacterTemplate(
+        'setup-1',
+        'https://img/uploaded.png',
+        'character-other',
+      ),
+    ).rejects.toThrow('WorkflowRun 已绑定到另一角色，不能改绑')
   })
 
   it('页面通过订阅接收命令保存和 SSE 写回后的同一份 WorkflowRun', async () => {
@@ -711,10 +765,14 @@ describe('WorkflowController', () => {
     ])
     const { controller } = createController(run)
 
-    await controller.confirmCharacterTemplate('template-1', 'https://img/knight.png')
+    await controller.confirmCharacterTemplate('template-1', 'https://img/knight.png', 'character-1')
 
     expect(controller.getWorkflow().nodes).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          id: 'setup-1',
+          input: expect.objectContaining({ characterId: 'character-1' }),
+        }),
         expect.objectContaining({ id: 'template-1', status: 'passed', phase: 'completed' }),
         expect.objectContaining({ id: 'action-walk', status: 'active' }),
         expect.objectContaining({ id: 'action-jump', status: 'active' }),
@@ -1294,7 +1352,7 @@ describe('WorkflowController', () => {
     ])
     const { controller } = createController(run)
 
-    await controller.confirmCharacterTemplate('template-1', 'https://img/knight.png')
+    await controller.confirmCharacterTemplate('template-1', 'https://img/knight.png', 'character-1')
 
     expect(controller.getWorkflow().nodes[2]).toMatchObject({
       status: 'locked',
@@ -1311,13 +1369,40 @@ describe('WorkflowController', () => {
     vi.mocked(workflow.apis.update).mockRejectedValueOnce(new Error('后端保存失败'))
 
     await expect(
-      controller.confirmCharacterTemplate('template-1', 'https://img/knight.png'),
+      controller.confirmCharacterTemplate('template-1', 'https://img/knight.png', 'character-1'),
     ).rejects.toThrow('后端保存失败')
 
     expect(controller.getWorkflow().nodes[1]).toMatchObject({
       status: 'active',
       phase: 'selecting',
       selectedImageUrl: null,
+    })
+  })
+
+  it('PATCH 已落库但响应丢失时接纳回读快照并将命令视为成功', async () => {
+    const run = createRun([
+      setupNode({ status: 'passed', phase: 'completed' }),
+      templateNode({ status: 'active', phase: 'selecting' }),
+    ])
+    const { controller, workflow } = createController(run)
+    const update = vi.mocked(workflow.apis.update)
+    const persist = update.getMockImplementation()!
+    update.mockImplementationOnce(async (candidate) => {
+      await persist(candidate)
+      throw new WorkflowRunConflictError('执行记录版本冲突')
+    })
+
+    await controller.confirmCharacterTemplate('template-1', 'https://img/knight.png', 'character-1')
+
+    expect(controller.getWorkflow()).toMatchObject({
+      version: 2,
+      nodes: expect.arrayContaining([
+        expect.objectContaining({
+          id: 'setup-1',
+          input: expect.objectContaining({ characterId: 'character-1' }),
+        }),
+        expect.objectContaining({ id: 'template-1', status: 'passed' }),
+      ]),
     })
   })
 

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -88,8 +88,6 @@ export interface WorkflowController {
     nodeId: CharacterSetupWorkflowNode['id'],
     options: GenerateCharacterTemplateOptions,
   ): Promise<void>
-  /** 将已创建的 Character 绑定到入口节点；一条 Run 不允许改绑到另一角色。 */
-  bindCharacter(nodeId: CharacterSetupWorkflowNode['id'], characterId: string): Promise<void>
   /** 仅在入口节点尚未提交时修改角色描述和参考媒体。 */
   updateCharacterSetup(
     nodeId: CharacterSetupWorkflowNode['id'],
@@ -99,10 +97,12 @@ export interface WorkflowController {
   acceptUploadedCharacterTemplate(
     nodeId: CharacterSetupWorkflowNode['id'],
     selectedImageUrl: string,
+    characterId: string,
   ): Promise<void>
   confirmCharacterTemplate(
     nodeId: CharacterTemplateWorkflowNode['id'],
     selectedImageUrl: string,
+    characterId: string,
   ): Promise<void>
   generateFirstFrame(
     nodeId: ActionFirstFrameWorkflowNode['id'],
@@ -213,8 +213,19 @@ export function createWorkflowController({
       const candidate = transform(before)
       if (candidate === before) return structuredClone(before)
 
-      // 只有后端确认保存后才替换内存快照；失败时页面不会看到“假成功”。
-      const saved = await workflowRunApis.update(candidate)
+      // 只有更新响应或回读结果确认已落库后才替换内存快照，避免页面显示“假成功”。
+      let saved: WorkflowRun
+      try {
+        saved = await workflowRunApis.update(candidate)
+      } catch (cause) {
+        try {
+          const latest = await workflowRunApis.get(candidate.id)
+          if (!hasSamePersistedState(candidate, latest)) throw cause
+          saved = latest
+        } catch {
+          throw cause
+        }
+      }
       current = structuredClone(saved)
       notifyListeners()
       return structuredClone(saved)
@@ -395,42 +406,42 @@ export function createWorkflowController({
   function confirmCharacterTemplate(
     nodeId: CharacterTemplateWorkflowNode['id'],
     selectedImageUrl: string,
+    characterId: string,
   ) {
     ensureRunning()
     const imageUrl = nonEmpty(selectedImageUrl, 'selectedImageUrl')
-    return persist((run) =>
-      updateNode(run, nodeId, (node) => {
-        if (node.type !== 'character-template') throw new Error('目标节点不是角色母版')
-        if (node.status !== 'active' || node.phase !== 'selecting') {
-          throw new Error('角色母版节点当前不能确认候选图')
-        }
-        return unlockReadyNodes({
-          ...run,
-          nodes: run.nodes.map((item) =>
-            item.id === node.id
-              ? { ...node, selectedImageUrl: imageUrl, phase: 'completed', status: 'passed' }
-              : item,
-          ),
-        })
-      }),
-    )
-  }
-
-  function bindCharacter(nodeId: CharacterSetupWorkflowNode['id'], characterId: string) {
-    ensureRunning()
     const normalizedCharacterId = nonEmpty(characterId, 'characterId')
-    return persist((run) =>
-      updateNode(run, nodeId, (node) => {
-        if (node.type !== 'character-setup') throw new Error('目标节点不是角色设定')
-        if (node.input.characterId && node.input.characterId !== normalizedCharacterId) {
-          throw new Error('WorkflowRun 已绑定到另一角色，不能改绑')
-        }
-        return replaceNode(run, {
-          ...node,
-          input: { ...node.input, characterId: normalizedCharacterId },
-        })
-      }),
-    )
+    return persist((run) => {
+      const templateNode = findNode(run, nodeId)
+      if (templateNode.type !== 'character-template') throw new Error('目标节点不是角色母版')
+      if (templateNode.status !== 'active' || templateNode.phase !== 'selecting') {
+        throw new Error('角色母版节点当前不能确认候选图')
+      }
+      const setupNode = findSingleDependencyNode(run, templateNode, 'character-setup')
+      if (setupNode.input.characterId && setupNode.input.characterId !== normalizedCharacterId) {
+        throw new Error('WorkflowRun 已绑定到另一角色，不能改绑')
+      }
+      return unlockReadyNodes({
+        ...run,
+        nodes: run.nodes.map((node) => {
+          if (node.id === setupNode.id) {
+            return {
+              ...setupNode,
+              input: { ...setupNode.input, characterId: normalizedCharacterId },
+            }
+          }
+          if (node.id === templateNode.id) {
+            return {
+              ...templateNode,
+              selectedImageUrl: imageUrl,
+              phase: 'completed',
+              status: 'passed',
+            }
+          }
+          return node
+        }),
+      })
+    })
   }
 
   function updateCharacterSetup(
@@ -460,9 +471,11 @@ export function createWorkflowController({
   function acceptUploadedCharacterTemplate(
     nodeId: CharacterSetupWorkflowNode['id'],
     selectedImageUrl: string,
+    characterId: string,
   ) {
     ensureRunning()
     const imageUrl = nonEmpty(selectedImageUrl, 'selectedImageUrl')
+    const normalizedCharacterId = nonEmpty(characterId, 'characterId')
     return persist((run) => {
       const setupNode = findNode(run, nodeId)
       if (setupNode.type !== 'character-setup') throw new Error('目标节点不是角色设定')
@@ -473,11 +486,20 @@ export function createWorkflowController({
       if (templateNode.status !== 'locked' || templateNode.phase !== 'ready') {
         throw new Error('角色母版节点当前不能使用上传图片')
       }
+      if (setupNode.input.characterId && setupNode.input.characterId !== normalizedCharacterId) {
+        throw new Error('WorkflowRun 已绑定到另一角色，不能改绑')
+      }
       return unlockReadyNodes({
         ...run,
         nodes: run.nodes.map((node) => {
           if (node.id === setupNode.id) {
-            return { ...setupNode, status: 'passed', phase: 'completed', error: null }
+            return {
+              ...setupNode,
+              status: 'passed',
+              phase: 'completed',
+              error: null,
+              input: { ...setupNode.input, characterId: normalizedCharacterId },
+            }
           }
           if (node.id === templateNode.id) {
             return {
@@ -980,7 +1002,6 @@ export function createWorkflowController({
     setCharacterName: asCommand(setCharacterName),
     addAction: asCommand(addAction),
     generateCharacterTemplate: asCommand(generateCharacterTemplate),
-    bindCharacter: asCommand(bindCharacter),
     updateCharacterSetup: asCommand(updateCharacterSetup),
     acceptUploadedCharacterTemplate: asCommand(acceptUploadedCharacterTemplate),
     confirmCharacterTemplate: asCommand(confirmCharacterTemplate),
@@ -997,6 +1018,15 @@ export function createWorkflowController({
     getGeneration,
     dispose,
   }
+}
+
+function hasSamePersistedState(expected: WorkflowRun, actual: WorkflowRun) {
+  return (
+    expected.id === actual.id &&
+    expected.projectId === actual.projectId &&
+    expected.storageStatus === actual.storageStatus &&
+    JSON.stringify(expected.nodes) === JSON.stringify(actual.nodes)
+  )
 }
 
 function asCommand<TArgs extends unknown[]>(

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1,10 +1,10 @@
 import { StrictMode } from 'react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { QuickStartEntryService, QuickStartSession } from './service'
-import type { WorkflowRun } from '@/entities'
+import { WorkflowRunConflictError, type WorkflowRun } from '@/entities'
 import type { ExportPackageModel } from '@/features/export-package'
 import { QuickStartPage } from './index'
 
@@ -116,6 +116,7 @@ function serviceFor(run: WorkflowRun | null, overrides: Partial<QuickStartMock> 
     startAction: vi.fn(async () => service),
     getWorkflow: vi.fn(() => fallbackRun),
     subscribe: vi.fn(() => () => undefined),
+    subscribeErrors: vi.fn(() => () => undefined),
     resume: vi.fn(async () => fallbackRun),
     interrupt: vi.fn(async () => fallbackRun),
     dispose: vi.fn(),
@@ -247,7 +248,7 @@ describe('QuickStartPage', () => {
     )
   })
 
-  it('hands the created session to the run page under the production StrictMode lifecycle', async () => {
+  it('consumes the created session once and reopens it after StrictMode disposes it', async () => {
     const service = serviceFor(null)
     render(
       <StrictMode>
@@ -264,7 +265,8 @@ describe('QuickStartPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '开始生成' }))
 
     await waitFor(() => expect(service.resume).toHaveBeenCalled())
-    expect(service.open).not.toHaveBeenCalled()
+    expect(service.open).toHaveBeenCalledTimes(1)
+    expect(service.open).toHaveBeenCalledWith('run-new')
     expect(service.dispose).toHaveBeenCalled()
   })
 
@@ -349,6 +351,356 @@ describe('QuickStartPage', () => {
     expect((await screen.findByRole('alert')).textContent).toContain('重新生成失败')
     fireEvent.click(screen.getByRole('button', { name: '新建一次创作' }))
     expect(screen.getByRole('heading', { name: /用一句角色设定/u })).toBeTruthy()
+  })
+
+  it('保存发生乐观锁冲突时提示加载当前 WorkflowRun 的最新版本', async () => {
+    const run = workflow(setupAndTemplate())
+    const service = serviceFor(run, {
+      getTemplateCandidates: vi.fn(async () => ['https://example.test/candidate.png']),
+      confirmCandidate: vi.fn(async () => {
+        throw new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试')
+      }),
+    })
+    renderAt('/quick-start/run-1', service)
+
+    fireEvent.click(await screen.findByRole('img', { name: '角色图候选 1' }))
+    fireEvent.click(screen.getByRole('button', { name: '确认选择，继续下一步' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('工作流已在其他位置更新，请加载最新版本后继续。')
+    expect(screen.getByRole('link', { name: '加载最新版本' }).getAttribute('href')).toBe(
+      '/quick-start/run-1',
+    )
+    const confirm = screen.getByRole('button', { name: '确认选择，继续下一步' })
+    expect((confirm as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(confirm)
+    expect(service.confirmCandidate).toHaveBeenCalledTimes(1)
+  })
+
+  it('自动推进发生乐观锁冲突时也提示加载最新版本', async () => {
+    const run = workflow(setupAndTemplate())
+    let reportError: ((error: Error) => void) | null = null
+    const service = serviceFor(run) as QuickStartMock & {
+      subscribeErrors(listener: (error: Error) => void): () => void
+    }
+    service.subscribeErrors = vi.fn((listener) => {
+      reportError = listener
+      return () => undefined
+    })
+    renderAt('/quick-start/run-1', service)
+
+    await waitFor(() => expect(service.subscribeErrors).toHaveBeenCalledOnce())
+    act(() => {
+      reportError?.(new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试'))
+    })
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('工作流已在其他位置更新，请加载最新版本后继续。')
+    expect(screen.getByRole('link', { name: '加载最新版本' }).getAttribute('href')).toBe(
+      '/quick-start/run-1',
+    )
+  })
+
+  it('发生冲突后持续保留刷新入口，不被后续普通错误覆盖', async () => {
+    const run = workflow(setupAndTemplate())
+    const service = serviceFor(run, {
+      getTemplateCandidates: vi.fn(async () => ['https://example.test/candidate.png']),
+      confirmCandidate: vi.fn(async () => {
+        throw new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试')
+      }),
+      start: vi.fn(async () => {
+        throw new Error('重新生成失败')
+      }),
+    })
+    renderAt('/quick-start/run-1', service)
+
+    fireEvent.click(await screen.findByRole('img', { name: '角色图候选 1' }))
+    fireEvent.click(screen.getByRole('button', { name: '确认选择，继续下一步' }))
+    expect(await screen.findByRole('link', { name: '加载最新版本' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: '重新生成' }))
+    await waitFor(() => expect(service.start).toHaveBeenCalledWith('像素骑士'))
+    expect(screen.getByRole('alert').textContent).toContain(
+      '工作流已在其他位置更新，请加载最新版本后继续。',
+    )
+    expect(screen.getByRole('link', { name: '加载最新版本' })).toBeTruthy()
+  })
+
+  it('恢复期间收到冲突后不被随后成功返回的 resume 清除', async () => {
+    const run = workflow(setupAndTemplate())
+    let reportError: ((error: Error) => void) | null = null
+    const service = serviceFor(run) as QuickStartMock & {
+      subscribeErrors(listener: (error: Error) => void): () => void
+    }
+    service.subscribeErrors = vi.fn((listener) => {
+      reportError = listener
+      return () => undefined
+    })
+    service.resume = vi.fn(async () => {
+      reportError?.(new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试'))
+      return run
+    })
+    renderAt('/quick-start/run-1', service)
+
+    expect(await screen.findByRole('link', { name: '加载最新版本' })).toBeTruthy()
+    expect(screen.getByRole('alert').textContent).toContain(
+      '工作流已在其他位置更新，请加载最新版本后继续。',
+    )
+  })
+
+  it('切换 Run 后忽略旧会话延迟返回的恢复结果', async () => {
+    const oldRun = workflow(setupAndTemplate(), 'run-old')
+    const newNodes = setupAndTemplate()
+    const setup = newNodes[0]
+    if (setup?.type !== 'character-setup') throw new Error('测试工作流缺少角色设定节点')
+    setup.input.prompt = '新角色'
+    const newRun = workflow(newNodes, 'run-new')
+    const oldResumeControl: { resolve?: (run: WorkflowRun) => void } = {}
+    const oldResume = new Promise<WorkflowRun>((resolve) => {
+      oldResumeControl.resolve = resolve
+    })
+    const oldSession = serviceFor(oldRun, { resume: vi.fn(() => oldResume) })
+    const newSession = serviceFor(newRun)
+    const entryService = serviceFor(null, {
+      open: vi.fn(async (id) => (id === oldRun.id ? oldSession : newSession)),
+    })
+
+    function RunSwitcher() {
+      const navigate = useNavigate()
+      return (
+        <button type="button" onClick={() => navigate(`/quick-start/${newRun.id}`)}>
+          切换运行
+        </button>
+      )
+    }
+
+    render(
+      <MemoryRouter initialEntries={[`/quick-start/${oldRun.id}`]}>
+        <RunSwitcher />
+        <Routes>
+          <Route path="/quick-start/:runId" element={<QuickStartPage service={entryService} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('heading', { name: '像素骑士' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '切换运行' }))
+    expect(await screen.findByRole('heading', { name: '新角色' })).toBeTruthy()
+
+    await act(async () => {
+      if (!oldResumeControl.resolve) throw new Error('旧会话恢复请求没有启动')
+      oldResumeControl.resolve(oldRun)
+      await oldResume
+    })
+    expect(screen.getByRole('heading', { name: '新角色' })).toBeTruthy()
+  })
+
+  it('切换 Run 后旧会话完成自动发布也不会跳走', async () => {
+    const oldRun = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'active' })
+    const newNodes = setupAndTemplate()
+    const setup = newNodes[0]
+    if (setup?.type !== 'character-setup') throw new Error('测试工作流缺少角色设定节点')
+    setup.input.prompt = '保留在新运行'
+    const newRun = workflow(newNodes, 'run-new')
+    const publishControl: { resolve?: (run: WorkflowRun) => void } = {}
+    const pendingPublish = new Promise<WorkflowRun>((resolve) => {
+      publishControl.resolve = resolve
+    })
+    const oldSession = serviceFor(oldRun, {
+      getActionFrames: vi.fn(async () => [
+        { index: 0, imageUrl: 'https://example.test/frame.png', durationMs: 80 },
+      ]),
+      approveReview: vi.fn(() => pendingPublish),
+    })
+    const newSession = serviceFor(newRun)
+    const entryService = serviceFor(null, {
+      open: vi.fn(async (id) => (id === oldRun.id ? oldSession : newSession)),
+    })
+
+    function Controls() {
+      const navigate = useNavigate()
+      const location = useLocation()
+      return (
+        <>
+          <button type="button" onClick={() => navigate(`/quick-start/${newRun.id}`)}>
+            切换到新运行
+          </button>
+          <output aria-label="当前位置">{location.pathname}</output>
+        </>
+      )
+    }
+
+    render(
+      <MemoryRouter initialEntries={[`/quick-start/${oldRun.id}`]}>
+        <Controls />
+        <Routes>
+          <Route path="/quick-start/:runId" element={<QuickStartPage service={entryService} />} />
+          <Route path="/playtest/:characterId/:outfitId" element={<h1>旧预览台</h1>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(oldSession.approveReview).toHaveBeenCalled())
+    fireEvent.click(screen.getByRole('button', { name: '切换到新运行' }))
+    expect(await screen.findByRole('heading', { name: '保留在新运行' })).toBeTruthy()
+
+    await act(async () => {
+      if (!publishControl.resolve) throw new Error('旧会话发布请求没有启动')
+      publishControl.resolve(oldRun)
+      await pendingPublish
+    })
+    expect(screen.getByRole('status', { name: '当前位置' }).textContent).toBe(
+      '/quick-start/run-new',
+    )
+  })
+
+  it('切换 Run 后旧会话完成重新生成也不会跳走', async () => {
+    const oldRun = workflow(setupAndTemplate(), 'run-old')
+    const newNodes = setupAndTemplate()
+    const newSetup = newNodes[0]
+    if (newSetup?.type !== 'character-setup') throw new Error('测试工作流缺少角色设定节点')
+    newSetup.input.prompt = '当前新运行'
+    const newRun = workflow(newNodes, 'run-new')
+    const regeneratedRun = workflow(setupAndTemplate(), 'run-regenerated')
+    const regeneratedSession = serviceFor(regeneratedRun)
+    const regenerateControl: { resolve?: (session: QuickStartSession) => void } = {}
+    const pendingRegenerate = new Promise<QuickStartSession>((resolve) => {
+      regenerateControl.resolve = resolve
+    })
+    const oldSession = serviceFor(oldRun, {
+      getTemplateCandidates: vi.fn(async () => ['https://example.test/candidate.png']),
+    })
+    const newSession = serviceFor(newRun)
+    const entryService = serviceFor(null, {
+      start: vi.fn(() => pendingRegenerate),
+      open: vi.fn(async (id) => (id === oldRun.id ? oldSession : newSession)),
+    })
+
+    function Controls() {
+      const navigate = useNavigate()
+      const location = useLocation()
+      return (
+        <>
+          <button type="button" onClick={() => navigate(`/quick-start/${newRun.id}`)}>
+            切换当前运行
+          </button>
+          <output aria-label="当前位置">{location.pathname}</output>
+        </>
+      )
+    }
+
+    render(
+      <MemoryRouter initialEntries={[`/quick-start/${oldRun.id}`]}>
+        <Controls />
+        <Routes>
+          <Route path="/quick-start/:runId" element={<QuickStartPage service={entryService} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: '重新生成' }))
+    await waitFor(() => expect(entryService.start).toHaveBeenCalled())
+    fireEvent.click(screen.getByRole('button', { name: '切换当前运行' }))
+    expect(await screen.findByRole('heading', { name: '当前新运行' })).toBeTruthy()
+
+    await act(async () => {
+      if (!regenerateControl.resolve) throw new Error('旧会话重新生成请求没有启动')
+      regenerateControl.resolve(regeneratedSession)
+      await pendingRegenerate
+    })
+    expect(screen.getByRole('status', { name: '当前位置' }).textContent).toBe(
+      '/quick-start/run-new',
+    )
+  })
+
+  it('新建 Session 只交付一次，再次进入同一 Run 时重新读取后端', async () => {
+    const createdNodes = setupAndTemplate()
+    const createdSetup = createdNodes[0]
+    if (createdSetup?.type !== 'character-setup') throw new Error('测试工作流缺少角色设定节点')
+    createdSetup.input.prompt = '首次创建版本'
+    const createdRun = workflow(createdNodes, 'run-created')
+    const freshNodes = setupAndTemplate()
+    const freshSetup = freshNodes[0]
+    if (freshSetup?.type !== 'character-setup') throw new Error('测试工作流缺少角色设定节点')
+    freshSetup.input.prompt = '后端最新版本'
+    const freshRun = workflow(freshNodes, createdRun.id)
+    const otherRun = workflow(setupAndTemplate(), 'run-other')
+    const createdSession = serviceFor(createdRun)
+    const freshSession = serviceFor(freshRun)
+    const otherSession = serviceFor(otherRun)
+    const entryService = serviceFor(null, {
+      start: vi.fn(async () => createdSession),
+      open: vi.fn(async (id) => (id === createdRun.id ? freshSession : otherSession)),
+    })
+
+    function Controls() {
+      const navigate = useNavigate()
+      return (
+        <>
+          <button type="button" onClick={() => navigate(`/quick-start/${otherRun.id}`)}>
+            前往其他运行
+          </button>
+          <button type="button" onClick={() => navigate(`/quick-start/${createdRun.id}`)}>
+            返回已创建运行
+          </button>
+        </>
+      )
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/quick-start']}>
+        <Controls />
+        <Routes>
+          <Route path="/quick-start" element={<QuickStartPage service={entryService} />} />
+          <Route path="/quick-start/:runId" element={<QuickStartPage service={entryService} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByLabelText('创作指令'), { target: { value: '首次创建版本' } })
+    fireEvent.click(screen.getByRole('button', { name: '开始生成' }))
+    expect(await screen.findByRole('heading', { name: '首次创建版本' })).toBeTruthy()
+    expect(entryService.open).not.toHaveBeenCalledWith(createdRun.id)
+
+    fireEvent.click(screen.getByRole('button', { name: '前往其他运行' }))
+    await waitFor(() => expect(entryService.open).toHaveBeenCalledWith(otherRun.id))
+    fireEvent.click(screen.getByRole('button', { name: '返回已创建运行' }))
+
+    await waitFor(() => expect(entryService.open).toHaveBeenCalledWith(createdRun.id))
+    expect(await screen.findByRole('heading', { name: '后端最新版本' })).toBeTruthy()
+  })
+
+  it('冲突提示不被更早发起的生成结果读取失败覆盖', async () => {
+    const run = workflow(setupAndTemplate())
+    let reportError: ((error: Error) => void) | null = null
+    let rejectRead: ((error: Error) => void) | null = null
+    const pendingRead = new Promise<readonly string[]>((_resolve, reject) => {
+      rejectRead = reject
+    })
+    const service = serviceFor(run, {
+      getTemplateCandidates: vi.fn(() => pendingRead),
+    }) as QuickStartMock & {
+      subscribeErrors(listener: (error: Error) => void): () => void
+    }
+    service.subscribeErrors = vi.fn((listener) => {
+      reportError = listener
+      return () => undefined
+    })
+    renderAt('/quick-start/run-1', service)
+
+    await waitFor(() => expect(service.getTemplateCandidates).toHaveBeenCalled())
+    act(() => {
+      reportError?.(new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试'))
+    })
+    expect(await screen.findByRole('link', { name: '加载最新版本' })).toBeTruthy()
+
+    act(() => rejectRead?.(new Error('候选读取失败')))
+    await waitFor(() =>
+      expect(screen.getByRole('alert').textContent).toContain(
+        '工作流已在其他位置更新，请加载最新版本后继续。',
+      ),
+    )
+    expect(screen.getByRole('link', { name: '加载最新版本' })).toBeTruthy()
   })
 
   it('confirms a generated first frame before starting the full animation', async () => {

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -401,6 +401,34 @@ describe('QuickStartPage', () => {
     )
   })
 
+  it('冲突后即使流程进入可发布状态也不自动发布', async () => {
+    const run = workflow(setupAndTemplate())
+    const publishableRun = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'active' })
+    let reportError: ((error: Error) => void) | null = null
+    let reportRun: ((run: WorkflowRun) => void) | null = null
+    const service = serviceFor(run) as QuickStartMock & {
+      subscribeErrors(listener: (error: Error) => void): () => void
+    }
+    service.subscribeErrors = vi.fn((listener) => {
+      reportError = listener
+      return () => undefined
+    })
+    service.subscribe = vi.fn((listener) => {
+      reportRun = listener
+      return () => undefined
+    })
+    renderAt('/quick-start/run-1', service)
+
+    await waitFor(() => expect(service.subscribeErrors).toHaveBeenCalledOnce())
+    act(() => {
+      reportError?.(new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试'))
+      reportRun?.(publishableRun)
+    })
+
+    expect(await screen.findByRole('link', { name: '加载最新版本' })).toBeTruthy()
+    await waitFor(() => expect(service.approveReview).not.toHaveBeenCalled())
+  })
+
   it('发生冲突后持续保留刷新入口，不被后续普通错误覆盖', async () => {
     const run = workflow(setupAndTemplate())
     const service = serviceFor(run, {
@@ -493,6 +521,62 @@ describe('QuickStartPage', () => {
       await oldResume
     })
     expect(screen.getByRole('heading', { name: '新角色' })).toBeTruthy()
+  })
+
+  it('切换 Run 后忽略旧会话迟到的错误与读取失败', async () => {
+    const oldRun = workflow(setupAndTemplate(), 'run-old')
+    const newNodes = setupAndTemplate()
+    const newSetup = newNodes[0]
+    if (newSetup?.type !== 'character-setup') throw new Error('测试工作流缺少角色设定节点')
+    newSetup.input.prompt = '新运行不受旧错误影响'
+    const newRun = workflow(newNodes, 'run-new')
+    let reportOldError: ((error: Error) => void) | null = null
+    let rejectOldRead: ((error: Error) => void) | null = null
+    const oldRead = new Promise<string[]>((_resolve, reject) => {
+      rejectOldRead = reject
+    })
+    const oldSession = serviceFor(oldRun, {
+      getTemplateCandidates: vi.fn(() => oldRead),
+      subscribeErrors: vi.fn((listener) => {
+        reportOldError = listener
+        return () => undefined
+      }),
+    })
+    const newSession = serviceFor(newRun)
+    const entryService = serviceFor(null, {
+      open: vi.fn(async (id) => (id === oldRun.id ? oldSession : newSession)),
+    })
+
+    function RunSwitcher() {
+      const navigate = useNavigate()
+      return (
+        <button type="button" onClick={() => navigate(`/quick-start/${newRun.id}`)}>
+          切换运行
+        </button>
+      )
+    }
+
+    render(
+      <MemoryRouter initialEntries={[`/quick-start/${oldRun.id}`]}>
+        <RunSwitcher />
+        <Routes>
+          <Route path="/quick-start/:runId" element={<QuickStartPage service={entryService} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(oldSession.getTemplateCandidates).toHaveBeenCalled())
+    fireEvent.click(screen.getByRole('button', { name: '切换运行' }))
+    expect(await screen.findByRole('heading', { name: '新运行不受旧错误影响' })).toBeTruthy()
+
+    await act(async () => {
+      reportOldError?.(new Error('旧会话错误'))
+      rejectOldRead?.(new Error('旧会话读取失败'))
+      await oldRead.catch(() => undefined)
+    })
+
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.getByRole('heading', { name: '新运行不受旧错误影响' })).toBeTruthy()
   })
 
   it('切换 Run 后旧会话完成自动发布也不会跳走', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -7,7 +7,7 @@ import {
   type ChangeEvent,
   type FormEvent,
 } from 'react'
-import { Link, useNavigate, useParams, useSearchParams } from 'react-router'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router'
 
 import {
   type ActionFirstFrameWorkflowNode,
@@ -15,6 +15,7 @@ import {
   type WorkflowRun,
   type WorkflowNode,
   type WorkflowNodeType,
+  WorkflowRunConflictError,
 } from '@/entities'
 import { ExportButton, type ExportPackageModel } from '@/features/export-package'
 import {
@@ -72,15 +73,20 @@ export function QuickStartPage({ service }: QuickStartPageProps) {
     return service ?? quickStartService
   }, [service])
   const [createdSession, setCreatedSession] = useState<QuickStartSession | null>(null)
+  const consumeCreatedSession = useCallback((consumed: QuickStartSession) => {
+    setCreatedSession((current) => (current === consumed ? null : current))
+  }, [])
   const characterId = searchParams.get('characterId')
   const outfitId = searchParams.get('outfitId')
 
   return runId ? (
     <QuickStartRun
+      key={runId}
       service={activeService}
       runId={runId}
       initialSession={createdSession?.runId === runId ? createdSession : null}
       onSessionCreated={setCreatedSession}
+      onInitialSessionConsumed={consumeCreatedSession}
     />
   ) : characterId && outfitId ? (
     <QuickStartActionInput
@@ -392,17 +398,21 @@ function QuickStartRun({
   runId,
   initialSession,
   onSessionCreated,
+  onInitialSessionConsumed,
 }: {
   service: QuickStartEntryService
   runId: string
   initialSession: QuickStartSession | null
   onSessionCreated: (session: QuickStartSession) => void
+  onInitialSessionConsumed: (session: QuickStartSession) => void
 }) {
   const navigate = useNavigate()
+  const location = useLocation()
   const [session, setSession] = useState<QuickStartSession | null>(null)
   const [run, setRun] = useState<WorkflowRun | null>(null)
   const [restoring, setRestoring] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [workflowConflict, setWorkflowConflict] = useState(false)
   const [selectedCandidate, setSelectedCandidate] = useState<string | null>(null)
   const [selectedFirstFrame, setSelectedFirstFrame] = useState<string | null>(null)
   const [actionDescription, setActionDescription] = useState('')
@@ -414,38 +424,75 @@ function QuickStartRun({
   const [confirmingCandidate, setConfirmingCandidate] = useState(false)
   const [confirmingFirstFrame, setConfirmingFirstFrame] = useState(false)
   const automaticPublishAttempt = useRef<string | null>(null)
+  const workflowConflictRef = useRef(false)
+  const initialSessionRef = useRef(initialSession)
+  const activeSessionRef = useRef<QuickStartSession | null>(null)
+  const mountedRef = useRef(true)
+  const reportWorkflowError = useCallback((cause: unknown, fallback: string) => {
+    const presented = presentWorkflowError(cause, fallback)
+    if (workflowConflictRef.current && !presented.conflict) return
+    workflowConflictRef.current ||= presented.conflict
+    setError(presented.message)
+    setWorkflowConflict(workflowConflictRef.current)
+  }, [])
+  const clearWorkflowError = useCallback(() => {
+    if (workflowConflictRef.current) return
+    setError(null)
+    setWorkflowConflict(false)
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      activeSessionRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     let active = true
     let currentSession: QuickStartSession | null = null
     let unsubscribe: () => void = () => undefined
+    let unsubscribeErrors: () => void = () => undefined
     setRestoring(true)
     setSession(null)
     setRun(null)
+    workflowConflictRef.current = false
+    setError(null)
+    setWorkflowConflict(false)
 
     void (async () => {
-      const nextSession = initialSession ?? (await service.open(runId))
+      const providedSession = initialSessionRef.current
+      initialSessionRef.current = null
+      const nextSession = providedSession ?? (await service.open(runId))
       if (!active) {
         nextSession.dispose()
         return
       }
       currentSession = nextSession
+      activeSessionRef.current = nextSession
+      if (providedSession) onInitialSessionConsumed(providedSession)
       setSession(nextSession)
       setRun(nextSession.getWorkflow())
+      unsubscribeErrors = nextSession.subscribeErrors((nextError) => {
+        if (!active) return
+        reportWorkflowError(nextError, '自动生成流程失败')
+      })
       unsubscribe = nextSession.subscribe((updated) => {
         if (active) {
           setRun(updated)
-          setError(null)
+          clearWorkflowError()
         }
       })
-      setRun(await nextSession.resume())
+      const resumed = await nextSession.resume()
       if (active) {
-        setError(null)
+        setRun(resumed)
+        clearWorkflowError()
         setRestoring(false)
       }
     })().catch((cause) => {
       if (active) {
-        setError(errorMessage(cause, '恢复生成任务失败'))
+        reportWorkflowError(cause, '恢复生成任务失败')
         setRestoring(false)
       }
     })
@@ -453,9 +500,11 @@ function QuickStartRun({
     return () => {
       active = false
       unsubscribe()
+      unsubscribeErrors()
+      if (activeSessionRef.current === currentSession) activeSessionRef.current = null
       currentSession?.dispose()
     }
-  }, [initialSession, runId, service])
+  }, [clearWorkflowError, onInitialSessionConsumed, reportWorkflowError, runId, service])
 
   useEffect(() => {
     if (!run || !session) {
@@ -480,31 +529,46 @@ function QuickStartRun({
         setExportModel(nextExportModel)
       })
       .catch((cause) => {
-        if (active) setError(errorMessage(cause, '读取生成结果失败'))
+        if (active) {
+          reportWorkflowError(cause, '读取生成结果失败')
+        }
       })
     return () => {
       active = false
     }
-  }, [run, session])
+  }, [reportWorkflowError, run, session])
 
   const publishToPlaytest = useCallback(async () => {
-    if (publishing || !session) return
+    const targetSession = session
+    if (
+      workflowConflictRef.current ||
+      publishing ||
+      !targetSession ||
+      activeSessionRef.current !== targetSession
+    )
+      return
     setPublishing(true)
-    setError(null)
+    clearWorkflowError()
     try {
-      const approved = await session.approveReview()
+      const approved = await targetSession.approveReview()
+      if (!mountedRef.current || activeSessionRef.current !== targetSession) return
       setRun(approved)
-      const info = session.getCharacterInfo() ?? (await session.resolveCharacterInfo())
+      let info = targetSession.getCharacterInfo()
+      if (!info) {
+        info = await targetSession.resolveCharacterInfo()
+        if (!mountedRef.current || activeSessionRef.current !== targetSession) return
+      }
       if (!info) throw new Error('动作已生成，但没有找到对应的角色资产')
       const approvedAction = latestActionStep(approved)
       const actionId = approvedAction?.type === 'action-full-frame' ? approvedAction.id : undefined
       navigate(playtestPath(info.characterId, info.outfitId, actionId))
     } catch (cause) {
-      setError(errorMessage(cause, '导入预览台失败'))
+      if (!mountedRef.current || activeSessionRef.current !== targetSession) return
+      reportWorkflowError(cause, '导入预览台失败')
     } finally {
-      setPublishing(false)
+      if (mountedRef.current && activeSessionRef.current === targetSession) setPublishing(false)
     }
-  }, [navigate, publishing, session])
+  }, [clearWorkflowError, navigate, publishing, reportWorkflowError, session])
 
   useEffect(() => {
     const publishKey = run ? automaticPublishKey(run) : null
@@ -568,17 +632,17 @@ function QuickStartRun({
 
   async function interrupt() {
     try {
-      if (!session) return
+      if (workflowConflictRef.current || !session) return
       setRun(await session.interrupt())
     } catch (cause) {
-      setError(errorMessage(cause, '中断自动制作失败'))
+      reportWorkflowError(cause, '中断自动制作失败')
     }
   }
 
   async function confirmSelection() {
-    if (!selectedCandidate || confirmingCandidate) return
+    if (workflowConflictRef.current || !selectedCandidate || confirmingCandidate) return
     setConfirmingCandidate(true)
-    setError(null)
+    clearWorkflowError()
     try {
       if (!session) return
       const updated = await session.confirmCandidate(selectedCandidate, actionDescription)
@@ -586,38 +650,44 @@ function QuickStartRun({
       setSelectedCandidate(null)
       setActionDescription('')
     } catch (cause) {
-      setError(errorMessage(cause, '确认选择失败'))
+      reportWorkflowError(cause, '确认选择失败')
     } finally {
       setConfirmingCandidate(false)
     }
   }
 
   async function confirmFirstFrame() {
-    if (!selectedFirstFrame || confirmingFirstFrame) return
+    if (workflowConflictRef.current || !selectedFirstFrame || confirmingFirstFrame) return
     setConfirmingFirstFrame(true)
-    setError(null)
+    clearWorkflowError()
     try {
       if (!session) return
       const updated = await session.confirmFirstFrame(selectedFirstFrame)
       setRun(updated)
       setSelectedFirstFrame(null)
     } catch (cause) {
-      setError(errorMessage(cause, '确认动作首帧失败'))
+      reportWorkflowError(cause, '确认动作首帧失败')
     } finally {
       setConfirmingFirstFrame(false)
     }
   }
 
   async function regenerate() {
-    if (!run) return
+    const targetSession = session
+    if (!run || !targetSession || activeSessionRef.current !== targetSession) return
     const prompt = workflowPrompt(run)
     if (!prompt) return
     try {
       const newSession = await service.start(prompt)
+      if (!mountedRef.current || activeSessionRef.current !== targetSession) {
+        newSession.dispose()
+        return
+      }
       onSessionCreated(newSession)
       navigate(`/quick-start/${encodeURIComponent(newSession.runId)}`)
     } catch (cause) {
-      setError(errorMessage(cause, '重新生成失败'))
+      if (!mountedRef.current || activeSessionRef.current !== targetSession) return
+      reportWorkflowError(cause, '重新生成失败')
     }
   }
 
@@ -733,7 +803,7 @@ function QuickStartRun({
                   <button
                     type="button"
                     onClick={() => void confirmFirstFrame()}
-                    disabled={!selectedFirstFrame || confirmingFirstFrame}
+                    disabled={!selectedFirstFrame || confirmingFirstFrame || workflowConflict}
                     className="rounded-xl bg-app-accent px-6 py-3 text-sm font-bold text-app-on-accent transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {confirmingFirstFrame ? '正在确认…' : '确认首帧，生成完整动作'}
@@ -814,7 +884,7 @@ function QuickStartRun({
                       <button
                         type="button"
                         onClick={() => void confirmSelection()}
-                        disabled={confirmingCandidate}
+                        disabled={confirmingCandidate || workflowConflict}
                         className="rounded-xl bg-app-accent px-6 py-3 text-sm font-bold text-app-on-accent transition hover:bg-app-accent-hover"
                       >
                         {confirmingCandidate ? '正在提交…' : '确认选择，继续下一步'}
@@ -891,6 +961,7 @@ function QuickStartRun({
                 <button
                   type="button"
                   onClick={() => void interrupt()}
+                  disabled={workflowConflict}
                   className="rounded-xl border border-app-line-strong px-4 py-2 text-xs font-semibold text-app-ink-soft"
                 >
                   中断自动制作
@@ -900,7 +971,7 @@ function QuickStartRun({
                 <button
                   type="button"
                   onClick={() => void publishToPlaytest()}
-                  disabled={publishing}
+                  disabled={publishing || workflowConflict}
                   className="rounded-lg bg-app-info px-4 py-2 text-xs font-bold text-app-on-accent transition hover:bg-app-info-hover disabled:cursor-wait disabled:opacity-60"
                 >
                   {publishing ? '正在自动导入…' : '重新导入预览台'}
@@ -918,9 +989,21 @@ function QuickStartRun({
             </div>
           </div>
           {error ? (
-            <p role="alert" className="mt-3 text-sm text-app-danger">
-              {error}
-            </p>
+            <div
+              role="alert"
+              className="mt-3 flex flex-wrap items-center gap-3 text-sm text-app-danger"
+            >
+              <span>{error}</span>
+              {workflowConflict ? (
+                <Link
+                  reloadDocument
+                  to={`${location.pathname}${location.search}${location.hash}`}
+                  className="rounded-lg border border-current px-3 py-1.5 text-xs font-bold text-inherit"
+                >
+                  加载最新版本
+                </Link>
+              ) : null}
+            </div>
           ) : null}
           {status.error ? (
             <p role="alert" className="mt-3 text-sm text-app-danger">
@@ -1081,4 +1164,14 @@ function nodeStatusLabel(node: WorkflowNode) {
 
 function errorMessage(cause: unknown, fallback: string) {
   return cause instanceof Error && cause.message.trim() ? cause.message.trim() : fallback
+}
+
+function presentWorkflowError(cause: unknown, fallback: string) {
+  if (cause instanceof WorkflowRunConflictError) {
+    return {
+      message: '工作流已在其他位置更新，请加载最新版本后继续。',
+      conflict: true,
+    }
+  }
+  return { message: errorMessage(cause, fallback), conflict: false }
 }

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -979,6 +979,55 @@ describe('createQuickStartService', () => {
     expect((await workflowRunApis.get(run.id)).nodes).toEqual(run.nodes)
   })
 
+  it.each([
+    { reconcileCause: new Error('WorkflowRun 回读失败'), reportedMessage: 'WorkflowRun 回读失败' },
+    { reconcileCause: '回读失败', reportedMessage: 'WorkflowRun 保存结果对账失败' },
+  ])(
+    '无法回读 Run 确认保存结果时保留可幂等 Character',
+    async ({ reconcileCause, reportedMessage }) => {
+      const run: WorkflowRun = {
+        id: 'run-template-reconcile-failed',
+        projectId: 'project-1',
+        version: 1,
+        storageStatus: 'active',
+        nodes: setupNodes(null, null),
+      }
+      const storedApis = createWorkflowRunApis([run])
+      const workflowRunApis: WorkflowRunApis = {
+        ...storedApis,
+        get: vi
+          .fn()
+          .mockImplementationOnce((id: string) => storedApis.get(id))
+          .mockRejectedValue(reconcileCause),
+        update: vi.fn().mockRejectedValue(new WorkflowRunConflictError('执行记录版本冲突')),
+      }
+      let character = characterFixture({ workflowRunId: run.id })
+      const characterApis = mutableCharacterApis(
+        () => character,
+        (value) => (character = value),
+      )
+      const onAsyncError = vi.fn()
+      const service = createQuickStartService({
+        workflowRunApis,
+        generationApis: pendingGenerationApis(),
+        characterApis,
+        prepareProject: vi.fn(),
+        projectApis: projectReader(),
+        onAsyncError,
+      })
+      const session = await service.open(run.id)
+
+      await expect(session.confirmCandidate('candidate.png', '挥手')).rejects.toBeInstanceOf(
+        WorkflowRunConflictError,
+      )
+
+      expect(characterApis.remove).not.toHaveBeenCalled()
+      expect(onAsyncError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: reportedMessage }),
+      )
+    },
+  )
+
   it('creates a fresh run when an existing character has no workflow history', async () => {
     const character = characterFixture({
       id: 'character-existing',

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -416,6 +416,17 @@ describe('createQuickStartService', () => {
       upload: vi.fn(async () => 'https://example.test/template.png' as MediaReference),
     }
     const workflowRunApis = createWorkflowRunApis()
+    const persistRun = workflowRunApis.update.bind(workflowRunApis)
+    let droppedTemplateResponse = false
+    vi.spyOn(workflowRunApis, 'update').mockImplementation(async (nextRun) => {
+      const saved = await persistRun(nextRun)
+      const template = saved.nodes.find((node) => node.type === 'character-template')
+      if (!droppedTemplateResponse && template?.status === 'passed') {
+        droppedTemplateResponse = true
+        throw new Error('上传母版响应丢失')
+      }
+      return saved
+    })
     const service = createQuickStartService({
       workflowRunApis,
       generationApis,
@@ -538,6 +549,7 @@ describe('createQuickStartService', () => {
       (value) => (character = value),
     )
     const workflowRunApis = createWorkflowRunApis([run])
+    const updateRun = vi.spyOn(workflowRunApis, 'update')
     const getRun = vi.spyOn(workflowRunApis, 'get')
     const service = createQuickStartService({
       workflowRunApis,
@@ -561,11 +573,23 @@ describe('createQuickStartService', () => {
     expect(session.getWorkflow().nodes.find((node) => node.type === 'review')?.status).toBe(
       'active',
     )
+    updateRun.mockRejectedValueOnce(new WorkflowRunConflictError('执行记录版本冲突'))
+    vi.mocked(characterApis.update)
+      .mockImplementationOnce(async (value) => {
+        character = structuredClone(value)
+        return structuredClone(character)
+      })
+      .mockRejectedValueOnce(new Error('Character 版本冲突'))
+    await expect(session.approveReview()).rejects.toBeInstanceOf(WorkflowRunConflictError)
+    expect(character.outfits[0]!.actions).toEqual([])
+    expect(session.getWorkflow().nodes.find((node) => node.type === 'review')?.status).toBe(
+      'active',
+    )
     await session.approveReview()
     await session.approveReview()
 
-    expect(getRun).toHaveBeenCalledTimes(1)
-    expect(characterApis.update).toHaveBeenCalledTimes(3)
+    expect(getRun).toHaveBeenCalledTimes(3)
+    expect(characterApis.update).toHaveBeenCalledTimes(6)
     expect(session.getWorkflow().nodes.find((node) => node.type === 'review')?.status).toBe(
       'passed',
     )
@@ -814,8 +838,10 @@ describe('createQuickStartService', () => {
       status: 1,
       outfits: [],
     }
+    const workflowRunApis = createWorkflowRunApis()
+    const updateRun = vi.spyOn(workflowRunApis, 'update')
     const service = createQuickStartService({
-      workflowRunApis: createWorkflowRunApis(),
+      workflowRunApis,
       generationApis,
       characterApis: {
         create: vi.fn(async () => structuredClone(character)),
@@ -849,6 +875,108 @@ describe('createQuickStartService', () => {
 
     expect(character.outfits).toHaveLength(1)
     expect(started.getCharacterInfo()?.characterId).toBe('candidate-character')
+    const confirmationSave = updateRun.mock.calls
+      .map(([run]) => run)
+      .find(
+        (run) => run.nodes.find((node) => node.type === 'character-template')?.status === 'passed',
+      )
+    expect(confirmationSave?.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'character-setup',
+          input: expect.objectContaining({ characterId: 'candidate-character' }),
+        }),
+        expect.objectContaining({ type: 'character-template', status: 'passed' }),
+      ]),
+    )
+  })
+
+  it('Run 已落库但响应丢失时不删除已绑定的 Character', async () => {
+    const run: WorkflowRun = {
+      id: 'run-response-lost',
+      projectId: 'project-1',
+      version: 1,
+      storageStatus: 'active',
+      nodes: setupNodes(null, null),
+    }
+    const workflowRunApis = createWorkflowRunApis([run])
+    const realUpdate = workflowRunApis.update.bind(workflowRunApis)
+    vi.spyOn(workflowRunApis, 'update').mockImplementation(async (nextRun) => {
+      const saved = await realUpdate(nextRun)
+      const template = saved.nodes.find((node) => node.type === 'character-template')
+      if (template?.status === 'passed') throw new Error('网络响应丢失')
+      return saved
+    })
+    let character = characterFixture({
+      workflowRunId: run.id,
+      referenceImageUrl: 'candidate.png',
+    })
+    const remove = vi.fn()
+    const characterApis = mutableCharacterApis(
+      () => character,
+      (value) => (character = value),
+    )
+    characterApis.remove = remove
+    const service = createQuickStartService({
+      workflowRunApis,
+      generationApis: pendingGenerationApis(),
+      characterApis,
+      prepareProject: vi.fn(),
+      projectApis: projectReader(),
+    })
+    const session = await service.open(run.id)
+
+    await expect(session.confirmCandidate('candidate.png', '挥手')).resolves.toMatchObject({
+      nodes: expect.arrayContaining([
+        expect.objectContaining({ type: 'action-first-frame', phase: 'generating' }),
+      ]),
+    })
+
+    expect(remove).not.toHaveBeenCalled()
+    const latest = await workflowRunApis.get(run.id)
+    expect(latest.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'character-setup',
+          input: expect.objectContaining({ characterId: character.id }),
+        }),
+        expect.objectContaining({ type: 'character-template', status: 'passed' }),
+      ]),
+    )
+  })
+
+  it('母版确认冲突且最新 Run 未落库时删除孤儿 Character', async () => {
+    const run: WorkflowRun = {
+      id: 'run-template-conflict',
+      projectId: 'project-1',
+      version: 1,
+      storageStatus: 'active',
+      nodes: setupNodes(null, null),
+    }
+    const workflowRunApis = createWorkflowRunApis([run])
+    vi.spyOn(workflowRunApis, 'update').mockRejectedValue(
+      new WorkflowRunConflictError('执行记录版本冲突'),
+    )
+    let character = characterFixture({ workflowRunId: run.id })
+    const characterApis = mutableCharacterApis(
+      () => character,
+      (value) => (character = value),
+    )
+    const service = createQuickStartService({
+      workflowRunApis,
+      generationApis: pendingGenerationApis(),
+      characterApis,
+      prepareProject: vi.fn(),
+      projectApis: projectReader(),
+    })
+    const session = await service.open(run.id)
+
+    await expect(session.confirmCandidate('candidate.png', '挥手')).rejects.toBeInstanceOf(
+      WorkflowRunConflictError,
+    )
+
+    expect(characterApis.remove).toHaveBeenCalledWith(character.id)
+    expect((await workflowRunApis.get(run.id)).nodes).toEqual(run.nodes)
   })
 
   it('creates a fresh run when an existing character has no workflow history', async () => {
@@ -1110,6 +1238,48 @@ describe('createQuickStartService', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(methodAttempts).toBe(1)
     unsubscribe()
+  })
+
+  it('错误上报器和页面订阅者抛错时仍完成容错', async () => {
+    const run = actionRun(true)
+    const storedApis = createWorkflowRunApis([run])
+    const workflowRunApis: WorkflowRunApis = {
+      ...storedApis,
+      update: vi.fn(async (nextRun: WorkflowRun) => {
+        const method = nextRun.nodes.find((node) => node.type === 'action-generation-method')
+        if (method?.type === 'action-generation-method' && method.method === 'video-cropping') {
+          throw '非 Error 异常'
+        }
+        return storedApis.update(nextRun)
+      }),
+    }
+    const onAsyncError = vi.fn(() => {
+      throw new Error('上报器异常')
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    try {
+      const service = createQuickStartService({
+        workflowRunApis,
+        generationApis: pendingGenerationApis(),
+        prepareProject: async () => ({ id: 'project-1', spriteSize: { width: 256, height: 256 } }),
+        projectApis: projectReader(),
+        onAsyncError,
+      })
+      const session = await service.open(run.id)
+      session.subscribeErrors(() => {
+        throw new Error('页面订阅者异常')
+      })
+
+      await session.confirmFirstFrame('https://example.test/first-frame-2.png')
+
+      await vi.waitFor(() => expect(consoleError).toHaveBeenCalledTimes(2))
+      expect(onAsyncError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Quick Start 自动推进失败' }),
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 
   it('会话销毁后不再报告尚未结束的自动推进错误', async () => {

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -16,7 +16,7 @@ import {
   createRealQuickStartService,
   type QuickStartMediaApis,
 } from './service'
-import { ProjectNameConflictError } from '@/entities'
+import { ProjectNameConflictError, WorkflowRunConflictError } from '@/entities'
 import { registerApiAccessTokenProvider } from '@/shared/api'
 
 function createWorkflowRunApis(initialRuns: readonly WorkflowRun[] = []): WorkflowRunApis {
@@ -1076,5 +1076,83 @@ describe('createQuickStartService', () => {
         }),
       )
     })
+  })
+
+  it('向会话订阅者报告自动推进中的乐观锁冲突', async () => {
+    const run = actionRun(true)
+    const storedApis = createWorkflowRunApis([run])
+    let methodAttempts = 0
+    const workflowRunApis: WorkflowRunApis = {
+      ...storedApis,
+      update: vi.fn(async (nextRun: WorkflowRun) => {
+        const method = nextRun.nodes.find((node) => node.type === 'action-generation-method')
+        if (method?.type === 'action-generation-method' && method.method === 'video-cropping') {
+          methodAttempts += 1
+          throw new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试')
+        }
+        return storedApis.update(nextRun)
+      }),
+    }
+    const service = createQuickStartService({
+      workflowRunApis,
+      generationApis: pendingGenerationApis(),
+      prepareProject: async () => ({ id: 'project-1', spriteSize: { width: 256, height: 256 } }),
+      projectApis: projectReader(),
+    })
+    const session = await service.open(run.id)
+    const errors: Error[] = []
+    const unsubscribe = session.subscribeErrors((error) => errors.push(error))
+
+    await session.confirmFirstFrame('https://example.test/first-frame-2.png')
+
+    await vi.waitFor(() => expect(errors).toEqual([expect.any(WorkflowRunConflictError)]))
+    await session.interrupt()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(methodAttempts).toBe(1)
+    unsubscribe()
+  })
+
+  it('会话销毁后不再报告尚未结束的自动推进错误', async () => {
+    const run = actionRun(true)
+    const storedApis = createWorkflowRunApis([run])
+    const advanceControl: { reject?: (error: Error) => void } = {}
+    let markAdvanceStarted: (() => void) | null = null
+    const advanceStarted = new Promise<void>((resolve) => {
+      markAdvanceStarted = resolve
+    })
+    const workflowRunApis: WorkflowRunApis = {
+      ...storedApis,
+      update: vi.fn(async (nextRun: WorkflowRun) => {
+        const method = nextRun.nodes.find((node) => node.type === 'action-generation-method')
+        if (method?.type === 'action-generation-method' && method.method === 'video-cropping') {
+          markAdvanceStarted?.()
+          return new Promise<WorkflowRun>((_resolve, reject) => {
+            advanceControl.reject = reject
+          })
+        }
+        return storedApis.update(nextRun)
+      }),
+    }
+    const onAsyncError = vi.fn()
+    const service = createQuickStartService({
+      workflowRunApis,
+      generationApis: pendingGenerationApis(),
+      prepareProject: async () => ({ id: 'project-1', spriteSize: { width: 256, height: 256 } }),
+      projectApis: projectReader(),
+      onAsyncError,
+    })
+    const session = await service.open(run.id)
+    const pageError = vi.fn()
+    session.subscribeErrors(pageError)
+
+    await session.confirmFirstFrame('https://example.test/first-frame-2.png')
+    await advanceStarted
+    session.dispose()
+    if (!advanceControl.reject) throw new Error('自动推进请求没有启动')
+    advanceControl.reject(new Error('旧会话保存失败'))
+    await Promise.resolve()
+
+    expect(onAsyncError).not.toHaveBeenCalled()
+    expect(pageError).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -8,6 +8,7 @@ import {
   type Action,
   type Character,
   type CharacterApis,
+  type CharacterSetupWorkflowNode,
   type GenerationApis,
   type Generation,
   type MediaReference,
@@ -122,6 +123,37 @@ export function createQuickStartService({
       report(error: Error): void
     }
   >()
+
+  async function shouldRollbackWorkflowChange(
+    runId: WorkflowRun['id'],
+    isPersisted: (latest: WorkflowRun) => boolean,
+  ) {
+    try {
+      return !isPersisted(await workflowRunApis.get(runId))
+    } catch (reconcileCause) {
+      onAsyncError(
+        reconcileCause instanceof Error
+          ? reconcileCause
+          : new Error('WorkflowRun 保存结果对账失败'),
+      )
+      // 无法确认 PATCH 是否落库时保留幂等资产，避免删掉已被 Run 引用的数据。
+      return false
+    }
+  }
+
+  function hasPersistedCharacterTemplate(
+    latest: WorkflowRun,
+    imageUrl: string,
+    characterId: Character['id'],
+  ) {
+    const latestSetup = setupNode(latest)
+    const latestTemplate = templateNode(latest)
+    return (
+      latestSetup.input.characterId === characterId &&
+      latestTemplate.status === 'passed' &&
+      latestTemplate.selectedImageUrl === imageUrl
+    )
+  }
 
   async function resolveProjectSpriteSize(projectId: Project['id']) {
     const cached = projectSpriteSizes.get(projectId)
@@ -284,6 +316,11 @@ export function createQuickStartService({
   async function persistCharacterTemplate(
     controller: WorkflowController,
     selectedImageUrl: string,
+    persistRun: (
+      setupId: CharacterSetupWorkflowNode['id'],
+      characterId: Character['id'],
+    ) => Promise<void>,
+    isRunPersisted: (latest: WorkflowRun, characterId: Character['id']) => boolean,
   ): Promise<{ characterId: string; outfitId: string }> {
     if (!characterApis) throw new Error('角色服务尚未配置，不能确认角色母版')
     const run = controller.getWorkflow()
@@ -293,6 +330,7 @@ export function createQuickStartService({
       const existing = await characterApis.get(existingCharacterId)
       const outfit = existing.outfits.find((item) => item.previewUrl === selectedImageUrl)
       if (!outfit) throw new Error('已绑定角色中没有与当前母版对应的造型')
+      await persistRun(setup.id, existing.id)
       return { characterId: existing.id, outfitId: outfit.id }
     }
 
@@ -304,6 +342,7 @@ export function createQuickStartService({
       referenceImageUrl: selectedImageUrl,
     })
     const outfitId = `outfit-${Date.now().toString(36)}`
+    let runSaveAttempted = false
     try {
       await characterApis.update({
         ...character,
@@ -319,15 +358,22 @@ export function createQuickStartService({
           },
         ],
       })
-      await controller.bindCharacter(setup.id, character.id)
+      runSaveAttempted = true
+      await persistRun(setup.id, character.id)
     } catch (cause) {
-      // Character 与 Run 的绑定没有服务端事务；后续两步失败时尽力清掉刚建的孤儿角色。
-      try {
-        await characterApis.remove(character.id)
-      } catch (rollbackCause) {
-        onAsyncError(
-          rollbackCause instanceof Error ? rollbackCause : new Error('创建角色后的回滚失败'),
-        )
+      const shouldRollback =
+        !runSaveAttempted ||
+        (await shouldRollbackWorkflowChange(run.id, (latest) =>
+          isRunPersisted(latest, character.id),
+        ))
+      if (shouldRollback) {
+        try {
+          await characterApis.remove(character.id)
+        } catch (rollbackCause) {
+          onAsyncError(
+            rollbackCause instanceof Error ? rollbackCause : new Error('创建角色后的回滚失败'),
+          )
+        }
       }
       throw cause
     }
@@ -478,8 +524,14 @@ export function createQuickStartService({
           throw new Error('当前角色母版节点不能直接替换图片，请先从角色母版节点重做')
         }
         const templateReference = await mediaApis.upload(file, 'reference-image', signal)
-        await controller.confirmCharacterTemplate(template.id, templateReference)
-        const target = await persistCharacterTemplate(controller, templateReference)
+        const target = await persistCharacterTemplate(
+          controller,
+          templateReference,
+          (_setupId, characterId) =>
+            controller.confirmCharacterTemplate(template.id, templateReference, characterId),
+          (latest, characterId) =>
+            hasPersistedCharacterTemplate(latest, templateReference, characterId),
+        )
         const spriteSize =
           knownSpriteSize ?? (await resolveProjectSpriteSize(controller.getWorkflow().projectId))
         await prepareAction(controller, target.outfitId, actionDescription, spriteSize)
@@ -490,8 +542,14 @@ export function createQuickStartService({
         if (candidateCommand) return candidateCommand
         const command = (async () => {
           const template = templateNode(controller.getWorkflow())
-          await controller.confirmCharacterTemplate(template.id, selectedImageUrl)
-          const target = await persistCharacterTemplate(controller, selectedImageUrl)
+          const target = await persistCharacterTemplate(
+            controller,
+            selectedImageUrl,
+            (_setupId, characterId) =>
+              controller.confirmCharacterTemplate(template.id, selectedImageUrl, characterId),
+            (latest, characterId) =>
+              hasPersistedCharacterTemplate(latest, selectedImageUrl, characterId),
+          )
           const spriteSize =
             knownSpriteSize ?? (await resolveProjectSpriteSize(controller.getWorkflow().projectId))
           await prepareAction(controller, target.outfitId, actionDescription ?? '', spriteSize)
@@ -570,7 +628,7 @@ export function createQuickStartService({
             durationMs: frame.durationMs,
           })),
         }
-        await characterApis.update({
+        const publishedCharacter = await characterApis.update({
           ...character,
           outfits: character.outfits.map((outfit) =>
             outfit.id === info.outfitId
@@ -581,7 +639,48 @@ export function createQuickStartService({
               : outfit,
           ),
         })
-        if (review.status === 'active') await controller.approveReview(review.id)
+        if (review.status === 'active') {
+          try {
+            await controller.approveReview(review.id)
+          } catch (cause) {
+            const shouldRollback = await shouldRollbackWorkflowChange(
+              run.id,
+              (latest) => findReview(latest, fullFrame.id)?.status === 'passed',
+            )
+            if (shouldRollback) {
+              try {
+                await characterApis.update({
+                  ...character,
+                  dataVersion: publishedCharacter.dataVersion,
+                })
+              } catch {
+                try {
+                  const latestCharacter = await characterApis.get(character.id)
+                  const originalAction = character.outfits
+                    .flatMap((outfit) => outfit.actions)
+                    .find((item) => item.id === action.id)
+                  await characterApis.update({
+                    ...latestCharacter,
+                    outfits: latestCharacter.outfits.map((outfit) => ({
+                      ...outfit,
+                      actions: [
+                        ...outfit.actions.filter((item) => item.id !== action.id),
+                        ...(originalAction?.outfitId === outfit.id ? [originalAction] : []),
+                      ],
+                    })),
+                  })
+                } catch (rollbackCause) {
+                  onAsyncError(
+                    rollbackCause instanceof Error
+                      ? rollbackCause
+                      : new Error('审核冲突后恢复角色资产失败'),
+                  )
+                }
+              }
+            }
+            throw cause
+          }
+        }
         return controller.getWorkflow()
       },
       getCharacterInfo: () => getCharacterInfo(controller),
@@ -694,8 +793,14 @@ export function createQuickStartService({
         prompt,
         referenceMedia: [templateReference],
       })
-      await controller.acceptUploadedCharacterTemplate('character-setup', templateReference)
-      const target = await persistCharacterTemplate(controller, templateReference)
+      const target = await persistCharacterTemplate(
+        controller,
+        templateReference,
+        (setupId, characterId) =>
+          controller.acceptUploadedCharacterTemplate(setupId, templateReference, characterId),
+        (latest, characterId) =>
+          hasPersistedCharacterTemplate(latest, templateReference, characterId),
+      )
       await prepareAction(controller, target.outfitId, actionDescription, project.spriteSize)
       return createSession(controller, project.spriteSize)
     },

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -41,6 +41,7 @@ export interface QuickStartSession {
   readonly runId: WorkflowRun['id']
   getWorkflow(): WorkflowRun
   subscribe(listener: (run: WorkflowRun) => void): () => void
+  subscribeErrors(listener: (error: Error) => void): () => void
   resume(): Promise<WorkflowRun>
   interrupt(): Promise<WorkflowRun>
   dispose(): void
@@ -114,6 +115,13 @@ export function createQuickStartService({
   onAsyncError = (error) => console.error('[quick-start] 异步工作流错误', error),
 }: CreateQuickStartServiceOptions): QuickStartEntryService {
   const projectSpriteSizes = new Map<Project['id'], Project['spriteSize']>()
+  const controllerErrorChannels = new WeakMap<
+    WorkflowController,
+    {
+      listeners: Set<(error: Error) => void>
+      report(error: Error): void
+    }
+  >()
 
   async function resolveProjectSpriteSize(projectId: Project['id']) {
     const cached = projectSpriteSizes.get(projectId)
@@ -124,7 +132,33 @@ export function createQuickStartService({
   }
 
   function createController(workflow?: WorkflowRun): WorkflowController {
-    return createWorkflowController({ workflow, workflowRunApis, generationApis, onAsyncError })
+    const listeners = new Set<(error: Error) => void>()
+    const report = (error: Error) => {
+      try {
+        onAsyncError(error)
+      } catch (reportError) {
+        console.error('[quick-start] 异步错误上报器执行失败', reportError, error)
+      }
+      for (const listener of listeners) {
+        try {
+          listener(error)
+        } catch (listenerError) {
+          console.error('[quick-start] 页面错误订阅者执行失败', listenerError, error)
+        }
+      }
+    }
+    const controller = createWorkflowController({
+      workflow,
+      workflowRunApis,
+      generationApis,
+      onAsyncError: report,
+    })
+    controllerErrorChannels.set(controller, { listeners, report })
+    return controller
+  }
+
+  function reportControllerError(controller: WorkflowController, error: Error) {
+    controllerErrorChannels.get(controller)?.report(error)
   }
 
   function setupNode(run: WorkflowRun) {
@@ -335,9 +369,10 @@ export function createQuickStartService({
 
   function startAutomaticActionAdvance(controller: WorkflowController): () => void {
     let advancing = false
+    let stopped = false
 
     const advance = (run: WorkflowRun) => {
-      if (advancing) return
+      if (advancing || stopped) return
       const method = run.nodes.find(
         (node) =>
           node.type === 'action-generation-method' && !node.deletedAt && node.status === 'active',
@@ -369,17 +404,29 @@ export function createQuickStartService({
           characterId,
           referenceMedia: [],
         })
-      })()
-        .catch(onAsyncError)
-        .finally(() => {
+      })().then(
+        () => {
           advancing = false
-          advance(controller.getWorkflow())
-        })
+          if (!stopped) advance(controller.getWorkflow())
+        },
+        (cause: unknown) => {
+          advancing = false
+          if (stopped) return
+          stopped = true
+          reportControllerError(
+            controller,
+            cause instanceof Error ? cause : new Error('Quick Start 自动推进失败'),
+          )
+        },
+      )
     }
 
     const stop = controller.subscribe(advance)
     advance(controller.getWorkflow())
-    return stop
+    return () => {
+      stopped = true
+      stop()
+    }
   }
 
   function createSession(
@@ -398,6 +445,12 @@ export function createQuickStartService({
       runId: controller.getWorkflow().id,
       getWorkflow: () => controller.getWorkflow(),
       subscribe: (listener) => controller.subscribe(listener),
+      subscribeErrors(listener) {
+        const listeners = controllerErrorChannels.get(controller)?.listeners
+        if (!listeners) return () => undefined
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      },
       async resume() {
         disposed = false
         await controller.resume()
@@ -414,6 +467,7 @@ export function createQuickStartService({
         disposed = true
         stopAutomaticAdvance?.()
         stopAutomaticAdvance = null
+        controllerErrorChannels.get(controller)?.listeners.clear()
         controller.dispose()
       },
       async continueWithUploadedTemplate(file, actionDescription, signal) {

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -244,7 +244,7 @@ describe('WorkflowEditorPage real runtime boundary', () => {
       }),
     })
     const confirmCharacterTemplate = vi.fn(async (nodeId: string, imageUrl: string) => {
-      await session.controller.confirmCharacterTemplate(nodeId, imageUrl)
+      await session.controller.confirmCharacterTemplate(nodeId, imageUrl, 'character-1')
       const character = characterFixture()
       return {
         ...character,
@@ -453,8 +453,8 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     )
   })
 
-  it('发布成功但审核保存失败时仍显式刷新 Character', async () => {
-    const publishReviewedAction = vi.fn(async () => characterFixture())
+  it('发布与审核命令失败时显示错误并释放分支锁', async () => {
+    const publishReviewedAction = vi.fn(() => Promise.reject(new Error('审核保存失败')))
     const session = createSession(reviewingActionWorkflow(), {
       character: { ...characterFixture(), outfits: [] },
       generationApis: generationApisFixture({
@@ -462,7 +462,6 @@ describe('WorkflowEditorPage real runtime boundary', () => {
       }),
       publishReviewedAction,
     })
-    vi.spyOn(session.controller, 'approveReview').mockRejectedValue(new Error('审核保存失败'))
     defaultSessionLoader.mockResolvedValue(session)
     renderEditor('/workflow-editor/42')
 
@@ -470,9 +469,10 @@ describe('WorkflowEditorPage real runtime boundary', () => {
 
     expect((await screen.findByRole('alert')).textContent).toContain('审核保存失败')
     expect(publishReviewedAction).toHaveBeenCalledWith('action-walk:review')
-    fireEvent.click(screen.getByRole('button', { name: '添加动作分支' }))
-    expect((screen.getByRole('button', { name: '生成动作 ›' }) as HTMLButtonElement).disabled).toBe(
-      false,
+    await waitFor(() =>
+      expect((screen.getByRole('button', { name: '审核通过' }) as HTMLButtonElement).disabled).toBe(
+        false,
+      ),
     )
   })
 
@@ -784,6 +784,30 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     expect(screen.getByRole('link', { name: '加载最新版本' })).toBeTruthy()
   })
 
+  it('异步冲突后收到工作流状态通知仍保留刷新入口', async () => {
+    let reportError: ((error: Error) => void) | null = null
+    let reportRun: ((run: WorkflowRun) => void) | null = null
+    const session = createSession()
+    const subscribe = session.controller.subscribe.bind(session.controller)
+    vi.spyOn(session.controller, 'subscribe').mockImplementation((listener) => {
+      reportRun = listener
+      return subscribe(listener)
+    })
+    session.subscribeErrors = vi.fn((listener) => {
+      reportError = listener
+      return () => undefined
+    })
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+    await screen.findByLabelText('当前项目')
+
+    act(() => reportError?.(new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试')))
+    expect(screen.getByRole('link', { name: '加载最新版本' })).toBeTruthy()
+
+    act(() => reportRun?.(session.controller.getWorkflow()))
+    expect(screen.getByRole('link', { name: '加载最新版本' })).toBeTruthy()
+  })
+
   it('把 React Flow 限定为系统节点的拖动画布，不允许自由连线、重连或删除', async () => {
     defaultSessionLoader.mockResolvedValue(createSession())
     renderEditor('/workflow-editor/42')
@@ -885,7 +909,7 @@ function createSession(
       options.uploadReferenceImage ??
       vi.fn(() => Promise.reject(new Error('媒体上传服务尚未装配'))),
     confirmCharacterTemplate: async (nodeId, selectedImageUrl) => {
-      await controller.confirmCharacterTemplate(nodeId, selectedImageUrl)
+      await controller.confirmCharacterTemplate(nodeId, selectedImageUrl, 'character-1')
       return options.character ?? characterFixture()
     },
     publishReviewedAction:

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -4,15 +4,16 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Link, MemoryRouter, Route, Routes } from 'react-router'
 
-import type {
-  Character,
-  CharacterTemplateWorkflowNode,
-  Generation,
-  GenerationApis,
-  MediaReference,
-  Project,
-  WorkflowRun,
-  WorkflowRunApis,
+import {
+  WorkflowRunConflictError,
+  type Character,
+  type CharacterTemplateWorkflowNode,
+  type Generation,
+  type GenerationApis,
+  type MediaReference,
+  type Project,
+  type WorkflowRun,
+  type WorkflowRunApis,
 } from '@/entities'
 import { createWorkflowController, type WorkflowController } from '@/features/workflow-controller'
 import { WorkflowEditorPage } from './index'
@@ -199,6 +200,41 @@ describe('WorkflowEditorPage real runtime boundary', () => {
 
     expect((await screen.findByRole('alert')).textContent).toContain('Generation 后端尚未实现')
     expect(screen.queryByRole('button', { name: /选择角色候选/ })).toBeNull()
+  })
+
+  it('保存发生乐观锁冲突时提示加载当前 WorkflowRun 的最新版本', async () => {
+    const session = createSession(workflowFixture(), {
+      workflowRunApis: {
+        update: vi.fn(async () => {
+          throw new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试')
+        }),
+      },
+    })
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    fireEvent.click(await screen.findByRole('button', { name: '生成角色候选' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('工作流已在其他位置更新，请加载最新版本后继续。')
+    expect(screen.getByRole('link', { name: '加载最新版本' }).getAttribute('href')).toBe(
+      '/workflow-editor/42',
+    )
+  })
+
+  it('恢复后台任务时发生乐观锁冲突也提示加载最新版本', async () => {
+    const session = createSession()
+    vi.spyOn(session.controller, 'resume').mockRejectedValue(
+      new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试'),
+    )
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('工作流已在其他位置更新，请加载最新版本后继续。')
+    expect(screen.getByRole('link', { name: '加载最新版本' }).getAttribute('href')).toBe(
+      '/workflow-editor/42',
+    )
   })
 
   it('确认身份母版后采用会话创建的 Character 继续动作流程', async () => {
@@ -723,6 +759,31 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     expect(screen.getByRole('alert').textContent).toContain('异步保存失败')
   })
 
+  it('异步冲突出现后不被后续普通命令错误清除', async () => {
+    let reportError: ((error: Error) => void) | null = null
+    const create = vi.fn(() => Promise.reject(new Error('Generation 后端尚未实现')))
+    const session = createSession(workflowFixture(), {
+      generationApis: generationApisFixture({ create: create as GenerationApis['create'] }),
+    })
+    session.subscribeErrors = vi.fn((listener) => {
+      reportError = listener
+      return () => undefined
+    })
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+    await screen.findByLabelText('当前项目')
+
+    act(() => reportError?.(new WorkflowRunConflictError('执行记录版本冲突，请刷新后重试')))
+    expect(screen.getByRole('link', { name: '加载最新版本' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: '生成角色候选' }))
+    expect(create).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert').textContent).toContain(
+      '工作流已在其他位置更新，请加载最新版本后继续。',
+    )
+    expect(screen.getByRole('link', { name: '加载最新版本' })).toBeTruthy()
+  })
+
   it('把 React Flow 限定为系统节点的拖动画布，不允许自由连线、重连或删除', async () => {
     defaultSessionLoader.mockResolvedValue(createSession())
     renderEditor('/workflow-editor/42')
@@ -784,6 +845,7 @@ function renderEditor(path: string) {
 interface SessionFixtureOptions {
   character?: Character | null
   generationApis?: GenerationApis
+  workflowRunApis?: Partial<WorkflowRunApis>
   uploadReferenceImage?: WorkflowEditorSession['uploadReferenceImage']
   publishReviewedAction?(reviewNodeId: string): Promise<Character>
 }
@@ -805,6 +867,7 @@ function createSession(
       return structuredClone(workflow)
     },
     async remove() {},
+    ...options.workflowRunApis,
   }
   const generationApis = options.generationApis ?? generationApisFixture()
   const controller = createWorkflowController({

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { useParams } from 'react-router'
+import { Link, useLocation, useParams } from 'react-router'
 
 import {
   CHARACTER_PERSPECTIVE,
@@ -30,6 +30,7 @@ import {
   type WorkflowGenerationRole,
   type WorkflowNode,
   type WorkflowRun,
+  WorkflowRunConflictError,
 } from '@/entities'
 import type { WorkflowController } from '@/features/workflow-controller'
 import {
@@ -134,6 +135,7 @@ const nodeTypes = { 'workflow-card': WorkflowCard }
  */
 export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}) {
   const { runId } = useParams<{ runId: string }>()
+  const location = useLocation()
   const [session, setSession] = useState<WorkflowEditorSession | null>(null)
   const [character, setCharacter] = useState<Character | null>(null)
   const [run, setRun] = useState<WorkflowRun | null>(null)
@@ -145,15 +147,30 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
   /** 正在执行命令的分支。必须是集合：并行分支各自持锁，后起的不能顶掉先起的。 */
   const [busyBranches, setBusyBranches] = useState<ReadonlySet<string>>(() => new Set())
   const [error, setError] = useState<string | null>(null)
+  const [workflowConflict, setWorkflowConflict] = useState(false)
   const [resumeError, setResumeError] = useState<string | null>(null)
   const [generationReadError, setGenerationReadError] = useState<string | null>(null)
   const [canvasNodes, setCanvasNodes] = useState<WorkflowCardNode[]>([])
   /** 当前会话的有效期。换 WorkflowRun 就 abort，所有异步回调只认这一个信号。 */
   const sessionAbortRef = useRef<AbortController | null>(null)
+  const workflowConflictRef = useRef(false)
   /** 最近一次生成结果读取。同一会话内被新的读取顶掉时 abort，避免旧结果盖住新结果。 */
   const latestReadAbortRef = useRef<AbortController | null>(null)
   /** 已到终态的生成结果，按 taskId 记住，避免每次推进都重拉一遍。 */
   const settledGenerationsRef = useRef(new Map<Generation['id'], Generation>())
+  const reportWorkflowError = useCallback((cause: unknown, fallback: string) => {
+    const presented = presentWorkflowError(cause, fallback)
+    if (workflowConflictRef.current && !presented.conflict) return
+    workflowConflictRef.current ||= presented.conflict
+    if (presented.conflict) setResumeError(null)
+    setError(presented.message)
+    setWorkflowConflict(workflowConflictRef.current)
+  }, [])
+  const clearWorkflowError = useCallback(() => {
+    if (workflowConflictRef.current) return
+    setError(null)
+    setWorkflowConflict(false)
+  }, [])
 
   const requestGenerations = useCallback(
     (targetSession: WorkflowEditorSession, targetRun: WorkflowRun, sessionSignal: AbortSignal) => {
@@ -178,14 +195,14 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
   const runCommand = useCallback(
     (branchKey: string, command: () => Promise<void>) => {
       // 同一分支内互斥，防重复提交；别的分支照常能操作，也不会被这条命令解锁。
-      if (busyBranches.has(branchKey)) return
+      if (workflowConflictRef.current || busyBranches.has(branchKey)) return
       const sessionSignal = sessionAbortRef.current?.signal
       setBusyBranches((current) => new Set(current).add(branchKey))
-      setError(null)
+      clearWorkflowError()
       void command()
         .catch((cause: unknown) => {
           if (sessionSignal?.aborted) return
-          setError(errorMessage(cause, '工作流命令执行失败'))
+          reportWorkflowError(cause, '工作流命令执行失败')
         })
         .finally(() => {
           if (sessionSignal?.aborted) return
@@ -197,7 +214,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
           })
         })
     },
-    [busyBranches],
+    [busyBranches, clearWorkflowError, reportWorkflowError],
   )
 
   useEffect(() => {
@@ -214,7 +231,9 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
     setActionMenuLevel('root')
     setSelectedOutfitId(null)
     setBusyBranches(new Set())
+    workflowConflictRef.current = false
     setError(null)
+    setWorkflowConflict(false)
     setResumeError(null)
     setGenerationReadError(null)
     setCanvasNodes([])
@@ -237,7 +256,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
         setCharacter(nextSession.character)
         unsubscribeErrors = nextSession.subscribeErrors((nextError) => {
           if (signal.aborted) return
-          setError(errorMessage(nextError, '工作流异步处理失败'))
+          reportWorkflowError(nextError, '工作流异步处理失败')
         })
         unsubscribe = nextSession.controller.subscribe((nextRun) => {
           if (signal.aborted) return
@@ -248,12 +267,17 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
           await nextSession.controller.resume()
         } catch (cause: unknown) {
           if (signal.aborted) return
-          setResumeError(errorMessage(cause, '恢复 WorkflowRun 失败'))
+          const presented = presentWorkflowError(cause, '恢复 WorkflowRun 失败')
+          if (presented.conflict) {
+            reportWorkflowError(cause, '恢复 WorkflowRun 失败')
+          } else if (!workflowConflictRef.current) {
+            setResumeError(presented.message)
+          }
         }
       })
       .catch((cause: unknown) => {
         if (signal.aborted) return
-        setError(errorMessage(cause, '恢复 WorkflowRun 失败'))
+        reportWorkflowError(cause, '恢复 WorkflowRun 失败')
       })
 
     return () => {
@@ -263,7 +287,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
       unsubscribeErrors()
       loaded?.dispose()
     }
-  }, [loadSession, requestGenerations, runId])
+  }, [loadSession, reportWorkflowError, requestGenerations, runId])
 
   const exportModels = useMemo(() => {
     const models = new Map<string, ExportPackageModel>()
@@ -406,6 +430,15 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
           role="alert"
         >
           <span>{visibleError}</span>
+          {workflowConflict ? (
+            <Link
+              reloadDocument
+              to={`${location.pathname}${location.search}${location.hash}`}
+              className="rounded-md border border-current bg-transparent px-2 py-[5px] font-bold text-inherit"
+            >
+              加载最新版本
+            </Link>
+          ) : null}
           {!error && !resumeError && generationReadError ? (
             <button
               type="button"
@@ -1292,4 +1325,14 @@ function findDependency<T extends WorkflowNode['type']>(
 
 function errorMessage(cause: unknown, fallback: string) {
   return cause instanceof Error && cause.message ? cause.message : fallback
+}
+
+function presentWorkflowError(cause: unknown, fallback: string) {
+  if (cause instanceof WorkflowRunConflictError) {
+    return {
+      message: '工作流已在其他位置更新，请加载最新版本后继续。',
+      conflict: true,
+    }
+  }
+  return { message: errorMessage(cause, fallback), conflict: false }
 }

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -1147,7 +1147,6 @@ function ReviewContent({ node, input }: { node: ReviewWorkflowNode; input: Proje
           input.runCommand(branchKey, async () => {
             const character = await input.publishReviewedAction(node.id)
             input.setCharacter(character)
-            await input.controller.approveReview(node.id)
           })
         }
       >

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -580,7 +580,6 @@ describe('createRealWorkflowEditorSession', () => {
       WorkflowRunConflictError,
     )
 
-    expect(getRun).toHaveBeenCalledTimes(3)
     expect(updateCharacter).toHaveBeenCalledTimes(1)
     expect(character.outfits[0]!.actions).toEqual([expect.objectContaining({ id: 'action-walk' })])
   })

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -265,6 +265,44 @@ describe('createRealWorkflowEditorSession', () => {
     )
   })
 
+  it('无法回读 Run 确认保存结果时保留可幂等 Character', async () => {
+    const workflow = selectingCharacterTemplateWorkflowFixture()
+    const reconcileError = new Error('WorkflowRun 回读失败')
+    const getRun = vi.fn().mockResolvedValueOnce(workflow).mockRejectedValue(reconcileError)
+    const remove = vi.fn()
+    const onAsyncError = vi.fn()
+    const session = await createRealWorkflowEditorSession('42', {
+      workflowRunApis: {
+        create: vi.fn(),
+        get: getRun,
+        update: vi.fn().mockRejectedValue(new WorkflowRunConflictError('执行记录版本冲突')),
+        remove: vi.fn(),
+      },
+      generationApis: {
+        create: vi.fn() as GenerationApis['create'],
+        get: vi.fn(),
+        subscribe: vi.fn(() => () => undefined),
+      },
+      mediaApis: { upload: vi.fn() },
+      projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
+      characterApis: {
+        listByProject: vi.fn().mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 100 }),
+        create: vi.fn().mockResolvedValue(characterFixture()),
+        get: vi.fn(),
+        update: vi.fn(async (character) => structuredClone(character)),
+        remove,
+      },
+      onAsyncError,
+    })
+
+    await expect(
+      session.confirmCharacterTemplate('template', 'https://assets.windup.test/master.png'),
+    ).rejects.toBeInstanceOf(WorkflowRunConflictError)
+
+    expect(remove).not.toHaveBeenCalled()
+    expect(onAsyncError).toHaveBeenCalledWith(reconcileError)
+  })
+
   it('拒绝确认当前不可选择的身份母版节点', async () => {
     const { session, create } = await createCharacterTemplateSession()
 
@@ -397,6 +435,43 @@ describe('createRealWorkflowEditorSession', () => {
     expect(
       session.controller.getWorkflow().nodes.find((node) => node.id === 'action-walk:review'),
     ).toMatchObject({ status: 'passed', phase: 'completed' })
+  })
+
+  it('拒绝发布缺少动作首帧依赖的完整动画', async () => {
+    const workflow = reviewingWorkflowFixture()
+    workflow.nodes = workflow.nodes.filter((node) => node.type !== 'action-first-frame')
+    const session = await createRealWorkflowEditorSession('42', {
+      workflowRunApis: {
+        create: vi.fn(),
+        get: vi.fn().mockResolvedValue(workflow),
+        update: vi.fn(),
+        remove: vi.fn(),
+      },
+      generationApis: {
+        create: vi.fn() as GenerationApis['create'],
+        get: vi.fn(),
+        subscribe: vi.fn(() => () => undefined),
+      },
+      mediaApis: { upload: vi.fn() },
+      projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
+      characterApis: {
+        listByProject: vi.fn().mockResolvedValue({
+          items: [characterWithOutfitFixture()],
+          total: 1,
+          page: 1,
+          pageSize: 100,
+        }),
+        create: vi.fn(),
+        get: vi.fn(),
+        update: vi.fn(),
+        remove: vi.fn(),
+      },
+      onAsyncError: vi.fn(),
+    })
+
+    await expect(session.publishReviewedAction('action-walk:review')).rejects.toThrow(
+      '完整动画缺少动作首帧节点',
+    )
   })
 
   it('审核 Run 已落库但响应丢失时保留已发布的动作资产', async () => {

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -10,6 +10,7 @@ import type {
   WorkflowRun,
   WorkflowRunApis,
 } from '@/entities'
+import { WorkflowRunConflictError } from '@/entities'
 import { registerApiAccessTokenProvider, registerApiUnauthorizedRecovery } from '@/shared/api'
 import { createDefaultRealWorkflowEditorSession, createRealWorkflowEditorSession } from './runtime'
 
@@ -60,7 +61,9 @@ describe('createRealWorkflowEditorSession', () => {
           pageSize: 100,
         }),
       create: vi.fn(),
+      get: vi.fn(),
       update: vi.fn(),
+      remove: vi.fn(),
     }
 
     const session = await createRealWorkflowEditorSession('42', {
@@ -99,7 +102,9 @@ describe('createRealWorkflowEditorSession', () => {
         pageSize: 100,
       }),
       create: vi.fn(),
+      get: vi.fn(),
       update: vi.fn(),
+      remove: vi.fn(),
     }
 
     await expect(
@@ -148,7 +153,9 @@ describe('createRealWorkflowEditorSession', () => {
           pageSize: 100,
         }),
         create: vi.fn(),
+        get: vi.fn(),
         update: vi.fn(),
+        remove: vi.fn(),
       },
       onAsyncError,
     })
@@ -194,7 +201,9 @@ describe('createRealWorkflowEditorSession', () => {
           pageSize: 100,
         }),
         create,
+        get: vi.fn(),
         update,
+        remove: vi.fn(),
       },
       onAsyncError: vi.fn(),
     })
@@ -239,6 +248,23 @@ describe('createRealWorkflowEditorSession', () => {
     expect(create).not.toHaveBeenCalled()
   })
 
+  it('新建 Character 后 Run 冲突时删除未绑定的孤儿角色', async () => {
+    const { session, remove } = await createCharacterTemplateSession({
+      workflowRunUpdate: vi
+        .fn()
+        .mockRejectedValue(new WorkflowRunConflictError('执行记录版本冲突')),
+    })
+
+    await expect(
+      session.confirmCharacterTemplate('template', 'https://assets.windup.test/master.png'),
+    ).rejects.toBeInstanceOf(WorkflowRunConflictError)
+
+    expect(remove).toHaveBeenCalledWith('9')
+    expect(session.controller.getWorkflow().nodes).toEqual(
+      selectingCharacterTemplateWorkflowFixture().nodes,
+    )
+  })
+
   it('拒绝确认当前不可选择的身份母版节点', async () => {
     const { session, create } = await createCharacterTemplateSession()
 
@@ -278,7 +304,53 @@ describe('createRealWorkflowEditorSession', () => {
     ).toMatchObject({ status: 'passed', phase: 'completed' })
   })
 
-  it('发布 Character 动作资产后由调用方单独推进审核节点', async () => {
+  it('已有 Character 新增造型后 Run 冲突时恢复修改前的角色资产', async () => {
+    const existing = characterFixture()
+    const updates: Character[] = []
+    const workflow = selectingCharacterTemplateWorkflowFixture()
+    const session = await createRealWorkflowEditorSession('42', {
+      workflowRunApis: {
+        create: vi.fn(),
+        get: vi.fn().mockResolvedValue(workflow),
+        update: vi.fn().mockRejectedValue(new WorkflowRunConflictError('执行记录版本冲突')),
+        remove: vi.fn(),
+      },
+      generationApis: {
+        create: vi.fn() as GenerationApis['create'],
+        get: vi.fn(),
+        subscribe: vi.fn(() => () => undefined),
+      },
+      mediaApis: { upload: vi.fn() },
+      projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
+      characterApis: {
+        listByProject: vi.fn().mockResolvedValue({
+          items: [existing],
+          total: 1,
+          page: 1,
+          pageSize: 100,
+        }),
+        create: vi.fn(),
+        get: vi.fn().mockResolvedValue(existing),
+        update: vi.fn(async (character) => {
+          updates.push(structuredClone(character))
+          return { ...structuredClone(character), dataVersion: character.dataVersion + 1 }
+        }),
+        remove: vi.fn(),
+      },
+      onAsyncError: vi.fn(),
+    })
+
+    await expect(
+      session.confirmCharacterTemplate('template', 'https://assets.windup.test/master.png'),
+    ).rejects.toBeInstanceOf(WorkflowRunConflictError)
+
+    expect(updates).toHaveLength(2)
+    expect(updates[0]!.outfits).toHaveLength(1)
+    expect(updates[1]).toMatchObject({ dataVersion: 2, outfits: [] })
+    expect(session.controller.getWorkflow().nodes).toEqual(workflow.nodes)
+  })
+
+  it('发布 Character 动作资产并在同一会话内推进审核节点', async () => {
     const events: string[] = []
     const workflow = reviewingWorkflowFixture()
     const session = await createRealWorkflowEditorSession('42', {
@@ -306,30 +378,205 @@ describe('createRealWorkflowEditorSession', () => {
           pageSize: 100,
         }),
         create: vi.fn(),
+        get: vi.fn().mockResolvedValue(characterWithOutfitFixture()),
         update: vi.fn(async (character) => {
           events.push('publish')
           return structuredClone(character)
         }),
+        remove: vi.fn(),
       },
       onAsyncError: vi.fn(),
     })
 
     const published = await session.publishReviewedAction('action-walk:review')
 
-    expect(events).toEqual(['publish'])
+    expect(events).toEqual(['publish', 'approve'])
     expect(published.outfits[0]?.actions).toEqual([
       expect.objectContaining({ id: 'action-walk', frameCount: 2 }),
     ])
     expect(
       session.controller.getWorkflow().nodes.find((node) => node.id === 'action-walk:review'),
-    ).toMatchObject({ status: 'active', phase: 'reviewing' })
+    ).toMatchObject({ status: 'passed', phase: 'completed' })
+  })
 
-    await session.controller.approveReview('action-walk:review')
+  it('审核 Run 已落库但响应丢失时保留已发布的动作资产', async () => {
+    let savedWorkflow = reviewingWorkflowFixture()
+    let savedCharacter = characterWithOutfitFixture()
+    const updateCharacter = vi.fn(async (character: Character) => {
+      savedCharacter = { ...structuredClone(character), dataVersion: character.dataVersion + 1 }
+      return structuredClone(savedCharacter)
+    })
+    const session = await createRealWorkflowEditorSession('42', {
+      workflowRunApis: {
+        create: vi.fn(),
+        get: vi.fn(async () => structuredClone(savedWorkflow)),
+        update: vi.fn(async (run) => {
+          savedWorkflow = { ...structuredClone(run), version: run.version + 1 }
+          throw new Error('网络响应丢失')
+        }),
+        remove: vi.fn(),
+      },
+      generationApis: {
+        create: vi.fn() as GenerationApis['create'],
+        get: vi.fn().mockResolvedValue(completeAnimationFixture()),
+        subscribe: vi.fn(() => () => undefined),
+      },
+      mediaApis: { upload: vi.fn() },
+      projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
+      characterApis: {
+        get: vi.fn(async () => structuredClone(savedCharacter)),
+        listByProject: vi.fn().mockResolvedValue({
+          items: [savedCharacter],
+          total: 1,
+          page: 1,
+          pageSize: 100,
+        }),
+        create: vi.fn(),
+        update: updateCharacter,
+        remove: vi.fn(),
+      },
+      onAsyncError: vi.fn(),
+    })
 
-    expect(events).toEqual(['publish', 'approve'])
+    await expect(session.publishReviewedAction('action-walk:review')).resolves.toMatchObject({
+      id: savedCharacter.id,
+    })
+
+    expect(updateCharacter).toHaveBeenCalledTimes(1)
+    expect(savedCharacter.outfits[0]!.actions).toEqual([
+      expect.objectContaining({ id: 'action-walk' }),
+    ])
+    expect(savedWorkflow.nodes.find((node) => node.id === 'action-walk:review')).toMatchObject({
+      status: 'passed',
+    })
     expect(
       session.controller.getWorkflow().nodes.find((node) => node.id === 'action-walk:review'),
-    ).toMatchObject({ status: 'passed', phase: 'completed' })
+    ).toMatchObject({ status: 'passed' })
+  })
+
+  it('其他客户端已完成同一审核时当前 409 不撤销已发布动作', async () => {
+    const initialWorkflow = reviewingWorkflowFixture()
+    const latestWorkflow = structuredClone(initialWorkflow)
+    const latestSetup = latestWorkflow.nodes.find((node) => node.type === 'character-setup')
+    const latestReview = latestWorkflow.nodes.find((node) => node.type === 'review')
+    if (!latestSetup || latestSetup.type !== 'character-setup' || !latestReview) {
+      throw new Error('测试工作流缺少节点')
+    }
+    latestSetup.input = { ...latestSetup.input, name: '并发客户端改名' }
+    latestReview.status = 'passed'
+    latestReview.phase = 'completed'
+    latestWorkflow.version += 1
+    let character = characterWithOutfitFixture()
+    const updateCharacter = vi.fn(async (next: Character) => {
+      character = { ...structuredClone(next), dataVersion: next.dataVersion + 1 }
+      return structuredClone(character)
+    })
+    const getRun = vi.fn().mockResolvedValueOnce(initialWorkflow).mockResolvedValue(latestWorkflow)
+    const session = await createRealWorkflowEditorSession('42', {
+      workflowRunApis: {
+        create: vi.fn(),
+        get: getRun,
+        update: vi.fn().mockRejectedValue(new WorkflowRunConflictError('执行记录版本冲突')),
+        remove: vi.fn(),
+      },
+      generationApis: {
+        create: vi.fn() as GenerationApis['create'],
+        get: vi.fn().mockResolvedValue(completeAnimationFixture()),
+        subscribe: vi.fn(() => () => undefined),
+      },
+      mediaApis: { upload: vi.fn() },
+      projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
+      characterApis: {
+        get: vi.fn(async () => structuredClone(character)),
+        listByProject: vi.fn().mockResolvedValue({
+          items: [character],
+          total: 1,
+          page: 1,
+          pageSize: 100,
+        }),
+        create: vi.fn(),
+        update: updateCharacter,
+        remove: vi.fn(),
+      },
+      onAsyncError: vi.fn(),
+    })
+
+    await expect(session.publishReviewedAction('action-walk:review')).rejects.toBeInstanceOf(
+      WorkflowRunConflictError,
+    )
+
+    expect(getRun).toHaveBeenCalledTimes(3)
+    expect(updateCharacter).toHaveBeenCalledTimes(1)
+    expect(character.outfits[0]!.actions).toEqual([expect.objectContaining({ id: 'action-walk' })])
+  })
+
+  it('动作资产发布后 Run 冲突时恢复修改前的 Character', async () => {
+    const original = characterWithOutfitFixture()
+    const updates: Character[] = []
+    let published: Character | null = null
+    const unrelatedAction = {
+      id: 'action-jump',
+      outfitId: 'outfit-default',
+      name: '跳跃',
+      type: 'jump',
+      loop: false,
+      fps: 12,
+      frameCount: 0,
+      frames: [],
+    }
+    const session = await createRealWorkflowEditorSession('42', {
+      workflowRunApis: {
+        create: vi.fn(),
+        get: vi.fn().mockResolvedValue(reviewingWorkflowFixture()),
+        update: vi.fn().mockRejectedValue(new WorkflowRunConflictError('执行记录版本冲突')),
+        remove: vi.fn(),
+      },
+      generationApis: {
+        create: vi.fn() as GenerationApis['create'],
+        get: vi.fn().mockResolvedValue(completeAnimationFixture()),
+        subscribe: vi.fn(() => () => undefined),
+      },
+      mediaApis: { upload: vi.fn() },
+      projectApis: { get: vi.fn().mockResolvedValue(projectFixture()) },
+      characterApis: {
+        listByProject: vi.fn().mockResolvedValue({
+          items: [original],
+          total: 1,
+          page: 1,
+          pageSize: 100,
+        }),
+        create: vi.fn(),
+        get: vi.fn(async () => ({
+          ...(published ?? original),
+          dataVersion: 3,
+          outfits: (published ?? original).outfits.map((outfit) => ({
+            ...outfit,
+            actions: [...outfit.actions, unrelatedAction],
+          })),
+        })),
+        update: vi.fn(async (character) => {
+          updates.push(structuredClone(character))
+          if (updates.length === 2) throw new Error('Character 版本冲突')
+          const saved = { ...structuredClone(character), dataVersion: character.dataVersion + 1 }
+          if (updates.length === 1) published = saved
+          return saved
+        }),
+        remove: vi.fn(),
+      },
+      onAsyncError: vi.fn(),
+    })
+
+    await expect(session.publishReviewedAction('action-walk:review')).rejects.toBeInstanceOf(
+      WorkflowRunConflictError,
+    )
+
+    expect(updates).toHaveLength(3)
+    expect(updates[0]!.outfits[0]!.actions).toHaveLength(1)
+    expect(updates[1]).toMatchObject({ dataVersion: 2, outfits: original.outfits })
+    expect(updates[2]!.outfits[0]!.actions).toEqual([unrelatedAction])
+    expect(
+      session.controller.getWorkflow().nodes.find((node) => node.id === 'action-walk:review'),
+    ).toMatchObject({ status: 'active', phase: 'reviewing' })
   })
 })
 
@@ -425,17 +672,21 @@ async function createCharacterTemplateSession(
     workflow?: WorkflowRun
     characters?: Character[]
     mediaApis?: Pick<MediaApis, 'upload'>
+    workflowRunUpdate?: WorkflowRunApis['update']
   } = {},
 ) {
   const workflow = options.workflow ?? selectingCharacterTemplateWorkflowFixture()
   const characters = options.characters ?? []
   const create = vi.fn().mockResolvedValue(characterFixture())
   const update = vi.fn(async (character: Character) => structuredClone(character))
+  const remove = vi.fn()
   const session = await createRealWorkflowEditorSession('42', {
     workflowRunApis: {
       create: vi.fn(),
       get: vi.fn().mockResolvedValue(workflow),
-      update: vi.fn(async (run) => ({ ...structuredClone(run), version: run.version + 1 })),
+      update:
+        options.workflowRunUpdate ??
+        vi.fn(async (run) => ({ ...structuredClone(run), version: run.version + 1 })),
       remove: vi.fn(),
     },
     generationApis: {
@@ -452,12 +703,14 @@ async function createCharacterTemplateSession(
         pageSize: 100,
       }),
       create,
+      get: vi.fn().mockResolvedValue(characters[0] ?? characterFixture()),
       update,
+      remove,
     },
     mediaApis: options.mediaApis ?? { upload: vi.fn() },
     onAsyncError: vi.fn(),
   })
-  return { session, create, update }
+  return { session, create, update, remove }
 }
 
 function workflowFixture(): WorkflowRun {

--- a/frontend/src/pages/workflow-editor/runtime.ts
+++ b/frontend/src/pages/workflow-editor/runtime.ts
@@ -8,6 +8,7 @@ import type {
   ProjectApis,
   CharacterTemplateWorkflowNode,
   ReviewWorkflowNode,
+  WorkflowRun,
   WorkflowRunApis,
 } from '@/entities'
 import {
@@ -32,7 +33,7 @@ export interface WorkflowEditorSession {
   ): Promise<Character>
   /** 上传角色生成约束图；页面不接触 multipart 协议或用途枚举。 */
   uploadReferenceImage(file: File, signal?: AbortSignal): Promise<MediaReference>
-  /** 幂等发布动作资产；审核节点仍由页面随后通过 Controller 推进。 */
+  /** 幂等发布动作资产，并与审核节点的保存作为一个用户命令处理。 */
   publishReviewedAction(reviewNodeId: ReviewWorkflowNode['id']): Promise<Character>
   subscribeErrors(listener: (error: Error) => void): () => void
   dispose(): void
@@ -43,7 +44,7 @@ export interface RealWorkflowEditorDependencies {
   generationApis: GenerationApis
   mediaApis: Pick<MediaApis, 'upload'>
   projectApis: Pick<ProjectApis, 'get'>
-  characterApis: Pick<CharacterApis, 'listByProject' | 'create' | 'update'>
+  characterApis: Pick<CharacterApis, 'get' | 'listByProject' | 'create' | 'update' | 'remove'>
   onAsyncError(error: Error): void
 }
 
@@ -83,6 +84,48 @@ export async function createRealWorkflowEditorSession(
     onAsyncError: reportAsyncError,
   })
   const publisher = createCharacterAssetPublisher(dependencies.characterApis)
+  async function shouldRollbackWorkflowChange(isPersisted: (latest: WorkflowRun) => boolean) {
+    try {
+      return !isPersisted(await dependencies.workflowRunApis.get(workflow.id))
+    } catch (reconcileCause) {
+      reportAsyncError(
+        reconcileCause instanceof Error
+          ? reconcileCause
+          : new Error('WorkflowRun 保存结果对账失败'),
+      )
+      // 无法确认 PATCH 是否已落库时保留幂等资产，避免删掉已被 Run 引用的数据。
+      return false
+    }
+  }
+
+  async function restorePublishedAction(
+    original: Character,
+    published: Character,
+    actionId: string,
+  ) {
+    try {
+      return await dependencies.characterApis.update({
+        ...original,
+        dataVersion: published.dataVersion,
+      })
+    } catch {
+      // Character 又被并发更新时，在最新资产树上只恢复本命令触及的 Action。
+      const latest = await dependencies.characterApis.get(original.id)
+      const originalAction = original.outfits
+        .flatMap((outfit) => outfit.actions)
+        .find((action) => action.id === actionId)
+      return dependencies.characterApis.update({
+        ...latest,
+        outfits: latest.outfits.map((outfit) => ({
+          ...outfit,
+          actions: [
+            ...outfit.actions.filter((action) => action.id !== actionId),
+            ...(originalAction?.outfitId === outfit.id ? [originalAction] : []),
+          ],
+        })),
+      })
+    }
+  }
 
   return {
     controller,
@@ -112,32 +155,72 @@ export async function createRealWorkflowEditorSession(
         throw new Error('角色母版缺少角色设定')
       }
 
-      if (!currentCharacter) {
-        currentCharacter = await dependencies.characterApis.create({
-          projectId: currentWorkflow.projectId,
-          workflowRunId: currentWorkflow.id,
-          description: setupNode.input.prompt,
-          referenceImageUrl: imageUrl,
-        })
-      }
-      if (currentCharacter.outfits.length === 0) {
-        currentCharacter = await dependencies.characterApis.update({
-          ...currentCharacter,
-          outfits: [
-            {
-              id: 'outfit-default',
-              characterId: currentCharacter.id,
-              name: '常态造型',
-              description: null,
-              previewUrl: imageUrl,
-              actions: [],
-            },
-          ],
-        })
-      }
+      const originalCharacter = currentCharacter ? structuredClone(currentCharacter) : null
+      let nextCharacter = currentCharacter
+      let createdCharacter = false
+      let updatedExistingCharacter = false
+      try {
+        if (!nextCharacter) {
+          nextCharacter = await dependencies.characterApis.create({
+            projectId: currentWorkflow.projectId,
+            workflowRunId: currentWorkflow.id,
+            description: setupNode.input.prompt,
+            referenceImageUrl: imageUrl,
+          })
+          createdCharacter = true
+        }
+        if (nextCharacter.outfits.length === 0) {
+          nextCharacter = await dependencies.characterApis.update({
+            ...nextCharacter,
+            outfits: [
+              {
+                id: 'outfit-default',
+                characterId: nextCharacter.id,
+                name: '常态造型',
+                description: null,
+                previewUrl: imageUrl,
+                actions: [],
+              },
+            ],
+          })
+          updatedExistingCharacter = !createdCharacter
+        }
 
-      await controller.confirmCharacterTemplate(nodeId, imageUrl)
-      return currentCharacter
+        await controller.confirmCharacterTemplate(nodeId, imageUrl, nextCharacter.id)
+        currentCharacter = nextCharacter
+        return nextCharacter
+      } catch (cause) {
+        const shouldRollback = await shouldRollbackWorkflowChange((latest) => {
+          const latestTemplate = latest.nodes.find((node) => node.id === nodeId)
+          const latestSetup = latest.nodes.find((node) => node.id === setupNode.id)
+          return (
+            latestTemplate?.type === 'character-template' &&
+            latestTemplate.status === 'passed' &&
+            latestTemplate.selectedImageUrl === imageUrl &&
+            latestSetup?.type === 'character-setup' &&
+            latestSetup.input.characterId === nextCharacter?.id
+          )
+        })
+        if (shouldRollback) {
+          try {
+            if (createdCharacter && nextCharacter) {
+              await dependencies.characterApis.remove(nextCharacter.id)
+            } else if (updatedExistingCharacter && originalCharacter && nextCharacter) {
+              currentCharacter = await dependencies.characterApis.update({
+                ...originalCharacter,
+                dataVersion: nextCharacter.dataVersion,
+              })
+            }
+          } catch (rollbackCause) {
+            reportAsyncError(
+              rollbackCause instanceof Error
+                ? rollbackCause
+                : new Error('母版确认冲突后恢复角色资产失败'),
+            )
+          }
+        }
+        throw cause
+      }
     },
     async publishReviewedAction(reviewNodeId) {
       if (!currentCharacter) throw new Error('当前 WorkflowRun 尚未关联 Character')
@@ -148,16 +231,53 @@ export async function createRealWorkflowEditorSession(
         throw new Error(`${reviewNode.id} 必须且只能依赖一个完整动画节点`)
       }
       const fullFrameNodeId = reviewNode.dependsOnNodeIds[0]!
+      const fullFrameNode = currentWorkflow.nodes.find((node) => node.id === fullFrameNodeId)
+      const methodNode = currentWorkflow.nodes.find((node) =>
+        fullFrameNode?.dependsOnNodeIds.includes(node.id),
+      )
+      const firstFrameNode = currentWorkflow.nodes.find((node) =>
+        methodNode?.dependsOnNodeIds.includes(node.id),
+      )
+      if (!firstFrameNode || firstFrameNode.type !== 'action-first-frame') {
+        throw new Error('完整动画缺少动作首帧节点')
+      }
       const generation = await controller.getGeneration(fullFrameNodeId, 'complete_animation')
       if (!generation) throw new Error('完整动画生成结果不存在')
 
-      currentCharacter = await publisher.publishReviewedAction({
-        character: currentCharacter,
+      const originalCharacter = structuredClone(currentCharacter)
+      const publishedCharacter = await publisher.publishReviewedAction({
+        character: originalCharacter,
         workflow: currentWorkflow,
         reviewNodeId,
         generation,
       })
-      return currentCharacter
+      try {
+        await controller.approveReview(reviewNodeId)
+        currentCharacter = publishedCharacter
+        return publishedCharacter
+      } catch (cause) {
+        const shouldRollback = await shouldRollbackWorkflowChange((latest) => {
+          const latestReview = latest.nodes.find((node) => node.id === reviewNodeId)
+          return latestReview?.type === 'review' && latestReview.status === 'passed'
+        })
+        if (shouldRollback) {
+          try {
+            currentCharacter = await restorePublishedAction(
+              originalCharacter,
+              publishedCharacter,
+              firstFrameNode.id,
+            )
+          } catch (rollbackCause) {
+            currentCharacter = publishedCharacter
+            reportAsyncError(
+              rollbackCause instanceof Error
+                ? rollbackCause
+                : new Error('审核冲突后恢复角色资产失败'),
+            )
+          }
+        }
+        throw cause
+      }
     },
     subscribeErrors(listener) {
       errorListeners.add(listener)


### PR DESCRIPTION
## 改动内容

- WorkflowRun 更新请求回传当前 `version`，并把后端业务 `409` 映射为明确的乐观锁冲突错误
- Quick Start 与 Workflow Editor 统一展示冲突提示、阻止继续修改，并提供整页加载最新版本入口
- 修复自动推进、路由切换、StrictMode 重放及旧 Session 异步回调造成的状态污染
- 角色母版确认与 Character 绑定合并为一次 WorkflowRun 保存，避免第二次保存冲突后流程卡死
- Workflow Editor 的审核发布并入同一个 Session 命令；资产写入失败时按最新 WorkflowRun 状态精确补偿
- 对“后端已保存但响应丢失”和“另一客户端已完成同一目标”进行回读对账，避免误报冲突或误删有效资产

## 对齐依据

配合后端 PR [#345](https://github.com/1024XEngineer/Windup/pull/345) 的 WorkflowRun 乐观锁契约，前端以后端返回的版本号为准。

## 验证

- `npm run lint -- --deny-warnings`
- `npm run typecheck`
- `npm run test:coverage`：51 个测试文件，561 项通过，4 项跳过
- `npm run build`
- 本次改动文件通过 `oxfmt --check`
- 按 Codecov patch 口径本地估算约 88.28%