### PR TITLE
fix(invite): clarify reward copy

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -253,8 +253,8 @@ describe('AppHeader', () => {
     renderHeader('/workspace')
 
     const hint = await screen.findByRole('status', { name: '邀请奖励提示' })
-    expect(screen.getByText('每日前 3 位好友，你各得 200 积分')).toBeTruthy()
-    expect(screen.getByText('好友注册共得 500 积分')).toBeTruthy()
+    expect(screen.getByText('邀请成功，双方各得 200 积分')).toBeTruthy()
+    expect(screen.getByText('每日前 3 次邀请可得奖励')).toBeTruthy()
     expect(screen.getByRole('link', { name: '去看看邀请奖励' }).getAttribute('href')).toBe(
       '/account?section=invite',
     )

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -245,10 +245,10 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
                   <div className="relative flex items-start gap-3">
                     <div className="min-w-0">
                       <p className="text-[13px] font-medium leading-5 text-app-ink-soft">
-                        每日前 3 位好友，你各得 200 积分
+                        邀请成功，双方各得 200 积分
                       </p>
                       <p className="mt-0.5 text-[11px] leading-4 text-app-faint">
-                        好友注册共得 500 积分
+                        每日前 3 次邀请可得奖励
                       </p>
                       <Link
                         to="/account?section=invite"

--- a/frontend/src/pages/invite/index.test.tsx
+++ b/frontend/src/pages/invite/index.test.tsx
@@ -78,8 +78,8 @@ describe('InviteSection', () => {
     expect(screen.getByText('2')).toBeTruthy()
     expect(screen.getByText('100')).toBeTruthy()
     expect(screen.getByText('当前码注册')).toBeTruthy()
-    expect(screen.getByText(/好友注册共得 500 积分/)).toBeTruthy()
-    expect(screen.getByText(/每日前 3 位各得 200 积分/)).toBeTruthy()
+    expect(screen.getByText(/邀请成功，双方各得 200 积分/)).toBeTruthy()
+    expect(screen.getByText(/每日前 3 次邀请可得奖励/)).toBeTruthy()
     expect(screen.getByText('有效至 2026年9月16日')).toBeTruthy()
   })
 

--- a/frontend/src/pages/invite/index.tsx
+++ b/frontend/src/pages/invite/index.tsx
@@ -80,7 +80,7 @@ export function InviteSection({ apis = defaultQuotaApis }: { apis?: QuotaApis })
         <div className="max-w-2xl">
           <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">邀请奖励</h2>
           <p className="mt-1.5 text-sm leading-6 text-app-muted">
-            好友注册共得 500 积分；你每日前 3 位各得 200 积分，之后好友仍可获得奖励。
+            邀请成功，双方各得 200 积分；每日前 3 次邀请可得奖励。
           </p>
         </div>
 


### PR DESCRIPTION
本 PR 统一账号中心与工作台气泡的邀请奖励文案，去除注册总福利和第二人称表达带来的歧义。

## Why

原文案把好友注册福利与邀请奖励混在一起，`你每日前 3 位各得 200 积分` 的主语和“各得”搭配也不自然，容易让用户误解实际奖励规则。

## Changes

- 两处主文案统一为“邀请成功，双方各得 200 积分”。
- 补充说明统一为“每日前 3 次邀请可得奖励”。
- 同步更新对应文案断言。

## Verification

- `npm test -- src/app/layout/app-header.test.tsx src/pages/invite/index.test.tsx`：2 个文件、34 项测试通过。
- `npm run format:check -- <4 touched files>`：通过。
- `npm run lint -- <4 touched files>`：通过。

## Scope

- 仅修改文案及对应断言。
- 不修改奖励算法、接口、交互、布局或视觉样式。

## Related Issues

Closes #398
Refs #362
