### PR TITLE
feat(account): add optional invite code registration step

### DIFF
--- a/frontend/src/features/account-panel/account-panel.css
+++ b/frontend/src/features/account-panel/account-panel.css
@@ -213,6 +213,18 @@
   font-weight: 500;
 }
 
+.auth-invite-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.auth-invite-helper {
+  margin: 0 0.15rem;
+  color: var(--auth-muted);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
 .auth-register-field-shell {
   position: relative;
   display: grid;
@@ -883,6 +895,7 @@
   .auth-register-fields .auth-screen-toast,
   .auth-submit-label,
   .auth-screen-helper,
+  .auth-invite-helper,
   .auth-screen-entry-switch {
     animation: none;
     filter: none;

--- a/frontend/src/features/account-panel/index.test.tsx
+++ b/frontend/src/features/account-panel/index.test.tsx
@@ -105,7 +105,7 @@ describe('AccountPanel', () => {
 
     expect(screen.getByRole('dialog', { name: '创建 Windup 账号' })).toBeTruthy()
     expect(screen.getByRole('heading', { name: '欢迎来到 Windup' })).toBeTruthy()
-    expect(screen.queryByLabelText('邀请码')).toBeNull()
+    expect(screen.queryByLabelText('邀请码（选填）')).toBeNull()
     expect(screen.getByText('注册即赠 300 积分。')).toBeTruthy()
     await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText('邮箱')))
   })
@@ -120,14 +120,19 @@ describe('AccountPanel', () => {
     expect(screen.queryByText('继续搭建，')).toBeNull()
     expect(screen.getByTestId('register-fields').className).toContain('auth-register-fields')
     expect(screen.queryByRole('tablist', { name: '账号操作' })).toBeNull()
-    expect(screen.queryByLabelText('邀请码')).toBeNull()
     expect(screen.getByLabelText('邮箱')).toBeTruthy()
-    expect(screen.queryByLabelText('密码')).toBeNull()
-    expect(screen.queryByLabelText('昵称（选填）')).toBeNull()
-    expect(screen.queryByLabelText('验证码')).toBeNull()
     expect(screen.getByTestId('register-fields').querySelector('[aria-live]')).toBeNull()
     expect(screen.getByRole('button', { name: '继续' })).toBeTruthy()
     await waitFor(() => expect(document.activeElement).toBe(screen.getByLabelText('邮箱')))
+
+    fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'new@example.com' } })
+    fireEvent.submit(screen.getByRole('button', { name: '继续' }).closest('form')!)
+
+    expect(await screen.findByRole('heading', { name: '填写邀请码' })).toBeTruthy()
+    expect((screen.getByLabelText('邀请码（选填）') as HTMLInputElement).value).toBe('I0O1')
+    expect(screen.getByText('已从邀请链接带入，可修改或清空。')).toBeTruthy()
+    expect(screen.queryByLabelText('邮箱')).toBeNull()
+    expect(screen.queryByLabelText('密码')).toBeNull()
   })
 
   it('keeps the close control inside the dialog focus boundary', () => {
@@ -392,11 +397,18 @@ describe('AccountPanel', () => {
     fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'new@example.com' } })
     fireEvent.submit(screen.getByRole('button', { name: '继续' }).closest('form')!)
 
+    expect(await screen.findByLabelText('邀请码（选填）')).toBeTruthy()
+    fireEvent.submit(screen.getByRole('button', { name: '继续' }).closest('form')!)
+
     const password = await screen.findByLabelText('密码')
     expect(password.getAttribute('type')).toBe('password')
     fireEvent.click(screen.getByRole('button', { name: '显示密码' }))
     expect(password.getAttribute('type')).toBe('text')
 
+    fireEvent.click(screen.getByRole('button', { name: '返回上一步' }))
+    expect(((await screen.findByLabelText('邀请码（选填）')) as HTMLInputElement).value).toBe(
+      'AB23CD45',
+    )
     fireEvent.click(screen.getByRole('button', { name: '返回上一步' }))
     expect(((await screen.findByLabelText('邮箱')) as HTMLInputElement).value).toBe(
       'new@example.com',
@@ -407,9 +419,12 @@ describe('AccountPanel', () => {
   it('submits the invite link code and shows backend expiry errors inline', async () => {
     const { apis } = renderPanel('/?account=register&invite=ab23cd45&returnTo=%2Fworkspace')
     apis.register.mockRejectedValue(new Error('邀请码已过期'))
-    expect(screen.queryByLabelText('邀请码')).toBeNull()
     fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'new@example.com' } })
 
+    fireEvent.submit(screen.getByRole('button', { name: '继续' }).closest('form')!)
+    fireEvent.change(await screen.findByLabelText('邀请码（选填）'), {
+      target: { value: '  xy67za89  ' },
+    })
     fireEvent.submit(screen.getByRole('button', { name: '继续' }).closest('form')!)
     expect(screen.getByRole('dialog', { name: '创建 Windup 账号' })).toBeTruthy()
     expect(screen.getByRole('heading', { name: '为账号加一道保护' })).toBeTruthy()
@@ -450,7 +465,7 @@ describe('AccountPanel', () => {
         email: 'new@example.com',
         password: 'password-123',
         code: '123456',
-        inviteCode: 'AB23CD45',
+        inviteCode: 'XY67ZA89',
         nickname: '新用户',
       }),
     )
@@ -460,6 +475,12 @@ describe('AccountPanel', () => {
   it('submits public registration without an invite code', async () => {
     const { apis } = renderPanel('/?account=register&returnTo=%2Fworkspace')
     fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'direct@example.com' } })
+    fireEvent.submit(screen.getByRole('button', { name: '继续' }).closest('form')!)
+
+    fireEvent.change(await screen.findByLabelText('邀请码（选填）'), {
+      target: { value: 'AB23CD45' },
+    })
+    fireEvent.change(screen.getByLabelText('邀请码（选填）'), { target: { value: '' } })
     fireEvent.submit(screen.getByRole('button', { name: '继续' }).closest('form')!)
 
     fireEvent.change(await screen.findByLabelText('密码'), {

--- a/frontend/src/features/account-panel/index.tsx
+++ b/frontend/src/features/account-panel/index.tsx
@@ -19,6 +19,7 @@ import {
   EyeClosed,
   Keyhole,
   SealCheck,
+  Ticket,
   UserCircle,
   X,
   type Icon,
@@ -57,6 +58,10 @@ const registrationStepCopy = [
     description: '从一个角色开始，慢慢搭建属于你的世界。',
   },
   {
+    title: '填写邀请码',
+    description: '有邀请码就填在这里，没有也可以直接继续。',
+  },
+  {
     title: '为账号加一道保护',
     description: '设置 8–128 位密码，方便安全地回到你的创作。',
   },
@@ -87,7 +92,7 @@ const loginMotionCopy = [
   ['从上一次确认出发，', '让灵感继续向前。'],
 ] as const
 
-const REGISTER_STEP_COUNT = 4
+const REGISTER_STEP_COUNT = 5
 const AUTH_ICON_PROPS = { weight: 'light' as const }
 const AUTH_FIELD_CLASS = 'auth-screen-field w-full outline-none disabled:cursor-not-allowed'
 
@@ -206,7 +211,7 @@ export function AccountPanel() {
 /** 只有面板真正打开时才读取会话，关闭状态不把认证 Context 强加给应用外壳。 */
 function AccountPanelDialog({
   entry,
-  inviteCode,
+  inviteCode: initialInviteCode,
 }: {
   entry: AccountEntry
   inviteCode: string | null
@@ -220,6 +225,7 @@ function AccountPanelDialog({
   const [showPassword, setShowPassword] = useState(false)
   const [code, setCode] = useState('')
   const [nickname, setNickname] = useState('')
+  const [inviteCode, setInviteCode] = useState(initialInviteCode ?? '')
   const [registerStep, setRegisterStep] = useState(0)
   const [motionDirection, setMotionDirection] = useState<MotionDirection>('forward')
   const [copyIndex, setCopyIndex] = useState(0)
@@ -245,6 +251,7 @@ function AccountPanelDialog({
   const nicknameId = useId()
   const passwordId = useId()
   const codeId = useId()
+  const inviteCodeId = useId()
   const isRegister = entry === 'register'
   const shouldShowMotionCopy = !isRegister || registerStep === 0
   const motionCopy = isRegister ? registrationWelcomeMotionCopy : loginMotionCopy
@@ -252,6 +259,7 @@ function AccountPanelDialog({
   const passwordChanged =
     session.state.status === 'guest' && session.state.reason === 'password-changed'
   const normalizedEmail = email.trim()
+  const normalizedInviteCode = inviteCode.trim().toUpperCase()
   const cooldownSeconds = Math.max(
     0,
     Math.ceil(((cooldowns.get(email.trim().toLowerCase()) ?? 0) - now) / 1_000),
@@ -410,9 +418,9 @@ function AccountPanelDialog({
     let validationError: string | null = null
     if (registerStep === 0 && !EMAIL_PATTERN.test(normalizedEmail)) {
       validationError = '请输入有效邮箱地址'
-    } else if (registerStep === 1 && (password.length < 8 || password.length > 128)) {
+    } else if (registerStep === 2 && (password.length < 8 || password.length > 128)) {
       validationError = '密码需为 8–128 位'
-    } else if (registerStep === 2 && nickname.length > 50) {
+    } else if (registerStep === 3 && nickname.length > 50) {
       validationError = '昵称不能超过 50 个字符'
     }
 
@@ -423,7 +431,7 @@ function AccountPanelDialog({
 
     setError(null)
     setSuccess(null)
-    if (registerStep === 2) {
+    if (registerStep === 3) {
       if (cooldownSeconds === 0 && !(await sendCode())) return
     }
     setMotionDirection('forward')
@@ -462,7 +470,7 @@ function AccountPanelDialog({
           email: normalizedEmail,
           password,
           code,
-          ...(inviteCode ? { inviteCode } : {}),
+          ...(normalizedInviteCode ? { inviteCode: normalizedInviteCode } : {}),
           ...(nickname.trim() ? { nickname: nickname.trim() } : {}),
         })
         successMessage = '账号已创建，正在继续。'
@@ -514,7 +522,9 @@ function AccountPanelDialog({
 
   const tabClass = 'auth-screen-tab min-h-11 flex-1 px-2 text-sm font-semibold'
   const submitLabel = isRegister ? '创建账号' : loginModeCopy[mode].submit
-  const RegisterFieldIcon: Icon = [EnvelopeSimple, Keyhole, UserCircle, SealCheck][registerStep]
+  const RegisterFieldIcon: Icon = [EnvelopeSimple, Ticket, Keyhole, UserCircle, SealCheck][
+    registerStep
+  ]
   const registerCopy = registrationStepCopy[registerStep]
   const titleCopy = isRegister ? registerCopy.title : loginWelcomeCopy.title
   const descriptionCopy = isRegister ? registerCopy.description : loginWelcomeCopy.description
@@ -688,7 +698,27 @@ function AccountPanelDialog({
                 />
               )}
 
-              {((isRegister && registerStep === 1) || (!isRegister && mode === 'password')) && (
+              {isRegister && registerStep === 1 && (
+                <div className="auth-invite-field">
+                  <AuthField
+                    id={inviteCodeId}
+                    label="邀请码（选填）"
+                    icon={RegisterFieldIcon}
+                    value={inviteCode}
+                    onValueChange={setInviteCode}
+                    disabled={isSubmitting || isSendingCode}
+                    placeholder="邀请码（选填）"
+                    autoComplete="off"
+                    autoCapitalize="characters"
+                    spellCheck={false}
+                  />
+                  {initialInviteCode && (
+                    <p className="auth-invite-helper">已从邀请链接带入，可修改或清空。</p>
+                  )}
+                </div>
+              )}
+
+              {((isRegister && registerStep === 2) || (!isRegister && mode === 'password')) && (
                 <AuthField
                   id={passwordId}
                   label="密码"
@@ -709,7 +739,7 @@ function AccountPanelDialog({
                 />
               )}
 
-              {isRegister && registerStep === 2 && (
+              {isRegister && registerStep === 3 && (
                 <AuthField
                   id={nicknameId}
                   label="昵称（选填）"
@@ -723,7 +753,7 @@ function AccountPanelDialog({
                 />
               )}
 
-              {((isRegister && registerStep === 3) || (!isRegister && mode === 'code')) && (
+              {((isRegister && registerStep === 4) || (!isRegister && mode === 'code')) && (
                 <AuthField
                   id={codeId}
                   label="验证码"
@@ -793,8 +823,8 @@ function AccountPanelDialog({
             </button>
           </p>
           {isRegister && (
-            <p className="mt-2 text-center text-xs text-app-faint">
-              {inviteCode ? '邀请链接已带入，注册后共得 500 积分。' : '注册即赠 300 积分。'}
+            <p className="auth-screen-helper mt-2 text-center text-sm">
+              {normalizedInviteCode ? '填写邀请码，注册后共得 500 积分。' : '注册即赠 300 积分。'}
             </p>
           )}
         </div>


### PR DESCRIPTION
在现有注册流程中加入独立的可选邀请码步骤，统一覆盖邀请链接入口与普通注册入口，并继续复用现有后端注册接口。

## Why

此前邀请链接可以隐式携带邀请码，但用户无法在注册界面确认、修改或清空；普通注册用户也没有填写入口。

## Changes

- 邀请链接进入时自动预填邀请码，普通入口保持为空。
- 邀请码可修改或清空，空值不提交，非空值经 `trim + uppercase` 后提交。
- 邀请码使用注册流程中的独立步骤，不新增第二套注册页面。

## Implementation

- 沿用现有 `AccountPanel` 多步骤结构与 `/auth/register` 接口。
- 不增加前端格式正则，格式、有效期和奖励发放仍由后端负责。

## Verification

- [x] `npm test -- src/features/account-panel/index.test.tsx src/entities/user/api.test.ts`：35 项通过。
- [x] `npx oxfmt --check src/features/account-panel/index.tsx src/features/account-panel/index.test.tsx src/features/account-panel/account-panel.css`：通过。
- [x] `npx oxlint src/features/account-panel/index.tsx src/features/account-panel/index.test.tsx`：通过。
- [x] `npm run build`：通过。
- [x] 真实本地页面：邀请链接预填、普通入口为空，均进入同一独立邀请码步骤。

## Scope

- 本 PR 不修改邀请奖励规则、邀请中心或工作台提示气泡。
- 本 PR 按要求不附截图。

## Related Issues

Closes #397
