### PR TITLE
feat(quick-start): add minimal agent runtime

### DIFF
--- a/frontend/src/pages/quick-start/agent-runtime.test.ts
+++ b/frontend/src/pages/quick-start/agent-runtime.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { MediaReference, WorkflowRun } from '@/entities'
+import {
+  getQuickStartWorkflowContext,
+  runQuickStartAgentTurn,
+  type AgentTransport,
+  type AgentTransportEvent,
+  type QuickStartAgentRuntimeEvent,
+} from './agent-runtime'
+
+function workflow(): WorkflowRun {
+  return {
+    id: 'run-1',
+    projectId: 'project-1',
+    version: 4,
+    storageStatus: 'active',
+    nodes: [
+      {
+        id: 'character-setup',
+        type: 'character-setup',
+        status: 'passed',
+        phase: 'completed',
+        dependsOnNodeIds: [],
+        generations: [],
+        error: null,
+        input: {
+          characterId: 'character-1',
+          prompt: '戴星形单片眼镜的像素裁缝',
+          referenceMedia: ['https://example.test/private-reference.png' as MediaReference],
+        },
+      },
+      {
+        id: 'character-template',
+        type: 'character-template',
+        status: 'passed',
+        phase: 'completed',
+        dependsOnNodeIds: ['character-setup'],
+        generations: [{ taskId: 'template-task', role: 'character_template' }],
+        error: null,
+        selectedImageUrl: 'https://example.test/template.png',
+      },
+      {
+        id: 'action-first',
+        type: 'action-first-frame',
+        status: 'active',
+        phase: 'selecting',
+        dependsOnNodeIds: ['character-template'],
+        generations: [{ taskId: 'first-task', role: 'first_frame' }],
+        error: null,
+        input: {
+          outfitId: 'outfit-1',
+          name: '挥手',
+          type: 'custom',
+          prompt: '慢慢挥手',
+          fps: 12,
+        },
+        selectedFirstFrameUrl: null,
+      },
+      {
+        id: 'deleted-action',
+        type: 'action-first-frame',
+        status: 'passed',
+        phase: 'completed',
+        dependsOnNodeIds: ['character-template'],
+        generations: [],
+        error: null,
+        deletedAt: '2026-08-18T10:00:00Z',
+        input: {
+          outfitId: 'outfit-1',
+          name: '旧动作',
+          type: 'custom',
+          prompt: '旧动作',
+          fps: 12,
+        },
+        selectedFirstFrameUrl: 'https://example.test/deleted.png',
+      },
+    ],
+  }
+}
+
+async function* events(...items: AgentTransportEvent[]): AsyncIterable<AgentTransportEvent> {
+  yield* items
+}
+
+describe('Quick Start agent runtime', () => {
+  it('projects the WorkflowRun into a small read-only context', () => {
+    const context = getQuickStartWorkflowContext(workflow())
+
+    expect(context).toEqual({
+      runId: 'run-1',
+      projectId: 'project-1',
+      version: 4,
+      characterPrompt: '戴星形单片眼镜的像素裁缝',
+      currentNode: {
+        id: 'action-first',
+        type: 'action-first-frame',
+        status: 'active',
+        phase: 'selecting',
+        error: null,
+      },
+      nodes: [
+        {
+          id: 'character-setup',
+          type: 'character-setup',
+          status: 'passed',
+          phase: 'completed',
+          error: null,
+        },
+        {
+          id: 'character-template',
+          type: 'character-template',
+          status: 'passed',
+          phase: 'completed',
+          error: null,
+        },
+        {
+          id: 'action-first',
+          type: 'action-first-frame',
+          status: 'active',
+          phase: 'selecting',
+          error: null,
+        },
+      ],
+    })
+    expect(JSON.stringify(context)).not.toContain('template-task')
+    expect(JSON.stringify(context)).not.toContain('private-reference.png')
+    expect(JSON.stringify(context)).not.toContain('deleted-action')
+  })
+
+  it('executes get_workflow_context and sends its tool result back before completing', async () => {
+    const stream = vi
+      .fn<AgentTransport['stream']>()
+      .mockImplementationOnce(() =>
+        events(
+          { type: 'text', text: '我先看看当前进度。' },
+          {
+            type: 'function-call',
+            callId: 'call-1',
+            name: 'get_workflow_context',
+            arguments: {},
+          },
+          { type: 'completed' },
+        ),
+      )
+      .mockImplementationOnce(() =>
+        events({ type: 'text', text: '现在正在选择挥手动作的首帧。' }, { type: 'completed' }),
+      )
+    const transport: AgentTransport = { stream }
+    const observed: QuickStartAgentRuntimeEvent[] = []
+
+    const result = await runQuickStartAgentTurn({
+      transport,
+      history: [],
+      input: '现在做到哪一步了？',
+      getWorkflow: workflow,
+      onEvent: (event) => observed.push(event),
+    })
+
+    expect(stream).toHaveBeenCalledTimes(2)
+    expect(stream.mock.calls[0]?.[0].instructions).toContain(
+      '不要声称已经创建、重生成、微调、回退或保存',
+    )
+    expect(stream.mock.calls[0]?.[0].tools).toEqual([
+      expect.objectContaining({ name: 'get_workflow_context' }),
+    ])
+    expect(stream.mock.calls[1]?.[0].messages.at(-1)).toEqual({
+      role: 'tool',
+      callId: 'call-1',
+      name: 'get_workflow_context',
+      content: JSON.stringify(getQuickStartWorkflowContext(workflow())),
+    })
+    expect(observed.map((event) => event.type)).toEqual([
+      'text',
+      'function-call',
+      'tool-result',
+      'text',
+      'completed',
+    ])
+    expect(result.assistantText).toBe('我先看看当前进度。现在正在选择挥手动作的首帧。')
+    expect(result.history.at(-1)).toEqual({
+      role: 'assistant',
+      content: '现在正在选择挥手动作的首帧。',
+    })
+  })
+
+  it('fails closed when one user turn attempts a second function call', async () => {
+    const transport: AgentTransport = {
+      stream: vi
+        .fn<AgentTransport['stream']>()
+        .mockImplementationOnce(() =>
+          events(
+            {
+              type: 'function-call',
+              callId: 'call-1',
+              name: 'get_workflow_context',
+              arguments: {},
+            },
+            { type: 'completed' },
+          ),
+        )
+        .mockImplementationOnce(() =>
+          events({
+            type: 'function-call',
+            callId: 'call-2',
+            name: 'get_workflow_context',
+            arguments: {},
+          }),
+        ),
+    }
+    const observed: QuickStartAgentRuntimeEvent[] = []
+
+    await expect(
+      runQuickStartAgentTurn({
+        transport,
+        history: [],
+        input: '再读一次',
+        getWorkflow: workflow,
+        onEvent: (event) => observed.push(event),
+      }),
+    ).rejects.toThrow('每轮最多调用一次 function')
+    expect(observed.at(-1)).toMatchObject({ type: 'failed' })
+  })
+
+  it('does not execute unknown functions', async () => {
+    const transport: AgentTransport = {
+      stream: () =>
+        events({ type: 'function-call', callId: 'call-1', name: 'regenerate', arguments: {} }),
+    }
+
+    await expect(
+      runQuickStartAgentTurn({
+        transport,
+        history: [],
+        input: '重新生成',
+        getWorkflow: workflow,
+      }),
+    ).rejects.toThrow('不支持 function：regenerate')
+  })
+
+  it('surfaces transport failures as a failed runtime event', async () => {
+    const transport: AgentTransport = {
+      stream: () => events({ type: 'failed', error: '模型暂时不可用' }),
+    }
+    const observed: QuickStartAgentRuntimeEvent[] = []
+
+    await expect(
+      runQuickStartAgentTurn({
+        transport,
+        history: [],
+        input: '你好',
+        getWorkflow: workflow,
+        onEvent: (event) => observed.push(event),
+      }),
+    ).rejects.toThrow('模型暂时不可用')
+    expect(observed).toEqual([{ type: 'failed', error: '模型暂时不可用' }])
+  })
+
+  it('treats completed as the hard end of one transport stream', async () => {
+    const getWorkflow = vi.fn(workflow)
+    const stream = vi.fn<AgentTransport['stream']>(() =>
+      events(
+        { type: 'text', text: '回答结束。' },
+        { type: 'completed' },
+        { type: 'text', text: '不应出现' },
+        {
+          type: 'function-call',
+          callId: 'late-call',
+          name: 'get_workflow_context',
+          arguments: {},
+        },
+      ),
+    )
+
+    const result = await runQuickStartAgentTurn({
+      transport: { stream },
+      history: [],
+      input: '回答我',
+      getWorkflow,
+    })
+
+    expect(result.assistantText).toBe('回答结束。')
+    expect(stream).toHaveBeenCalledTimes(1)
+    expect(getWorkflow).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/quick-start/agent-runtime.test.ts
+++ b/frontend/src/pages/quick-start/agent-runtime.test.ts
@@ -88,44 +88,21 @@ describe('Quick Start agent runtime', () => {
     const context = getQuickStartWorkflowContext(workflow())
 
     expect(context).toEqual({
-      runId: 'run-1',
-      projectId: 'project-1',
-      version: 4,
-      characterPrompt: '戴星形单片眼镜的像素裁缝',
-      currentNode: {
-        id: 'action-first',
-        type: 'action-first-frame',
-        status: 'active',
-        phase: 'selecting',
-        error: null,
-      },
-      nodes: [
-        {
-          id: 'character-setup',
-          type: 'character-setup',
-          status: 'passed',
-          phase: 'completed',
-          error: null,
-        },
-        {
-          id: 'character-template',
-          type: 'character-template',
-          status: 'passed',
-          phase: 'completed',
-          error: null,
-        },
-        {
-          id: 'action-first',
-          type: 'action-first-frame',
-          status: 'active',
-          phase: 'selecting',
-          error: null,
-        },
-      ],
+      currentStage: 'action-first-frame',
+      currentStatus: 'active',
+      currentPhase: 'selecting',
+      isGenerating: false,
+      awaitingUserSelection: true,
+      failed: false,
+      allowedActions: ['select-action-first-frame'],
+      error: null,
     })
     expect(JSON.stringify(context)).not.toContain('template-task')
     expect(JSON.stringify(context)).not.toContain('private-reference.png')
     expect(JSON.stringify(context)).not.toContain('deleted-action')
+    expect(JSON.stringify(context)).not.toContain('projectId')
+    expect(JSON.stringify(context)).not.toContain('characterPrompt')
+    expect(JSON.stringify(context)).not.toContain('nodes')
   })
 
   it('executes get_workflow_context and sends its tool result back before completing', async () => {
@@ -238,6 +215,32 @@ describe('Quick Start agent runtime', () => {
     ).rejects.toThrow('不支持 function：regenerate')
   })
 
+  it('rejects arguments for the read-only context function', async () => {
+    const getWorkflow = vi.fn(workflow)
+    const transport: AgentTransport = {
+      stream: () =>
+        events(
+          {
+            type: 'function-call',
+            callId: 'call-1',
+            name: 'get_workflow_context',
+            arguments: { includeNodes: true },
+          },
+          { type: 'completed' },
+        ),
+    }
+
+    await expect(
+      runQuickStartAgentTurn({
+        transport,
+        history: [],
+        input: '读取详细节点',
+        getWorkflow,
+      }),
+    ).rejects.toThrow('get_workflow_context 不接受参数')
+    expect(getWorkflow).not.toHaveBeenCalled()
+  })
+
   it('surfaces transport failures as a failed runtime event', async () => {
     const transport: AgentTransport = {
       stream: () => events({ type: 'failed', error: '模型暂时不可用' }),
@@ -282,5 +285,28 @@ describe('Quick Start agent runtime', () => {
     expect(result.assistantText).toBe('回答结束。')
     expect(stream).toHaveBeenCalledTimes(1)
     expect(getWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('does not execute a function call when the transport stream ends early', async () => {
+    const getWorkflow = vi.fn(workflow)
+    const stream = vi.fn<AgentTransport['stream']>(() =>
+      events({
+        type: 'function-call',
+        callId: 'unfinished-call',
+        name: 'get_workflow_context',
+        arguments: {},
+      }),
+    )
+
+    await expect(
+      runQuickStartAgentTurn({
+        transport: { stream },
+        history: [],
+        input: '读取进度',
+        getWorkflow,
+      }),
+    ).rejects.toThrow('Agent Transport 未发送完成事件')
+    expect(getWorkflow).not.toHaveBeenCalled()
+    expect(stream).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/pages/quick-start/agent-runtime.ts
+++ b/frontend/src/pages/quick-start/agent-runtime.ts
@@ -66,31 +66,21 @@ export type QuickStartAgentRuntimeEvent =
   | { type: 'completed' }
   | { type: 'failed'; error: string }
 
-interface WorkflowNodeContext {
-  id: string
-  type: WorkflowNode['type']
-  status: WorkflowNode['status']
-  phase: WorkflowNode['phase']
-  error: string | null
-}
+type QuickStartAllowedAction =
+  | 'select-character-template'
+  | 'select-action-first-frame'
+  | 'approve-review'
+  | 'retry-generation'
 
 export interface QuickStartWorkflowContext {
-  runId: string
-  projectId: string
-  version: number
-  characterPrompt: string | null
-  currentNode: WorkflowNodeContext | null
-  nodes: WorkflowNodeContext[]
-}
-
-function nodeContext(node: WorkflowNode): WorkflowNodeContext {
-  return {
-    id: node.id,
-    type: node.type,
-    status: node.status,
-    phase: node.phase,
-    error: node.error,
-  }
+  currentStage: WorkflowNode['type'] | null
+  currentStatus: WorkflowNode['status'] | null
+  currentPhase: WorkflowNode['phase'] | null
+  isGenerating: boolean
+  awaitingUserSelection: boolean
+  failed: boolean
+  allowedActions: QuickStartAllowedAction[]
+  error: string | null
 }
 
 /**
@@ -99,19 +89,30 @@ function nodeContext(node: WorkflowNode): WorkflowNodeContext {
  */
 export function getQuickStartWorkflowContext(run: WorkflowRun): QuickStartWorkflowContext {
   const nodes = run.nodes.filter((node) => !node.deletedAt)
-  const setup = nodes.find((node) => node.type === 'character-setup')
   const current =
     nodes.findLast((node) => node.status === 'active' || node.status === 'failed') ??
     nodes.at(-1) ??
     null
+  const allowedActions: QuickStartAllowedAction[] =
+    current?.status === 'failed'
+      ? ['retry-generation']
+      : current?.type === 'character-template' && current.phase === 'selecting'
+        ? ['select-character-template']
+        : current?.type === 'action-first-frame' && current.phase === 'selecting'
+          ? ['select-action-first-frame']
+          : current?.type === 'review' && current.status === 'active'
+            ? ['approve-review']
+            : []
 
   return {
-    runId: run.id,
-    projectId: run.projectId,
-    version: run.version,
-    characterPrompt: setup?.type === 'character-setup' ? setup.input.prompt : null,
-    currentNode: current ? nodeContext(current) : null,
-    nodes: nodes.map(nodeContext),
+    currentStage: current?.type ?? null,
+    currentStatus: current?.status ?? null,
+    currentPhase: current?.phase ?? null,
+    isGenerating: current?.phase === 'generating',
+    awaitingUserSelection: current?.phase === 'selecting',
+    failed: current?.status === 'failed',
+    allowedActions,
+    error: current?.error ?? null,
   }
 }
 
@@ -194,6 +195,8 @@ export async function runQuickStartAgentTurn({
         break
       }
 
+      if (!completed) throw new Error('Agent Transport 未发送完成事件')
+
       if (pendingFunctionCall) {
         messages.push({
           role: 'assistant',
@@ -216,7 +219,6 @@ export async function runQuickStartAgentTurn({
         continue
       }
 
-      if (!completed) throw new Error('Agent Transport 未发送完成事件')
       messages.push({ role: 'assistant', content: responseText })
       onEvent?.({ type: 'completed' })
       return { history: messages, assistantText }

--- a/frontend/src/pages/quick-start/agent-runtime.ts
+++ b/frontend/src/pages/quick-start/agent-runtime.ts
@@ -1,0 +1,228 @@
+import type { WorkflowNode, WorkflowRun } from '@/entities'
+
+const GET_WORKFLOW_CONTEXT = 'get_workflow_context' as const
+
+export const QUICK_START_AGENT_INSTRUCTIONS = [
+  '你是 Windup Quick Start 的对话助手，只围绕当前 WorkflowRun 回答。',
+  '需要了解当前进度时调用 get_workflow_context；每轮最多调用一次 function。',
+  '你没有修改工作流的能力，不要声称已经创建、重生成、微调、回退或保存任何资产。',
+].join('\n')
+
+export interface AgentFunctionDefinition {
+  name: typeof GET_WORKFLOW_CONTEXT
+  description: string
+  parameters: {
+    type: 'object'
+    properties: Record<string, never>
+    additionalProperties: false
+  }
+}
+
+export const QUICK_START_AGENT_TOOLS: readonly AgentFunctionDefinition[] = [
+  {
+    name: GET_WORKFLOW_CONTEXT,
+    description: '读取当前 Quick Start WorkflowRun 的阶段与节点状态，不修改任何业务数据。',
+    parameters: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+]
+
+export interface AgentFunctionCall {
+  callId: string
+  name: string
+  arguments: Record<string, unknown>
+}
+
+export type AgentTransportMessage =
+  | { role: 'user'; content: string }
+  | { role: 'assistant'; content: string; functionCall?: AgentFunctionCall }
+  | { role: 'tool'; callId: string; name: string; content: string }
+
+export interface AgentTransportRequest {
+  instructions: string
+  messages: readonly AgentTransportMessage[]
+  tools: readonly AgentFunctionDefinition[]
+  signal?: AbortSignal
+}
+
+export type AgentTransportEvent =
+  | { type: 'text'; text: string }
+  | ({ type: 'function-call' } & AgentFunctionCall)
+  | { type: 'completed' }
+  | { type: 'failed'; error: string }
+
+/** 模型 SDK、HTTP 与流协议留给适配器；Quick Start 只依赖这一条可注入边界。 */
+export interface AgentTransport {
+  stream(request: AgentTransportRequest): AsyncIterable<AgentTransportEvent>
+}
+
+export type QuickStartAgentRuntimeEvent =
+  | { type: 'text'; text: string }
+  | ({ type: 'function-call' } & AgentFunctionCall)
+  | { type: 'tool-result'; callId: string; name: typeof GET_WORKFLOW_CONTEXT; content: string }
+  | { type: 'completed' }
+  | { type: 'failed'; error: string }
+
+interface WorkflowNodeContext {
+  id: string
+  type: WorkflowNode['type']
+  status: WorkflowNode['status']
+  phase: WorkflowNode['phase']
+  error: string | null
+}
+
+export interface QuickStartWorkflowContext {
+  runId: string
+  projectId: string
+  version: number
+  characterPrompt: string | null
+  currentNode: WorkflowNodeContext | null
+  nodes: WorkflowNodeContext[]
+}
+
+function nodeContext(node: WorkflowNode): WorkflowNodeContext {
+  return {
+    id: node.id,
+    type: node.type,
+    status: node.status,
+    phase: node.phase,
+    error: node.error,
+  }
+}
+
+/**
+ * Agent 只看懂回答当前进度所需的投影，不接触任务引用、媒体地址或完整节点输入。
+ * 所有业务写入仍只能发生在 QuickStartSession 背后的 WorkflowController。
+ */
+export function getQuickStartWorkflowContext(run: WorkflowRun): QuickStartWorkflowContext {
+  const nodes = run.nodes.filter((node) => !node.deletedAt)
+  const setup = nodes.find((node) => node.type === 'character-setup')
+  const current =
+    nodes.findLast((node) => node.status === 'active' || node.status === 'failed') ??
+    nodes.at(-1) ??
+    null
+
+  return {
+    runId: run.id,
+    projectId: run.projectId,
+    version: run.version,
+    characterPrompt: setup?.type === 'character-setup' ? setup.input.prompt : null,
+    currentNode: current ? nodeContext(current) : null,
+    nodes: nodes.map(nodeContext),
+  }
+}
+
+export interface RunQuickStartAgentTurnOptions {
+  transport: AgentTransport
+  history: readonly AgentTransportMessage[]
+  input: string
+  getWorkflow: () => WorkflowRun
+  signal?: AbortSignal
+  onEvent?: (event: QuickStartAgentRuntimeEvent) => void
+}
+
+export interface QuickStartAgentTurnResult {
+  history: AgentTransportMessage[]
+  assistantText: string
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+/** 执行一轮最小 Agent 循环；一轮最多读一次上下文，避免模型自行扩张调用链。 */
+export async function runQuickStartAgentTurn({
+  transport,
+  history,
+  input,
+  getWorkflow,
+  signal,
+  onEvent,
+}: RunQuickStartAgentTurnOptions): Promise<QuickStartAgentTurnResult> {
+  const normalizedInput = input.trim()
+  if (!normalizedInput) throw new Error('Agent 消息不能为空')
+
+  const messages: AgentTransportMessage[] = [...history, { role: 'user', content: normalizedInput }]
+  let assistantText = ''
+  let functionCallCount = 0
+  let failureEmitted = false
+
+  try {
+    while (true) {
+      let responseText = ''
+      let pendingFunctionCall: AgentFunctionCall | null = null
+      let completed = false
+
+      for await (const event of transport.stream({
+        instructions: QUICK_START_AGENT_INSTRUCTIONS,
+        messages: [...messages],
+        tools: QUICK_START_AGENT_TOOLS,
+        signal,
+      })) {
+        if (event.type === 'text') {
+          responseText += event.text
+          assistantText += event.text
+          onEvent?.(event)
+          continue
+        }
+        if (event.type === 'function-call') {
+          functionCallCount += 1
+          if (functionCallCount > 1) throw new Error('每轮最多调用一次 function')
+          if (event.name !== GET_WORKFLOW_CONTEXT) {
+            throw new Error(`不支持 function：${event.name}`)
+          }
+          if (Object.keys(event.arguments).length > 0) {
+            throw new Error(`${GET_WORKFLOW_CONTEXT} 不接受参数`)
+          }
+          pendingFunctionCall = {
+            callId: event.callId,
+            name: event.name,
+            arguments: event.arguments,
+          }
+          onEvent?.(event)
+          continue
+        }
+        if (event.type === 'failed') {
+          failureEmitted = true
+          onEvent?.(event)
+          throw new Error(event.error)
+        }
+        completed = true
+        break
+      }
+
+      if (pendingFunctionCall) {
+        messages.push({
+          role: 'assistant',
+          content: responseText,
+          functionCall: pendingFunctionCall,
+        })
+        const content = JSON.stringify(getQuickStartWorkflowContext(getWorkflow()))
+        messages.push({
+          role: 'tool',
+          callId: pendingFunctionCall.callId,
+          name: GET_WORKFLOW_CONTEXT,
+          content,
+        })
+        onEvent?.({
+          type: 'tool-result',
+          callId: pendingFunctionCall.callId,
+          name: GET_WORKFLOW_CONTEXT,
+          content,
+        })
+        continue
+      }
+
+      if (!completed) throw new Error('Agent Transport 未发送完成事件')
+      messages.push({ role: 'assistant', content: responseText })
+      onEvent?.({ type: 'completed' })
+      return { history: messages, assistantText }
+    }
+  } catch (cause) {
+    if (!failureEmitted) onEvent?.({ type: 'failed', error: errorMessage(cause) })
+    throw cause
+  }
+}

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { QuickStartEntryService, QuickStartSession } from './service'
 import { WorkflowRunConflictError, type WorkflowRun } from '@/entities'
 import type { ExportPackageModel } from '@/features/export-package'
+import type { AgentTransport, AgentTransportEvent } from './agent-runtime'
 import { QuickStartPage } from './index'
 
 afterEach(() => {
@@ -148,7 +149,7 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
-function renderAt(path: string, service: QuickStartEntryService) {
+function renderAt(path: string, service: QuickStartEntryService, agentTransport?: AgentTransport) {
   function PlaytestLocation() {
     const location = useLocation()
     return <h1>{`${location.pathname}${location.search}`}</h1>
@@ -156,8 +157,14 @@ function renderAt(path: string, service: QuickStartEntryService) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/quick-start" element={<QuickStartPage service={service} />} />
-        <Route path="/quick-start/:runId" element={<QuickStartPage service={service} />} />
+        <Route
+          path="/quick-start"
+          element={<QuickStartPage service={service} agentTransport={agentTransport} />}
+        />
+        <Route
+          path="/quick-start/:runId"
+          element={<QuickStartPage service={service} agentTransport={agentTransport} />}
+        />
         <Route path="/projects/:projectId/assets" element={<PlaytestLocation />} />
         <Route path="/playtest/:characterId/:outfitId" element={<PlaytestLocation />} />
       </Routes>
@@ -169,6 +176,7 @@ function renderWithRunSwitcher(
   service: QuickStartEntryService,
   initialRunId: string,
   nextRunId: string,
+  agentTransport?: AgentTransport,
 ) {
   function Controls() {
     const navigate = useNavigate()
@@ -187,10 +195,17 @@ function renderWithRunSwitcher(
     <MemoryRouter initialEntries={[`/quick-start/${initialRunId}`]}>
       <Controls />
       <Routes>
-        <Route path="/quick-start/:runId" element={<QuickStartPage service={service} />} />
+        <Route
+          path="/quick-start/:runId"
+          element={<QuickStartPage service={service} agentTransport={agentTransport} />}
+        />
       </Routes>
     </MemoryRouter>,
   )
+}
+
+async function* agentEvents(...items: AgentTransportEvent[]): AsyncIterable<AgentTransportEvent> {
+  yield* items
 }
 
 function renderStateFixture(
@@ -685,6 +700,76 @@ describe('QuickStartPage', () => {
     expect(transcript.className).toContain('content-end')
     expect(turns.slice(0, -1).every((turn) => turn.dataset.currentTurn === 'false')).toBe(true)
     expect(turns.at(-1)?.dataset.currentTurn).toBe('true')
+  })
+
+  it('uses an injected Agent transport for free-form conversation without changing workflow state', async () => {
+    const run = actionWorkflow({ fullStatus: 'active' })
+    const service = serviceFor(run)
+    const transport: AgentTransport = {
+      stream: vi.fn(() =>
+        agentEvents(
+          { type: 'text', text: '我看到了。' },
+          { type: 'text', text: '当前正在生成完整动作。' },
+          { type: 'completed' },
+        ),
+      ),
+    }
+    renderAt('/quick-start/run-1', service, transport)
+
+    await screen.findByTestId('quick-start-transcript')
+    fireEvent.change(screen.getByLabelText('继续描述你的想法'), {
+      target: { value: '现在做到哪一步了？' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+
+    expect(await screen.findByText('现在做到哪一步了？')).toBeTruthy()
+    expect(await screen.findByText('我看到了。当前正在生成完整动作。')).toBeTruthy()
+    expect(transport.stream).toHaveBeenCalledTimes(1)
+    expect(service.getWorkflow).toHaveBeenCalled()
+    expect(service.confirmCandidate).not.toHaveBeenCalled()
+    expect(service.confirmFirstFrame).not.toHaveBeenCalled()
+  })
+
+  it('drops temporary Agent messages when the selected run changes', async () => {
+    const run = actionWorkflow({ fullStatus: 'active' })
+    const service = serviceFor(run)
+    const transport: AgentTransport = {
+      stream: () =>
+        agentEvents({ type: 'text', text: '这条消息只属于 run-1。' }, { type: 'completed' }),
+    }
+    renderWithRunSwitcher(service, 'run-1', 'run-2', transport)
+
+    await screen.findByTestId('quick-start-transcript')
+    fireEvent.change(screen.getByLabelText('继续描述你的想法'), {
+      target: { value: '记住当前进度' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+    expect(await screen.findByText('这条消息只属于 run-1。')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: '切换当前运行' }))
+    await waitFor(() =>
+      expect(screen.getByLabelText('当前位置').textContent).toBe('/quick-start/run-2'),
+    )
+    await screen.findByTestId('quick-start-transcript')
+    expect(screen.queryByText('记住当前进度')).toBeNull()
+    expect(screen.queryByText('这条消息只属于 run-1。')).toBeNull()
+  })
+
+  it('shows an Agent transport failure without replacing the workflow error channel', async () => {
+    const run = actionWorkflow({ fullStatus: 'active' })
+    const transport: AgentTransport = {
+      stream: () => agentEvents({ type: 'failed', error: '对话服务暂时不可用' }),
+    }
+    renderAt('/quick-start/run-1', serviceFor(run), transport)
+
+    await screen.findByTestId('quick-start-transcript')
+    fireEvent.change(screen.getByLabelText('继续描述你的想法'), {
+      target: { value: '帮我看一下' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+
+    expect(await screen.findByLabelText('对话服务暂时不可用')).toBeTruthy()
+    expect(screen.getByText('帮我看一下')).toBeTruthy()
   })
 
   it('hands the creation entry off to the generating canvas instead of hard-cutting routes', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -19,6 +19,11 @@ import {
   WorkflowRunConflictError,
 } from '@/entities'
 import { ExportButton, type ExportPackageModel } from '@/features/export-package'
+import {
+  runQuickStartAgentTurn,
+  type AgentTransport,
+  type AgentTransportMessage,
+} from './agent-runtime'
 import { KineticCopyCycle, type KineticCopyMessage } from './kinetic-copy-cycle'
 import {
   quickStartService,
@@ -34,6 +39,14 @@ export type {
   QuickStartEntryService,
   QuickStartSession,
 } from './service'
+export type {
+  AgentFunctionDefinition,
+  AgentTransport,
+  AgentTransportEvent,
+  AgentTransportMessage,
+  AgentTransportRequest,
+  QuickStartAgentRuntimeEvent,
+} from './agent-runtime'
 
 const STYLE_PROMPTS = [
   {
@@ -119,10 +132,12 @@ export interface QuickStartPageProps {
    * 未注入时，Quick Start 自己装配真实实体接口，避免 app 层承担流程细节。
    */
   service?: QuickStartEntryService
+  /** 未配置模型适配器时，完整保留原有确定性 Quick Start 行为。 */
+  agentTransport?: AgentTransport
 }
 
 /** Quick Start 独立完成 AI 入口；它不跳转 Workflow Editor。 */
-export function QuickStartPage({ service }: QuickStartPageProps) {
+export function QuickStartPage({ service, agentTransport }: QuickStartPageProps) {
   const { runId } = useParams()
   const [searchParams] = useSearchParams()
   const activeService = useMemo(() => {
@@ -138,6 +153,7 @@ export function QuickStartPage({ service }: QuickStartPageProps) {
     <QuickStartRun
       key={runId}
       service={activeService}
+      agentTransport={agentTransport}
       runId={runId}
       initialSession={createdSession?.runId === runId ? createdSession : null}
       onSessionCreated={setCreatedSession}
@@ -592,12 +608,14 @@ function GenerationCanvas({ label }: { label: string }) {
 
 function QuickStartRun({
   service,
+  agentTransport,
   runId,
   initialSession,
   onSessionCreated,
   onInitialSessionConsumed,
 }: {
   service: QuickStartEntryService
+  agentTransport?: AgentTransport
   runId: string
   initialSession: QuickStartSession | null
   onSessionCreated: (session: QuickStartSession) => void
@@ -620,6 +638,11 @@ function QuickStartRun({
   const [publishing, setPublishing] = useState(false)
   const [confirmingCandidate, setConfirmingCandidate] = useState(false)
   const [confirmingFirstFrame, setConfirmingFirstFrame] = useState(false)
+  const [agentTurns, setAgentTurns] = useState<
+    readonly { id: number; role: 'user' | 'assistant'; content: string }[]
+  >([])
+  const [agentBusy, setAgentBusy] = useState(false)
+  const [agentError, setAgentError] = useState<string | null>(null)
   const automaticPublishAttempt = useRef<string | null>(null)
   const transcriptScrollRegion = useRef<HTMLElement>(null)
   const workflowConflictRef = useRef(false)
@@ -630,6 +653,9 @@ function QuickStartRun({
     timer: ReturnType<typeof setTimeout>
   } | null>(null)
   const mountedRef = useRef(true)
+  const agentHistoryRef = useRef<readonly AgentTransportMessage[]>([])
+  const agentAbortController = useRef<AbortController | null>(null)
+  const agentTurnId = useRef(0)
   const reportWorkflowError = useCallback((cause: unknown, fallback: string) => {
     const presented = presentWorkflowError(cause, fallback)
     if (workflowConflictRef.current && !presented.conflict) return
@@ -648,6 +674,7 @@ function QuickStartRun({
     return () => {
       mountedRef.current = false
       activeSessionRef.current = null
+      agentAbortController.current?.abort()
     }
   }, [])
 
@@ -796,7 +823,7 @@ function QuickStartRun({
   useEffect(() => {
     const region = transcriptScrollRegion.current
     region?.scrollTo?.({ top: region.scrollHeight, behavior: 'smooth' })
-  }, [actionFrames, candidates, firstFrameCandidates, run])
+  }, [actionFrames, agentTurns, candidates, firstFrameCandidates, run])
 
   if (!run) {
     return (
@@ -933,6 +960,72 @@ function QuickStartRun({
     }
   }
 
+  async function sendAgentMessage() {
+    const targetSession = session
+    const prompt = actionDescription.trim()
+    if (
+      !agentTransport ||
+      !targetSession ||
+      !prompt ||
+      agentBusy ||
+      workflowConflictRef.current ||
+      activeSessionRef.current !== targetSession
+    )
+      return
+
+    const userTurnId = ++agentTurnId.current
+    const assistantTurnId = ++agentTurnId.current
+    const abortController = new AbortController()
+    agentAbortController.current = abortController
+    setActionDescription('')
+    setAgentError(null)
+    setAgentBusy(true)
+    setAgentTurns((current) => [...current, { id: userTurnId, role: 'user', content: prompt }])
+
+    try {
+      const result = await runQuickStartAgentTurn({
+        transport: agentTransport,
+        history: agentHistoryRef.current,
+        input: prompt,
+        getWorkflow: () => targetSession.getWorkflow(),
+        signal: abortController.signal,
+        onEvent(event) {
+          if (
+            !mountedRef.current ||
+            abortController.signal.aborted ||
+            activeSessionRef.current !== targetSession
+          )
+            return
+          if (event.type === 'text') {
+            setAgentTurns((current) => {
+              const existing = current.find((turn) => turn.id === assistantTurnId)
+              return existing
+                ? current.map((turn) =>
+                    turn.id === assistantTurnId
+                      ? { ...turn, content: turn.content + event.text }
+                      : turn,
+                  )
+                : [...current, { id: assistantTurnId, role: 'assistant', content: event.text }]
+            })
+          }
+          if (event.type === 'failed') setAgentError(event.error)
+        },
+      })
+      if (
+        mountedRef.current &&
+        !abortController.signal.aborted &&
+        activeSessionRef.current === targetSession
+      ) {
+        agentHistoryRef.current = result.history
+      }
+    } catch {
+      // runtime 已通过 failed 事件提供可展示错误；这里仅结束本轮提交状态。
+    } finally {
+      if (agentAbortController.current === abortController) agentAbortController.current = null
+      if (mountedRef.current && activeSessionRef.current === targetSession) setAgentBusy(false)
+    }
+  }
+
   function continueConversation(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     if (workflowConflictRef.current) return
@@ -944,6 +1037,7 @@ function QuickStartRun({
       void confirmFirstFrame()
       return
     }
+    if (agentTransport) void sendAgentMessage()
   }
 
   const composerPlaceholder = isTemplateSelecting
@@ -954,15 +1048,22 @@ function QuickStartRun({
       ? selectedFirstFrame
         ? '按发送确认这张首帧…'
         : '先从上面选择一个动作首帧…'
-      : workflowHasFailure(run)
-        ? '这次未完成，可以新建一次创作…'
-        : canPublish
-          ? '确认保存后，还可以继续描述修改…'
-          : '制作中，完成后可以继续修改…'
+      : agentTransport
+        ? '继续描述你的想法…'
+        : workflowHasFailure(run)
+          ? '这次未完成，可以新建一次创作…'
+          : canPublish
+            ? '确认保存后，还可以继续描述修改…'
+            : '制作中，完成后可以继续修改…'
 
   const composerCanSubmit =
     (isTemplateSelecting && Boolean(selectedCandidate)) ||
-    (isFirstFrameSelecting && Boolean(selectedFirstFrame))
+    (isFirstFrameSelecting && Boolean(selectedFirstFrame)) ||
+    (Boolean(agentTransport) &&
+      !isTemplateSelecting &&
+      !isFirstFrameSelecting &&
+      !agentBusy &&
+      Boolean(actionDescription.trim()))
   const selectedTemplateUrl = templateStep?.selectedImageUrl
   const selectedFirstFrameUrl = firstFrameStep?.selectedFirstFrameUrl
   const requestedAction = firstFrameStep?.input.prompt || firstFrameStep?.input.name
@@ -1278,6 +1379,15 @@ function QuickStartRun({
                 </AgentTurn>
               </>
             ) : null}
+
+            {agentTurns.map((turn) =>
+              turn.role === 'user' ? (
+                <UserTurn key={turn.id}>{turn.content}</UserTurn>
+              ) : (
+                <AgentCopy key={turn.id} lines={[turn.content]} />
+              ),
+            )}
+            {agentError ? <AgentCopy tone="danger" lines={[agentError]} /> : null}
 
             {error ? (
               <div


### PR DESCRIPTION
为 Quick Start 增加最小前端 Agent runtime，在不建立第二套业务状态机的前提下支持自然语言对话与只读工作流上下文查询。

## Why

现有 Quick Start 具备对话式界面，但交互流程仍是确定性的页面逻辑，无法接入模型流式响应与 function call。需要先建立稳定、可替换的前端 Agent 边界，同时确保所有业务动作继续由 WorkflowController 管理。

## Changes

- 增加可注入的 `AgentTransport`，支持文本、function call、tool result、完成与失败事件。
- 提供唯一只读 function `get_workflow_context()`。
- 在现有 Quick Start 对话壳中展示临时用户与 Agent 消息。
- 切换 WorkflowRun 或离开页面时清空临时会话。
- 未配置 Transport 时保持原有 Quick Start 行为。

## Implementation

- Agent runtime 不依赖具体模型 SDK 或后端协议。
- 工作流上下文通过 `QuickStartSession.getWorkflow()` 获取，并过滤媒体地址、Generation task 与已删除节点。
- 每轮最多执行一次 function call；未知 function、重复调用及完成后的迟到事件均失败关闭。
- 所有现有确认与生成动作继续通过 QuickStartSession 背后的 WorkflowController 执行。

## Verification

- [x] `npm test -- --run src/pages/quick-start/agent-runtime.test.ts src/pages/quick-start/index.test.tsx`：68 tests passed
- [x] `npm run build`：通过
- [x] 定向 `oxlint`、`oxfmt --check`：通过
- [x] `git diff --check upstream/main...HEAD`：通过
- [ ] `npm run test:coverage`：未在本地运行全量门禁，由 GitHub CI 执行

## Scope

- 本 PR 不包含：真实模型适配器、后端 `/ai/chat`、写 Tool、重生成、微调、回退、Memory、多 Session 或 MCP。
- 后续事项：在独立 PR 中接入具体 Transport 与后端模型通道。

## Related Issues

Closes #410
Refs #409
