### PR TITLE
refactor(playtest): replace asset catalog with recent launcher

### DIFF
--- a/frontend/src/pages/playtest/entry.test.tsx
+++ b/frontend/src/pages/playtest/entry.test.tsx
@@ -86,4 +86,18 @@ describe('PlaytestEntryPage', () => {
       (await screen.findByRole('link', { name: '继续预览 角色 1 · 造型 1' })).getAttribute('href'),
     ).toBe('/playtest/51/outfit-1')
   })
+
+  it('renders a real preview image and falls back for an unnamed character', async () => {
+    rememberRecentPreview(
+      '7',
+      { ...preview(1), characterName: '', previewUrl: 'https://cdn.windup.test/outfit-1.png' },
+      window.localStorage,
+    )
+
+    renderEntry()
+
+    expect(
+      (await screen.findByRole('img', { name: '未命名角色 · 造型 1预览图' })).getAttribute('src'),
+    ).toBe('https://cdn.windup.test/outfit-1.png')
+  })
 })

--- a/frontend/src/pages/playtest/entry.test.tsx
+++ b/frontend/src/pages/playtest/entry.test.tsx
@@ -93,11 +93,21 @@ describe('PlaytestEntryPage', () => {
       { ...preview(1), characterName: '', previewUrl: 'https://cdn.windup.test/outfit-1.png' },
       window.localStorage,
     )
+    rememberRecentPreview(
+      '7',
+      { ...preview(2), previewUrl: 'https://cdn.windup.test/outfit-2.png' },
+      window.localStorage,
+    )
 
     renderEntry()
 
-    expect(
-      (await screen.findByRole('img', { name: '未命名角色 · 造型 1预览图' })).getAttribute('src'),
-    ).toBe('https://cdn.windup.test/outfit-1.png')
+    const newestPreview = await screen.findByRole('img', { name: '角色 2 · 造型 2预览图' })
+    const olderPreview = screen.getByRole('img', { name: '未命名角色 · 造型 1预览图' })
+
+    expect(newestPreview.getAttribute('loading')).toBe('eager')
+    expect(newestPreview.getAttribute('fetchpriority')).toBe('high')
+    expect(olderPreview.getAttribute('src')).toBe('https://cdn.windup.test/outfit-1.png')
+    expect(olderPreview.getAttribute('loading')).toBe('lazy')
+    expect(olderPreview.getAttribute('fetchpriority')).toBe('auto')
   })
 })

--- a/frontend/src/pages/playtest/entry.test.tsx
+++ b/frontend/src/pages/playtest/entry.test.tsx
@@ -5,86 +5,80 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AppRoutes } from '@/app'
 import { AuthenticatedAuthSession } from '@/test/auth-session'
-import { createProjectAssetsBackend } from '@/test/project-assets-backend'
+
+import { rememberRecentPreview, type RecentPreview } from './recent-previews'
 
 beforeEach(() => {
-  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+  vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+  window.localStorage.clear()
 })
 
 afterEach(() => {
   cleanup()
-  vi.restoreAllMocks()
   vi.unstubAllEnvs()
   vi.unstubAllGlobals()
 })
 
-function renderEntryWith(fetchFn: typeof globalThis.fetch) {
-  vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
-  vi.stubGlobal('fetch', fetchFn)
-
-  return render(
+function renderEntry() {
+  const fetch = vi.fn<typeof globalThis.fetch>()
+  vi.stubGlobal('fetch', fetch)
+  render(
     <AuthenticatedAuthSession>
       <MemoryRouter initialEntries={['/playtest']}>
         <AppRoutes />
       </MemoryRouter>
     </AuthenticatedAuthSession>,
   )
+  return fetch
 }
 
-function renderEntry(characterCount = 2) {
-  return renderEntryWith(createProjectAssetsBackend({ characterCount }).fetch)
+function preview(index: number): RecentPreview {
+  return {
+    characterId: String(50 + index),
+    outfitId: `outfit-${index}`,
+    characterName: `角色 ${index}`,
+    outfitName: `造型 ${index}`,
+    projectId: '42',
+    projectName: '点灯人 · MVP',
+    previewUrl: null,
+    lastOpenedAt: index,
+  }
 }
 
 describe('PlaytestEntryPage', () => {
-  it('links playable outfits to their concrete Playtest route', async () => {
-    renderEntry()
+  it('does not call project or character APIs and points new users to the asset library', async () => {
+    const fetch = renderEntry()
 
-    expect(await screen.findByRole('heading', { name: '选择可预览资产' })).toBeTruthy()
-    expect(screen.getByTestId('playtest-pixel-stage').getAttribute('aria-hidden')).toBe('true')
-    expect(
-      (await screen.findByRole('link', { name: '预览 轻装信使 · 常态造型' })).getAttribute('href'),
-    ).toBe('/playtest/51/outfit-default')
-    expect(screen.getByText('2 个动作 · 5 帧')).toBeTruthy()
-    expect(screen.getByText('尚无可播放帧')).toBeTruthy()
+    expect(await screen.findByRole('heading', { name: '预览台' })).toBeTruthy()
+    expect(screen.getByText('还没有最近预览')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '从项目资产中选择' }).getAttribute('href')).toBe(
+      '/projects',
+    )
+    expect(fetch).not.toHaveBeenCalled()
   })
 
-  it('directs an empty account back to character creation', async () => {
-    renderEntry(0)
+  it('shows at most three recent previews', async () => {
+    for (let index = 0; index < 5; index += 1) {
+      rememberRecentPreview('7', preview(index), window.localStorage)
+    }
 
-    expect(await screen.findByText('还没有可预览的角色')).toBeTruthy()
-    expect(screen.getByRole('link', { name: '开始创作' }).getAttribute('href')).toBe('/quick-start')
-    expect(screen.getByRole('link', { name: '查看项目资产' }).getAttribute('href')).toBe(
+    renderEntry()
+
+    expect(await screen.findByRole('heading', { name: '角色 4 · 造型 4' })).toBeTruthy()
+    expect(screen.getAllByRole('link', { name: /继续预览/ })).toHaveLength(3)
+    expect(screen.queryByText('角色 1')).toBeNull()
+    expect(screen.getByRole('link', { name: '从项目资产中选择' }).getAttribute('href')).toBe(
       '/projects',
     )
   })
 
-  it('keeps a failed asset request distinct from an empty account', async () => {
-    renderEntryWith(() => Promise.reject(new TypeError('network unavailable')))
+  it('keeps the recent preview link on the existing parameterized workbench route', async () => {
+    rememberRecentPreview('7', preview(1), window.localStorage)
 
-    expect(await screen.findByText('可预览资产暂时无法读取')).toBeTruthy()
-    expect(screen.queryByText('还没有可预览的角色')).toBeNull()
-  })
+    renderEntry()
 
-  it('loads every project and character page before presenting the asset count', async () => {
-    const backend = createProjectAssetsBackend({ projectCount: 101, characterCount: 101 })
-    renderEntryWith(backend.fetch)
-
-    expect(await screen.findByText('101 套造型已接入')).toBeTruthy()
     expect(
-      backend.requests.some((request) => {
-        const url = new URL(request.url)
-        return url.pathname === '/projects' && url.searchParams.get('page') === '2'
-      }),
-    ).toBe(true)
-    expect(
-      backend.requests.some((request) => {
-        const url = new URL(request.url)
-        return (
-          url.pathname === '/characters' &&
-          url.searchParams.get('project_id') === '42' &&
-          url.searchParams.get('page') === '2'
-        )
-      }),
-    ).toBe(true)
+      (await screen.findByRole('link', { name: '继续预览 角色 1 · 造型 1' })).getAttribute('href'),
+    ).toBe('/playtest/51/outfit-1')
   })
 })

--- a/frontend/src/pages/playtest/entry.test.tsx
+++ b/frontend/src/pages/playtest/entry.test.tsx
@@ -8,6 +8,11 @@ import { AuthenticatedAuthSession } from '@/test/auth-session'
 
 import { rememberRecentPreview, type RecentPreview } from './recent-previews'
 
+vi.mock('./recent-previews', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./recent-previews')>()
+  return { ...actual, getRecentPreviewOwnerId: () => '7' }
+})
+
 beforeEach(() => {
   vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
   window.localStorage.clear()

--- a/frontend/src/pages/playtest/entry.tsx
+++ b/frontend/src/pages/playtest/entry.tsx
@@ -2,18 +2,16 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router'
 
 import playtestArtwork from '@/assets/workspace/playtest.png'
-import { useAuthSession } from '@/features/auth-session'
 
-import { readRecentPreviews, type RecentPreview } from './recent-previews'
+import { getRecentPreviewOwnerId, readRecentPreviews, type RecentPreview } from './recent-previews'
 
 export function PlaytestEntryPage() {
-  const session = useAuthSession()
-  const userId = session.state.status === 'authenticated' ? session.state.user.id : null
+  const recentOwnerId = getRecentPreviewOwnerId()
   const [recent, setRecent] = useState<RecentPreview[]>([])
 
   useEffect(() => {
-    setRecent(userId ? readRecentPreviews(userId) : [])
-  }, [userId])
+    setRecent(recentOwnerId ? readRecentPreviews(recentOwnerId) : [])
+  }, [recentOwnerId])
 
   return (
     <div className="mx-auto w-full max-w-[1560px] px-4 pb-8 pt-[clamp(4.75rem,11vh,7rem)] sm:px-6 xl:px-8">

--- a/frontend/src/pages/playtest/entry.tsx
+++ b/frontend/src/pages/playtest/entry.tsx
@@ -1,278 +1,161 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router'
 
-import {
-  characterApis,
-  getOutfitPlayback,
-  projectApis,
-  type Character,
-  type Outfit,
-  type Project,
-} from '@/entities'
-import type { Paged } from '@/shared/pagination'
-import { PageContainer } from '@/shared/ui'
+import playtestArtwork from '@/assets/workspace/playtest.png'
+import { useAuthSession } from '@/features/auth-session'
 
-import { PlaytestPixelStage } from './pixel-stage'
+import { readRecentPreviews, type RecentPreview } from './recent-previews'
 
-interface ProjectCharacters {
-  project: Project
-  characters: Character[]
-}
-
-interface EntryState {
-  groups: ProjectCharacters[] | null
-  error: string | null
-}
-
-const initialState: EntryState = { groups: null, error: null }
-const ASSET_PAGE_SIZE = 100
-
-async function loadAllPages<T>(loadPage: (page: number) => Promise<Paged<T>>) {
-  const firstPage = await loadPage(1)
-  const pageCount = Math.ceil(firstPage.total / firstPage.pageSize)
-  if (pageCount <= 1) return firstPage.items
-
-  const remainingPages = await Promise.all(
-    Array.from({ length: pageCount - 1 }, (_, index) => loadPage(index + 2)),
-  )
-  return [firstPage, ...remainingPages].flatMap((page) => page.items)
-}
-
-function characterName(character: Character) {
-  return character.name ?? '未命名角色'
-}
-
-/**
- * Playtest 的全局入口只负责定位已落入 Character 资产树的 Outfit。
- * 它不生成测试数据；具体操控仍交给带 characterId 与 outfitId 的预览台。
- */
 export function PlaytestEntryPage() {
-  const [state, setState] = useState<EntryState>(initialState)
+  const session = useAuthSession()
+  const userId = session.state.status === 'authenticated' ? session.state.user.id : null
+  const [recent, setRecent] = useState<RecentPreview[]>([])
 
   useEffect(() => {
-    let active = true
-    setState(initialState)
-
-    void loadAllPages((page) => projectApis.list({ page, pageSize: ASSET_PAGE_SIZE }))
-      .then(async (projects) =>
-        Promise.all(
-          projects.map(async (project) => ({
-            project,
-            characters: await loadAllPages((page) =>
-              characterApis.listByProject(project.id, { page, pageSize: ASSET_PAGE_SIZE }),
-            ),
-          })),
-        ),
-      )
-      .then(
-        (groups) => {
-          if (active) setState({ groups, error: null })
-        },
-        () => {
-          if (active) setState({ groups: [], error: '可预览资产暂时无法读取' })
-        },
-      )
-
-    return () => {
-      active = false
-    }
-  }, [])
-
-  const outfitCount =
-    state.groups?.reduce(
-      (total, group) =>
-        total + group.characters.reduce((sum, character) => sum + character.outfits.length, 0),
-      0,
-    ) ?? 0
+    setRecent(userId ? readRecentPreviews(userId) : [])
+  }, [userId])
 
   return (
-    <PageContainer>
-      <section aria-labelledby="playtest-entry-title">
-        <header className="relative overflow-hidden border-b border-app-line bg-[linear-gradient(105deg,var(--color-app-surface-raised)_0%,var(--color-app-surface-raised)_54%,var(--color-app-surface)_100%)] pb-7 md:min-h-64 md:px-2 md:py-7">
-          <div className="relative z-10 max-w-xl">
-            <p className="font-mono text-[0.68rem] font-semibold tracking-[0.2em] text-app-faint uppercase">
-              Character field test
+    <div className="mx-auto w-full max-w-[1560px] px-4 pb-8 pt-[clamp(4.75rem,11vh,7rem)] sm:px-6 xl:px-8">
+      <section aria-labelledby="playtest-entry-title" className="pb-10">
+        <header className="flex flex-col gap-4 border-b border-app-line pb-6 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h1
+              id="playtest-entry-title"
+              className="font-serif text-[clamp(2.15rem,4.5vw,4rem)] leading-none font-medium tracking-[-0.055em] text-app-ink"
+            >
+              预览台
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-app-muted">
+              继续最近打开的角色造型，或回到项目资产库选择新的预览对象。
             </p>
-            <div className="mt-3">
-              <h1
-                id="playtest-entry-title"
-                className="font-serif text-4xl font-medium tracking-[-0.045em] text-app-ink"
-              >
-                选择可预览资产
-              </h1>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-app-muted">
-                选择一套已有造型，检查动作衔接、移动反馈和实际播放效果。
-              </p>
-            </div>
-            <div className="mt-5 flex items-center gap-3 font-mono text-[0.68rem] text-app-faint">
-              <span className="inline-block h-1.5 w-1.5 bg-app-accent" />
-              <span>{state.groups !== null ? `${outfitCount} 套造型已接入` : '正在接入资产'}</span>
-            </div>
           </div>
-
-          <PlaytestPixelStage />
+          <p className="shrink-0 pb-0.5 font-mono text-[0.68rem] text-app-faint">
+            {recent.length > 0 ? `${recent.length} 条最近预览` : '等待第一次预览'}
+          </p>
         </header>
 
-        {state.error ? (
-          <ErrorState />
-        ) : state.groups === null ? (
-          <p className="mt-8 text-sm text-app-muted">正在整理可预览资产…</p>
-        ) : outfitCount === 0 ? (
-          <EmptyState />
-        ) : (
-          <div className="mt-7 space-y-8">
-            {state.groups.map((group) => {
-              const charactersWithOutfits = group.characters.filter(
-                (character) => character.outfits.length > 0,
-              )
-              if (charactersWithOutfits.length === 0) return null
-
-              return (
-                <section key={group.project.id} aria-labelledby={`project-${group.project.id}`}>
-                  <div className="flex items-center justify-between gap-4">
-                    <h2
-                      id={`project-${group.project.id}`}
-                      className="text-sm font-semibold text-app-ink-soft"
-                    >
-                      {group.project.name}
-                    </h2>
-                    <Link
-                      to={`/projects/${group.project.id}/assets`}
-                      className="text-xs font-medium text-app-muted underline decoration-app-line underline-offset-4 hover:text-app-accent"
-                    >
-                      查看项目资产
-                    </Link>
-                  </div>
-                  <div className="mt-3 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                    {charactersWithOutfits.flatMap((character) =>
-                      character.outfits.map((outfit) => (
-                        <OutfitCard
-                          key={`${character.id}:${outfit.id}`}
-                          character={character}
-                          outfit={outfit}
-                        />
-                      )),
-                    )}
-                  </div>
-                </section>
-              )
-            })}
-          </div>
-        )}
+        <AssetPickerEntry hasRecent={recent.length > 0} />
+        {recent.length > 0 ? <RecentPreviewGrid previews={recent} /> : null}
       </section>
-    </PageContainer>
-  )
-}
-
-function OutfitCard({ character, outfit }: { character: Character; outfit: Outfit }) {
-  const { frameCount, playable } = getOutfitPlayback(outfit)
-  const name = characterName(character)
-  const content = (
-    <article
-      className={`group overflow-hidden rounded-[1.4rem] border bg-app-surface ${
-        playable
-          ? 'border-app-line transition duration-300 hover:-translate-y-0.5 hover:border-app-line-strong hover:bg-app-surface-raised'
-          : 'border-app-line text-app-faint'
-      }`}
-    >
-      <div className="relative aspect-[16/9] overflow-hidden border-b border-app-line bg-app-surface-muted">
-        {outfit.previewUrl ? (
-          <img
-            src={outfit.previewUrl}
-            alt={`${name}的${outfit.name}预览`}
-            className={`h-full w-full object-contain p-5 [image-rendering:pixelated] ${
-              playable
-                ? 'transition duration-300 group-hover:scale-[1.025]'
-                : 'opacity-55 grayscale'
-            }`}
-          />
-        ) : (
-          <div className="grid h-full place-items-center bg-[linear-gradient(135deg,var(--color-app-surface-muted)_25%,var(--color-app-surface)_25%,var(--color-app-surface)_50%,var(--color-app-surface-muted)_50%,var(--color-app-surface-muted)_75%,var(--color-app-surface)_75%)] bg-[length:24px_24px]">
-            <span className="rounded-full border border-app-line bg-app-surface-raised/90 px-3 py-1 text-xs font-medium text-app-muted">
-              暂无造型预览
-            </span>
-          </div>
-        )}
-        <span
-          className={`absolute right-3 top-3 rounded-full border px-2.5 py-1 text-[0.65rem] font-semibold ${
-            playable
-              ? 'border-app-line-strong bg-app-accent-muted/95 text-app-accent'
-              : 'border-app-line bg-app-surface/95 text-app-faint'
-          }`}
-        >
-          {playable ? '可预览' : '待补帧'}
-        </span>
-      </div>
-      <div className="p-4">
-        <p className="text-xs text-app-faint">{name}</p>
-        <div className="mt-1 flex items-start justify-between gap-3">
-          <h3 className="font-serif text-xl font-medium tracking-[-0.03em] text-app-ink">
-            {outfit.name}
-          </h3>
-          <span aria-hidden="true" className="text-app-faint">
-            {playable ? '↗' : '—'}
-          </span>
-        </div>
-        <p className="mt-4 border-t border-app-line pt-3 text-xs text-app-muted">
-          {playable ? `${outfit.actions.length} 个动作 · ${frameCount} 帧` : '尚无可播放帧'}
-        </p>
-      </div>
-    </article>
-  )
-
-  if (!playable) return content
-
-  return (
-    <Link
-      to={`/playtest/${character.id}/${outfit.id}`}
-      aria-label={`预览 ${name} · ${outfit.name}`}
-      className="block rounded-[1.4rem] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-    >
-      {content}
-    </Link>
-  )
-}
-
-function EmptyState() {
-  return (
-    <div className="mt-7 rounded-[1.5rem] border border-dashed border-app-line bg-app-surface-raised p-7 sm:p-9">
-      <h2 className="font-serif text-2xl font-medium tracking-[-0.03em] text-app-ink">
-        还没有可预览的角色
-      </h2>
-      <p className="mt-2 max-w-xl text-sm leading-6 text-app-muted">
-        完成角色与动作制作后，可以在这里检查移动和动画效果。
-      </p>
-      <div className="mt-6 flex flex-wrap gap-3">
-        <Link
-          to="/quick-start"
-          className="inline-flex min-h-10 items-center rounded-full bg-app-accent px-5 text-sm font-semibold text-app-on-accent hover:bg-app-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-        >
-          开始创作
-        </Link>
-        <Link
-          to="/projects"
-          className="inline-flex min-h-10 items-center rounded-full border border-app-line px-5 text-sm font-semibold text-app-ink-soft hover:border-app-line-strong hover:bg-app-surface-raised focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-        >
-          查看项目资产
-        </Link>
-      </div>
     </div>
   )
 }
 
-function ErrorState() {
+function RecentPreviewGrid({ previews }: { previews: RecentPreview[] }) {
   return (
-    <div className="mt-7 rounded-[1.5rem] border border-app-danger-line bg-app-danger-soft p-7">
-      <h2 className="font-semibold text-app-danger">可预览资产暂时无法读取</h2>
-      <p className="mt-2 text-sm text-app-danger-muted">
-        稍后刷新页面，或先回项目资产检查角色数据。
-      </p>
+    <section aria-labelledby="recent-preview-title" className="mt-7">
+      <div className="mb-4">
+        <h2
+          id="recent-preview-title"
+          className="text-sm font-medium tracking-[0.04em] text-app-ink"
+        >
+          最近预览 · {String(previews.length).padStart(2, '0')}
+        </h2>
+      </div>
+      <div className="grid gap-x-4 gap-y-7 md:grid-cols-2 xl:grid-cols-3">
+        {previews.map((preview, index) => (
+          <RecentPreviewCard
+            key={`${preview.characterId}:${preview.outfitId}`}
+            preview={preview}
+            priority={index === 0}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function RecentPreviewCard({ preview, priority }: { preview: RecentPreview; priority: boolean }) {
+  const label = `${preview.characterName || '未命名角色'} · ${preview.outfitName}`
+  return (
+    <article className="group/tile relative min-w-0">
+      <Link
+        to={`/playtest/${preview.characterId}/${preview.outfitId}`}
+        aria-label={`继续预览 ${label}`}
+        className="block focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-ink"
+      >
+        <div className="relative aspect-[16/10] overflow-hidden rounded-[1.25rem] border border-app-line bg-app-surface-muted transition duration-300 group-hover/tile:-translate-y-0.5 group-hover/tile:border-app-line-strong">
+          {preview.previewUrl ? (
+            <img
+              src={preview.previewUrl}
+              alt={`${label}预览图`}
+              loading={priority ? 'eager' : 'lazy'}
+              decoding="async"
+              fetchPriority={priority ? 'high' : 'auto'}
+              className="h-full w-full object-contain p-6 [image-rendering:pixelated] transition-transform duration-500 group-hover/tile:scale-[1.025]"
+            />
+          ) : (
+            <div className="relative h-full overflow-hidden bg-app-surface-muted">
+              <div
+                aria-hidden="true"
+                className="absolute inset-0 opacity-55"
+                style={{
+                  backgroundImage:
+                    'linear-gradient(to right, var(--color-app-line) 1px, transparent 1px), linear-gradient(to bottom, var(--color-app-line) 1px, transparent 1px)',
+                  backgroundPosition: 'center center',
+                  backgroundSize: '24px 24px',
+                }}
+              />
+              <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-app-surface/85 px-2 py-1 font-mono text-[10px] tracking-[0.06em] text-app-faint backdrop-blur-sm">
+                暂无造型预览
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="mt-3 flex min-w-0 items-baseline justify-between gap-4 px-0.5">
+          <h3 className="min-w-0 truncate text-sm font-semibold text-app-ink">{label}</h3>
+          <span className="shrink-0 truncate text-xs text-app-faint">{preview.projectName}</span>
+        </div>
+      </Link>
+    </article>
+  )
+}
+
+function AssetPickerEntry({ hasRecent }: { hasRecent: boolean }) {
+  return (
+    <div className="mt-5">
       <Link
         to="/projects"
-        className="mt-5 inline-flex min-h-10 items-center rounded-full border border-app-danger-line px-5 text-sm font-semibold text-app-danger"
+        aria-label="从项目资产中选择"
+        className="group relative block min-h-[13.5rem] overflow-hidden rounded-[1.5rem] border border-app-line bg-transparent p-6 transition duration-300 ease-out hover:-translate-y-0.5 hover:border-app-line-strong focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-ink"
       >
-        查看项目资产
+        <div className="relative z-10 flex h-full max-w-[18rem] flex-col">
+          <h2 className="font-serif text-[clamp(1.7rem,3vw,2.5rem)] leading-none font-medium tracking-[-0.045em] text-app-ink">
+            {hasRecent ? '预览其他角色' : '还没有最近预览'}
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-app-muted">
+            {hasRecent
+              ? '需要更换角色或造型时，从项目资产库继续选择；这里仅保留最近打开的预览。'
+              : '从项目资产库选择一套已有造型，成功打开后可以从这里继续。'}
+          </p>
+          <span className="mt-auto inline-flex items-center gap-2 text-sm font-semibold text-app-ink-soft transition-colors group-hover:text-app-accent">
+            {hasRecent ? '打开项目资产' : '从项目资产中选择'}
+            <span aria-hidden="true">→</span>
+          </span>
+        </div>
+        <div className="pointer-events-none absolute -right-3 top-1/2 hidden h-[13.5rem] w-[17rem] -translate-y-1/2 overflow-hidden sm:block">
+          <img
+            data-testid="playtest-entry-artwork"
+            src={playtestArtwork}
+            alt=""
+            aria-hidden="true"
+            draggable="false"
+            className="absolute h-[17.875rem] w-[17.875rem] max-w-none translate-x-8 rotate-[5deg] object-contain opacity-65 saturate-[0.48] transition duration-500 ease-out group-hover:translate-x-7 group-hover:rotate-[4deg] group-hover:scale-[1.015] group-hover:opacity-75"
+            style={{ imageRendering: 'pixelated', left: '-0.75rem', top: '-2.2rem' }}
+          />
+        </div>
       </Link>
+      {!hasRecent ? (
+        <div className="mt-3 flex justify-end">
+          <Link
+            to="/quick-start"
+            className="text-xs font-medium text-app-muted underline decoration-app-line underline-offset-4 hover:text-app-accent"
+          >
+            还没有角色？开始创作
+          </Link>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
+import { Link, MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AppRoutes } from '@/app'
@@ -33,13 +33,14 @@ function freezeAnimationFrame() {
   vi.stubGlobal('cancelAnimationFrame', () => undefined)
 }
 
-function renderPlaytest(path: string, fetchFn?: typeof globalThis.fetch) {
+function renderPlaytest(path: string, fetchFn?: typeof globalThis.fetch, switchTo?: string) {
   freezeAnimationFrame()
   vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
   vi.stubGlobal('fetch', fetchFn ?? createProjectAssetsBackend().fetch)
   return render(
     <AuthenticatedAuthSession>
       <MemoryRouter initialEntries={[path]}>
+        {switchTo ? <Link to={switchTo}>切换到另一条预览</Link> : null}
         <AppRoutes />
       </MemoryRouter>
     </AuthenticatedAuthSession>,
@@ -133,6 +134,34 @@ describe('PlaytestPage', () => {
     )
 
     expect(await screen.findByText('角色读取失败')).toBeTruthy()
+  })
+
+  it('keeps the previous recent record when the next routed character fails to load', async () => {
+    const backend = createProjectAssetsBackend()
+    const fetchWithFailedNextCharacter: typeof globalThis.fetch = (input, init) => {
+      const path = new URL(new Request(input, init).url).pathname
+      if (path === '/characters/52') return Promise.reject(new TypeError('network unavailable'))
+      return backend.fetch(input, init)
+    }
+
+    renderPlaytest(
+      '/playtest/51/outfit-default',
+      fetchWithFailedNextCharacter,
+      '/playtest/52/outfit-default',
+    )
+    expect(await screen.findByRole('heading', { name: '51 · 常态造型' })).toBeTruthy()
+    await waitFor(() =>
+      expect(readRecentPreviews('7', window.localStorage).map((item) => item.characterId)).toEqual([
+        '51',
+      ]),
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: '切换到另一条预览' }))
+
+    expect(await screen.findByText('角色读取失败')).toBeTruthy()
+    expect(readRecentPreviews('7', window.localStorage).map((item) => item.characterId)).toEqual([
+      '51',
+    ])
   })
 
   it('shows an empty stage for an outfit whose actions have no frames', async () => {

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -9,6 +9,11 @@ import { createProjectAssetsBackend } from '@/test/project-assets-backend'
 
 import { readRecentPreviews, rememberRecentPreview } from './recent-previews'
 
+vi.mock('./recent-previews', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./recent-previews')>()
+  return { ...actual, getRecentPreviewOwnerId: () => '7' }
+})
+
 beforeEach(() => {
   window.localStorage.clear()
 })

--- a/frontend/src/pages/playtest/index.test.tsx
+++ b/frontend/src/pages/playtest/index.test.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AppRoutes } from '@/app'
 import { AuthenticatedAuthSession } from '@/test/auth-session'
 import { createProjectAssetsBackend } from '@/test/project-assets-backend'
+
+import { readRecentPreviews, rememberRecentPreview } from './recent-previews'
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
 
 afterEach(() => {
   cleanup()
@@ -47,6 +53,13 @@ describe('PlaytestPage', () => {
     expect(screen.getByRole('button', { name: '绑定动作：呼吸待机' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '绑定动作：行走' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '导出Playtest 运行包' })).toBeTruthy()
+    await waitFor(() =>
+      expect(readRecentPreviews('7', window.localStorage)[0]).toMatchObject({
+        characterId: '51',
+        outfitId: 'outfit-default',
+        projectId: '42',
+      }),
+    )
   })
 
   it('plays frames in backend index order, not array order', async () => {
@@ -89,9 +102,24 @@ describe('PlaytestPage', () => {
   })
 
   it('maps the business not-found code to a stable message', async () => {
+    rememberRecentPreview(
+      '7',
+      {
+        characterId: '9999',
+        outfitId: 'outfit-default',
+        characterName: '已删除角色',
+        outfitName: '常态造型',
+        projectId: '42',
+        projectName: '点灯人 · MVP',
+        previewUrl: null,
+        lastOpenedAt: 1,
+      },
+      window.localStorage,
+    )
     renderPlaytest('/playtest/9999/outfit-default')
 
     expect(await screen.findByText('角色不存在')).toBeTruthy()
+    await waitFor(() => expect(readRecentPreviews('7', window.localStorage)).toEqual([]))
   })
 
   it('does not mislabel a transport failure as not found', async () => {

--- a/frontend/src/pages/playtest/index.tsx
+++ b/frontend/src/pages/playtest/index.tsx
@@ -1,10 +1,18 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { useParams, useSearchParams } from 'react-router'
 
-import { characterApis, projectApis, type Character, type Project } from '@/entities'
+import {
+  characterApis,
+  getOutfitPlayback,
+  projectApis,
+  type Character,
+  type Project,
+} from '@/entities'
 import { ApiError } from '@/shared/api'
+import { useAuthSession } from '@/features/auth-session'
 
 import { PlaytestWorkbench } from './workbench'
+import { rememberRecentPreview, removeRecentPreview } from './recent-previews'
 
 export { PlaytestEntryPage } from './entry'
 
@@ -34,6 +42,13 @@ function isNotFoundError(error: unknown): boolean {
   return error instanceof ApiError && (error.code === 404 || error.status === 404)
 }
 
+function isUnavailableAssetError(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    (error.code === 403 || error.code === 404 || error.status === 403 || error.status === 404)
+  )
+}
+
 /**
  * 预览台：用角色造型里已经确认的动作帧真实操控角色。
  * 页面只读 Character，不写回资产树，也不参与生成与审核。
@@ -42,8 +57,10 @@ function isNotFoundError(error: unknown): boolean {
 export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
   const { characterId, outfitId } = useParams()
   const [searchParams] = useSearchParams()
+  const session = useAuthSession()
   const initialActionId = searchParams.get('actionId')
   const [data, setData] = useState<PageData>(initialPageData)
+  const userId = session.state.status === 'authenticated' ? session.state.user.id : null
 
   useEffect(() => {
     if (characterId === undefined) return
@@ -62,6 +79,9 @@ export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
         },
         (error: unknown) => {
           if (!cancelled) {
+            if (userId && outfitId && isUnavailableAssetError(error)) {
+              removeRecentPreview(userId, characterId, outfitId)
+            }
             setData({
               ...initialPageData,
               error: isNotFoundError(error) ? '角色不存在' : '角色读取失败',
@@ -73,7 +93,28 @@ export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
     return () => {
       cancelled = true
     }
-  }, [characterId])
+  }, [characterId, outfitId, userId])
+
+  useEffect(() => {
+    if (!userId || !characterId || !data.character || !data.project || data.error !== null) return
+
+    const outfit = data.character.outfits.find((candidate) => candidate.id === outfitId)
+    if (!outfit || !getOutfitPlayback(outfit).playable) {
+      removeRecentPreview(userId, characterId, outfitId ?? '')
+      return
+    }
+
+    rememberRecentPreview(userId, {
+      characterId,
+      outfitId: outfit.id,
+      characterName: data.character.name ?? '未命名角色',
+      outfitName: outfit.name,
+      projectId: data.character.projectId,
+      projectName: data.project.name,
+      previewUrl: outfit.previewUrl,
+      lastOpenedAt: Date.now(),
+    })
+  }, [characterId, data.character, data.error, data.project, outfitId, userId])
 
   if (characterId === undefined || outfitId === undefined)
     return <PlaytestPageMessage>预览台路由参数不完整</PlaytestPageMessage>

--- a/frontend/src/pages/playtest/index.tsx
+++ b/frontend/src/pages/playtest/index.tsx
@@ -9,10 +9,13 @@ import {
   type Project,
 } from '@/entities'
 import { ApiError } from '@/shared/api'
-import { useAuthSession } from '@/features/auth-session'
 
 import { PlaytestWorkbench } from './workbench'
-import { rememberRecentPreview, removeRecentPreview } from './recent-previews'
+import {
+  getRecentPreviewOwnerId,
+  rememberRecentPreview,
+  removeRecentPreview,
+} from './recent-previews'
 
 export { PlaytestEntryPage } from './entry'
 
@@ -57,10 +60,9 @@ function isUnavailableAssetError(error: unknown): boolean {
 export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
   const { characterId, outfitId } = useParams()
   const [searchParams] = useSearchParams()
-  const session = useAuthSession()
+  const recentOwnerId = getRecentPreviewOwnerId()
   const initialActionId = searchParams.get('actionId')
   const [data, setData] = useState<PageData>(initialPageData)
-  const userId = session.state.status === 'authenticated' ? session.state.user.id : null
 
   useEffect(() => {
     if (characterId === undefined) return
@@ -79,8 +81,8 @@ export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
         },
         (error: unknown) => {
           if (!cancelled) {
-            if (userId && outfitId && isUnavailableAssetError(error)) {
-              removeRecentPreview(userId, characterId, outfitId)
+            if (recentOwnerId && outfitId && isUnavailableAssetError(error)) {
+              removeRecentPreview(recentOwnerId, characterId, outfitId)
             }
             setData({
               ...initialPageData,
@@ -93,18 +95,19 @@ export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
     return () => {
       cancelled = true
     }
-  }, [characterId, outfitId, userId])
+  }, [characterId, outfitId, recentOwnerId])
 
   useEffect(() => {
-    if (!userId || !characterId || !data.character || !data.project || data.error !== null) return
+    if (!recentOwnerId || !characterId || !data.character || !data.project || data.error !== null)
+      return
 
     const outfit = data.character.outfits.find((candidate) => candidate.id === outfitId)
     if (!outfit || !getOutfitPlayback(outfit).playable) {
-      removeRecentPreview(userId, characterId, outfitId ?? '')
+      removeRecentPreview(recentOwnerId, characterId, outfitId ?? '')
       return
     }
 
-    rememberRecentPreview(userId, {
+    rememberRecentPreview(recentOwnerId, {
       characterId,
       outfitId: outfit.id,
       characterName: data.character.name ?? '未命名角色',
@@ -114,7 +117,7 @@ export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
       previewUrl: outfit.previewUrl,
       lastOpenedAt: Date.now(),
     })
-  }, [characterId, data.character, data.error, data.project, outfitId, userId])
+  }, [characterId, data.character, data.error, data.project, outfitId, recentOwnerId])
 
   if (characterId === undefined || outfitId === undefined)
     return <PlaytestPageMessage>预览台路由参数不完整</PlaytestPageMessage>

--- a/frontend/src/pages/playtest/index.tsx
+++ b/frontend/src/pages/playtest/index.tsx
@@ -29,13 +29,20 @@ export interface PlaytestPageProps {
 }
 
 interface PageData {
+  loadedCharacterId: string | null
   character: Character | null
   project: Project | null
   error: string | null
   loading: boolean
 }
 
-const initialPageData: PageData = { character: null, project: null, error: null, loading: false }
+const initialPageData: PageData = {
+  loadedCharacterId: null,
+  character: null,
+  project: null,
+  error: null,
+  loading: false,
+}
 
 /**
  * 后端把「角色不存在」表达成 HTTP 200 里的业务码 404，真正的传输失败才落在 status 上。
@@ -77,7 +84,15 @@ export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
       }))
       .then(
         ({ character, project }) => {
-          if (!cancelled) setData({ character, project, error: null, loading: false })
+          if (!cancelled) {
+            setData({
+              loadedCharacterId: characterId,
+              character,
+              project,
+              error: null,
+              loading: false,
+            })
+          }
         },
         (error: unknown) => {
           if (!cancelled) {
@@ -98,7 +113,14 @@ export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
   }, [characterId, outfitId, recentOwnerId])
 
   useEffect(() => {
-    if (!recentOwnerId || !characterId || !data.character || !data.project || data.error !== null)
+    if (
+      !recentOwnerId ||
+      !characterId ||
+      data.loadedCharacterId !== characterId ||
+      !data.character ||
+      !data.project ||
+      data.error !== null
+    )
       return
 
     const outfit = data.character.outfits.find((candidate) => candidate.id === outfitId)
@@ -117,7 +139,15 @@ export function PlaytestPage({ renderToolbar }: PlaytestPageProps = {}) {
       previewUrl: outfit.previewUrl,
       lastOpenedAt: Date.now(),
     })
-  }, [characterId, data.character, data.error, data.project, outfitId, recentOwnerId])
+  }, [
+    characterId,
+    data.character,
+    data.error,
+    data.loadedCharacterId,
+    data.project,
+    outfitId,
+    recentOwnerId,
+  ])
 
   if (characterId === undefined || outfitId === undefined)
     return <PlaytestPageMessage>预览台路由参数不完整</PlaytestPageMessage>

--- a/frontend/src/pages/playtest/recent-previews.test.ts
+++ b/frontend/src/pages/playtest/recent-previews.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  MAX_RECENT_PREVIEWS,
+  readRecentPreviews,
+  rememberRecentPreview,
+  removeRecentPreview,
+  type RecentPreview,
+} from './recent-previews'
+
+const preview = (overrides: Partial<RecentPreview> = {}): RecentPreview => ({
+  characterId: '51',
+  outfitId: 'outfit-default',
+  characterName: '轻装信使',
+  outfitName: '常态造型',
+  projectId: '42',
+  projectName: '点灯人 · MVP',
+  previewUrl: 'https://cdn.windup.test/messenger-outfit.png',
+  lastOpenedAt: 1,
+  ...overrides,
+})
+
+function createStorage() {
+  const values = new Map<string, string>()
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+  }
+}
+
+describe('recent previews', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-17T12:00:00Z'))
+  })
+
+  it('keeps recent previews isolated by user and caps them at three unique outfits', () => {
+    const storage = createStorage()
+
+    for (let index = 0; index < MAX_RECENT_PREVIEWS + 1; index += 1) {
+      rememberRecentPreview(
+        'user-7',
+        preview({ characterId: String(index), outfitId: `outfit-${index}` }),
+        storage,
+      )
+    }
+    rememberRecentPreview('user-7', preview({ characterId: '2', outfitId: 'outfit-2' }), storage)
+    rememberRecentPreview('user-8', preview({ characterId: '99', outfitId: 'outfit-99' }), storage)
+
+    expect(readRecentPreviews('user-7', storage).map((item) => item.outfitId)).toEqual([
+      'outfit-2',
+      'outfit-3',
+      'outfit-1',
+    ])
+    expect(readRecentPreviews('user-8', storage).map((item) => item.outfitId)).toEqual([
+      'outfit-99',
+    ])
+  })
+
+  it('drops an invalid recent record without throwing when storage contains malformed data', () => {
+    const storage = createStorage()
+    storage.setItem('windup.playtest.recent.v1:user-7', '{"bad":true}')
+
+    expect(readRecentPreviews('user-7', storage)).toEqual([])
+  })
+
+  it('removes only the requested character and outfit pair', () => {
+    const storage = createStorage()
+    rememberRecentPreview('user-7', preview(), storage)
+    rememberRecentPreview(
+      'user-7',
+      preview({ characterId: '52', outfitId: 'outfit-draft', outfitName: '另一套' }),
+      storage,
+    )
+
+    removeRecentPreview('user-7', '51', 'outfit-default', storage)
+
+    expect(readRecentPreviews('user-7', storage).map((item) => item.outfitId)).toEqual([
+      'outfit-draft',
+    ])
+  })
+})

--- a/frontend/src/pages/playtest/recent-previews.test.ts
+++ b/frontend/src/pages/playtest/recent-previews.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   MAX_RECENT_PREVIEWS,
+  getRecentPreviewOwnerId,
   recentPreviewOwnerIdFromAccessToken,
   readRecentPreviews,
   rememberRecentPreview,
@@ -39,6 +40,10 @@ describe('recent previews', () => {
   it('uses the authenticated JWT subject as the account namespace', () => {
     expect(recentPreviewOwnerIdFromAccessToken('header.eyJzdWIiOiI3In0.signature')).toBe('7')
     expect(recentPreviewOwnerIdFromAccessToken('not-a-jwt')).toBeNull()
+    expect(recentPreviewOwnerIdFromAccessToken('header.bm90LWpzb24.signature')).toBeNull()
+    expect(recentPreviewOwnerIdFromAccessToken('header.bnVsbA.signature')).toBeNull()
+    expect(recentPreviewOwnerIdFromAccessToken('header.e30.signature')).toBeNull()
+    expect(getRecentPreviewOwnerId()).toBeNull()
   })
 
   it('keeps recent previews isolated by user and caps them at three unique outfits', () => {
@@ -68,6 +73,9 @@ describe('recent previews', () => {
     const storage = createStorage()
     storage.setItem('windup.playtest.recent.v1:user-7', '{"bad":true}')
 
+    expect(readRecentPreviews('user-7', storage)).toEqual([])
+
+    storage.setItem('windup.playtest.recent.v1:user-7', '{')
     expect(readRecentPreviews('user-7', storage)).toEqual([])
   })
 

--- a/frontend/src/pages/playtest/recent-previews.test.ts
+++ b/frontend/src/pages/playtest/recent-previews.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   MAX_RECENT_PREVIEWS,
+  recentPreviewOwnerIdFromAccessToken,
   readRecentPreviews,
   rememberRecentPreview,
   removeRecentPreview,
@@ -33,6 +34,11 @@ describe('recent previews', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-17T12:00:00Z'))
+  })
+
+  it('uses the authenticated JWT subject as the account namespace', () => {
+    expect(recentPreviewOwnerIdFromAccessToken('header.eyJzdWIiOiI3In0.signature')).toBe('7')
+    expect(recentPreviewOwnerIdFromAccessToken('not-a-jwt')).toBeNull()
   })
 
   it('keeps recent previews isolated by user and caps them at three unique outfits', () => {

--- a/frontend/src/pages/playtest/recent-previews.ts
+++ b/frontend/src/pages/playtest/recent-previews.ts
@@ -1,3 +1,5 @@
+import { getApiAccessToken } from '@/shared/api'
+
 export const MAX_RECENT_PREVIEWS = 3
 
 const STORAGE_PREFIX = 'windup.playtest.recent.v1:'
@@ -14,6 +16,28 @@ export interface RecentPreview {
 }
 
 type RecentPreviewStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+export function recentPreviewOwnerIdFromAccessToken(
+  accessToken: string | null | undefined,
+): string | null {
+  const payload = accessToken?.split('.')[1]
+  if (!payload) return null
+
+  try {
+    const normalized = payload.replaceAll('-', '+').replaceAll('_', '/')
+    const padding = '='.repeat((4 - (normalized.length % 4)) % 4)
+    const claims: unknown = JSON.parse(globalThis.atob(`${normalized}${padding}`))
+    if (typeof claims !== 'object' || claims === null) return null
+    const subject = (claims as { sub?: unknown }).sub
+    return typeof subject === 'string' && subject.length > 0 ? subject : null
+  } catch {
+    return null
+  }
+}
+
+export function getRecentPreviewOwnerId(): string | null {
+  return recentPreviewOwnerIdFromAccessToken(getApiAccessToken())
+}
 
 function storageKey(userId: string) {
   return `${STORAGE_PREFIX}${userId}`

--- a/frontend/src/pages/playtest/recent-previews.ts
+++ b/frontend/src/pages/playtest/recent-previews.ts
@@ -1,0 +1,107 @@
+export const MAX_RECENT_PREVIEWS = 3
+
+const STORAGE_PREFIX = 'windup.playtest.recent.v1:'
+
+export interface RecentPreview {
+  characterId: string
+  outfitId: string
+  characterName: string
+  outfitName: string
+  projectId: string
+  projectName: string
+  previewUrl: string | null
+  lastOpenedAt: number
+}
+
+type RecentPreviewStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+function storageKey(userId: string) {
+  return `${STORAGE_PREFIX}${userId}`
+}
+
+function getStorage(storage?: RecentPreviewStorage): RecentPreviewStorage | null {
+  if (storage) return storage
+  try {
+    return globalThis.localStorage
+  } catch {
+    return null
+  }
+}
+
+function isRecentPreview(value: unknown): value is RecentPreview {
+  if (typeof value !== 'object' || value === null) return false
+  const item = value as Partial<RecentPreview>
+  return (
+    typeof item.characterId === 'string' &&
+    typeof item.outfitId === 'string' &&
+    typeof item.characterName === 'string' &&
+    typeof item.outfitName === 'string' &&
+    typeof item.projectId === 'string' &&
+    typeof item.projectName === 'string' &&
+    (typeof item.previewUrl === 'string' || item.previewUrl === null) &&
+    typeof item.lastOpenedAt === 'number'
+  )
+}
+
+export function readRecentPreviews(
+  userId: string,
+  storage?: RecentPreviewStorage,
+): RecentPreview[] {
+  const target = getStorage(storage)
+  if (!target) return []
+
+  try {
+    const raw = target.getItem(storageKey(userId))
+    if (!raw) return []
+    const value: unknown = JSON.parse(raw)
+    if (!Array.isArray(value)) return []
+    return value.filter(isRecentPreview).slice(0, MAX_RECENT_PREVIEWS)
+  } catch {
+    return []
+  }
+}
+
+export function rememberRecentPreview(
+  userId: string,
+  preview: RecentPreview,
+  storage?: RecentPreviewStorage,
+): RecentPreview[] {
+  const target = getStorage(storage)
+  if (!target) return [preview]
+
+  const current = readRecentPreviews(userId, target)
+  const next = [
+    { ...preview, lastOpenedAt: Date.now() },
+    ...current.filter(
+      (item) => !(item.characterId === preview.characterId && item.outfitId === preview.outfitId),
+    ),
+  ].slice(0, MAX_RECENT_PREVIEWS)
+
+  try {
+    target.setItem(storageKey(userId), JSON.stringify(next))
+  } catch {
+    // localStorage is an enhancement; the current workbench remains usable if it is blocked.
+  }
+  return next
+}
+
+export function removeRecentPreview(
+  userId: string,
+  characterId: string,
+  outfitId: string,
+  storage?: RecentPreviewStorage,
+): RecentPreview[] {
+  const target = getStorage(storage)
+  if (!target) return []
+
+  const next = readRecentPreviews(userId, target).filter(
+    (item) => !(item.characterId === characterId && item.outfitId === outfitId),
+  )
+  try {
+    if (next.length === 0) target.removeItem(storageKey(userId))
+    else target.setItem(storageKey(userId), JSON.stringify(next))
+  } catch {
+    // A stale shortcut must never block entering the real preview workbench.
+  }
+  return next
+}


### PR DESCRIPTION
将 `/playtest` 从重复的跨项目资产目录收敛为轻量最近预览启动页，项目资产库继续承担完整选择职责，参数化预览工作台保持原有操控能力。

## Why

原入口重复读取并展示项目、角色和造型，既与项目资产库职责重叠，也会产生跨项目请求扇出。预览台首页只需要帮助用户继续最近预览，或回到项目资产选择新的对象。

## Changes

- 移除 `/playtest` 的跨项目资产画廊、项目分区和弹跳像素舞台。
- 提供长期保留的项目资产入口，并使用项目资产页一致的标题、入口卡与预览卡语言。
- 最多保留 3 条按账号隔离的最近预览；重复打开时去重置前。
- 仅在真实工作台成功读取可播放造型后写入记录；403、404、缺失或不可播放造型会移除失效记录。

## Implementation

- 最近记录保存在账号命名空间下的 `localStorage`，只保存路由定位和卡片展示所需字段，不缓存完整角色资产。
- `/playtest` 首次挂载只读取本地快捷记录，不请求项目或角色目录。
- 最近卡继续进入既有 `/playtest/:characterId/:outfitId`，由工作台重新读取真实 Character 与 Project 数据。
- 工作台只允许与当前 `characterId` 匹配的已加载数据更新最近记录，避免参数路由切换时混用旧角色数据。

## Verification

- [x] `npm run test:coverage -- src/pages/playtest/playtest-boundaries.test.ts src/pages/playtest/recent-previews.test.ts src/pages/playtest/index.test.tsx src/pages/playtest/entry.test.tsx`：4 个文件、22 条测试通过；`entry.tsx` 行覆盖 100%，`recent-previews.ts` 行覆盖 97.82%。
- [x] `node_modules/.bin/oxfmt --check <6 个 Playtest 文件>`：通过。
- [x] `node_modules/.bin/oxlint <6 个 Playtest 文件>`：通过。
- [x] `npm run build`：TypeScript 与 Vite 构建通过。
- [x] `git diff --check upstream/main...HEAD`：通过。
- [x] 真实本地登录环境：`/playtest` 空态与 3 条最近预览在 1440×900、390×844 均完成浏览器检查。

## Screenshots

### Desktop

![Playtest recent preview desktop](https://github.com/user-attachments/assets/6207a363-86a5-453a-b952-791805ccf614)

## Scope

- 本 PR 仅修改 `frontend/src/pages/playtest/` 下 6 个文件。
- 本 PR 不修改项目资产页、后端接口、全局共享 UI、实际预览工作台布局与操控逻辑。
- 本 PR 不包含当前工作区中的 Workflow Editor 或本地工具文件改动。

## Related Issues

Closes #328
