### PR TITLE
fix(tests): 三渲二 fixture 补 flush 与积分账户

### DIFF
--- a/backend/tests/test_render3d_asset_endpoints.py
+++ b/backend/tests/test_render3d_asset_endpoints.py
@@ -117,6 +117,9 @@ def api(auth_client, engine, render3d):
     session = sessionmaker(bind=engine)()
     session.add(Project(id=1, user_id=1, project_name="p", character_perspective=1,
                         directional_movement=1, sprite_width=64, sprite_height=64))
+    # 先落 project 再插 character:两者在同一 session 里时 SQLAlchemy 不保证插入顺序,
+    # 而 character.project_id 有真外键 —— 顺序反了就是 FOREIGN KEY constraint failed。
+    session.flush()
     session.add(Character(
         id=7, project_id=1, workflow_run_id=1, name="仙月",
         character_data={"version": 1, "outfits": [

--- a/backend/tests/test_render3d_route_and_assets.py
+++ b/backend/tests/test_render3d_route_and_assets.py
@@ -248,13 +248,21 @@ def test_real_server_path_stays_on_i2v_when_the_outfit_has_no_model():
     assert renderer.calls == 0
 
 
-def test_web_layer_reads_the_outfit_model_url_into_the_task_input(auth_client, monkeypatch):
+def test_web_layer_reads_the_outfit_model_url_into_the_task_input(auth_client, engine, monkeypatch):
     """Web 层要把造型上的 model_3d_url **真的填进任务入参**。
 
     这一步是上次那个缺陷的落点:字段从没被赋过值,而下游全部正常运行、只是永远
     走不到三渲二。所以要断言的是"值到底进没进入参",不是"端点返回 200"。
     """
+    from sqlalchemy.orm import sessionmaker
+
+    from conftest import seed_credit_account
     from windup_app.web.api import generation as gen_api
+
+    # 提交动作生成会预冻结积分(#351),没有账户就在扣费那一步 404。
+    with sessionmaker(bind=engine)() as s:
+        seed_credit_account(s, 1)
+        s.commit()
 
     project = auth_client.post("/projects", json={
         "project_name": "三渲二", "character_perspective": 1, "directional_movement": 2,
@@ -290,10 +298,18 @@ def test_web_layer_reads_the_outfit_model_url_into_the_task_input(auth_client, m
     assert captured[0].outfit_id == OUTFIT
 
 
-def test_web_layer_does_not_guess_an_outfit_when_none_is_given(auth_client, monkeypatch):
+def test_web_layer_does_not_guess_an_outfit_when_none_is_given(auth_client, engine, monkeypatch):
     """没给 outfit_id 就不许挑一个造型顶上 —— 猜错等于拿另一套衣服渲这次的动作,
     而帧数、时长、成色全部正常,没有任何一道会红。"""
+    from sqlalchemy.orm import sessionmaker
+
+    from conftest import seed_credit_account
     from windup_app.web.api import generation as gen_api
+
+    # 提交动作生成会预冻结积分(#351),没有账户就在扣费那一步 404。
+    with sessionmaker(bind=engine)() as s:
+        seed_credit_account(s, 1)
+        s.commit()
 
     project = auth_client.post("/projects", json={
         "project_name": "三渲二", "character_perspective": 1, "directional_movement": 2,


### PR DESCRIPTION
## Summary

`main` 上 `uv run pytest -q` 有 30 项失败，全在三渲二的两个测试文件。修两处 fixture 前置条件，不动被测代码。

**一、`test_render3d_asset_endpoints.py` 的 `api` fixture 缺 `flush()`。**

同一 session 里先 `add(Project(id=1))` 再 `add(Character(project_id=1))`，而 `Character.project_id` 有真外键。SQLAlchemy 不保证同一 session 内跨表的插入顺序，character 先落就是 `FOREIGN KEY constraint failed`。补一次 `flush()` 把顺序钉死。

**二、`test_render3d_route_and_assets.py` 两个用例缺积分账户。**

它们走真实端点 `POST /generation/action`，而 #351 让该端点提交时预冻结积分，无账户返回 `{'code': 404, 'message': '积分账户不存在'}`。用 conftest 已有的 `seed_credit_account` 补上。

Closes #376

## Test plan

- [x] `uv run pytest -q` → **893 passed**, 14 skipped（修前 30 failed）
- [x] `uv run pytest -q tests/test_render3d_asset_endpoints.py` 单跑 → 20 passed（这条路径正是暴露顺序问题的地方）
- [x] `uv run pytest -q tests/test_render3d_route_and_assets.py` 单跑 → 25 passed
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run lint-imports` → 2 kept, 0 broken