### PR TITLE
feat(quota): 优化积分流水筛选与分页

### DIFF
--- a/backend/packages/app/src/windup_app/server/quota/interface.py
+++ b/backend/packages/app/src/windup_app/server/quota/interface.py
@@ -4,6 +4,8 @@ API 层只依赖本模块定义的抽象，不感知具体实现（ORM / SQL）�
 """
 
 from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Literal
 
 from sqlalchemy.orm import Session
 
@@ -85,9 +87,18 @@ class QuotaService(ABC):
 
     @abstractmethod
     def list_transactions(
-        self, session: Session, user_id: int, page: int = 1, page_size: int = 20
+        self,
+        session: Session,
+        user_id: int,
+        page: int = 1,
+        page_size: int = 20,
+        *,
+        direction: Literal["income", "expense"] | None = None,
+        reason: int | None = None,
+        created_from: datetime | None = None,
+        created_before: datetime | None = None,
     ) -> tuple[list[CreditTransactionView], int]:
-        """分页查询积分流水，返回 (列表, 总数)。"""
+        """筛选并分页查询积分流水，返回 (列表, 总数)。"""
 
     # -- 邀请码 -----------------------------------------------------------
 

--- a/backend/packages/app/src/windup_app/server/quota/service.py
+++ b/backend/packages/app/src/windup_app/server/quota/service.py
@@ -15,6 +15,7 @@ import logging
 import re
 import secrets
 from datetime import datetime, timedelta, timezone
+from typing import Literal
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -345,18 +346,39 @@ class SqlAlchemyQuotaService(QuotaService):
     # -- 流水查询 ---------------------------------------------------------
 
     def list_transactions(
-        self, session: Session, user_id: int, page: int = 1, page_size: int = 20
+        self,
+        session: Session,
+        user_id: int,
+        page: int = 1,
+        page_size: int = 20,
+        *,
+        direction: Literal["income", "expense"] | None = None,
+        reason: int | None = None,
+        created_from: datetime | None = None,
+        created_before: datetime | None = None,
     ) -> tuple[list[CreditTransactionView], int]:
-        """分页查询积分流水。"""
+        """筛选并分页查询积分流水。"""
+        conditions = [CreditTransaction.user_id == user_id]
+        if direction == "income":
+            conditions.append(CreditTransaction.delta > 0)
+        elif direction == "expense":
+            conditions.append(CreditTransaction.delta < 0)
+        if reason is not None:
+            conditions.append(CreditTransaction.reason == reason)
+        if created_from is not None:
+            conditions.append(CreditTransaction.create_at >= created_from)
+        if created_before is not None:
+            conditions.append(CreditTransaction.create_at < created_before)
+
         total = session.scalar(
             select(func.count())
             .select_from(CreditTransaction)
-            .where(CreditTransaction.user_id == user_id)
+            .where(*conditions)
         )
 
         rows = session.scalars(
             select(CreditTransaction)
-            .where(CreditTransaction.user_id == user_id)
+            .where(*conditions)
             .order_by(CreditTransaction.id.desc())
             .offset((page - 1) * page_size)
             .limit(page_size)

--- a/backend/packages/app/src/windup_app/web/api/quota.py
+++ b/backend/packages/app/src/windup_app/web/api/quota.py
@@ -12,11 +12,14 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from typing import Literal
 
 from fastapi import APIRouter, Depends, Query, Request
-from pydantic import BaseModel, ConfigDict
+from pydantic import AwareDatetime, BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
+from windup_common.enums.biz_code import BizCode
+from windup_common.exceptions import BizException
 from windup_common.result import ListResponse, Response
 from windup_framework.db import get_session
 
@@ -94,12 +97,26 @@ def list_transactions(
     request: Request,
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
+    direction: Literal["income", "expense"] | None = Query(None),
+    reason: int | None = Query(None, ge=0),
+    created_from: AwareDatetime | None = Query(None),
+    created_before: AwareDatetime | None = Query(None),
     session: Session = Depends(get_session),
 ) -> ListResponse[CreditTransactionOut]:
-    """查询积分流水（分页）。"""
+    """查询积分流水（筛选、分页）。"""
+    if created_from is not None and created_before is not None:
+        if created_from >= created_before:
+            raise BizException("开始时间必须早于结束时间", code=BizCode.BAD_REQUEST)
     user_id = request.state.current_user.id
     txns, total = service.list_transactions(
-        session, user_id, page=page, page_size=page_size
+        session,
+        user_id,
+        page=page,
+        page_size=page_size,
+        direction=direction,
+        reason=reason,
+        created_from=created_from,
+        created_before=created_before,
     )
     return ListResponse.success(
         [CreditTransactionOut.model_validate(t) for t in txns],

--- a/backend/tests/test_quota.py
+++ b/backend/tests/test_quota.py
@@ -5,6 +5,8 @@
 2. API 层：余额端点、流水端点、无账户时 404、分页参数
 """
 
+from datetime import datetime, timezone
+
 import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -366,6 +368,57 @@ class TestListTransactions:
         assert total == 0
         assert txns == []
 
+    def test_filters_direction_reason_and_created_range_before_paginating(
+        self, db_session, quota_service, user_with_account
+    ):
+        uid = user_with_account.id
+        db_session.add_all(
+            [
+                CreditTransaction(
+                    user_id=uid,
+                    delta=30,
+                    reason=CreditReason.ADMIN_ADJUST,
+                    billing_mode=0,
+                    ref_id="filter:income-in-range",
+                    balance_after=130,
+                    create_at=datetime(2026, 8, 10, 3, tzinfo=timezone.utc),
+                ),
+                CreditTransaction(
+                    user_id=uid,
+                    delta=-20,
+                    reason=CreditReason.GENERATE_IMAGE,
+                    billing_mode=0,
+                    ref_id="filter:expense-in-range",
+                    balance_after=110,
+                    create_at=datetime(2026, 8, 10, 8, tzinfo=timezone.utc),
+                ),
+                CreditTransaction(
+                    user_id=uid,
+                    delta=10,
+                    reason=CreditReason.ADMIN_ADJUST,
+                    billing_mode=0,
+                    ref_id="filter:income-outside-range",
+                    balance_after=120,
+                    create_at=datetime(2026, 8, 11, tzinfo=timezone.utc),
+                ),
+            ]
+        )
+        db_session.flush()
+
+        txns, total = quota_service.list_transactions(
+            db_session,
+            uid,
+            page=1,
+            page_size=1,
+            direction="income",
+            reason=CreditReason.ADMIN_ADJUST,
+            created_from=datetime(2026, 8, 10, tzinfo=timezone.utc),
+            created_before=datetime(2026, 8, 11, tzinfo=timezone.utc),
+        )
+
+        assert total == 1
+        assert [txn.ref_id for txn in txns] == ["filter:income-in-range"]
+
 
 # -- 预付费完整流程 ----------------------------------------------------------
 
@@ -489,6 +542,62 @@ class TestQuotaAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert data["total"] == 1
+
+    def test_list_transactions_forwards_filters(
+        self, auth_quota_client, db_session, user_with_account
+    ):
+        uid = user_with_account.id
+        db_session.add_all(
+            [
+                CreditTransaction(
+                    user_id=uid,
+                    delta=15,
+                    reason=CreditReason.ADMIN_ADJUST,
+                    billing_mode=0,
+                    ref_id="api-filter:income",
+                    balance_after=115,
+                    create_at=datetime(2026, 8, 10, 12, tzinfo=timezone.utc),
+                ),
+                CreditTransaction(
+                    user_id=uid,
+                    delta=-5,
+                    reason=CreditReason.GENERATE_IMAGE,
+                    billing_mode=0,
+                    ref_id="api-filter:expense",
+                    balance_after=110,
+                    create_at=datetime(2026, 8, 10, 13, tzinfo=timezone.utc),
+                ),
+            ]
+        )
+        db_session.commit()
+
+        resp = auth_quota_client.get(
+            "/quota/transactions",
+            params={
+                "direction": "expense",
+                "reason": int(CreditReason.GENERATE_IMAGE),
+                "created_from": "2026-08-10T00:00:00Z",
+                "created_before": "2026-08-11T00:00:00Z",
+            },
+        )
+
+        data = resp.json()
+        assert data["code"] == 200
+        assert data["total"] == 1
+        assert data["data"][0]["ref_id"] == "api-filter:expense"
+
+    def test_list_transactions_rejects_an_inverted_created_range(
+        self, auth_quota_client
+    ):
+        resp = auth_quota_client.get(
+            "/quota/transactions",
+            params={
+                "created_from": "2026-08-11T00:00:00Z",
+                "created_before": "2026-08-10T00:00:00Z",
+            },
+        )
+
+        assert resp.json()["code"] == 400
 
     def test_unauthenticated_access(self, client):
         """未登录访问应返回 401。"""

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -11,7 +11,9 @@ export type {
   CreditAccount,
   CreditTransaction,
   InviteCode,
+  CreditTransactionDirection,
   QuotaApis,
+  QuotaTransactionFilters,
   QuotaTransactionPageQuery,
 } from './quota'
 

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -125,6 +125,30 @@ describe('createQuotaApis', () => {
     expect(request).toHaveBeenNthCalledWith(1, '/quota/invite/generate', { method: 'POST' })
   })
 
+  it('将方向、原因和时间范围作为服务端筛选参数', async () => {
+    requestList.mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 50 })
+
+    await createQuotaApis({ client }).listTransactions({
+      page: 1,
+      pageSize: 50,
+      direction: 'expense',
+      reason: 3,
+      createdFrom: '2026-08-09T16:00:00.000Z',
+      createdBefore: '2026-08-12T16:00:00.000Z',
+    } as never)
+
+    expect(requestList).toHaveBeenCalledWith('/quota/transactions', {
+      query: {
+        page: 1,
+        page_size: 50,
+        direction: 'expense',
+        reason: 3,
+        created_from: '2026-08-09T16:00:00.000Z',
+        created_before: '2026-08-12T16:00:00.000Z',
+      },
+    })
+  })
+
   it('默认适配器读取环境地址并携带当前登录凭证', async () => {
     vi.resetModules()
     const fetchFn = vi.fn<typeof fetch>(async (input) => {

--- a/frontend/src/entities/quota/api.ts
+++ b/frontend/src/entities/quota/api.ts
@@ -93,10 +93,18 @@ export function createQuotaApis(options: CreateQuotaApisOptions = {}): QuotaApis
       return toCreditAccount(await protectedClient.request<CreditAccountDto>('/quota/balance'))
     },
     async listTransactions(query: QuotaTransactionPageQuery = {}) {
+      const requestQuery = {
+        page: query.page,
+        page_size: query.pageSize,
+        ...(query.direction ? { direction: query.direction } : {}),
+        ...(query.reason === undefined ? {} : { reason: query.reason }),
+        ...(query.createdFrom ? { created_from: query.createdFrom } : {}),
+        ...(query.createdBefore ? { created_before: query.createdBefore } : {}),
+      }
       const result = await protectedClient.requestList<CreditTransactionDto>(
         '/quota/transactions',
         {
-          query: { page: query.page, page_size: query.pageSize },
+          query: requestQuery,
         },
       )
       return { ...result, items: result.items.map(toCreditTransaction) }

--- a/frontend/src/entities/quota/index.ts
+++ b/frontend/src/entities/quota/index.ts
@@ -4,6 +4,8 @@ export type {
   CreditAccount,
   CreditTransaction,
   InviteCode,
+  CreditTransactionDirection,
   QuotaApis,
+  QuotaTransactionFilters,
   QuotaTransactionPageQuery,
 } from './types'

--- a/frontend/src/entities/quota/types.ts
+++ b/frontend/src/entities/quota/types.ts
@@ -24,7 +24,18 @@ export interface CreditTransaction {
   createdAt: string
 }
 
-export type QuotaTransactionPageQuery = PageQuery
+export type CreditTransactionDirection = 'income' | 'expense'
+
+export interface QuotaTransactionFilters {
+  direction?: CreditTransactionDirection
+  reason?: number
+  /** ISO 时刻，包含该边界。 */
+  createdFrom?: string
+  /** ISO 时刻，不包含该边界。 */
+  createdBefore?: string
+}
+
+export type QuotaTransactionPageQuery = PageQuery & QuotaTransactionFilters
 
 /** 当前登录用户未过期的邀请码；usedCount 只统计当前码的成功注册次数。 */
 export interface InviteCode {

--- a/frontend/src/features/quota/index.test.ts
+++ b/frontend/src/features/quota/index.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { CreditAccount, QuotaApis } from '@/entities'
 
 import {
+  CREDIT_REASON_OPTIONS,
   formatCreditDateTime,
   getCreditReasonLabel,
   useQuotaBalance,
@@ -166,6 +167,9 @@ describe('quota queries', () => {
   })
 
   it('为已知和未知原因码提供文案，并处理无效时间', () => {
+    expect(CREDIT_REASON_OPTIONS.map(({ value }) => getCreditReasonLabel(value))).toEqual(
+      CREDIT_REASON_OPTIONS.map(({ label }) => label),
+    )
     expect(getCreditReasonLabel(4)).toBe('生成角色动作')
     expect(getCreditReasonLabel(99)).toBe('积分变动（原因码 99）')
     expect(formatCreditDateTime('not-a-date')).toBe('时间未知')

--- a/frontend/src/features/quota/index.test.ts
+++ b/frontend/src/features/quota/index.test.ts
@@ -107,6 +107,41 @@ describe('quota queries', () => {
     await waitFor(() => expect(result.current.page).toBe(2))
   })
 
+  it('应用筛选或修改每页条数时回到第一页', async () => {
+    const apis = createQuotaApis()
+    const { result } = renderHook(() => useQuotaTransactions(true, apis))
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    act(() => result.current.loadPage(3))
+    await waitFor(() => expect(result.current.page).toBe(3))
+
+    act(() =>
+      result.current.applyFilters({
+        direction: 'income',
+        reason: 5,
+        createdFrom: '2026-08-09T16:00:00.000Z',
+        createdBefore: '2026-08-12T16:00:00.000Z',
+      }),
+    )
+    await waitFor(() =>
+      expect(apis.listTransactions).toHaveBeenLastCalledWith({
+        page: 1,
+        pageSize: 20,
+        direction: 'income',
+        reason: 5,
+        createdFrom: '2026-08-09T16:00:00.000Z',
+        createdBefore: '2026-08-12T16:00:00.000Z',
+      }),
+    )
+
+    act(() => result.current.setPageSize(50))
+    await waitFor(() =>
+      expect(apis.listTransactions).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 1, pageSize: 50 }),
+      ),
+    )
+  })
+
   it('禁用时不读取流水', () => {
     const apis = createQuotaApis()
     const { result } = renderHook(() => useQuotaTransactions(false, apis))

--- a/frontend/src/features/quota/index.ts
+++ b/frontend/src/features/quota/index.ts
@@ -155,16 +155,20 @@ export function useQuotaTransactions(
   return { ...result, loadPage, setPageSize, applyFilters, reload }
 }
 
-const reasonLabels: Readonly<Record<number, string>> = {
-  1: '注册赠送',
-  2: '邀请奖励',
-  3: '生成角色参考图',
-  4: '生成角色动作',
-  5: '管理员调整',
-  6: '退款 / 回退',
-  7: '积分冻结',
-  8: '实际扣减',
-}
+export const CREDIT_REASON_OPTIONS = [
+  { value: 1, label: '注册赠送' },
+  { value: 2, label: '邀请奖励' },
+  { value: 3, label: '生成角色参考图' },
+  { value: 4, label: '生成角色动作' },
+  { value: 5, label: '管理员调整' },
+  { value: 6, label: '退款 / 回退' },
+  { value: 7, label: '积分冻结' },
+  { value: 8, label: '实际扣减' },
+] as const
+
+const reasonLabels: Readonly<Record<number, string>> = Object.fromEntries(
+  CREDIT_REASON_OPTIONS.map(({ value, label }) => [value, label]),
+)
 
 export function getCreditReasonLabel(reason: number): string {
   return reasonLabels[reason] ?? `积分变动（原因码 ${reason}）`

--- a/frontend/src/features/quota/index.ts
+++ b/frontend/src/features/quota/index.ts
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import { quotaApis as defaultQuotaApis } from '@/entities'
-import type { CreditAccount, CreditTransaction, QuotaApis } from '@/entities'
+import type {
+  CreditAccount,
+  CreditTransaction,
+  QuotaApis,
+  QuotaTransactionFilters,
+  QuotaTransactionPageQuery,
+} from '@/entities'
 
 const TRANSACTIONS_PAGE_SIZE = 20
 
@@ -23,6 +29,8 @@ type TransactionsResult = {
 
 export type QuotaTransactionsState = TransactionsResult & {
   loadPage(page: number): void
+  setPageSize(pageSize: number): void
+  applyFilters(filters: QuotaTransactionFilters, pageSize?: number): void
   reload(): void
 }
 
@@ -83,7 +91,10 @@ export function useQuotaTransactions(
   apis: QuotaApis = defaultQuotaApis,
 ): QuotaTransactionsState {
   const [attempt, setAttempt] = useState(0)
-  const [requestedPage, setRequestedPage] = useState(1)
+  const [query, setQuery] = useState<QuotaTransactionPageQuery>({
+    page: 1,
+    pageSize: TRANSACTIONS_PAGE_SIZE,
+  })
   const [result, setResult] = useState<TransactionsResult>(initialTransactions)
 
   useEffect(() => {
@@ -95,7 +106,7 @@ export function useQuotaTransactions(
     let active = true
     setResult((current) => ({ ...current, status: 'loading', error: null }))
     void Promise.resolve()
-      .then(() => apis.listTransactions({ page: requestedPage, pageSize: TRANSACTIONS_PAGE_SIZE }))
+      .then(() => apis.listTransactions(query))
       .then(
         (page) => {
           if (!active) return
@@ -122,11 +133,26 @@ export function useQuotaTransactions(
     return () => {
       active = false
     }
-  }, [apis, attempt, enabled, requestedPage])
+  }, [apis, attempt, enabled, query])
 
-  const loadPage = useCallback((page: number) => setRequestedPage(Math.max(1, page)), [])
+  const loadPage = useCallback(
+    (page: number) => setQuery((current) => ({ ...current, page: Math.max(1, page) })),
+    [],
+  )
+  const setPageSize = useCallback(
+    (pageSize: number) =>
+      setQuery((current) => ({ ...current, page: 1, pageSize: Math.max(1, pageSize) })),
+    [],
+  )
+  const applyFilters = useCallback((filters: QuotaTransactionFilters, pageSize?: number) => {
+    setQuery((current) => ({
+      page: 1,
+      pageSize: pageSize ?? current.pageSize,
+      ...filters,
+    }))
+  }, [])
   const reload = useCallback(() => setAttempt((current) => current + 1), [])
-  return { ...result, loadPage, reload }
+  return { ...result, loadPage, setPageSize, applyFilters, reload }
 }
 
 const reasonLabels: Readonly<Record<number, string>> = {

--- a/frontend/src/pages/account/account.css
+++ b/frontend/src/pages/account/account.css
@@ -34,6 +34,43 @@
   color: var(--color-app-faint);
 }
 
+.account-filter-field {
+  min-height: 2.35rem;
+  width: 100%;
+  border: 1px solid var(--color-app-line);
+  border-radius: 0.375rem;
+  background: var(--color-app-surface);
+  padding-inline: 0.625rem;
+  color: var(--color-app-ink-soft);
+  font-size: 0.8125rem;
+  outline: none;
+}
+
+.account-filter-field:focus {
+  border-color: var(--color-app-accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-app-accent) 10%, transparent);
+}
+
+.account-filter-button,
+.account-filter-reset {
+  min-height: 2.35rem;
+  border-radius: 0.375rem;
+  padding-inline: 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.account-filter-button {
+  background: var(--color-app-accent);
+  color: var(--color-app-on-accent);
+}
+
+.account-filter-reset {
+  border: 1px solid var(--color-app-line);
+  color: var(--color-app-muted);
+}
+
 .account-primary-button {
   display: inline-flex;
   min-height: 2.75rem;

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -248,6 +248,52 @@ describe('AccountPage', () => {
     )
   })
 
+  it('按收支、原因和本地日期筛选流水并调整分页', async () => {
+    vi.spyOn(quotaApis, 'getBalance').mockResolvedValue({
+      id: '11',
+      userId: '7',
+      balance: 90,
+      frozen: 0,
+      totalEarned: 100,
+      totalSpent: 10,
+      createdAt: '2026-08-12T01:02:03Z',
+      updatedAt: '2026-08-17T01:02:03Z',
+    })
+    const listTransactions = vi
+      .spyOn(quotaApis, 'listTransactions')
+      .mockImplementation(async ({ page = 1, pageSize = 20 } = {}) => ({
+        items: [],
+        total: 80,
+        page,
+        pageSize,
+      }))
+
+    renderAccount()
+    fireEvent.click(await screen.findByRole('button', { name: '积分账户' }))
+    await waitFor(() => expect(listTransactions).toHaveBeenCalled())
+
+    fireEvent.change(screen.getByLabelText('变动方向'), { target: { value: 'expense' } })
+    fireEvent.change(screen.getByLabelText('变动原因'), { target: { value: '3' } })
+    fireEvent.change(screen.getByLabelText('开始日期'), { target: { value: '2026-08-10' } })
+    fireEvent.change(screen.getByLabelText('结束日期'), { target: { value: '2026-08-12' } })
+    fireEvent.change(screen.getByLabelText('每页条数'), { target: { value: '50' } })
+    fireEvent.click(screen.getByRole('button', { name: '应用筛选' }))
+
+    await waitFor(() =>
+      expect(listTransactions).toHaveBeenLastCalledWith({
+        page: 1,
+        pageSize: 50,
+        direction: 'expense',
+        reason: 3,
+        createdFrom: new Date(2026, 7, 10).toISOString(),
+        createdBefore: new Date(2026, 7, 13).toISOString(),
+      }),
+    )
+    expect(screen.getByRole('button', { name: '第 1 页' }).getAttribute('aria-current')).toBe(
+      'page',
+    )
+  })
+
   it('reports a profile refresh failure without claiming the data is synchronized', async () => {
     const apis = createApis()
     apis.me.mockRejectedValue(new Error('资料读取失败'))

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -277,7 +277,7 @@ describe('AccountPage', () => {
     fireEvent.change(screen.getByLabelText('开始日期'), { target: { value: '2026-08-10' } })
     fireEvent.change(screen.getByLabelText('结束日期'), { target: { value: '2026-08-12' } })
     fireEvent.change(screen.getByLabelText('每页条数'), { target: { value: '50' } })
-    fireEvent.click(screen.getByRole('button', { name: '应用筛选' }))
+    fireEvent.submit(screen.getByRole('form', { name: '积分流水筛选' }))
 
     await waitFor(() =>
       expect(listTransactions).toHaveBeenLastCalledWith({
@@ -292,6 +292,49 @@ describe('AccountPage', () => {
     expect(screen.getByRole('button', { name: '第 1 页' }).getAttribute('aria-current')).toBe(
       'page',
     )
+
+    fireEvent.click(screen.getByRole('button', { name: '重置' }))
+    await waitFor(() =>
+      expect(listTransactions).toHaveBeenLastCalledWith({ page: 1, pageSize: 20 }),
+    )
+    expect((screen.getByLabelText('变动方向') as HTMLSelectElement).value).toBe('')
+    expect((screen.getByLabelText('变动原因') as HTMLSelectElement).value).toBe('')
+    expect((screen.getByLabelText('开始日期') as HTMLInputElement).value).toBe('')
+    expect((screen.getByLabelText('结束日期') as HTMLInputElement).value).toBe('')
+    expect((screen.getByLabelText('每页条数') as HTMLSelectElement).value).toBe('20')
+
+    const callsBeforeEmptyApply = listTransactions.mock.calls.length
+    fireEvent.click(screen.getByRole('button', { name: '应用筛选' }))
+    await waitFor(() => expect(listTransactions).toHaveBeenCalledTimes(callsBeforeEmptyApply + 1))
+    await waitFor(() =>
+      expect(listTransactions).toHaveBeenLastCalledWith({ page: 1, pageSize: 20 }),
+    )
+  })
+
+  it('在本地拒绝开始日期晚于结束日期的筛选', async () => {
+    vi.spyOn(quotaApis, 'getBalance').mockResolvedValue({
+      id: '11',
+      userId: '7',
+      balance: 90,
+      frozen: 0,
+      totalEarned: 100,
+      totalSpent: 10,
+      createdAt: '2026-08-12T01:02:03Z',
+      updatedAt: '2026-08-17T01:02:03Z',
+    })
+    const listTransactions = vi
+      .spyOn(quotaApis, 'listTransactions')
+      .mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 20 })
+
+    renderAccount()
+    fireEvent.click(await screen.findByRole('button', { name: '积分账户' }))
+    await waitFor(() => expect(listTransactions).toHaveBeenCalledTimes(1))
+    fireEvent.change(screen.getByLabelText('开始日期'), { target: { value: '2026-08-12' } })
+    fireEvent.change(screen.getByLabelText('结束日期'), { target: { value: '2026-08-10' } })
+    fireEvent.submit(screen.getByRole('form', { name: '积分流水筛选' }))
+
+    expect((await screen.findByRole('alert')).textContent).toContain('开始日期不能晚于结束日期')
+    expect(listTransactions).toHaveBeenCalledTimes(1)
   })
 
   it('reports a profile refresh failure without claiming the data is synchronized', async () => {

--- a/frontend/src/pages/account/index.tsx
+++ b/frontend/src/pages/account/index.tsx
@@ -5,6 +5,7 @@ import accountBadgeArtwork from '@/assets/account/illustrations/account-badge.we
 import type { User } from '@/entities'
 import { useAuthSession } from '@/features/auth-session'
 import {
+  CREDIT_REASON_OPTIONS,
   formatCreditDateTime,
   getCreditReasonLabel,
   useQuotaBalance,
@@ -17,16 +18,6 @@ import './account.css'
 import { createProfileState, initialSecurityState, profileReducer, securityReducer } from './state'
 
 const MAX_NICKNAME_LENGTH = 50
-const CREDIT_REASON_OPTIONS = [
-  [1, '注册赠送'],
-  [2, '邀请奖励'],
-  [3, '生成角色参考图'],
-  [4, '生成角色动作'],
-  [5, '管理员调整'],
-  [6, '退款 / 回退'],
-  [7, '积分冻结'],
-  [8, '实际扣减'],
-] as const
 
 function localDateStart(value: string): Date | null {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
@@ -173,7 +164,7 @@ function QuotaSection() {
               className="account-filter-field"
             >
               <option value="">全部原因</option>
-              {CREDIT_REASON_OPTIONS.map(([value, label]) => (
+              {CREDIT_REASON_OPTIONS.map(({ value, label }) => (
                 <option key={value} value={value}>
                   {label}
                 </option>

--- a/frontend/src/pages/account/index.tsx
+++ b/frontend/src/pages/account/index.tsx
@@ -17,6 +17,26 @@ import './account.css'
 import { createProfileState, initialSecurityState, profileReducer, securityReducer } from './state'
 
 const MAX_NICKNAME_LENGTH = 50
+const CREDIT_REASON_OPTIONS = [
+  [1, '注册赠送'],
+  [2, '邀请奖励'],
+  [3, '生成角色参考图'],
+  [4, '生成角色动作'],
+  [5, '管理员调整'],
+  [6, '退款 / 回退'],
+  [7, '积分冻结'],
+  [8, '实际扣减'],
+] as const
+
+function localDateStart(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return null
+  return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
+}
+
+function dayAfter(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1)
+}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : '操作失败，请稍后重试'
@@ -41,6 +61,12 @@ function formatCredits(value: number): string {
 function QuotaSection() {
   const balance = useQuotaBalance(true)
   const transactions = useQuotaTransactions(true)
+  const [direction, setDirection] = useState('')
+  const [reason, setReason] = useState('')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [pageSize, setPageSize] = useState('20')
+  const [filterError, setFilterError] = useState<string | null>(null)
   const account = balance.status === 'ready' ? balance.account : null
   const summaryRows: Array<[string, string]> = [
     ['可用积分', account ? formatCredits(account.balance) : '—'],
@@ -48,6 +74,36 @@ function QuotaSection() {
     ['累计获得', account ? formatCredits(account.totalEarned) : '—'],
     ['累计使用', account ? formatCredits(account.totalSpent) : '—'],
   ]
+
+  function applyTransactionFilters(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const createdFrom = startDate ? localDateStart(startDate) : null
+    const end = endDate ? localDateStart(endDate) : null
+    if (createdFrom && end && createdFrom > end) {
+      setFilterError('开始日期不能晚于结束日期')
+      return
+    }
+    setFilterError(null)
+    transactions.applyFilters(
+      {
+        ...(direction ? { direction: direction as 'income' | 'expense' } : {}),
+        ...(reason ? { reason: Number(reason) } : {}),
+        ...(createdFrom ? { createdFrom: createdFrom.toISOString() } : {}),
+        ...(end ? { createdBefore: dayAfter(end).toISOString() } : {}),
+      },
+      Number(pageSize),
+    )
+  }
+
+  function resetTransactionFilters() {
+    setDirection('')
+    setReason('')
+    setStartDate('')
+    setEndDate('')
+    setPageSize('20')
+    setFilterError(null)
+    transactions.applyFilters({}, 20)
+  }
 
   return (
     <div>
@@ -91,6 +147,89 @@ function QuotaSection() {
             <span className="text-xs text-app-faint">共 {transactions.total} 条</span>
           )}
         </div>
+
+        <form
+          aria-label="积分流水筛选"
+          onSubmit={applyTransactionFilters}
+          className="mt-3 grid gap-3 border-y border-app-line py-3 sm:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)_minmax(0,1fr)_minmax(0,1fr)_7rem_auto] xl:items-end"
+        >
+          <label className="grid gap-1 text-xs text-app-muted">
+            变动方向
+            <select
+              value={direction}
+              onChange={(event) => setDirection(event.target.value)}
+              className="account-filter-field"
+            >
+              <option value="">全部</option>
+              <option value="income">积分获得</option>
+              <option value="expense">积分支出</option>
+            </select>
+          </label>
+          <label className="grid gap-1 text-xs text-app-muted">
+            变动原因
+            <select
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              className="account-filter-field"
+            >
+              <option value="">全部原因</option>
+              {CREDIT_REASON_OPTIONS.map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="grid gap-1 text-xs text-app-muted">
+            开始日期
+            <input
+              type="date"
+              value={startDate}
+              max={endDate || undefined}
+              onChange={(event) => setStartDate(event.target.value)}
+              className="account-filter-field"
+            />
+          </label>
+          <label className="grid gap-1 text-xs text-app-muted">
+            结束日期
+            <input
+              type="date"
+              value={endDate}
+              min={startDate || undefined}
+              onChange={(event) => setEndDate(event.target.value)}
+              className="account-filter-field"
+            />
+          </label>
+          <label className="grid gap-1 text-xs text-app-muted">
+            每页条数
+            <select
+              value={pageSize}
+              onChange={(event) => setPageSize(event.target.value)}
+              className="account-filter-field"
+            >
+              <option value="10">10 条</option>
+              <option value="20">20 条</option>
+              <option value="50">50 条</option>
+            </select>
+          </label>
+          <div className="flex gap-2">
+            <button type="submit" className="account-filter-button">
+              应用筛选
+            </button>
+            <button
+              type="button"
+              onClick={resetTransactionFilters}
+              className="account-filter-reset"
+            >
+              重置
+            </button>
+          </div>
+          {filterError && (
+            <p role="alert" className="text-xs text-app-danger sm:col-span-2 xl:col-span-full">
+              {filterError}
+            </p>
+          )}
+        </form>
 
         {transactions.status === 'loading' ? (
           <p role="status" className="mt-3 text-sm text-app-muted">
@@ -136,6 +275,7 @@ function QuotaSection() {
           pageSize={transactions.pageSize}
           total={transactions.total}
           disabled={transactions.status === 'loading'}
+          showPageNumbers
           onPageChange={transactions.loadPage}
         />
       </section>

--- a/frontend/src/shared/ui/pagination.test.tsx
+++ b/frontend/src/shared/ui/pagination.test.tsx
@@ -18,7 +18,10 @@ describe('Pagination', () => {
       'page',
     )
     expect(screen.getByRole('button', { name: '第 10 页' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '上一页' }))
     fireEvent.click(screen.getByRole('button', { name: '第 6 页' }))
+    fireEvent.click(screen.getByRole('button', { name: '下一页' }))
+    expect(onPageChange).toHaveBeenCalledWith(4)
     expect(onPageChange).toHaveBeenCalledWith(6)
   })
 })

--- a/frontend/src/shared/ui/pagination.test.tsx
+++ b/frontend/src/shared/ui/pagination.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Pagination } from './pagination'
+
+afterEach(cleanup)
+
+describe('Pagination', () => {
+  it('在数字模式下显示稳定页码并保留首尾页', () => {
+    const onPageChange = vi.fn()
+    render(
+      <Pagination page={5} pageSize={10} total={100} showPageNumbers onPageChange={onPageChange} />,
+    )
+
+    expect(screen.getByRole('button', { name: '第 1 页' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '第 5 页' }).getAttribute('aria-current')).toBe(
+      'page',
+    )
+    expect(screen.getByRole('button', { name: '第 10 页' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '第 6 页' }))
+    expect(onPageChange).toHaveBeenCalledWith(6)
+  })
+})

--- a/frontend/src/shared/ui/pagination.tsx
+++ b/frontend/src/shared/ui/pagination.tsx
@@ -1,9 +1,19 @@
+import { CaretLeft, CaretRight } from '@phosphor-icons/react'
+
 export interface PaginationProps {
   page: number
   pageSize: number
   total: number
   disabled?: boolean
+  showPageNumbers?: boolean
   onPageChange: (page: number) => void
+}
+
+function visiblePages(page: number, totalPages: number): number[] {
+  if (totalPages <= 5) return Array.from({ length: totalPages }, (_, index) => index + 1)
+  return [...new Set([1, page - 1, page, page + 1, totalPages])]
+    .filter((value) => value >= 1 && value <= totalPages)
+    .sort((left, right) => left - right)
 }
 
 /** 后端分页列表共用的最小翻页控件，不解释具体业务项。 */
@@ -12,10 +22,69 @@ export function Pagination({
   pageSize,
   total,
   disabled = false,
+  showPageNumbers = false,
   onPageChange,
 }: PaginationProps) {
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
   if (totalPages === 1) return null
+
+  if (showPageNumbers) {
+    const pages = visiblePages(page, totalPages)
+    return (
+      <nav
+        aria-label="分页"
+        className="mt-6 flex flex-wrap items-center justify-center gap-1.5 text-xs"
+      >
+        <button
+          type="button"
+          aria-label="上一页"
+          title="上一页"
+          disabled={disabled || page <= 1}
+          onClick={() => onPageChange(page - 1)}
+          className="grid size-8 place-items-center rounded-md border border-app-line text-app-ink-soft disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <CaretLeft aria-hidden="true" size={15} weight="bold" />
+        </button>
+        {pages.map((value, index) => {
+          const previous = pages[index - 1]
+          return (
+            <span key={value} className="contents">
+              {previous !== undefined && value - previous > 1 && (
+                <span aria-hidden="true" className="px-1 text-app-faint">
+                  …
+                </span>
+              )}
+              <button
+                type="button"
+                aria-label={`第 ${value} 页`}
+                aria-current={value === page ? 'page' : undefined}
+                disabled={disabled}
+                onClick={() => onPageChange(value)}
+                className={`size-8 rounded-md border text-center font-semibold tabular-nums disabled:cursor-not-allowed disabled:opacity-40 ${
+                  value === page
+                    ? 'border-app-accent bg-app-accent text-app-on-accent'
+                    : 'border-app-line text-app-ink-soft hover:border-app-line-strong'
+                }`}
+              >
+                {value}
+              </button>
+            </span>
+          )
+        })}
+        <button
+          type="button"
+          aria-label="下一页"
+          title="下一页"
+          disabled={disabled || page >= totalPages}
+          onClick={() => onPageChange(page + 1)}
+          className="grid size-8 place-items-center rounded-md border border-app-line text-app-ink-soft disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <CaretRight aria-hidden="true" size={15} weight="bold" />
+        </button>
+        <span className="ml-2 tabular-nums text-app-faint">共 {total} 条</span>
+      </nav>
+    )
+  }
 
   return (
     <nav aria-label="分页" className="mt-6 flex items-center justify-center gap-3 text-xs">

--- a/openapi.json
+++ b/openapi.json
@@ -3350,7 +3350,7 @@
     },
     "/quota/transactions": {
       "get": {
-        "description": "查询积分流水（分页）。",
+        "description": "查询积分流水（筛选、分页）。",
         "operationId": "list_transactions_quota_transactions_get",
         "parameters": [
           {
@@ -3374,6 +3374,77 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "income",
+                    "expense"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Direction"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reason",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reason"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_from",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created From"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created Before"
             }
           }
         ],


### PR DESCRIPTION
Closes #379

Related to #378. This PR expands the date-range request with the confirmed direction/reason filters and numbered pagination.

## 改动

- `/quota/transactions` 增加收支方向、原因和创建时间范围筛选，筛选条件同时作用于列表与总数。
- 日期采用包含开始时刻、不包含结束时刻的边界；前端将结束日期转换为本地次日零点，完整包含当天记录。
- 账号中心增加方向、原因、开始/结束日期和每页条数筛选，应用或重置后回到第 1 页。
- 积分流水启用数字页码、首尾页与图标前后翻页；共享分页的其他使用方保持原有模式。
- 更新 OpenAPI 合约并补齐服务层、API、状态层、页面和分页组件测试。

## 验证

- `uv run pytest -q`: 896 passed, 14 skipped
- `uv run ruff check .`: passed
- `uv run python -m scripts.export_openapi`: contract updated
- `uv run lint-imports`: 2 contracts kept
- `npm run test:coverage -- --testTimeout=20000`: 620 passed, 4 skipped
- Frontend coverage: statements 90.48%, branches 83.13%, functions 92.81%, lines 93.70%
- `npm run typecheck`: passed
- `npm run lint`: passed
- `npm run build`: passed
- Targeted `oxfmt --check`: passed