### PR TITLE
feat(quick-start): add LLM prompt conversation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@xyflow/react": "^12.11.2",
+        "eventsource-parser": "^4.0.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-router": "^8.3.0"
+        "react-router": "^8.3.0",
+        "valibot": "^1.4.2"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.3",
@@ -2731,6 +2733,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-4.0.0.tgz",
+      "integrity": "sha512-aIpvYxbqTx4KYWw73KpCt1Rh22tEAJ144F1qR76CT3Ex+LNMEPKf5HFrK5Yz9fMP1EVT0GrfA35VZvWQhMPuSQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -3825,7 +3836,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3859,6 +3870,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,9 +17,11 @@
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
     "@xyflow/react": "^12.11.2",
+    "eventsource-parser": "^4.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router": "^8.3.0"
+    "react-router": "^8.3.0",
+    "valibot": "^1.4.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",

--- a/frontend/src/features/quick-start-conversation/api.test.ts
+++ b/frontend/src/features/quick-start-conversation/api.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createQuickStartConversationClient } from './api'
+
+function sseResponse(records: readonly string[], init: ResponseInit = {}) {
+  const encoder = new TextEncoder()
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const record of records) controller.enqueue(encoder.encode(record))
+        controller.close()
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+      ...init,
+    },
+  )
+}
+
+describe('Quick Start conversation client', () => {
+  it('sends bounded chat history and parses a fragmented prompt suggestion', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      sseResponse([
+        'data: {"choices":[{"delta":{"content":"{\\"type\\":\\"prompt_"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"suggestion\\",\\"reply\\":\\"整理好了\\",\\"optimizedPrompt\\":\\"单一角色，红衣金毛\\",\\"warnings\\":[]}"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    )
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn,
+      getAccessToken: () => 'access-token',
+    })
+
+    await expect(
+      client.respond([
+        { role: 'user', content: '一群奔跑的大狗' },
+        { role: 'assistant', content: '请只保留一个角色。' },
+        { role: 'user', content: '一只穿红色飞行夹克的金毛' },
+      ]),
+    ).resolves.toEqual({
+      type: 'prompt_suggestion',
+      reply: '整理好了',
+      optimizedPrompt: '单一角色，红衣金毛',
+      warnings: [],
+    })
+
+    expect(fetchFn).toHaveBeenCalledOnce()
+    const [url, request] = fetchFn.mock.calls[0]!
+    expect(url).toBe('/api/ai/chat')
+    expect(new Headers(request?.headers).get('authorization')).toBe('Bearer access-token')
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      messages: [
+        { role: 'user', content: '一群奔跑的大狗' },
+        { role: 'assistant', content: '请只保留一个角色。' },
+        { role: 'user', content: '一只穿红色飞行夹克的金毛' },
+      ],
+    })
+    expect(JSON.parse(String(request?.body))).not.toHaveProperty('tools')
+  })
+
+  it('rejects model output that does not match the conversation schema', async () => {
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn: async () =>
+        sseResponse([
+          'data: {"choices":[{"delta":{"content":"随便生成一个就好"}}]}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      getAccessToken: () => null,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '随便画一个' }])).rejects.toThrow(
+      'LLM 返回格式无效',
+    )
+  })
+
+  it('rejects an unterminated stream instead of accepting partial output', async () => {
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn: async () =>
+        sseResponse([
+          'data: {"choices":[{"delta":{"content":"{\\"type\\":\\"clarification\\",\\"reply\\":\\"请补充外观"}}]}\n\n',
+        ]),
+      getAccessToken: () => null,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).rejects.toThrow(
+      'LLM 响应未完成',
+    )
+  })
+
+  it('replays the chat request once after the existing session recovers a 401', async () => {
+    let accessToken = 'expired-token'
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(
+        sseResponse([
+          'data: {"choices":[{"delta":{"content":"{\\"type\\":\\"clarification\\",\\"reply\\":\\"请补充角色外观\\"}"}}]}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      )
+    const recoverUnauthorized = vi.fn(async () => {
+      accessToken = 'fresh-token'
+      return true
+    })
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn,
+      getAccessToken: () => accessToken,
+      recoverUnauthorized,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).resolves.toEqual({
+      type: 'clarification',
+      reply: '请补充角色外观',
+    })
+    expect(recoverUnauthorized).toHaveBeenCalledOnce()
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(new Headers(fetchFn.mock.calls[1]?.[1]?.headers).get('authorization')).toBe(
+      'Bearer fresh-token',
+    )
+  })
+
+  it('recovers the backend HTTP 200 business 401 before reading the event stream', async () => {
+    let accessToken = 'expired-token'
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json({ code: 401, message: '登录已过期', data: null }, { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        sseResponse([
+          'data: {"choices":[{"delta":{"content":"{\\"type\\":\\"clarification\\",\\"reply\\":\\"请补充角色外观\\"}"}}]}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      )
+    const recoverUnauthorized = vi.fn(async () => {
+      accessToken = 'fresh-token'
+      return true
+    })
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn,
+      getAccessToken: () => accessToken,
+      recoverUnauthorized,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).resolves.toEqual({
+      type: 'clarification',
+      reply: '请补充角色外观',
+    })
+    expect(recoverUnauthorized).toHaveBeenCalledOnce()
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('finishes as soon as the stream emits DONE even if the connection remains open', async () => {
+    const encoder = new TextEncoder()
+    let streamCancelled = false
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"choices":[{"delta":{"content":"{\\"type\\":\\"clarification\\",\\"reply\\":\\"请补充角色外观\\"}"}}]}\n\ndata: [DONE]\n\n',
+            ),
+          )
+        },
+        cancel() {
+          streamCancelled = true
+        },
+      }),
+      { headers: { 'content-type': 'text/event-stream' } },
+    )
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn: async () => response,
+      getAccessToken: () => null,
+    })
+
+    await expect(
+      Promise.race([
+        client.respond([{ role: 'user', content: '一个角色' }]),
+        new Promise((resolve) => setTimeout(() => resolve('still pending'), 50)),
+      ]),
+    ).resolves.toEqual({ type: 'clarification', reply: '请补充角色外观' })
+    expect(streamCancelled).toBe(true)
+  })
+})

--- a/frontend/src/features/quick-start-conversation/api.test.ts
+++ b/frontend/src/features/quick-start-conversation/api.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createQuickStartConversationClient } from './api'
+
+afterEach(() => vi.unstubAllGlobals())
 
 function sseResponse(records: readonly string[], init: ResponseInit = {}) {
   const encoder = new TextEncoder()
@@ -61,6 +63,26 @@ describe('Quick Start conversation client', () => {
     expect(JSON.parse(String(request?.body))).not.toHaveProperty('tools')
   })
 
+  it('uses the global fetch implementation when no transport override is provided', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      sseResponse([
+        'data: {"choices":[{"delta":{"content":"{\\"type\\":\\"clarification\\",\\"reply\\":\\"请补充角色外观\\"}"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    )
+    vi.stubGlobal('fetch', fetchFn)
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      getAccessToken: () => null,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).resolves.toEqual({
+      type: 'clarification',
+      reply: '请补充角色外观',
+    })
+    expect(fetchFn).toHaveBeenCalledOnce()
+  })
+
   it('rejects model output that does not match the conversation schema', async () => {
     const client = createQuickStartConversationClient({
       baseUrl: '/api',
@@ -75,6 +97,101 @@ describe('Quick Start conversation client', () => {
     await expect(client.respond([{ role: 'user', content: '随便画一个' }])).rejects.toThrow(
       'LLM 返回格式无效',
     )
+  })
+
+  it('rejects malformed JSON inside an SSE data event', async () => {
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn: async () => sseResponse(['data: not-json\n\n']),
+      getAccessToken: () => null,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).rejects.toThrow(
+      'LLM 流包含无效 JSON',
+    )
+  })
+
+  it('rejects a non-string content delta', async () => {
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn: async () => sseResponse(['data: {"choices":[{"delta":{"content":42}}]}\n\n']),
+      getAccessToken: () => null,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).rejects.toThrow(
+      'LLM 文本分片格式无效',
+    )
+  })
+
+  it('ignores metadata-only and null-content deltas', async () => {
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn: async () =>
+        sseResponse([
+          'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n',
+          'data: {"choices":[{"delta":{"content":null}}]}\n\n',
+          'data: {"choices":[{"delta":{"content":"{\\"type\\":\\"clarification\\",\\"reply\\":\\"请补充角色外观\\"}"}}]}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      getAccessToken: () => null,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).resolves.toEqual({
+      type: 'clarification',
+      reply: '请补充角色外观',
+    })
+  })
+
+  it('rejects malformed SSE fields received before the stream closes', async () => {
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn: async () => sseResponse(['retry: nope\n\n']),
+      getAccessToken: () => null,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).rejects.toThrow(
+      'LLM 流格式无效',
+    )
+  })
+
+  it('rejects a malformed pending SSE field when the stream closes', async () => {
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn: async () => sseResponse(['retry: nope']),
+      getAccessToken: () => null,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).rejects.toThrow(
+      'LLM 流格式无效',
+    )
+  })
+
+  it.each([
+    {
+      name: 'HTTP failure',
+      response: () => new Response(null, { status: 503 }),
+      message: 'LLM 请求失败（HTTP 503）',
+    },
+    {
+      name: 'missing response body',
+      response: () =>
+        new Response(null, { status: 200, headers: { 'content-type': 'text/event-stream' } }),
+      message: 'LLM 响应缺少消息流',
+    },
+    {
+      name: 'invalid JSON business response',
+      response: () =>
+        new Response('{', { status: 200, headers: { 'content-type': 'application/json' } }),
+      message: 'LLM 响应类型无效',
+    },
+  ])('rejects $name', async ({ response, message }) => {
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn: async () => response(),
+      getAccessToken: () => null,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).rejects.toThrow(message)
   })
 
   it('rejects an unterminated stream instead of accepting partial output', async () => {
@@ -125,6 +242,23 @@ describe('Quick Start conversation client', () => {
     )
   })
 
+  it('does not replay an unauthorized request when session recovery declines', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () => new Response(null, { status: 401 }))
+    const recoverUnauthorized = vi.fn(async () => false)
+    const client = createQuickStartConversationClient({
+      baseUrl: '/api',
+      fetchFn,
+      getAccessToken: () => 'expired-token',
+      recoverUnauthorized,
+    })
+
+    await expect(client.respond([{ role: 'user', content: '一个角色' }])).rejects.toThrow(
+      'LLM 请求失败（HTTP 401）',
+    )
+    expect(fetchFn).toHaveBeenCalledOnce()
+    expect(recoverUnauthorized).toHaveBeenCalledOnce()
+  })
+
   it('recovers the backend HTTP 200 business 401 before reading the event stream', async () => {
     let accessToken = 'expired-token'
     const fetchFn = vi
@@ -165,7 +299,7 @@ describe('Quick Start conversation client', () => {
         start(controller) {
           controller.enqueue(
             encoder.encode(
-              'data: {"choices":[{"delta":{"content":"{\\"type\\":\\"clarification\\",\\"reply\\":\\"请补充角色外观\\"}"}}]}\n\ndata: [DONE]\n\n',
+              'data: {"choices":[{"delta":{"content":"{\\"type\\":\\"clarification\\",\\"reply\\":\\"请补充角色外观\\"}"}}]}\n\ndata: [DONE]\n\ndata: not-json\n\n',
             ),
           )
         },

--- a/frontend/src/features/quick-start-conversation/api.ts
+++ b/frontend/src/features/quick-start-conversation/api.ts
@@ -1,0 +1,184 @@
+import { createParser } from 'eventsource-parser'
+import * as v from 'valibot'
+
+export type QuickStartConversationMessage = {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export type QuickStartConversationResult =
+  | { type: 'clarification'; reply: string }
+  | {
+      type: 'prompt_suggestion'
+      reply: string
+      optimizedPrompt: string
+      warnings: string[]
+    }
+
+export interface QuickStartConversationClient {
+  respond(
+    messages: readonly QuickStartConversationMessage[],
+    signal?: AbortSignal,
+  ): Promise<QuickStartConversationResult>
+}
+
+export interface CreateQuickStartConversationClientOptions {
+  baseUrl: string
+  fetchFn?: typeof fetch
+  getAccessToken: () => string | null | undefined
+  recoverUnauthorized?: () => Promise<boolean>
+}
+
+const nonEmptyText = v.pipe(v.string(), v.trim(), v.minLength(1))
+const responseSchema = v.variant('type', [
+  v.object({
+    type: v.literal('clarification'),
+    reply: nonEmptyText,
+  }),
+  v.object({
+    type: v.literal('prompt_suggestion'),
+    reply: nonEmptyText,
+    optimizedPrompt: nonEmptyText,
+    warnings: v.array(nonEmptyText),
+  }),
+])
+
+const QUICK_START_SYSTEM_PROMPT = `你是 Windup Quick Start 的角色描述助手，只处理单一角色母版的创作输入。
+保留用户明确给出的身份、外观和风格，不擅自增加或删除核心设定。
+信息不足、多主体、复杂场景或描述冲突时，每次只追问一个最关键的问题。
+信息充分时，将口语描述整理为适合单角色、完整身体和后续动作生成的提示词。
+只返回 JSON，不要使用 Markdown。格式只能是：
+{"type":"clarification","reply":"一个明确问题"}
+或
+{"type":"prompt_suggestion","reply":"简短说明","optimizedPrompt":"优化后的提示词","warnings":["必要提醒"]}`
+
+function chatEndpoint(baseUrl: string) {
+  return `${baseUrl.replace(/\/+$/u, '')}/ai/chat`
+}
+
+function parseDelta(value: string): string {
+  let payload: unknown
+  try {
+    payload = JSON.parse(value)
+  } catch (cause) {
+    throw new Error('LLM 流包含无效 JSON', { cause })
+  }
+  const content = (payload as { choices?: Array<{ delta?: { content?: unknown } }> }).choices?.[0]
+    ?.delta?.content
+  if (content === undefined || content === null) return ''
+  if (typeof content !== 'string') throw new Error('LLM 文本分片格式无效')
+  return content
+}
+
+async function readOpenAiEventStream(response: Response): Promise<string> {
+  if (!response.ok) throw new Error(`LLM 请求失败（HTTP ${response.status}）`)
+  if (!response.headers.get('content-type')?.includes('text/event-stream')) {
+    throw new Error('LLM 响应类型无效')
+  }
+  if (!response.body) throw new Error('LLM 响应缺少消息流')
+
+  let content = ''
+  let completed = false
+  let streamError: Error | null = null
+  const parser = createParser({
+    maxBufferSize: 128 * 1024,
+    onError(error) {
+      streamError = new Error('LLM 流格式无效', { cause: error })
+    },
+    onEvent(event) {
+      if (completed) return
+      if (event.data === '[DONE]') {
+        completed = true
+        return
+      }
+      content += parseDelta(event.data)
+    },
+  })
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      parser.feed(decoder.decode(value, { stream: true }))
+      if (streamError) throw streamError
+      if (completed) {
+        await reader.cancel()
+        break
+      }
+    }
+    if (!completed) {
+      parser.feed(decoder.decode())
+      parser.reset({ consume: true })
+      if (streamError) throw streamError
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  if (!completed) throw new Error('LLM 响应未完成')
+  return content
+}
+
+async function isBusinessUnauthorized(response: Response): Promise<boolean> {
+  if (
+    response.status !== 200 ||
+    !response.headers.get('content-type')?.includes('application/json')
+  ) {
+    return false
+  }
+  try {
+    const payload: unknown = await response.clone().json()
+    return (
+      typeof payload === 'object' &&
+      payload !== null &&
+      !Array.isArray(payload) &&
+      (payload as { code?: unknown }).code === 401
+    )
+  } catch {
+    return false
+  }
+}
+
+export function createQuickStartConversationClient(
+  options: CreateQuickStartConversationClientOptions,
+): QuickStartConversationClient {
+  const fetchFn = options.fetchFn ?? globalThis.fetch
+  return {
+    async respond(messages, signal) {
+      const body = JSON.stringify({
+        system: QUICK_START_SYSTEM_PROMPT,
+        messages: messages.slice(-8),
+      })
+      const request = () => {
+        const headers = new Headers({
+          Accept: 'text/event-stream',
+          'Content-Type': 'application/json',
+        })
+        const accessToken = options.getAccessToken()
+        if (accessToken) headers.set('Authorization', `Bearer ${accessToken}`)
+        return fetchFn(chatEndpoint(options.baseUrl), {
+          method: 'POST',
+          headers,
+          credentials: 'include',
+          signal,
+          body,
+        })
+      }
+      let response = await request()
+      const unauthorized = response.status === 401 || (await isBusinessUnauthorized(response))
+      if (unauthorized && options.recoverUnauthorized) {
+        if (await options.recoverUnauthorized()) response = await request()
+      }
+      const content = await readOpenAiEventStream(response)
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(content)
+      } catch (cause) {
+        throw new Error('LLM 返回格式无效', { cause })
+      }
+      const result = v.safeParse(responseSchema, parsed)
+      if (!result.success) throw new Error('LLM 返回格式无效', { cause: result.issues })
+      return result.output
+    },
+  }
+}

--- a/frontend/src/features/quick-start-conversation/conversation.test.tsx
+++ b/frontend/src/features/quick-start-conversation/conversation.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+
+import { useState } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { QuickStartConversationClient } from './api'
+import { QuickStartConversation } from './conversation'
+
+afterEach(cleanup)
+
+function renderConversation(
+  client: QuickStartConversationClient,
+  onConfirm: (prompt: string) => Promise<void> = async () => undefined,
+) {
+  function Fixture() {
+    const [draft, setDraft] = useState('')
+    return (
+      <QuickStartConversation
+        client={client}
+        draft={draft}
+        onDraftChange={setDraft}
+        onConfirm={onConfirm}
+      />
+    )
+  }
+  return render(<Fixture />)
+}
+
+describe('QuickStartConversation', () => {
+  it('continues the same conversation after a clarification', async () => {
+    const respond = vi
+      .fn<QuickStartConversationClient['respond']>()
+      .mockResolvedValueOnce({
+        type: 'clarification',
+        reply: '后续动作需要一个明确主体，你希望保留哪一只狗？',
+      })
+      .mockResolvedValueOnce({
+        type: 'prompt_suggestion',
+        reply: '角色已经整理清楚了。',
+        optimizedPrompt: '单一角色，一只穿红色飞行夹克的金毛，完整身体，纯净背景',
+        warnings: [],
+      })
+    renderConversation({ respond })
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '一群奔跑的大狗' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+    expect(await screen.findByText('后续动作需要一个明确主体，你希望保留哪一只狗？')).toBeTruthy()
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '一只穿红色飞行夹克的金毛' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+
+    expect(
+      await screen.findByDisplayValue('单一角色，一只穿红色飞行夹克的金毛，完整身体，纯净背景'),
+    ).toBeTruthy()
+    expect(respond).toHaveBeenLastCalledWith(
+      [
+        { role: 'user', content: '一群奔跑的大狗' },
+        {
+          role: 'assistant',
+          content: '后续动作需要一个明确主体，你希望保留哪一只狗？',
+        },
+        { role: 'user', content: '一只穿红色飞行夹克的金毛' },
+      ],
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('uses the user-edited suggestion only after explicit confirmation', async () => {
+    const onConfirm = vi.fn(async () => undefined)
+    renderConversation(
+      {
+        respond: async () => ({
+          type: 'prompt_suggestion',
+          reply: '我整理了一版适合动作生成的描述。',
+          optimizedPrompt: '单一角色，像素骑士，完整身体',
+          warnings: ['已移除复杂战场背景'],
+        }),
+      },
+      onConfirm,
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '战场上的像素骑士' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+
+    const suggestion = await screen.findByRole('textbox', { name: '优化后的角色描述' })
+    expect(screen.getByRole('list').textContent).toContain('已移除复杂战场背景')
+    expect(onConfirm).not.toHaveBeenCalled()
+    fireEvent.change(suggestion, {
+      target: { value: '单一角色，蓝甲像素骑士，完整身体，纯净背景' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '按此生成角色' }))
+
+    await waitFor(() =>
+      expect(onConfirm).toHaveBeenCalledWith('单一角色，蓝甲像素骑士，完整身体，纯净背景'),
+    )
+  })
+
+  it('keeps the previous prompt suggestion in model history for a revision request', async () => {
+    const respond = vi
+      .fn<QuickStartConversationClient['respond']>()
+      .mockResolvedValueOnce({
+        type: 'prompt_suggestion',
+        reply: '我整理了一版。',
+        optimizedPrompt: '单一角色，红甲骑士，完整身体',
+        warnings: [],
+      })
+      .mockResolvedValueOnce({
+        type: 'prompt_suggestion',
+        reply: '已经换成蓝色。',
+        optimizedPrompt: '单一角色，蓝甲骑士，完整身体',
+        warnings: [],
+      })
+    renderConversation({ respond })
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '红甲骑士' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+    await screen.findByDisplayValue('单一角色，红甲骑士，完整身体')
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '改成蓝色' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+
+    await screen.findByDisplayValue('单一角色，蓝甲骑士，完整身体')
+    expect(respond).toHaveBeenLastCalledWith(
+      [
+        { role: 'user', content: '红甲骑士' },
+        {
+          role: 'assistant',
+          content:
+            '{"type":"prompt_suggestion","reply":"我整理了一版。","optimizedPrompt":"单一角色，红甲骑士，完整身体","warnings":[]}',
+        },
+        { role: 'user', content: '改成蓝色' },
+      ],
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('keeps the draft when the LLM request fails', async () => {
+    renderConversation({
+      respond: async () => {
+        throw new Error('模型暂时不可用')
+      },
+    })
+
+    const input = screen.getByRole('textbox', { name: '创作指令' })
+    fireEvent.change(input, { target: { value: '戴星形眼镜的裁缝' } })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+
+    expect((await screen.findByRole('alert')).textContent).toContain('模型暂时不可用')
+    expect((input as HTMLInputElement).value).toBe('戴星形眼镜的裁缝')
+  })
+
+  it('aborts the active request when leaving the page', async () => {
+    let observedSignal: AbortSignal | undefined
+    const { unmount } = renderConversation({
+      respond: (_messages, signal) => {
+        observedSignal = signal
+        return new Promise(() => undefined)
+      },
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '戴星形眼镜的裁缝' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+    await waitFor(() => expect(observedSignal).toBeInstanceOf(AbortSignal))
+    unmount()
+
+    expect(observedSignal?.aborted).toBe(true)
+  })
+
+  it('lets the user cancel an active request without leaving the page', async () => {
+    let observedSignal: AbortSignal | undefined
+    renderConversation({
+      respond: (_messages, signal) => {
+        observedSignal = signal
+        return new Promise(() => undefined)
+      },
+    })
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '戴星形眼镜的裁缝' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+    fireEvent.click(await screen.findByRole('button', { name: '取消请求' }))
+
+    expect(observedSignal?.aborted).toBe(true)
+    expect(screen.getByRole('button', { name: '发送描述' }).hasAttribute('disabled')).toBe(false)
+  })
+
+  it('lets the user skip a clarification and request a suggestion from existing context', async () => {
+    const respond = vi
+      .fn<QuickStartConversationClient['respond']>()
+      .mockResolvedValueOnce({
+        type: 'clarification',
+        reply: '你希望角色穿什么颜色的衣服？',
+      })
+      .mockResolvedValueOnce({
+        type: 'prompt_suggestion',
+        reply: '我先按现有信息整理了一版。',
+        optimizedPrompt: '单一角色，像素裁缝，完整身体，纯净背景',
+        warnings: ['服装颜色未指定'],
+      })
+    renderConversation({ respond })
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '像素裁缝' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+    fireEvent.click(await screen.findByRole('button', { name: '跳过追问' }))
+
+    expect(await screen.findByDisplayValue('单一角色，像素裁缝，完整身体，纯净背景')).toBeTruthy()
+    expect(respond).toHaveBeenLastCalledWith(
+      [
+        { role: 'user', content: '像素裁缝' },
+        { role: 'assistant', content: '你希望角色穿什么颜色的衣服？' },
+        { role: 'user', content: '跳过追问，请基于现有信息直接整理提示词。' },
+      ],
+      expect.any(AbortSignal),
+    )
+  })
+})

--- a/frontend/src/features/quick-start-conversation/conversation.tsx
+++ b/frontend/src/features/quick-start-conversation/conversation.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useRef, useState, type FormEvent, type ReactNode } from 'react'
+import { ArrowUp } from '@phosphor-icons/react'
+
+import type { QuickStartConversationClient, QuickStartConversationMessage } from './api'
+
+export interface QuickStartConversationProps {
+  client: QuickStartConversationClient
+  draft: string
+  onDraftChange(value: string): void
+  onConfirm(prompt: string): Promise<void>
+  accessory?: ReactNode
+  onStarted?(): void
+}
+
+type ConversationStatus = 'idle' | 'requesting' | 'confirming'
+type ConversationEntry = QuickStartConversationMessage & { modelContent?: string }
+
+function errorMessage(cause: unknown, fallback: string) {
+  return cause instanceof Error && cause.message.trim() ? cause.message.trim() : fallback
+}
+
+export function QuickStartConversation({
+  client,
+  draft,
+  onDraftChange,
+  onConfirm,
+  accessory,
+  onStarted,
+}: QuickStartConversationProps) {
+  const [messages, setMessages] = useState<ConversationEntry[]>([])
+  const [suggestion, setSuggestion] = useState('')
+  const [warnings, setWarnings] = useState<string[]>([])
+  const [clarificationPending, setClarificationPending] = useState(false)
+  const [status, setStatus] = useState<ConversationStatus>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const request = useRef<AbortController | null>(null)
+
+  useEffect(
+    () => () => {
+      request.current?.abort()
+    },
+    [],
+  )
+
+  async function requestResponse(content: string) {
+    if (status !== 'idle') return
+    const controller = new AbortController()
+    request.current = controller
+    setStatus('requesting')
+    setError(null)
+    onStarted?.()
+    const nextEntries: ConversationEntry[] = [...messages, { role: 'user', content }]
+    const nextMessages: QuickStartConversationMessage[] = [
+      ...messages.map(({ role, content: displayContent, modelContent }) => ({
+        role,
+        content: modelContent ?? displayContent,
+      })),
+      { role: 'user', content },
+    ]
+    try {
+      const result = await client.respond(nextMessages, controller.signal)
+      if (controller.signal.aborted) return
+      const assistant: ConversationEntry = {
+        role: 'assistant',
+        content: result.reply,
+        ...(result.type === 'prompt_suggestion' ? { modelContent: JSON.stringify(result) } : {}),
+      }
+      setMessages([...nextEntries, assistant])
+      onDraftChange('')
+      if (result.type === 'prompt_suggestion') {
+        setSuggestion(result.optimizedPrompt)
+        setWarnings(result.warnings)
+        setClarificationPending(false)
+      } else {
+        setSuggestion('')
+        setWarnings([])
+        setClarificationPending(true)
+      }
+    } catch (cause) {
+      if (!controller.signal.aborted) setError(errorMessage(cause, '暂时无法理解这段描述'))
+    } finally {
+      if (request.current === controller) request.current = null
+      if (!controller.signal.aborted) setStatus('idle')
+    }
+  }
+
+  function send(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const content = draft.trim()
+    if (!content) return
+    void requestResponse(content)
+  }
+
+  function cancelRequest() {
+    const controller = request.current
+    if (!controller) return
+    request.current = null
+    controller.abort()
+    setStatus('idle')
+    setError(null)
+  }
+
+  async function confirm() {
+    const prompt = suggestion.trim()
+    if (!prompt || status !== 'idle') return
+    setStatus('confirming')
+    setError(null)
+    try {
+      await onConfirm(prompt)
+    } catch (cause) {
+      setError(errorMessage(cause, '创建失败，请稍后重试'))
+      setStatus('idle')
+    }
+  }
+
+  return (
+    <div className="grid gap-3">
+      {messages.length > 0 ? (
+        <div aria-live="polite" className="grid max-h-52 gap-2 overflow-y-auto pr-1">
+          {messages.map((message, index) => (
+            <div
+              key={`${message.role}-${index}`}
+              className={`max-w-[88%] rounded-xl px-4 py-2.5 text-sm leading-6 ${
+                message.role === 'user'
+                  ? 'ml-auto bg-app-accent text-app-on-accent'
+                  : 'border border-app-line bg-app-surface text-app-ink-soft'
+              }`}
+            >
+              {message.content}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {suggestion ? (
+        <section className="rounded-xl border border-app-accent/30 bg-app-surface p-4 shadow-app-card">
+          <div className="flex items-baseline justify-between gap-4">
+            <h2 className="font-serif text-lg text-app-ink">优化后的角色描述</h2>
+            <span className="font-mono text-[10px] font-bold tracking-[0.12em] text-app-accent">
+              READY
+            </span>
+          </div>
+          <textarea
+            aria-label="优化后的角色描述"
+            value={suggestion}
+            onChange={(event) => setSuggestion(event.target.value)}
+            className="mt-3 min-h-24 w-full resize-y rounded-lg border border-app-line-strong bg-app-surface-raised p-3 text-sm leading-6 text-app-ink outline-none focus:border-app-accent"
+          />
+          {warnings.length > 0 ? (
+            <ul className="mt-3 space-y-1 text-xs text-app-warning">
+              {warnings.map((warning) => (
+                <li key={warning}>· {warning}</li>
+              ))}
+            </ul>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => void confirm()}
+            disabled={!suggestion.trim() || status !== 'idle'}
+            className="mt-4 inline-flex h-10 items-center rounded-lg bg-app-accent px-4 text-sm font-bold text-app-on-accent disabled:opacity-45"
+          >
+            {status === 'confirming' ? '正在创建…' : '按此生成角色'}
+          </button>
+        </section>
+      ) : null}
+
+      {clarificationPending ? (
+        <button
+          type="button"
+          onClick={() => void requestResponse('跳过追问，请基于现有信息直接整理提示词。')}
+          disabled={status !== 'idle'}
+          className="w-fit text-xs font-semibold text-app-muted underline-offset-4 hover:text-app-accent hover:underline disabled:opacity-45"
+        >
+          跳过追问
+        </button>
+      ) : null}
+
+      <form
+        onSubmit={send}
+        className="grid items-center gap-1.5 rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)] sm:grid-cols-[1fr_auto_auto]"
+      >
+        <label className="min-w-0">
+          <span className="sr-only">创作指令</span>
+          <input
+            aria-label="创作指令"
+            value={draft}
+            onChange={(event) => onDraftChange(event.target.value)}
+            placeholder={messages.length > 0 ? '继续补充角色信息…' : '描述角色的外形、身份和气质…'}
+            className="h-10 w-full min-w-0 border-0 bg-transparent px-3 text-[15px] text-app-ink outline-none placeholder:text-app-faint"
+          />
+        </label>
+        {accessory}
+        {status === 'requesting' ? (
+          <button
+            type="button"
+            aria-label="取消请求"
+            onClick={cancelRequest}
+            className="inline-flex h-10 items-center rounded-lg border border-app-line-strong px-4 text-sm font-bold text-app-muted hover:border-app-accent hover:text-app-accent"
+          >
+            取消
+          </button>
+        ) : (
+          <button
+            type="submit"
+            aria-label="发送描述"
+            disabled={!draft.trim() || status !== 'idle'}
+            className="inline-flex h-10 items-center gap-2 rounded-lg bg-app-accent px-4 text-sm font-bold whitespace-nowrap text-app-on-accent disabled:cursor-not-allowed disabled:opacity-45"
+          >
+            发送
+            <ArrowUp aria-hidden="true" size={16} weight="bold" />
+          </button>
+        )}
+      </form>
+      {error ? (
+        <p role="alert" className="rounded-xl bg-app-danger px-4 py-3 text-sm text-app-danger-soft">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/features/quick-start-conversation/index.ts
+++ b/frontend/src/features/quick-start-conversation/index.ts
@@ -1,0 +1,21 @@
+import { getApiAccessToken, recoverApiUnauthorized, resolveApiBaseUrl } from '@/shared/api'
+
+import { createQuickStartConversationClient, type QuickStartConversationClient } from './api'
+
+export type {
+  QuickStartConversationClient,
+  QuickStartConversationMessage,
+  QuickStartConversationResult,
+} from './api'
+export { QuickStartConversation } from './conversation'
+
+/** 只在发送时解析 API 地址，避免未配置环境在模块加载阶段阻断 Quick Start。 */
+export const quickStartConversationClient: QuickStartConversationClient = {
+  respond(messages, signal) {
+    return createQuickStartConversationClient({
+      baseUrl: resolveApiBaseUrl(),
+      getAccessToken: getApiAccessToken,
+      recoverUnauthorized: recoverApiUnauthorized,
+    }).respond(messages, signal)
+  },
+}

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { QuickStartEntryService, QuickStartSession } from './service'
 import { WorkflowRunConflictError, type WorkflowRun } from '@/entities'
 import type { ExportPackageModel } from '@/features/export-package'
+import type { QuickStartConversationClient } from '@/features/quick-start-conversation'
 import { QuickStartPage } from './index'
 
 afterEach(() => {
@@ -148,7 +149,30 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
-function renderAt(path: string, service: QuickStartEntryService) {
+async function sendCurrentDraftAndConfirm() {
+  fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+  const confirm = await screen.findByRole('button', { name: '按此生成角色' })
+  fireEvent.click(confirm)
+}
+
+function conversationClientFor(
+  optimizedPrompt = '单一角色，戴星形单片眼镜的像素裁缝，完整身体，纯净背景',
+): QuickStartConversationClient {
+  return {
+    respond: vi.fn(async () => ({
+      type: 'prompt_suggestion' as const,
+      reply: '我整理了一版适合动作生成的描述。',
+      optimizedPrompt,
+      warnings: [],
+    })),
+  }
+}
+
+function renderAt(
+  path: string,
+  service: QuickStartEntryService,
+  conversationClient = conversationClientFor(),
+) {
   function PlaytestLocation() {
     const location = useLocation()
     return <h1>{`${location.pathname}${location.search}`}</h1>
@@ -156,8 +180,14 @@ function renderAt(path: string, service: QuickStartEntryService) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/quick-start" element={<QuickStartPage service={service} />} />
-        <Route path="/quick-start/:runId" element={<QuickStartPage service={service} />} />
+        <Route
+          path="/quick-start"
+          element={<QuickStartPage service={service} conversationClient={conversationClient} />}
+        />
+        <Route
+          path="/quick-start/:runId"
+          element={<QuickStartPage service={service} conversationClient={conversationClient} />}
+        />
         <Route path="/projects/:projectId/assets" element={<PlaytestLocation />} />
         <Route path="/playtest/:characterId/:outfitId" element={<PlaytestLocation />} />
       </Routes>
@@ -255,6 +285,29 @@ function renderStateFixture(
 }
 
 describe('QuickStartPage', () => {
+  it('starts the existing Quick Start service only after confirming the LLM suggestion', async () => {
+    const service = serviceFor(null)
+    const conversationClient = conversationClientFor()
+    renderAt('/quick-start', service, conversationClient)
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '戴星形眼镜的裁缝' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+
+    expect(
+      await screen.findByDisplayValue('单一角色，戴星形单片眼镜的像素裁缝，完整身体，纯净背景'),
+    ).toBeTruthy()
+    expect(service.start).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: '按此生成角色' }))
+
+    await waitFor(() =>
+      expect(service.start).toHaveBeenCalledWith(
+        '单一角色，戴星形单片眼镜的像素裁缝，完整身体，纯净背景',
+      ),
+    )
+  })
+
   it('keeps the main export capability available in the conversation UI', async () => {
     const run = workflow(setupAndTemplate({ selectedImageUrl: '/master.png' }))
     const model: ExportPackageModel = {
@@ -700,7 +753,10 @@ describe('QuickStartPage', () => {
     fireEvent.change(screen.getByLabelText('创作指令'), {
       target: { value: '提着风灯的森林守夜人' },
     })
-    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    await act(async () => undefined)
+    fireEvent.click(screen.getByRole('button', { name: '发送描述' }))
+    await act(async () => undefined)
+    fireEvent.click(screen.getByRole('button', { name: '按此生成角色' }))
     await act(async () => undefined)
 
     const entry = screen.getByLabelText('创作指令').closest('[data-layout="quick-start-entry"]')
@@ -824,13 +880,12 @@ describe('QuickStartPage', () => {
 
   it('submits both text and uploaded-template creation from the natural-language entry', async () => {
     const service = serviceFor(null)
-    const view = renderAt('/quick-start', service)
+    const stylePrompt = '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色'
+    const view = renderAt('/quick-start', service, conversationClientFor(stylePrompt))
 
     fireEvent.click(screen.getByRole('button', { name: /16-bit 日式 RPG/u }))
-    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
-    await waitFor(() =>
-      expect(service.start).toHaveBeenCalledWith('16-bit 日式 RPG 像素风，清晰轮廓，明亮配色'),
-    )
+    await sendCurrentDraftAndConfirm()
+    await waitFor(() => expect(service.start).toHaveBeenCalledWith(stylePrompt))
     expect(service.open).not.toHaveBeenCalled()
 
     view.unmount()
@@ -856,15 +911,25 @@ describe('QuickStartPage', () => {
       <StrictMode>
         <MemoryRouter initialEntries={['/quick-start']}>
           <Routes>
-            <Route path="/quick-start" element={<QuickStartPage service={service} />} />
-            <Route path="/quick-start/:runId" element={<QuickStartPage service={service} />} />
+            <Route
+              path="/quick-start"
+              element={
+                <QuickStartPage service={service} conversationClient={conversationClientFor()} />
+              }
+            />
+            <Route
+              path="/quick-start/:runId"
+              element={
+                <QuickStartPage service={service} conversationClient={conversationClientFor()} />
+              }
+            />
           </Routes>
         </MemoryRouter>
       </StrictMode>,
     )
 
     fireEvent.change(screen.getByLabelText('创作指令'), { target: { value: '像素骑士' } })
-    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    await sendCurrentDraftAndConfirm()
 
     await waitFor(() => expect(service.resume).toHaveBeenCalled())
     expect(service.open).not.toHaveBeenCalled()
@@ -884,7 +949,7 @@ describe('QuickStartPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '移除图片' }))
     expect(screen.queryByText('hero.png')).toBeNull()
     fireEvent.change(screen.getByLabelText('创作指令'), { target: { value: '骑士' } })
-    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    await sendCurrentDraftAndConfirm()
     expect((await screen.findByRole('alert')).textContent).toContain('服务繁忙')
   })
 

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -19,6 +19,11 @@ import {
   WorkflowRunConflictError,
 } from '@/entities'
 import { ExportButton, type ExportPackageModel } from '@/features/export-package'
+import {
+  QuickStartConversation,
+  quickStartConversationClient,
+  type QuickStartConversationClient,
+} from '@/features/quick-start-conversation'
 import { KineticCopyCycle, type KineticCopyMessage } from './kinetic-copy-cycle'
 import {
   quickStartService,
@@ -119,10 +124,15 @@ export interface QuickStartPageProps {
    * 未注入时，Quick Start 自己装配真实实体接口，避免 app 层承担流程细节。
    */
   service?: QuickStartEntryService
+  /** 页面测试可以注入确定性 LLM 响应；生产默认调用现有 `/ai/chat`。 */
+  conversationClient?: QuickStartConversationClient
 }
 
 /** Quick Start 独立完成 AI 入口；它不跳转 Workflow Editor。 */
-export function QuickStartPage({ service }: QuickStartPageProps) {
+export function QuickStartPage({
+  service,
+  conversationClient = quickStartConversationClient,
+}: QuickStartPageProps) {
   const { runId } = useParams()
   const [searchParams] = useSearchParams()
   const activeService = useMemo(() => {
@@ -150,7 +160,11 @@ export function QuickStartPage({ service }: QuickStartPageProps) {
       onSessionCreated={setCreatedSession}
     />
   ) : (
-    <QuickStartInput service={activeService} onSessionCreated={setCreatedSession} />
+    <QuickStartInput
+      service={activeService}
+      conversationClient={conversationClient}
+      onSessionCreated={setCreatedSession}
+    />
   )
 }
 
@@ -229,9 +243,11 @@ function QuickStartActionInput({
 
 function QuickStartInput({
   service,
+  conversationClient,
   onSessionCreated,
 }: {
   service: QuickStartEntryService
+  conversationClient: QuickStartConversationClient
   onSessionCreated: (session: QuickStartSession) => void
 }) {
   const navigate = useNavigate()
@@ -239,13 +255,14 @@ function QuickStartInput({
   const [templateFile, setTemplateFile] = useState<File | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [entryTransition, setEntryTransition] = useState<'idle' | 'leaving'>('idle')
+  const [conversationStarted, setConversationStarted] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const fileInput = useRef<HTMLInputElement>(null)
   const submitAbortController = useRef<AbortController | null>(null)
   const handoffTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const unavailableReason = service.unavailableReason
   const hasPrompt = Boolean(prompt.trim())
-  const showStylePrompts = !hasPrompt && !templateFile
+  const showStylePrompts = !hasPrompt && !templateFile && !conversationStarted
 
   useEffect(
     () => () => {
@@ -266,20 +283,16 @@ function QuickStartInput({
     if (fileInput.current) fileInput.current.value = ''
   }
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const normalizedPrompt = prompt.trim()
-    if ((!normalizedPrompt && !templateFile) || submitting || unavailableReason) return
-
+  async function handoffCreation(
+    startSession: (signal: AbortSignal) => Promise<QuickStartSession>,
+  ) {
     const abortController = new AbortController()
     submitAbortController.current = abortController
     setSubmitting(true)
     setEntryTransition('leaving')
     setError(null)
     try {
-      const sessionPromise = templateFile
-        ? service.startWithUploadedTemplate(templateFile, normalizedPrompt, abortController.signal)
-        : service.start(normalizedPrompt)
+      const sessionPromise = startSession(abortController.signal)
       const handoffPromise = new Promise<void>((resolve) => {
         handoffTimer.current = setTimeout(() => {
           handoffTimer.current = null
@@ -294,13 +307,31 @@ function QuickStartInput({
         if (handoffTimer.current) clearTimeout(handoffTimer.current)
         handoffTimer.current = null
         setEntryTransition('idle')
-        setError(errorMessage(cause, '创建失败，请稍后重试'))
       }
+      throw cause
     } finally {
       if (submitAbortController.current === abortController) {
         submitAbortController.current = null
         if (!abortController.signal.aborted) setSubmitting(false)
       }
+    }
+  }
+
+  async function confirmPrompt(optimizedPrompt: string) {
+    if (unavailableReason) throw new Error(unavailableReason)
+    if (submitting) throw new Error('正在创建角色，请稍候')
+    await handoffCreation(() => service.start(optimizedPrompt))
+  }
+
+  async function submitUploadedTemplate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!templateFile || submitting || unavailableReason) return
+    try {
+      await handoffCreation((signal) =>
+        service.startWithUploadedTemplate(templateFile, prompt.trim(), signal),
+      )
+    } catch (cause) {
+      setError(errorMessage(cause, '创建失败，请稍后重试'))
     }
   }
 
@@ -359,34 +390,31 @@ function QuickStartInput({
         </div>
 
         <div data-layout="quick-start-composer" className="mx-auto w-full max-w-3xl self-end">
-          <form
-            onSubmit={(event) => void submit(event)}
-            className="grid items-center gap-1.5 rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)] sm:grid-cols-[1fr_auto_auto]"
-          >
-            <label className="min-w-0" htmlFor="quick-start-prompt">
-              <span className="sr-only">创作指令</span>
-              <input
-                id="quick-start-prompt"
-                type="text"
-                aria-label="创作指令"
-                value={prompt}
-                onChange={(event) => setPrompt(event.target.value)}
-                placeholder={
-                  templateFile ? '描述动作，可留空生成待机动作…' : '描述角色的外形、身份和气质…'
-                }
-                className="h-10 w-full min-w-0 border-0 bg-transparent px-3 text-[15px] text-app-ink outline-none placeholder:text-app-faint"
-              />
-            </label>
-
-            <input
-              ref={fileInput}
-              type="file"
-              accept="image/*"
-              aria-label="上传角色母版"
-              className="sr-only"
-              onChange={selectTemplateFile}
-            />
-            {templateFile ? (
+          <input
+            ref={fileInput}
+            type="file"
+            accept="image/*"
+            aria-label="上传角色母版"
+            className="sr-only"
+            onChange={selectTemplateFile}
+          />
+          {templateFile ? (
+            <form
+              onSubmit={(event) => void submitUploadedTemplate(event)}
+              className="grid items-center gap-1.5 rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)] sm:grid-cols-[1fr_auto_auto]"
+            >
+              <label className="min-w-0" htmlFor="quick-start-prompt">
+                <span className="sr-only">创作指令</span>
+                <input
+                  id="quick-start-prompt"
+                  type="text"
+                  aria-label="创作指令"
+                  value={prompt}
+                  onChange={(event) => setPrompt(event.target.value)}
+                  placeholder="描述动作，可留空生成待机动作…"
+                  className="h-10 w-full min-w-0 border-0 bg-transparent px-3 text-[15px] text-app-ink outline-none placeholder:text-app-faint"
+                />
+              </label>
               <span className="flex h-10 min-w-0 max-w-56 items-center rounded-lg bg-app-surface-muted text-xs text-app-ink-soft">
                 <button
                   type="button"
@@ -406,27 +434,34 @@ function QuickStartInput({
                   <X aria-hidden="true" size={14} weight="bold" />
                 </button>
               </span>
-            ) : (
               <button
-                type="button"
-                onClick={() => fileInput.current?.click()}
-                className="inline-flex h-10 items-center gap-2 rounded-lg px-3 text-xs font-semibold whitespace-nowrap text-app-muted transition hover:bg-app-surface-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                type="submit"
+                disabled={submitting || Boolean(unavailableReason)}
+                className="inline-flex h-10 items-center gap-2 rounded-lg bg-app-accent px-4 text-sm font-bold whitespace-nowrap text-app-on-accent transition hover:bg-app-accent-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-45"
               >
-                <ImageSquare aria-hidden="true" size={17} weight="duotone" />
-                添加母版
+                {submitting ? '正在创建…' : '生成角色'}
+                {!submitting ? <ArrowUp aria-hidden="true" size={16} weight="bold" /> : null}
               </button>
-            )}
-            <button
-              type="submit"
-              disabled={
-                (!prompt.trim() && !templateFile) || submitting || Boolean(unavailableReason)
+            </form>
+          ) : (
+            <QuickStartConversation
+              client={conversationClient}
+              draft={prompt}
+              onDraftChange={setPrompt}
+              onStarted={() => setConversationStarted(true)}
+              onConfirm={confirmPrompt}
+              accessory={
+                <button
+                  type="button"
+                  onClick={() => fileInput.current?.click()}
+                  className="inline-flex h-10 items-center gap-2 rounded-lg px-3 text-xs font-semibold whitespace-nowrap text-app-muted transition hover:bg-app-surface-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                >
+                  <ImageSquare aria-hidden="true" size={17} weight="duotone" />
+                  添加母版
+                </button>
               }
-              className="inline-flex h-10 items-center gap-2 rounded-lg bg-app-accent px-4 text-sm font-bold whitespace-nowrap text-app-on-accent transition hover:bg-app-accent-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-45"
-            >
-              {submitting ? '正在创建…' : '生成角色'}
-              {!submitting ? <ArrowUp aria-hidden="true" size={16} weight="bold" /> : null}
-            </button>
-          </form>
+            />
+          )}
 
           {unavailableReason ? (
             <p className="mt-3 rounded-xl border border-app-warning-line bg-app-warning-soft px-4 py-3 text-sm text-app-warning">


### PR DESCRIPTION
本 PR 将 Quick Start 的初始角色描述从单次表单提交改为受限的 LLM 对话：模型可以追问并给出可编辑的优化提示词，只有用户明确确认后才进入现有角色创建流程。

## Why

Quick Start 被定位为自然语言入口，但此前原始提示词会直接触发生图，无法在付费生成前处理信息缺失、多主体、复杂场景或描述冲突，也缺少自然的追问体验。

## Changes

- 增加页面内连续对话、单次关键追问、跳过追问和主动取消。
- 展示可编辑的优化提示词与风险提醒，确认前不触发角色创建。
- 将确认后的提示词交回现有 `QuickStartEntryService.start()`。
- 上传角色母版继续走原有确定性路径，不经过 LLM。

## Implementation

- 复用 `eventsource-parser` 解析 OpenAI-compatible SSE，收到 `[DONE]` 后立即结束读取。
- 使用 `valibot` 将模型输出限制为 `clarification` 或 `prompt_suggestion` 两种结构。
- 每次只发送最近 8 条页面内消息，不传 `tools`，不读取 Project、Character 或 WorkflowRun。
- 复用现有 JWT 与 401 恢复机制，兼容 HTTP 200 业务 `401`，最多重放一次。
- 非法 JSON、非法结构和未完成消息流均 fail-closed。

## Verification

- [x] `npm run format:check`：通过。
- [x] `npm run lint`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run test:coverage`：56 个测试文件、676 项测试通过；总行覆盖率 94.48%。
- [x] Codecov patch：91.01%（152/167），高于 89% 门槛，远端检查通过。
- [x] `npm run build`：通过，仅保留既有的大 chunk 提示。
- [x] 独立验收：初检发现并修复业务 401、SSE 完成和主动取消边界，复验通过。
- [ ] 真实 LLM 浏览器联调：未执行；当前 `upstream/main` 的 `/ai/chat` 尚未挂载且仍为占位实现。

## Scope

- 本 PR 不包含 Agent Runtime、Tool Calling、Tool Loop、长期记忆、项目数据读取或后端实现。
- 本 PR 不修改 WorkflowController、WorkflowRun 或 PR #321 的后端 PromptAdapter。
- 用户已明确本 PR 不需要截图。

## Related Issues

Closes #418

Refs #321
