### PR TITLE
fix(matte): 两个显著性模型的 alpha 取并集补对方漏检

### DIFF
--- a/backend/packages/framework/src/windup_framework/providers/matte.py
+++ b/backend/packages/framework/src/windup_framework/providers/matte.py
@@ -11,6 +11,7 @@ onnxruntime 惰性导入(启动慢、按需加载),会话按需构建一次。
 from __future__ import annotations
 
 import io
+import logging
 import urllib.request
 from pathlib import Path
 
@@ -19,9 +20,19 @@ from PIL import Image
 
 from .interfaces import MatteProvider
 
-# u2netp:轻量版(~4.7MB)。rembg 官方 release 托管;国内不可达时可预置 model_path。
+logger = logging.getLogger("windup.matte")
+
+# u2netp:轻量版(~4.4MB)。rembg 官方 release 托管;国内不可达时可预置 model_path。
 _U2NETP_URL = "https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2netp.onnx"
 _DEFAULT_CACHE = Path.home() / ".cache" / "windup" / "u2netp.onnx"
+
+# 全量版(~176MB)。它不是"更好的轻量版",两者漏检的位置不重叠:
+#   · 轻量版把浅肤色角色的脸颊与小腿判成背景(测试反馈的"浅色角色被抠穿"就是这个);
+#   · 全量版把 T-pose 平举的细手臂整条丢掉。
+# 所以取两张 alpha 的逐像素较大值,而不是二选一。实测 9 张:主体覆盖 14.78% → 15.77%,
+# 漏检最严重那张(林间斥候)的洞从 11.69% 降到 0.06%,代价是 0.27s/帧 → 0.77s/帧。
+_U2NET_URL = "https://github.com/danielgatis/rembg/releases/download/v0.0.0/u2net.onnx"
+_REFINE_CACHE = Path.home() / ".cache" / "windup" / "u2net.onnx"
 
 # u2net 预处理常量(与 rembg 一致)。
 _MEAN = (0.485, 0.456, 0.406)
@@ -52,6 +63,13 @@ _BG_FLAT_STD = 8.0  # 四角色标准差上限;超过说明底不是纯色,不�
 # 取 2 是为容下 2 px 宽的边框;真正不均匀的底(噪声/渐变/拼色)让多少都照样超阈值,守卫不松。
 _EDGE_SKIP = 2
 _CORNER = 12        # 每个角的采样块边长
+
+
+def _saliency(session, tensor: np.ndarray) -> np.ndarray:
+    """一个 u2net 会话的前向 → 归一化到 [0,1] 的二维显著性图。"""
+    pred = session.run(None, {session.get_inputs()[0].name: tensor})[0][:, 0, :, :]
+    mi, ma = float(pred.min()), float(pred.max())
+    return ((pred - mi) / max(ma - mi, 1e-6)).squeeze()
 
 
 def _corner_pixels(rgb: np.ndarray) -> np.ndarray:
@@ -195,18 +213,60 @@ def _flat_bg_penalty(rgb: np.ndarray) -> np.ndarray:
 
 
 class OnnxU2NetMatteProvider(MatteProvider):
-    """u2netp.onnx via onnxruntime。frame bytes → 抠好的 PNG(RGBA) bytes。"""
+    """u2net onnx via onnxruntime。frame bytes → 抠好的 PNG(RGBA) bytes。
 
-    def __init__(self, model_path: str | Path | None = None, model_url: str = _U2NETP_URL) -> None:
+    两个模型的 alpha 取逐像素较大值 —— 理由见 :data:`_U2NET_URL` 上方。补充模型取不到时
+    退回单模型并留一条 WARNING:少一层补漏仍能出产物,而为了它整条生成失败不值得;但
+    "少了一层"必须留痕,否则浅色角色被抠穿会被当成模型本身的水平。
+    """
+
+    def __init__(
+        self,
+        model_path: str | Path | None = None,
+        model_url: str = _U2NETP_URL,
+        *,
+        refine_model_path: str | Path | None = None,
+        refine_model_url: str | None = _U2NET_URL,
+    ) -> None:
         self._model_path = Path(model_path) if model_path else _DEFAULT_CACHE
         self._model_url = model_url
         self._session = None  # 惰性
+        self._refine_path = (
+            Path(refine_model_path) if refine_model_path
+            else (_REFINE_CACHE if refine_model_url else None)
+        )
+        self._refine_url = refine_model_url
+        self._refine_session = None
+        self._refine_failed = False
 
     def _ensure_model(self) -> Path:
         if not self._model_path.exists():
             self._model_path.parent.mkdir(parents=True, exist_ok=True)
             urllib.request.urlretrieve(self._model_url, self._model_path)
         return self._model_path
+
+    def _get_refine_session(self):
+        """补充模型的会话;取不到就永久放弃并只警告一次。"""
+        if self._refine_session is not None or self._refine_failed or self._refine_path is None:
+            return self._refine_session
+        try:
+            import onnxruntime as ort
+
+            if not self._refine_path.exists():
+                if not self._refine_url:
+                    raise FileNotFoundError(self._refine_path)
+                self._refine_path.parent.mkdir(parents=True, exist_ok=True)
+                urllib.request.urlretrieve(self._refine_url, self._refine_path)
+            self._refine_session = ort.InferenceSession(
+                str(self._refine_path), providers=["CPUExecutionProvider"]
+            )
+        except Exception:
+            self._refine_failed = True
+            logger.warning(
+                "抠图补充模型不可用(%s),本进程只用轻量模型 —— 浅肤色角色的脸颊与小腿"
+                "可能被判成背景", self._refine_path, exc_info=True,
+            )
+        return self._refine_session
 
     def _get_session(self):
         if self._session is None:
@@ -226,7 +286,7 @@ class OnnxU2NetMatteProvider(MatteProvider):
         return self._session
 
     def _predict_mask(self, img: Image.Image) -> Image.Image:
-        """u2netp 前向 → 单通道显著性 mask(L,原图尺寸)。"""
+        """两个模型各前向一次,取逐像素较大值 → 单通道显著性 mask(L,原图尺寸)。"""
         im = img.convert("RGB").resize(_SIZE, Image.LANCZOS)
         ary = np.array(im).astype(np.float32)
         ary = ary / max(float(ary.max()), 1e-6)
@@ -235,12 +295,15 @@ class OnnxU2NetMatteProvider(MatteProvider):
             tmp[:, :, c] = (ary[:, :, c] - _MEAN[c]) / _STD[c]
         tensor = np.expand_dims(tmp.transpose(2, 0, 1), 0).astype(np.float32)
 
-        session = self._get_session()
-        pred = session.run(None, {session.get_inputs()[0].name: tensor})[0][:, 0, :, :]
-        mi, ma = float(pred.min()), float(pred.max())
-        pred = (pred - mi) / max(ma - mi, 1e-6)
-        mask = (pred.squeeze() * 255).astype(np.uint8)
-        return Image.fromarray(mask, "L").resize(img.size, Image.LANCZOS)
+        mask = _saliency(self._get_session(), tensor)
+        refine = self._get_refine_session()
+        if refine is not None:
+            # 归一化在每个模型内部各自做完再取 max:两个模型的原始输出量纲不同,
+            # 先合并再归一化会让量纲大的那个把另一个整体压掉。
+            mask = np.maximum(mask, _saliency(refine, tensor))
+        return Image.fromarray(
+            (mask * 255).astype(np.uint8), "L"
+        ).resize(img.size, Image.LANCZOS)
 
     def cutout(self, frame: bytes) -> bytes:
         img = Image.open(io.BytesIO(frame)).convert("RGBA")

--- a/backend/packages/framework/src/windup_framework/providers/matte.py
+++ b/backend/packages/framework/src/windup_framework/providers/matte.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import io
 import logging
+import shutil
+import tempfile
 import urllib.request
 from pathlib import Path
 
@@ -63,6 +65,26 @@ _BG_FLAT_STD = 8.0  # 四角色标准差上限;超过说明底不是纯色,不�
 # 取 2 是为容下 2 px 宽的边框;真正不均匀的底(噪声/渐变/拼色)让多少都照样超阈值,守卫不松。
 _EDGE_SKIP = 2
 _CORNER = 12        # 每个角的采样块边长
+
+
+def _download_atomic(url: str, dest: Path) -> None:
+    """下到同目录的临时文件,整个传完再原子改名。
+
+    直接写目标路径的话,176MB 传到一半断开会留下一个不完整文件,而之后每次都靠
+    ``exists()`` 判断"已经有了" —— 网络恢复了也不会重下,ONNX 会话建不起来,这台机器
+    就长期退回单模型,而单模型正是会把浅肤色角色抠穿的那条路。同目录是为了让 replace
+    落在同一文件系统上,跨设备改名不是原子的。
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=dest.parent, suffix=".part", delete=False) as tmp:
+        part = Path(tmp.name)
+    try:
+        with urllib.request.urlopen(url) as resp, part.open("wb") as out:
+            shutil.copyfileobj(resp, out)
+        part.replace(dest)
+    except BaseException:
+        part.unlink(missing_ok=True)
+        raise
 
 
 def _saliency(session, tensor: np.ndarray) -> np.ndarray:
@@ -241,8 +263,7 @@ class OnnxU2NetMatteProvider(MatteProvider):
 
     def _ensure_model(self) -> Path:
         if not self._model_path.exists():
-            self._model_path.parent.mkdir(parents=True, exist_ok=True)
-            urllib.request.urlretrieve(self._model_url, self._model_path)
+            _download_atomic(self._model_url, self._model_path)
         return self._model_path
 
     def _get_refine_session(self):
@@ -255,11 +276,16 @@ class OnnxU2NetMatteProvider(MatteProvider):
             if not self._refine_path.exists():
                 if not self._refine_url:
                     raise FileNotFoundError(self._refine_path)
-                self._refine_path.parent.mkdir(parents=True, exist_ok=True)
-                urllib.request.urlretrieve(self._refine_url, self._refine_path)
-            self._refine_session = ort.InferenceSession(
-                str(self._refine_path), providers=["CPUExecutionProvider"]
-            )
+                _download_atomic(self._refine_url, self._refine_path)
+            try:
+                self._refine_session = ort.InferenceSession(
+                    str(self._refine_path), providers=["CPUExecutionProvider"]
+                )
+            except Exception:
+                # 建会话失败说明这个文件本身不可用(上一次下载留下的残片、或版本不合)。
+                # 留着它会让之后每次都跳过重下,所以就地删掉。
+                self._refine_path.unlink(missing_ok=True)
+                raise
         except Exception:
             self._refine_failed = True
             logger.warning(

--- a/backend/tests/test_matte_provider.py
+++ b/backend/tests/test_matte_provider.py
@@ -1,6 +1,7 @@
 """OnnxU2NetMatteProvider 契约测试(不加载模型 / 不联网:构造 + 协议合规)。"""
 
 import numpy as np
+from PIL import Image
 import pytest
 
 from windup_framework.providers import MatteProvider, OnnxU2NetMatteProvider
@@ -513,3 +514,68 @@ def test_kill_radius_follows_background_noise():
 
     assert _kill_radius(clean) == _KEY_KILL_MIN
     assert _KEY_KILL_MIN < _kill_radius(noisy) <= _KEY_KILL_MAX
+
+
+# ── 两个模型的 alpha 取并集 ───────────────────────────────────────────────
+#
+# 两者漏检的位置不重叠:轻量版把浅肤色角色的脸颊与小腿判成背景(测试反馈的"浅色角色被
+# 抠穿"),全量版把 T-pose 平举的细手臂整条丢掉。实测 9 张:主体覆盖 14.78% → 15.77%,
+# 漏检最严重那张的洞 11.69% → 0.06%。
+
+
+class _SaliencySession:
+    """按给定的显著性图返回 u2net 形状的输出。"""
+
+    def __init__(self, sal):
+        self._sal = np.asarray(sal, dtype=np.float32)
+
+    class _In:
+        name = "input.1"
+
+    def get_inputs(self):
+        return [self._In()]
+
+    def run(self, _outputs, _feed):
+        return [self._sal[None, None, :, :]]
+
+
+def _provider_with(main_sal, refine_sal):
+    from windup_framework.providers import matte as M
+
+    prov = M.OnnxU2NetMatteProvider(model_path="/nonexistent.onnx", refine_model_url=None)
+    prov._session = _SaliencySession(main_sal)
+    prov._refine_session = _SaliencySession(refine_sal) if refine_sal is not None else None
+    return prov
+
+
+def test_the_two_models_cover_each_others_misses():
+    """一个模型漏左半、另一个漏右半 —— 并集两边都在。"""
+    n = 320
+    left = np.zeros((n, n), dtype=np.float32)
+    left[:, : n // 2] = 1.0
+    right = np.zeros((n, n), dtype=np.float32)
+    right[:, n // 2 :] = 1.0
+    prov = _provider_with(left, right)
+
+    mask = np.asarray(prov._predict_mask(Image.new("RGB", (n, n), (30, 30, 30))))
+    assert mask[:, 10].mean() > 200, "左半被丢了"
+    assert mask[:, -10].mean() > 200, "右半被丢了 —— 并集没生效"
+
+
+def test_a_missing_refine_model_degrades_to_one_model_and_says_so(caplog):
+    """补充模型取不到时不该整条失败,但必须留痕。"""
+    from windup_framework.providers import matte as M
+
+    prov = M.OnnxU2NetMatteProvider(
+        model_path="/nonexistent.onnx",
+        refine_model_path="/nonexistent-refine.onnx",
+        refine_model_url=None,
+    )
+    with caplog.at_level("WARNING"):
+        assert prov._get_refine_session() is None
+    assert any("补充模型" in r.message for r in caplog.records), \
+        f"降级没留痕:{[r.message for r in caplog.records]}"
+    # 第二次不再重试、也不再刷日志
+    n0 = len(caplog.records)
+    assert prov._get_refine_session() is None
+    assert len(caplog.records) == n0, "每帧都重试了一次取模型"

--- a/backend/tests/test_matte_provider.py
+++ b/backend/tests/test_matte_provider.py
@@ -579,3 +579,41 @@ def test_a_missing_refine_model_degrades_to_one_model_and_says_so(caplog):
     n0 = len(caplog.records)
     assert prov._get_refine_session() is None
     assert len(caplog.records) == n0, "每帧都重试了一次取模型"
+
+
+def test_an_interrupted_download_leaves_no_cache_file(tmp_path, monkeypatch):
+    """传输中途断开不能留下不完整文件。
+
+    留了的话之后每次都靠 exists() 判断"已经有了"，网络恢复也不会重下，这台机器就长期
+    退回单模型 —— 而单模型正是会把浅肤色角色抠穿的那条路。
+    """
+    from windup_framework.providers import matte as M
+
+    dest = tmp_path / "sub" / "u2net.onnx"
+
+    class _Half:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self, *_a): raise OSError("connection reset")
+
+    monkeypatch.setattr(M.urllib.request, "urlopen", lambda _u: _Half())
+    with pytest.raises(OSError):
+        M._download_atomic("https://example.invalid/m.onnx", dest)
+    assert not dest.exists(), "残片留在了缓存路径上"
+    assert list(dest.parent.glob("*.part")) == [], "临时文件没清掉"
+
+
+def test_an_unusable_cached_model_is_removed_so_the_next_run_can_redownload(
+    tmp_path, monkeypatch, caplog
+):
+    """已存在但建不起会话的文件要删掉，否则每次都跳过重下、永久降级。"""
+    from windup_framework.providers import matte as M
+
+    bad = tmp_path / "u2net.onnx"
+    bad.write_bytes(b"not-an-onnx")
+    prov = M.OnnxU2NetMatteProvider(
+        model_path="/nonexistent.onnx", refine_model_path=bad, refine_model_url=None,
+    )
+    with caplog.at_level("WARNING"):
+        assert prov._get_refine_session() is None
+    assert not bad.exists(), "坏文件留在缓存里，下次还会跳过重下"


### PR DESCRIPTION
Closes #402

浅色角色被抠穿的成因在显著性模型这一层，而换全量模型不成立：两个模型漏检的位置不重叠，u2netp 丢浅肤色角色的脸颊与小腿，u2net 丢 T-pose 平举的细手臂。九张样本的覆盖率只差 0.5pp，看数字像「换了没用」，看图才知道是各丢一半。

所以取两张 alpha 的逐像素较大值。补充模型取不到时退回单模型并留一条 WARNING（只警告一次），少一层补漏仍能出产物，但不能不留痕。

后端 897 项本地通过。对照图（品红衬底，抠穿一眼可见）在本地归档。
