### PR TITLE
ci: main 通过 CI 后自动发 Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Release
+
+# 只在 main 上跑,且要等 CI 绿 —— 直接挂 push 会在测试未过时就发版,
+# 而 #334 第四节要求部署只认 Release,发一个坏 Release 等于把坏代码送上生产。
+on:
+  workflow_run:
+    workflows: ["Backend CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 版本号进位方式
+        required: false
+        default: auto
+        type: choice
+        options: [auto, patch, minor, major]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    # workflow_run 会在 CI 失败时也触发,故必须自己判 conclusion。
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0        # 需要全部 tag 才能算出上一版和变更范围
+
+      - name: Decide next version
+        id: ver
+        env:
+          BUMP: ${{ inputs.bump || 'auto' }}
+        run: |
+          set -euo pipefail
+          last="$(git tag --list 'v*' --sort=-v:refname | head -1)"
+          if [ -z "$last" ]; then
+            echo "prev=" >> "$GITHUB_OUTPUT"
+            echo "next=v0.1.0" >> "$GITHUB_OUTPUT"
+            echo "range=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          IFS=. read -r maj min pat <<< "${last#v}"
+          subjects="$(git log "$last"..HEAD --pretty=%s)"
+          # 进位规则照 Conventional Commits:破坏性 → major,feat → minor,其余 → patch
+          kind=patch
+          grep -qE '^[a-z]+(\([^)]*\))?!:|BREAKING CHANGE' <<< "$subjects" && kind=major
+          [ "$kind" = patch ] && grep -qE '^feat(\([^)]*\))?:' <<< "$subjects" && kind=minor
+          [ "$BUMP" != auto ] && kind="$BUMP"
+          case "$kind" in
+            major) maj=$((maj+1)); min=0; pat=0 ;;
+            minor) min=$((min+1)); pat=0 ;;
+            patch) pat=$((pat+1)) ;;
+          esac
+          echo "prev=$last" >> "$GITHUB_OUTPUT"
+          echo "next=v$maj.$min.$pat" >> "$GITHUB_OUTPUT"
+          echo "range=$last..HEAD" >> "$GITHUB_OUTPUT"
+
+      - name: Skip when nothing new
+        id: gate
+        run: |
+          set -euo pipefail
+          if [ -n "${{ steps.ver.outputs.range }}" ] && \
+             [ -z "$(git log ${{ steps.ver.outputs.range }} --oneline)" ]; then
+            echo "有 tag 但无新提交,不发版"
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write release notes
+        if: steps.gate.outputs.go == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## 本次变更"
+            echo
+            for pair in "feat:功能" "fix:修复" "refactor:重构" "perf:性能" "docs:文档" "ci:构建与流水线"; do
+              t="${pair%%:*}"; label="${pair##*:}"
+              body="$(git log ${{ steps.ver.outputs.range }} --pretty='- %s' \
+                      | grep -E "^- $t(\([^)]*\))?!?:" || true)"
+              [ -n "$body" ] && { echo "### $label"; echo; echo "$body"; echo; }
+            done
+            echo "---"
+            echo
+            echo "部署以本 Release 的 tag 为准（#334 第四节）。"
+            [ -n "${{ steps.ver.outputs.prev }}" ] && \
+              echo "对比：${{ steps.ver.outputs.prev }}...${{ steps.ver.outputs.next }}"
+          } > notes.md
+          cat notes.md
+
+      - name: Tag and publish
+        if: steps.gate.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT: ${{ steps.ver.outputs.next }}
+        run: |
+          set -euo pipefail
+          # 幂等:同名 tag 已存在就不再发,避免 workflow_run 重放造成重复 Release
+          if git rev-parse "$NEXT" >/dev/null 2>&1; then
+            echo "$NEXT 已存在,跳过"; exit 0
+          fi
+          git tag -a "$NEXT" -m "$NEXT"
+          git push origin "$NEXT"
+          gh release create "$NEXT" --title "$NEXT" --notes-file notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0        # 需要全部 tag 才能算出上一版和变更范围
+          # 钉到触发本次发版的那轮 CI 所验证的提交。不钉的话取的是 checkout 时刻的
+          # main —— CI 绿之后又合进来的提交会一起被打进 tag,而它们一行都没跑过测试,
+          # 正是 #334 第四节要挡的东西。
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Decide next version
         id: ver
@@ -104,10 +108,21 @@ jobs:
           NEXT: ${{ steps.ver.outputs.next }}
         run: |
           set -euo pipefail
-          # 幂等:同名 tag 已存在就不再发,避免 workflow_run 重放造成重复 Release
-          if git rev-parse "$NEXT" >/dev/null 2>&1; then
-            echo "$NEXT 已存在,跳过"; exit 0
+          # 幂等判据看 **Release** 而不是 tag:打 tag 与建 Release 是两次独立操作,tag 推成功
+          # 之后建 Release 若因网络或 API 抖动失败,重跑时按 tag 判会永久跳过,仓库里留下一个
+          # 没有 Release 的版本 tag —— 而部署只认 Release,那个版本就永远上不了线。
+          if gh release view "$NEXT" >/dev/null 2>&1; then
+            echo "Release $NEXT 已存在,跳过"; exit 0
           fi
-          git tag -a "$NEXT" -m "$NEXT"
-          git push origin "$NEXT"
+          # tag 可能是上一次跑到一半留下的。已存在且指向同一个提交就沿用,指向别处则是
+          # 真冲突,必须报错而不是悄悄挪走别人的 tag。
+          if git rev-parse -q --verify "refs/tags/$NEXT" >/dev/null; then
+            if [ "$(git rev-parse "refs/tags/$NEXT^{commit}")" != "$(git rev-parse HEAD)" ]; then
+              echo "::error::$NEXT 已指向别的提交,不覆盖"; exit 1
+            fi
+            echo "$NEXT 已存在且指向本次提交,补建 Release"
+          else
+            git tag -a "$NEXT" -m "$NEXT"
+            git push origin "$NEXT"
+          fi
           gh release create "$NEXT" --title "$NEXT" --notes-file notes.md


### PR DESCRIPTION
## Summary

`main` 上 Backend CI 通过后自动计算版本号、打 Tag、发 Release。不涉及服务器，不需要任何新增 Secret。

这是 #384 的第一步：先让「有 Release 可部署」成立。部署本身仍由发布人手工执行，但从此有明确的 Tag 可依，不必再从分支检出。

## 行为

| 项 | 规则 |
|---|---|
| 触发 | `workflow_run` 监听 Backend CI，仅 `main` 分支且 `conclusion == success`；另支持手动触发 |
| 版本号 | 按 Conventional Commits 从上一个 tag 到 HEAD 判定：破坏性 → major，含 `feat` → minor，其余 → patch |
| 手动覆盖 | `workflow_dispatch` 可指定 `patch` / `minor` / `major` |
| 幂等 | 同名 tag 已存在则跳过，`workflow_run` 重放不会产生重复 Release |
| 空转 | 上一个 tag 到 HEAD 无新提交时不发版 |
| Release notes | 按 feat / fix / refactor / perf / docs / ci 分组列出提交 |

权限只要 `contents: write`。

## 为什么挂 workflow_run 而不是 push

直接挂 `push: main` 会在测试尚未跑完时发版。#334 第四节要求部署只认 Release，那么一个未经 CI 的 Release 等于把未验证的代码送上生产。`workflow_run` 会在 CI 失败时也触发，因此 job 里显式判 `conclusion == 'success'`。

## 验证

用仓库真实历史本地跑了一遍版本号计算与 notes 生成：

- 上一个 tag `v0.1.0`，到 HEAD 共 14 个提交，含 `feat` → 判定 minor → 下一版 `v0.2.0`
- notes 正确分出功能 7 条、修复 6 条、文档 1 条

Closes #384

## 不包含

- 自动部署到服务器（需要部署凭证，另议）
- 前端部署，见 #298
- 数据库迁移