### PR TITLE
fix(orchestrator): 让没有冻结流水的开放任务也拿到终态

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/recover.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/recover.py
@@ -35,16 +35,36 @@ def recover_orphaned_generation_tasks(
     run_image_task: Callable[..., Any],
     run_action_task: Callable[..., Any],
 ) -> None:
-    """扫描未结清冻结的开放任务并恢复。调用方负责 commit。"""
+    """扫描开放任务并恢复。调用方负责 commit。
+
+    没有开放冻结的任务此前被整个跳过,于是线上攒下 3 条 running 了四五天的任务和 1 条
+    同样久的 pending —— 既没有终态也没有错误信息,用户那侧就是一直转圈。
+
+    但"跳过重入队"和"跳过标终态"两件事的代价不对等,所以只放开后者:重入队一个没有
+    冻结的任务等于让它免费跑一次,而让它永远停在开放态没有任何好处。
+    """
     for task in task_repo.list_by_status(
         session, (TaskStatus.PENDING, TaskStatus.RUNNING),
     ):
-        if task.id is None or not billing.has_open_freeze(session, task.id):
+        if task.id is None:
+            continue
+        if not billing.has_open_freeze(session, task.id):
+            _fail_unrecoverable(session, task)
             continue
         if task.status is TaskStatus.RUNNING:
             _fail_interrupted(session, task)
             continue
         _requeue_pending(session, dispatcher, run_image_task, run_action_task, task)
+
+
+def _fail_unrecoverable(session: Session, task: GenerationTask) -> None:
+    """没有冻结可退,也不重跑;只保证它不再停在开放态。"""
+    assert task.id is not None
+    task_repo.update_status(
+        session, task.id, TaskStatus.FAILED,
+        error_message="任务已中断，请重新提交",
+    )
+    logger.warning("无冻结的开放任务已置为失败 | task_id=%s %s", task.id, task.status)
 
 
 def _fail_interrupted(session: Session, task: GenerationTask) -> None:

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -592,3 +592,94 @@ def test_recover_unfreezes_unknown_task_type(session_factory, monkeypatch):
         done = AiGenerationService().get_task(session, project_id=1, task_id=task_id)
         assert done.status is TaskStatus.FAILED
         assert _account(session, 1).frozen == 0
+
+
+# ── 没有冻结流水的开放任务也必须被恢复 ─────────────────────────────────────
+#
+# 线上攒下 3 条 running 了四五天、1 条同样久的 pending，它们都没有 FROZEN 流水
+# （136 条 completed 里 124 条也没有——多数任务早于计费接入）。用户那侧看到的是
+# 任务一直转圈：既没有终态，也没有错误信息。
+
+
+def _drop_freeze_rows(session: Session, task_id: int) -> None:
+    """把冻结流水抹掉，复刻线上那批任务的形状。"""
+    for txn in session.scalars(
+        select(CreditTransaction).where(
+            CreditTransaction.ref_id.like(f"task:{task_id}%")
+        )
+    ):
+        session.delete(txn)
+    session.flush()
+    assert not billing.has_open_freeze(session, task_id)
+
+
+def _open_task(session_factory, status: TaskStatus) -> int:
+    from windup_app.server.orchestrator import task_repo
+
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+    service = AiGenerationService()
+    with session_factory() as session:
+        task = service.generate_character_action(
+            session, user_id=1, project_id=7,
+            input=CharacterActionInput(
+                character_id=1, action_type=ActionType.WALK, num_frames=2,
+            ),
+        )
+        if status is not TaskStatus.PENDING:
+            task_repo.update_status(session, task.id, status)
+        _drop_freeze_rows(session, task.id)
+        session.commit()
+        return task.id
+
+
+def test_running_orphan_without_freeze_still_reaches_a_terminal_status(session_factory):
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    task_id = _open_task(session_factory, TaskStatus.RUNNING)
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=type("D", (), {"submit": staticmethod(lambda *a, **k: None)})(),
+            run_image_task=lambda *a: None,
+            run_action_task=lambda *a: None,
+        )
+        session.commit()
+
+    with session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=7, task_id=task_id)
+        assert done.status is TaskStatus.FAILED, "无冻结的 running 任务被跳过了"
+        assert "中断" in (done.error_message or "")
+        # 没退过积分就不能说"已解冻"，否则用户会去查一笔不存在的账。
+        assert "解冻" not in (done.error_message or "")
+        assert "重新提交" in (done.error_message or "")
+        assert CreditReason.REFUND not in _reasons(session, 1)
+
+
+def test_pending_orphan_without_freeze_reaches_a_terminal_status_without_rerunning(
+    session_factory,
+):
+    """免费重跑与永久开放态之间选前者不可接受，所以只保证它不再停在 pending。"""
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    task_id = _open_task(session_factory, TaskStatus.PENDING)
+    queued: list[tuple] = []
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=type("D", (), {
+                "submit": staticmethod(lambda *a: queued.append(a)),
+            })(),
+            run_image_task=lambda *a: None,
+            run_action_task=lambda *a: None,
+        )
+        session.commit()
+
+    assert queued == [], "没有冻结的任务被重入队了，等于免费跑一次"
+    with session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=7, task_id=task_id)
+        assert done.status is TaskStatus.FAILED, "无冻结的 pending 任务还停在开放态"
+        assert "重新提交" in (done.error_message or "")

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -12,6 +12,7 @@ from windup_app.server.orchestrator.model import (
     ActionType,
     CharacterActionInput,
     CharacterImageInput,
+    GenerationTask,
     GenerationTaskRecord,
     GenerationType,
     TaskStatus,
@@ -683,3 +684,33 @@ def test_pending_orphan_without_freeze_reaches_a_terminal_status_without_rerunni
         done = AiGenerationService().get_task(session, project_id=7, task_id=task_id)
         assert done.status is TaskStatus.FAILED, "无冻结的 pending 任务还停在开放态"
         assert "重新提交" in (done.error_message or "")
+
+
+def test_a_row_without_an_id_is_skipped_instead_of_crashing_recovery(
+    session_factory, monkeypatch
+):
+    """没有主键的任务行只跳过，不能让整轮对账炸掉、也不能被写成失败。
+
+    对账在进程启动时跑，一行坏数据把它打死等于所有开放任务都失去恢复机会。
+    """
+    from windup_app.server.orchestrator import recover as recover_mod
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    orphan = GenerationTask(
+        user_id=1, project_id=7, task_type=GenerationType.CHARACTER_ACTION,
+        status=TaskStatus.RUNNING, input_payload={},
+    )
+    assert orphan.id is None
+    monkeypatch.setattr(recover_mod.task_repo, "list_by_status", lambda *a, **k: [orphan])
+    monkeypatch.setattr(
+        recover_mod.task_repo, "update_status",
+        lambda *a, **k: pytest.fail("没有主键的行被写状态了"),
+    )
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(
+            session,
+            dispatcher=type("D", (), {"submit": staticmethod(lambda *a, **k: None)})(),
+            run_image_task=lambda *a: None,
+            run_action_task=lambda *a: None,
+        )


### PR DESCRIPTION
Closes #391

线上 3 条 running、1 条 pending 停了四五天，既没有终态也没有错误信息。原因是对账把「有开放冻结」当成「任务是真的」的代用标记，没有 FROZEN 流水的任务连标终态那一步都被跳过；而线上 136 条 completed 里有 124 条都没有 FROZEN 流水，多数任务早于预付费冻结接入。

这个 PR 只放开标终态，不放开重入队——重入队一个没有冻结的任务等于让它免费跑一次。

`test_generation_quota.py` 21 项本地通过，含既有那条断言「不重入队」的测试。
