### PR TITLE
test(account-panel): 冷却断言改判是否进入冷却而非剩余秒数

### DIFF
--- a/frontend/src/features/account-panel/index.test.tsx
+++ b/frontend/src/features/account-panel/index.test.tsx
@@ -206,7 +206,9 @@ describe('AccountPanel', () => {
         purpose: 'login',
       }),
     )
-    expect(screen.getByRole('button', { name: '60s' }).hasAttribute('disabled')).toBe(true)
+    // 断言"进入冷却"，不断言"还剩 60 秒"：这条用例走真实计时器，点击到断言之间过掉
+    // 一秒钟标签就成了 59s。近 30 小时里三个人的四条分支都栽在这一行。
+    expect(screen.getByRole('button', { name: /^\d+s$/u }).hasAttribute('disabled')).toBe(true)
 
     fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'new@example.com' } })
     expect(screen.getByRole('button', { name: '发送验证码' }).hasAttribute('disabled')).toBe(false)


### PR DESCRIPTION
Closes #393

这条用例走真实计时器，却断言按钮名恰好是 `60s`，点击到断言之间过掉一秒就找不到元素。近 30 小时里三个人的四条分支都栽在这一行。改成匹配 `/^\d+s$/u`，验的是「进入冷却」——剩余秒数由同文件那条 fake-timer 用例负责。

本地控制样本：断言前插 1.2 秒延迟，旧写法必崩、新写法通过。
