### PR TITLE
feat(workflow-controller): support reference-based regeneration

### DIFF
--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -833,6 +833,27 @@ describe('WorkflowController', () => {
     expect(asyncErrors).toEqual([])
   })
 
+  it('角色母版重生成使用调用方提供的上一版图片作为参考', async () => {
+    const previousImage = 'https://img/knight-previous.png'
+    const { controller, generation } = createController(createRun(completedCharacterNodes()))
+
+    await controller.restartFromNode('template-1')
+    await controller.generateCharacterTemplate('setup-1', {
+      spriteWidth: 64,
+      spriteHeight: 64,
+      sourceImageUrl: previousImage,
+    })
+
+    expect(generation.apis.create).toHaveBeenCalledWith({
+      type: 'character_template',
+      projectId: '1',
+      prompt: '像素骑士',
+      referenceMedia: [previousImage],
+      spriteWidth: 64,
+      spriteHeight: 64,
+    })
+  })
+
   it('角色设定已落库但生成请求失败后可以重试', async () => {
     const { controller, generation } = createController()
     vi.mocked(generation.apis.create).mockRejectedValueOnce(new Error('生成服务暂时不可用'))
@@ -1635,6 +1656,39 @@ describe('WorkflowController', () => {
       },
       { type: 'review', status: 'passed' },
     ])
+  })
+
+  it('动作首帧重生成使用调用方提供的上一版图片作为参考', async () => {
+    const previousImage = 'https://img/first-frame-previous.png'
+    const run = createRun([
+      ...completedCharacterNodes(),
+      firstFrameNode({
+        status: 'passed',
+        phase: 'completed',
+        selectedFirstFrameUrl: previousImage,
+      }),
+      generationMethodNode(),
+      fullFrameNode(),
+      reviewNode(),
+    ])
+    const { controller, generation } = createController(run)
+
+    await controller.restartFromNode('action-walk')
+    await controller.generateFirstFrame('action-walk', {
+      spriteWidth: 64,
+      spriteHeight: 96,
+      sourceImageUrl: previousImage,
+    })
+
+    expect(generation.apis.create).toHaveBeenCalledWith({
+      type: 'first_frame',
+      projectId: '1',
+      actionType: 'walk',
+      prompt: '行走',
+      referenceMedia: [previousImage],
+      spriteWidth: 64,
+      spriteHeight: 96,
+    })
   })
 
   it('生成动作首帧时使用清理后的自定义提示词', async () => {

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -13,6 +13,7 @@ import type {
   GenerationApis,
   GenerationEvent,
   GenerationExpectation,
+  GeneratedImage,
   MediaReference,
   ReviewWorkflowNode,
   WorkflowActionInput,
@@ -38,6 +39,8 @@ export interface AddActionInput {
 export interface GenerateCharacterTemplateOptions {
   spriteWidth: number
   spriteHeight: number
+  /** 重生成时用上一版图片约束本次结果；不覆盖角色设定中的原始参考素材。 */
+  sourceImageUrl?: GeneratedImage['url']
   /** 手动编辑器提交时覆盖 configuring 节点的初始输入；节点通过后不再改写。 */
   input?: WorkflowCharacterInput
 }
@@ -51,6 +54,8 @@ export interface GenerateActionOptions {
 export interface GenerateFirstFrameOptions {
   spriteWidth: number
   spriteHeight: number
+  /** 重生成时用上一版首帧约束本次结果；不改写已确认的角色母版。 */
+  sourceImageUrl?: GeneratedImage['url']
 }
 
 export interface ApplyGenerationResultInput {
@@ -357,6 +362,7 @@ export function createWorkflowController({
     nodeId: CharacterSetupWorkflowNode['id'],
     options: GenerateCharacterTemplateOptions,
   ): Promise<WorkflowRun> {
+    const sourceImage = generatedImageReference(options.sourceImageUrl)
     const before = requireWorkflow()
     const setupBefore = findNode(before, nodeId)
     if (setupBefore.type !== 'character-setup') throw new Error('目标节点不是角色设定')
@@ -395,7 +401,7 @@ export function createWorkflowController({
         type: 'character_template',
         projectId: run.projectId,
         prompt: setupNode.input.prompt,
-        referenceMedia: setupNode.input.referenceMedia,
+        referenceMedia: sourceImage ? [sourceImage] : setupNode.input.referenceMedia,
         spriteWidth: options.spriteWidth,
         spriteHeight: options.spriteHeight,
       }
@@ -519,6 +525,7 @@ export function createWorkflowController({
     nodeId: ActionFirstFrameWorkflowNode['id'],
     options: GenerateFirstFrameOptions,
   ) {
+    const sourceImage = generatedImageReference(options.sourceImageUrl)
     return submitGeneration(nodeId, 'first_frame', (run, node) => {
       if (node.type !== 'action-first-frame') throw new Error('目标节点不是动作首帧')
       if (node.phase !== 'configuring') throw new Error('动作首帧节点当前不能生成')
@@ -533,7 +540,7 @@ export function createWorkflowController({
         prompt: node.input.prompt?.trim() || node.input.name,
         spriteWidth: options.spriteWidth,
         spriteHeight: options.spriteHeight,
-        referenceMedia: [characterTemplateReference],
+        referenceMedia: [sourceImage ?? characterTemplateReference],
       }
       return input
     })
@@ -1300,6 +1307,10 @@ function nonEmpty(value: string, field: string) {
   const normalized = value.trim()
   if (!normalized) throw new Error(`${field} 不能为空`)
   return normalized
+}
+
+function generatedImageReference(value: GeneratedImage['url'] | undefined) {
+  return value === undefined ? undefined : (nonEmpty(value, 'sourceImageUrl') as MediaReference)
 }
 
 function ensurePositiveInteger(value: number, field: string) {


### PR DESCRIPTION
本 PR 为 `WorkflowController` 增加以上一版生成图片作为参考图重新执行节点的能力，让后续界面或 Agent 能复用同一业务入口实现更稳定的重生成。

## Why

现有 `restartFromNode` 可以把工作流退回指定节点，但重新生成角色母版时仍使用角色原始参考素材，重新生成动作首帧时仍使用已确认的角色母版，无法把用户选中的上一版结果传给生成服务，因此只能得到完全重新生成的效果。

## Changes

- 角色母版与动作首帧生成选项新增可选的 `sourceImageUrl`。
- 传入上一版图片时优先将其作为本次生成参考图；未传入时保持现有行为。
- 覆盖角色母版与动作首帧从节点重启后的引用图重生成场景。

## Implementation

- 能力只落在共享 `WorkflowController`，由 Controller 校验非空 URL 并转换为现有 `MediaReference` 契约。
- 引用图仅覆盖本次生成请求，不改写角色设定输入、已确认角色母版或已有工作流数据。

## Verification

- [x] `npm test -- --run src/features/workflow-controller/controller.test.ts src/entities/generation/api.test.ts`：2 个文件、96 项测试通过。
- [x] `npm run typecheck`：通过。
- [x] `npx oxlint src/features/workflow-controller/controller.ts src/features/workflow-controller/controller.test.ts --deny-warnings`：通过。
- [x] `npx oxfmt --check src/features/workflow-controller/controller.ts src/features/workflow-controller/controller.test.ts`：通过。
- [x] `npm run build`：通过。

## Scope

- 本 PR 不包含 Workflow Editor 或 Quick Start 的重新生成、微调按钮，也不修改当前 Quick Start 对话逻辑。
- 本 PR 不包含 Agent、历史版本、undo/redo、蒙版区域编辑或视频 motion-control；这些能力后续分别接入 Controller。

## Related Issues

Closes #370
