### PR TITLE
fix(workflow-editor): preserve regeneration recovery state

### DIFF
--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -941,6 +941,87 @@ describe('WorkflowController', () => {
     )
   })
 
+  it('角色母版回滚持久化失败时暴露工作流冲突', async () => {
+    const { controller, workflow, generation } = createController(
+      createRun(completedCharacterNodes()),
+    )
+    const update = vi.mocked(workflow.apis.update)
+    const save = update.getMockImplementation()!
+    update
+      .mockImplementationOnce(save)
+      .mockRejectedValueOnce(new Error('任务引用保存失败'))
+      .mockRejectedValueOnce(new Error('回滚保存失败'))
+
+    await expect(
+      controller.regenerateCharacterTemplate('template-1', {
+        spriteWidth: 64,
+        spriteHeight: 64,
+        mode: 'refine',
+        adjustmentPrompt: '换成水彩风格',
+      }),
+    ).rejects.toMatchObject({ name: 'WorkflowRunConflictError' })
+    expect(generation.apis.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('角色母版任务已创建但挂载失败时重试复用同一个任务', async () => {
+    const { controller, workflow, generation } = createController(
+      createRun(completedCharacterNodes()),
+    )
+    const update = vi.mocked(workflow.apis.update)
+    const save = update.getMockImplementation()!
+    update.mockImplementationOnce(save).mockRejectedValueOnce(new Error('任务引用保存失败'))
+
+    const options = {
+      spriteWidth: 64,
+      spriteHeight: 64,
+      mode: 'refine' as const,
+      adjustmentPrompt: '换成水彩风格',
+    }
+    await expect(controller.regenerateCharacterTemplate('template-1', options)).rejects.toThrow(
+      '任务引用保存失败',
+    )
+    await controller.regenerateCharacterTemplate('template-1', options)
+
+    expect(generation.apis.create).toHaveBeenCalledTimes(1)
+    expect(controller.getWorkflow().nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'template-1',
+          phase: 'generating',
+          generations: [{ taskId: 'task-1', role: 'character_template' }],
+        }),
+      ]),
+    )
+  })
+
+  it('角色母版任务已创建但订阅失败时重试复用同一个任务', async () => {
+    const { controller, generation } = createController(createRun(completedCharacterNodes()))
+    vi.mocked(generation.apis.subscribe).mockImplementationOnce(() => {
+      throw new Error('生成任务订阅失败')
+    })
+
+    const options = {
+      spriteWidth: 64,
+      spriteHeight: 64,
+      mode: 'regenerate' as const,
+    }
+    await expect(controller.regenerateCharacterTemplate('template-1', options)).rejects.toThrow(
+      '生成任务订阅失败',
+    )
+    await controller.regenerateCharacterTemplate('template-1', options)
+
+    expect(generation.apis.create).toHaveBeenCalledTimes(1)
+    expect(controller.getWorkflow().nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'template-1',
+          phase: 'generating',
+          generations: [{ taskId: 'task-1', role: 'character_template' }],
+        }),
+      ]),
+    )
+  })
+
   it('角色设定已落库但生成请求失败后可以重试', async () => {
     const { controller, generation } = createController()
     vi.mocked(generation.apis.create).mockRejectedValueOnce(new Error('生成服务暂时不可用'))

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -1022,6 +1022,41 @@ describe('WorkflowController', () => {
     )
   })
 
+  it('角色母版挂载时发现节点已被其他任务占用则保留现有引用', async () => {
+    const { controller, workflow, generation } = createController(
+      createRun(completedCharacterNodes()),
+    )
+    const update = vi.mocked(workflow.apis.update)
+    const save = update.getMockImplementation()!
+    update.mockImplementationOnce(save).mockImplementationOnce(async (run) => {
+      const saved = await save(run)
+      return {
+        ...saved,
+        nodes: saved.nodes.map((node) =>
+          node.id === 'template-1'
+            ? { ...node, generations: [{ taskId: 'other-task', role: 'character_template' }] }
+            : node,
+        ),
+      }
+    })
+
+    await controller.regenerateCharacterTemplate('template-1', {
+      spriteWidth: 64,
+      spriteHeight: 64,
+      mode: 'regenerate',
+    })
+
+    expect(generation.apis.create).toHaveBeenCalledTimes(1)
+    expect(controller.getWorkflow().nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'template-1',
+          generations: [{ taskId: 'other-task', role: 'character_template' }],
+        }),
+      ]),
+    )
+  })
+
   it('角色设定已落库但生成请求失败后可以重试', async () => {
     const { controller, generation } = createController()
     vi.mocked(generation.apis.create).mockRejectedValueOnce(new Error('生成服务暂时不可用'))

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -24,7 +24,7 @@ import type {
   WorkflowRun,
   WorkflowRunApis,
 } from '@/entities'
-import { IMAGE_CANDIDATE_COUNT } from '@/entities'
+import { IMAGE_CANDIDATE_COUNT, WorkflowRunConflictError } from '@/entities'
 
 const COMPLETE_ANIMATION_FRAME_COUNT = 32
 
@@ -174,6 +174,7 @@ interface PendingGenerationAttachment {
   nodeId: WorkflowNode['id']
   role: WorkflowGenerationRole
   expectedEpoch: number
+  regeneration: boolean
   generation: Generation
 }
 
@@ -193,6 +194,7 @@ export function createWorkflowController({
   const subscriptions = new Map<string, ActiveSubscription>()
   const nodeEpochs = new Map<WorkflowNode['id'], number>()
   const unattachedGenerations = new Map<string, PendingGenerationAttachment>()
+  const regenerationKeys = new Set<string>()
   const settlements = new Map<string, Promise<WorkflowRun>>()
   const listeners = new Set<(workflow: WorkflowRun) => void>()
 
@@ -593,18 +595,19 @@ export function createWorkflowController({
     const setupNode = findSingleDependencyNode(before, templateNode, 'character-setup')
     const prompt = adjustedPrompt(setupNode.input.prompt, options)
     const sourceImageUrl = options.mode === 'refine' ? templateNode.selectedImageUrl : undefined
+    const key = `${nodeId}:character_template`
+    const pending = unattachedGenerations.get(key)?.regeneration
+      ? unattachedGenerations.get(key)
+      : undefined
     await restartFromNode(nodeId)
-    try {
-      return await generateCharacterTemplate(setupNode.id, {
+    return runRegenerationAttempt(before, nodeId, key, pending, () => {
+      return generateCharacterTemplate(setupNode.id, {
         spriteWidth: options.spriteWidth,
         spriteHeight: options.spriteHeight,
         sourceImageUrl,
         prompt,
       })
-    } catch (cause) {
-      await rollbackRegeneration(before, nodeId)
-      throw cause
-    }
+    })
   }
 
   async function regenerateFirstFrame(
@@ -627,17 +630,45 @@ export function createWorkflowController({
     const prompt = adjustedPrompt(basePrompt, options)
     const sourceImageUrl =
       options.mode === 'refine' ? firstFrameNode.selectedFirstFrameUrl : undefined
+    const key = `${nodeId}:first_frame`
+    const pending = unattachedGenerations.get(key)?.regeneration
+      ? unattachedGenerations.get(key)
+      : undefined
     await restartFromNode(nodeId)
-    try {
-      return await generateFirstFrame(nodeId, {
+    return runRegenerationAttempt(before, nodeId, key, pending, () => {
+      return generateFirstFrame(nodeId, {
         spriteWidth: options.spriteWidth,
         spriteHeight: options.spriteHeight,
         sourceImageUrl,
         prompt,
       })
+    })
+  }
+
+  async function runRegenerationAttempt(
+    before: WorkflowRun,
+    nodeId: WorkflowNode['id'],
+    key: string,
+    pending: PendingGenerationAttachment | undefined,
+    generate: () => Promise<WorkflowRun>,
+  ): Promise<WorkflowRun> {
+    try {
+      if (pending) {
+        const retryAttachment = { ...pending, expectedEpoch: nodeEpoch(nodeId) }
+        unattachedGenerations.set(key, retryAttachment)
+        return await attachGeneration(retryAttachment)
+      }
+      regenerationKeys.add(key)
+      return await generate()
     } catch (cause) {
-      await rollbackRegeneration(before, nodeId)
+      try {
+        await rollbackRegeneration(before, nodeId)
+      } catch (rollbackCause) {
+        throw createRegenerationRecoveryError(cause, rollbackCause)
+      }
       throw cause
+    } finally {
+      regenerationKeys.delete(key)
     }
   }
 
@@ -646,26 +677,25 @@ export function createWorkflowController({
    * 不还原的话这条执行线会丢掉已接受的图片：重新生成还能从原始输入重来，微调却连参考图
    * 和临时描述都没有了，用户只能拿一张全新的图重新对齐。
    *
-   * 还原本身失败不覆盖原始错误——页面要看到的是"生成没成功"，而不是"回滚没成功"。
+   * 还原本身失败由调用方转换成 WorkflowRun 冲突，页面必须先刷新快照，不能继续使用不完整状态。
    */
   async function rollbackRegeneration(before: WorkflowRun, nodeId: WorkflowNode['id']) {
     const affectedIds = collectDescendantIds(before.nodes, nodeId)
     const restored = new Map(
       before.nodes.filter((node) => affectedIds.has(node.id)).map((node) => [node.id, node]),
     )
-    for (const affectedId of affectedIds) {
-      for (const [key] of unattachedGenerations) {
-        if (key.startsWith(`${affectedId}:`)) unattachedGenerations.delete(key)
+    for (const [key, pending] of unattachedGenerations) {
+      const belongsToAffectedBranch = [...affectedIds].some((affectedId) =>
+        key.startsWith(`${affectedId}:`),
+      )
+      if (belongsToAffectedBranch && !pending.regeneration) {
+        unattachedGenerations.delete(key)
       }
     }
-    try {
-      await persist((latest) => ({
-        ...latest,
-        nodes: normalizeAvailability(latest.nodes.map((node) => restored.get(node.id) ?? node)),
-      }))
-    } catch {
-      // 忽略：原始生成错误已经在向上抛出，页面按它给用户提示。
-    }
+    await persist((latest) => ({
+      ...latest,
+      nodes: normalizeAvailability(latest.nodes.map((node) => restored.get(node.id) ?? node)),
+    }))
   }
 
   function confirmFirstFrame(
@@ -836,7 +866,13 @@ export function createWorkflowController({
     // 重做发生在请求等待期间时，任务可以留在后端，但绝不能再挂回新的节点执行线。
     if (nodeEpoch(nodeId) !== expectedEpoch) return snapshot()
 
-    const attachment = { nodeId, role, expectedEpoch, generation }
+    const attachment = {
+      nodeId,
+      role,
+      expectedEpoch,
+      regeneration: regenerationKeys.has(key),
+      generation,
+    }
     unattachedGenerations.set(key, attachment)
     return attachGeneration(attachment)
   }
@@ -864,17 +900,23 @@ export function createWorkflowController({
     const attachedReference = findNode(attached, nodeId).generations.find(
       (item) => item.role === role,
     )
-    if (unattachedGenerations.get(key)?.generation.id === generation.id) {
-      unattachedGenerations.delete(key)
+    const forgetPendingAttachment = () => {
+      if (unattachedGenerations.get(key)?.generation.id === generation.id) {
+        unattachedGenerations.delete(key)
+      }
     }
     if (attachedReference?.taskId !== generation.id) {
+      forgetPendingAttachment()
       return attached
     }
 
     if (generation.status === 'completed' || generation.status === 'failed') {
-      return applyGenerationResult({ nodeId, taskId: generation.id, generation })
+      const settled = await applyGenerationResult({ nodeId, taskId: generation.id, generation })
+      forgetPendingAttachment()
+      return settled
     }
     await watchGeneration(nodeId, generation.id)
+    forgetPendingAttachment()
     return snapshot()
   }
 
@@ -1445,6 +1487,15 @@ function adjustedPrompt(basePrompt: string, options: RegenerateImageOptions) {
   }
   if (options.mode !== 'refine') throw new Error('不支持的重新生成模式')
   return `${base}\n${nonEmpty(options.adjustmentPrompt ?? '', 'adjustmentPrompt')}`
+}
+
+function createRegenerationRecoveryError(originalCause: unknown, rollbackCause: unknown) {
+  const original = asError(originalCause)
+  const rollback = asError(rollbackCause)
+  return new WorkflowRunConflictError(
+    `重新生成失败：${original.message}；恢复原有工作流失败：${rollback.message}，请加载最新版本后重试`,
+    { cause: rollback },
+  )
 }
 
 function ensurePositiveInteger(value: number, field: string) {

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -343,6 +343,27 @@ describe('createQuickStartService', () => {
     )
   })
 
+  it('continues to the next readable project name after five conflicts', async () => {
+    const create = vi.fn()
+    for (let sequence = 1; sequence <= 5; sequence += 1) {
+      create.mockRejectedValueOnce(new ProjectNameConflictError())
+    }
+    create.mockResolvedValueOnce({
+      id: 'project-6',
+      name: '像素骑士 6',
+      spriteSize: { width: 256, height: 256 },
+    })
+    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
+
+    await expect(prepare('像素骑士')).resolves.toEqual({
+      id: 'project-6',
+      spriteSize: { width: 256, height: 256 },
+    })
+
+    expect(create).toHaveBeenCalledTimes(6)
+    expect(create).toHaveBeenNthCalledWith(6, expect.objectContaining({ name: '像素骑士 6' }))
+  })
+
   it('uses a readable fallback for an empty project prompt', async () => {
     const create = vi.fn(async (input) => ({
       id: 'project-fallback',
@@ -398,13 +419,13 @@ describe('createQuickStartService', () => {
     expect(Array.from(create.mock.calls[1]?.[0].name ?? '')).toHaveLength(20)
   })
 
-  it('stops after five conflicting project names to avoid excessive write requests', async () => {
+  it('stops after a bounded number of conflicting project names', async () => {
     const conflict = new ProjectNameConflictError()
     const create = vi.fn().mockRejectedValue(conflict)
     const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
 
     await expect(prepare('像素骑士')).rejects.toBe(conflict)
-    expect(create).toHaveBeenCalledTimes(5)
+    expect(create).toHaveBeenCalledTimes(100)
   })
 
   it('creates one persisted node graph and starts the character image task', async () => {
@@ -1348,6 +1369,51 @@ describe('createQuickStartService', () => {
     })
     expect(run.nodes.find((node) => node.type === 'action-first-frame')).toMatchObject({
       input: { name: '待机', type: 'idle', prompt: null },
+    })
+  })
+
+  it('keeps a custom action display name bounded while preserving its full prompt', async () => {
+    const actionDescription = '挥手向远处的朋友打招呼并转身轻轻鞠躬并保持姿态'
+    const character = characterFixture({
+      workflowRunId: 'old-run',
+      referenceImageUrl: 'existing.png',
+      outfits: [
+        {
+          id: 'outfit-existing',
+          characterId: 'character-1',
+          name: '默认造型',
+          description: null,
+          previewUrl: 'existing.png',
+          actions: [],
+        },
+      ],
+    })
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis(),
+      generationApis: pendingGenerationApis(),
+      characterApis: {
+        get: vi.fn(async () => character),
+        listByProject: vi.fn(async () => ({ items: [character], total: 1, page: 1, pageSize: 20 })),
+        create: vi.fn(),
+        update: vi.fn(),
+        remove: vi.fn(),
+      } as unknown as CharacterApis,
+      projectApis: projectReader(),
+      prepareProject: vi.fn(),
+    })
+
+    const session = await service.startAction(
+      { characterId: character.id, outfitId: 'outfit-existing' },
+      actionDescription,
+    )
+    expect(
+      session.getWorkflow().nodes.find((node) => node.type === 'action-first-frame'),
+    ).toMatchObject({
+      input: {
+        name: '挥手向远处的朋友打招呼并转身轻轻鞠躬并…',
+        prompt: actionDescription,
+        type: 'custom',
+      },
     })
   })
 

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -93,6 +93,17 @@ export interface CreateQuickStartServiceOptions {
 
 type GeneratableActionType = 'idle' | 'walk' | 'jump' | 'attack' | 'custom'
 
+const PROJECT_NAME_MAX_LENGTH = 20
+const QUICK_START_PROJECT_NAME_ATTEMPTS = 100
+const ACTION_DISPLAY_NAME_MAX_LENGTH = 20
+
+function boundedDisplayName(value: string, maxLength: number): string {
+  const characters = Array.from(value)
+  return characters.length > maxLength
+    ? `${characters.slice(0, maxLength - 1).join('')}…`
+    : characters.join('')
+}
+
 function inferGeneratableActionType(description: string): GeneratableActionType {
   const normalized = description.trim().toLowerCase()
   if (!normalized || /^(待机|站立|呼吸|idle|stand|breathe)$/u.test(normalized)) return 'idle'
@@ -283,11 +294,10 @@ export function createQuickStartService({
     actionDescription: string,
     spriteSize: Project['spriteSize'],
   ) {
-    const name = actionDescription.trim() || '待机'
+    const prompt = actionDescription.trim()
+    const name = boundedDisplayName(prompt, ACTION_DISPLAY_NAME_MAX_LENGTH) || '待机'
     const type = inferGeneratableActionType(actionDescription)
-    await controller.addAction({
-      input: { outfitId, name, type, prompt: actionDescription.trim() || null, fps: 12 },
-    })
+    await controller.addAction({ input: { outfitId, name, type, prompt: prompt || null, fps: 12 } })
     const run = controller.getWorkflow()
     const firstFrame = latestActionFirstFrame(run)
     if (!firstFrame || firstFrame.type !== 'action-first-frame') {
@@ -803,15 +813,11 @@ export function createAutoPrepareProject(projectApis: ProjectApis): PrepareQuick
     const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
     let lastConflict: unknown
 
-    for (let sequence = 1; sequence <= 5; sequence += 1) {
+    for (let sequence = 1; sequence <= QUICK_START_PROJECT_NAME_ATTEMPTS; sequence += 1) {
       // 首次名称不预留编号空间；只有重名时才缩短前缀，为可读编号让出 20 字上限。
       const suffix = sequence === 1 ? '' : ` ${sequence}`
-      const maxBaseLength = 20 - Array.from(suffix).length
-      const promptCharacters = Array.from(normalizedPrompt)
-      const base =
-        promptCharacters.length > maxBaseLength
-          ? `${promptCharacters.slice(0, maxBaseLength - 1).join('')}…`
-          : promptCharacters.join('')
+      const maxBaseLength = PROJECT_NAME_MAX_LENGTH - Array.from(suffix).length
+      const base = boundedDisplayName(normalizedPrompt, maxBaseLength)
 
       try {
         const project = await projectApis.create({

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -109,6 +109,28 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     )
   })
 
+  it('角色母版微调失败时保留输入草稿以便重试', async () => {
+    const session = createSession(completedTemplateWorkflow('42'))
+    vi.spyOn(session.controller, 'regenerateCharacterTemplate').mockRejectedValueOnce(
+      new Error('生成服务暂时不可用'),
+    )
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    fireEvent.click(await screen.findByRole('button', { name: '微调角色母版' }))
+    fireEvent.change(screen.getByRole('textbox', { name: '角色母版微调描述' }), {
+      target: { value: '换成水彩风格' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '提交角色母版微调' }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert').textContent).toContain('生成服务暂时不可用'),
+    )
+    expect(
+      (screen.getByRole('textbox', { name: '角色母版微调描述' }) as HTMLTextAreaElement).value,
+    ).toBe('换成水彩风格')
+  })
+
   it('动作首帧完成后可以重新生成或提交微调描述', async () => {
     const session = createSession(reviewingActionWorkflow())
     const refine = vi.spyOn(session.controller, 'regenerateFirstFrame').mockResolvedValue(undefined)
@@ -136,6 +158,28 @@ describe('WorkflowEditorPage real runtime boundary', () => {
       'action-walk',
       expect.objectContaining({ mode: 'regenerate' }),
     )
+  })
+
+  it('动作首帧微调失败时保留输入草稿以便重试', async () => {
+    const session = createSession(reviewingActionWorkflow())
+    vi.spyOn(session.controller, 'regenerateFirstFrame').mockRejectedValueOnce(
+      new Error('生成服务暂时不可用'),
+    )
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    fireEvent.click(await screen.findByRole('button', { name: '微调动作首帧' }))
+    fireEvent.change(screen.getByRole('textbox', { name: '动作首帧微调描述' }), {
+      target: { value: '抬高手臂' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '提交动作首帧微调' }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert').textContent).toContain('生成服务暂时不可用'),
+    )
+    expect(
+      (screen.getByRole('textbox', { name: '动作首帧微调描述' }) as HTMLTextAreaElement).value,
+    ).toBe('抬高手臂')
   })
 
   it('默认路由只恢复真实 WorkflowRun 会话', async () => {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -297,7 +297,7 @@ interface ProjectionInput {
   setActionMenuLevel(level: ActionMenuLevel): void
   setSelectedOutfitId(outfitId: string | null): void
   setCharacter(character: Character): void
-  runCommand(branchKey: string, command: () => Promise<void>): void
+  runCommand(branchKey: string, command: () => Promise<void>, onSuccess?: () => void): void
 }
 
 function NodeExportButton({ model }: { model: ExportPackageModel | undefined }) {
@@ -613,16 +613,20 @@ function CharacterTemplateContent({
                 onClick={() => {
                   const prompt = adjustmentPrompt.trim()
                   if (!prompt) return
-                  input.runCommand(branchKey, () =>
-                    input.controller.regenerateCharacterTemplate(node.id, {
-                      spriteWidth: input.project.spriteSize.width,
-                      spriteHeight: input.project.spriteSize.height,
-                      mode: 'refine',
-                      adjustmentPrompt: prompt,
-                    }),
+                  input.runCommand(
+                    branchKey,
+                    () =>
+                      input.controller.regenerateCharacterTemplate(node.id, {
+                        spriteWidth: input.project.spriteSize.width,
+                        spriteHeight: input.project.spriteSize.height,
+                        mode: 'refine',
+                        adjustmentPrompt: prompt,
+                      }),
+                    () => {
+                      setRefining(false)
+                      setAdjustmentPrompt('')
+                    },
                   )
-                  setRefining(false)
-                  setAdjustmentPrompt('')
                 }}
               >
                 提交角色母版微调
@@ -891,16 +895,20 @@ function FirstFrameContent({
                 onClick={() => {
                   const prompt = adjustmentPrompt.trim()
                   if (!prompt) return
-                  input.runCommand(branchKey, () =>
-                    input.controller.regenerateFirstFrame(node.id, {
-                      spriteWidth: input.project.spriteSize.width,
-                      spriteHeight: input.project.spriteSize.height,
-                      mode: 'refine',
-                      adjustmentPrompt: prompt,
-                    }),
+                  input.runCommand(
+                    branchKey,
+                    () =>
+                      input.controller.regenerateFirstFrame(node.id, {
+                        spriteWidth: input.project.spriteSize.width,
+                        spriteHeight: input.project.spriteSize.height,
+                        mode: 'refine',
+                        adjustmentPrompt: prompt,
+                      }),
+                    () => {
+                      setRefining(false)
+                      setAdjustmentPrompt('')
+                    },
                   )
-                  setRefining(false)
-                  setAdjustmentPrompt('')
                 }}
               >
                 提交动作首帧微调

--- a/frontend/src/pages/workflow-editor/use-workflow-editor-session.ts
+++ b/frontend/src/pages/workflow-editor/use-workflow-editor-session.ts
@@ -94,13 +94,16 @@ export function useWorkflowEditorSession(
   )
 
   const runCommand = useCallback(
-    (branchKey: string, command: () => Promise<void>) => {
+    (branchKey: string, command: () => Promise<void>, onSuccess?: () => void) => {
       if (workflowConflictRef.current || busyBranchesRef.current.has(branchKey)) return
       const sessionSignal = sessionAbortRef.current?.signal
       busyBranchesRef.current = new Set(busyBranchesRef.current).add(branchKey)
       dispatch({ type: 'command-started', branchKey })
       dispatch({ type: 'workflow-error-cleared' })
       void command()
+        .then(() => {
+          if (!sessionSignal?.aborted) onSuccess?.()
+        })
         .catch((cause: unknown) => {
           if (!sessionSignal?.aborted) reportWorkflowError(cause, '工作流命令执行失败')
         })


### PR DESCRIPTION
Follow-up to #385.

Closes #408.

This patch closes the remaining regeneration, refinement, and Quick Start naming reliability gaps:

- Keep a created generation task available for retry when attachment, subscription, or the initial status read fails, so retrying does not create a duplicate task.
- Surface regeneration rollback persistence failures as a WorkflowRun conflict instead of hiding them.
- Clear refinement drafts only after the command succeeds, so failed requests remain retryable.
- Continue readable numbered project names when repeated Quick Start prompts collide, while keeping project names within the backend limit.
- Bound action display names without truncating the full generation prompt.

Validation:
- 660 frontend tests passed with coverage
- 91.16% statements / 85.16% branches
- typecheck passed
- lint passed
- build passed
- changed files pass oxfmt check