### PR TITLE
fix(quick-start): stop sending a self-derived character name

### DIFF
--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -452,6 +452,38 @@ describe('createQuickStartService', () => {
     )
   })
 
+  it('creates the character without a name so the backend derives it from the description', async () => {
+    const longPrompt = '一位穿着红色斗篷的像素风格女骑士手持长剑站立'
+    let savedCharacter = characterFixture({
+      description: longPrompt,
+      referenceImageUrl: 'https://example.test/template.png',
+    })
+    const characterApis = mutableCharacterApis(
+      () => savedCharacter,
+      (value) => (savedCharacter = value),
+    )
+    // 名称由后端按描述生成。前端一旦自己填，就会撞上 CharacterCreate.name 的 20 字
+    // 上限——这里的提示词有 22 字，正是线上创角失败的那一类输入。
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis(),
+      generationApis: pendingGenerationApis(),
+      characterApis,
+      mediaApis: {
+        upload: vi.fn(async () => 'https://example.test/template.png' as MediaReference),
+      },
+      prepareProject: async () => ({ id: 'project-1', spriteSize: { width: 256, height: 256 } }),
+      projectApis: projectReader(),
+      onAsyncError: vi.fn(),
+    })
+
+    await service.startWithUploadedTemplate(
+      new File(['pixels'], 'hero.png', { type: 'image/png' }),
+      longPrompt,
+    )
+
+    expect(vi.mocked(characterApis.create).mock.calls[0]?.[0].name).toBeUndefined()
+  })
+
   it('uploads a template, persists the character tree, and appends another action to it', async () => {
     const generationApis = pendingGenerationApis()
     let savedCharacter = characterFixture({

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -311,12 +311,13 @@ export function createQuickStartService({
     const run = controller.getWorkflow()
     const setup = setupNode(run)
     const existingCharacterId = setup.input.characterId
+    // 不传 name：后端按 description 生成并统一裁到 20 字。前端自己截会撞
+    // CharacterCreate.name 的 20 字上限，也让后端的自动起名永远走不到。
     const character = existingCharacterId
       ? await characterApis.get(existingCharacterId)
       : await characterApis.create({
           projectId: run.projectId,
           workflowRunId: run.id,
-          name: setup.input.prompt.trim().slice(0, 32) || '未命名角色',
           description: setup.input.prompt,
           referenceImageUrl: selectedImageUrl,
         })


### PR DESCRIPTION
Quick Start 创建角色时不再自己拼角色名，改由后端按描述生成。提示词超过 20 字的角色现在能正常完成确认母版，不再在最后一步失败。

## Why

`persistCharacterTemplate` 用提示词前 32 字作为角色名，而 `CharacterCreate.name` 的上限是 20 字（`web/api/character.py:35`，DB 字段为 `String(20)`）。提示词超过 20 字时 `POST /characters` 在参数校验阶段就被拒：

```json
{"code": 400, "message": "请求参数校验失败",
 "data": [{"type": "string_too_long", "loc": ["body", "name"],
           "msg": "String should have at most 20 characters"}]}
```

失败点在流程末尾——母版候选图已生成、用户已选定，点确认才报错，生成开销白花。中文描述几乎必然超过 20 字，因此这条路径基本不可用。

同时，因为 Quick Start 始终传入 `name`，#329 加的后端自动起名在这条路径上永远走不到。

## Changes

- Quick Start 创建角色时不再传 `name`，由后端按 `description` 生成。
- 补一条回归测试：`name` 一旦重新出现在创建请求里就失败。

## Implementation

`CreateCharacterInput.name` 本就是可选字段（`entities/character/index.ts:67`），`workflow-editor/runtime.ts` 一直是不传 `name` 的形状，这次让两条创建路径一致。

没有改成"前端截到 20 字"：截断提示词正是后端起名失败时的兜底值，前端硬截等于把最差结果写死，也会继续绕开 #329。删除后名称长度由后端单点保证。

## Verification

- [x] `npm run format:check`：通过，153 个文件
- [x] `npm run lint`：通过
- [x] `npm run typecheck`：通过
- [x] `npm run test:coverage`：51 个文件 / 530 passed、4 skipped
- [x] `npm run build`：通过
- [x] `uv run ruff check .`：通过
- [x] `uv run lint-imports`：2 kept, 0 broken
- [x] `uv run pytest -q`：723 passed、20 skipped
- [x] OpenAPI 契约漂移检查：`openapi.json` 无变化
- [ ] 端到端手动验证：Not run（需要配好 `AI_*` 凭据的本地全栈才能观察后端起名的真实结果）

## Scope

- 本 PR 不包含：Quick Start / Workflow Editor 的「角色名称（选填）」输入框。
- 本 PR 不包含：后端生成的名称回写 WorkflowRun 供工作流列表展示。当前工作流列表读 `setup.input.name`，取不到仍显示「工作流 #id」。
- 后续事项：以上两项属 #188 的前端范围，另开 issue 跟进。

## Related Issues

Closes #344
Refs #188, #284, #329
