### PR TITLE
fix(header): integrate back navigation with brand

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -112,6 +112,7 @@ function finishBackAnimation() {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.unstubAllGlobals()
   cleanup()
   window.localStorage.clear()
   window.sessionStorage.clear()
@@ -168,6 +169,44 @@ describe('AppHeader', () => {
 
     act(() => vi.advanceTimersByTime(50))
     expect(screen.getByTestId('location').textContent).toBe('/workspace')
+  })
+
+  it('动画进行中重复点击不会推迟返回', () => {
+    vi.useFakeTimers()
+    window.history.replaceState({ idx: 0 }, '')
+    renderHeader('/projects')
+
+    const back = screen.getByRole('button', { name: '返回上一页' })
+    fireEvent.click(back)
+    act(() => vi.advanceTimersByTime(150))
+    fireEvent.click(back)
+    act(() => vi.advanceTimersByTime(80))
+
+    expect(screen.getByTestId('location').textContent).toBe('/workspace')
+  })
+
+  it('减少动态效果时立即返回', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => ({ matches: true })),
+    )
+    window.history.replaceState({ idx: 0 }, '')
+    renderHeader('/projects')
+
+    fireEvent.click(screen.getByRole('button', { name: '返回上一页' }))
+
+    expect(screen.getByTestId('location').textContent).toBe('/workspace')
+  })
+
+  it('动画中卸载会取消待执行的返回', () => {
+    vi.useFakeTimers()
+    const { unmount } = renderHeader('/projects')
+
+    fireEvent.click(screen.getByRole('button', { name: '返回上一页' }))
+    expect(vi.getTimerCount()).toBe(1)
+    unmount()
+
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('提供预览台入口，并将工作流路由归入创作', () => {

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -106,7 +106,12 @@ function renderHeader(
   }
 }
 
+function finishBackAnimation() {
+  act(() => vi.advanceTimersByTime(240))
+}
+
 afterEach(() => {
+  vi.useRealTimers()
   cleanup()
   window.localStorage.clear()
   window.sessionStorage.clear()
@@ -122,6 +127,7 @@ describe('AppHeader', () => {
     ['/workspace', '/'],
     ['/account', '/workspace'],
   ])('直接打开 %s 时按页面层级返回 %s', (entry, expected) => {
+    vi.useFakeTimers()
     window.history.replaceState({ idx: 0 }, '')
     renderHeader(entry)
 
@@ -131,15 +137,37 @@ describe('AppHeader', () => {
     expect(back.className).toContain('w-9')
 
     fireEvent.click(back)
+    finishBackAnimation()
     expect(screen.getByTestId('location').textContent).toBe(expected)
   })
 
   it('存在站内浏览历史时返回真实上一页', () => {
+    vi.useFakeTimers()
     window.history.replaceState({ idx: 1 }, '')
     renderHeader('/quick-start', createApis(), '/projects')
 
-    fireEvent.click(screen.getByRole('button', { name: '返回上一页' }))
+    const back = screen.getByRole('button', { name: '返回上一页' })
+    fireEvent.click(back)
+    finishBackAnimation()
     expect(screen.getByTestId('location').textContent).toBe('/projects')
+  })
+
+  it('点击后先播放方向过渡，再执行返回', () => {
+    vi.useFakeTimers()
+    window.history.replaceState({ idx: 0 }, '')
+    renderHeader('/projects')
+
+    const back = screen.getByRole('button', { name: '返回上一页' })
+    fireEvent.click(back)
+
+    expect(back.classList.contains('app-header-back-in-flight')).toBe(true)
+    expect(screen.getByTestId('location').textContent).toBe('/projects')
+
+    act(() => vi.advanceTimersByTime(190))
+    expect(screen.getByTestId('location').textContent).toBe('/projects')
+
+    act(() => vi.advanceTimersByTime(50))
+    expect(screen.getByTestId('location').textContent).toBe('/workspace')
   })
 
   it('提供预览台入口，并将工作流路由归入创作', () => {
@@ -153,6 +181,16 @@ describe('AppHeader', () => {
     expect(screen.getByRole('link', { name: '项目资产' }).getAttribute('href')).toBe('/projects')
     expect(screen.getByRole('link', { name: '创作' }).getAttribute('aria-current')).toBe('page')
     expect(screen.getByRole('link', { name: '预览台' }).getAttribute('href')).toBe('/playtest')
+  })
+
+  it('左侧先显示品牌，再以无边框按钮承接返回操作', () => {
+    renderHeader('/projects')
+
+    const brand = screen.getByRole('link', { name: '返回 Windup 工作台' })
+    const back = screen.getByRole('button', { name: '返回上一页' })
+
+    expect(brand.compareDocumentPosition(back) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(back.className).not.toContain('border')
   })
 
   it('在工作台首页只高亮首页一项', () => {

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -153,7 +153,6 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
     >
       <div className="relative mx-auto grid min-h-14 w-full max-w-[90rem] grid-cols-[auto_1fr_auto] items-center gap-4 px-4 sm:px-6 lg:px-8">
         <div className="flex min-w-0 items-center gap-1.5">
-          <PageBackButton />
           <Link
             to="/workspace"
             aria-label="返回 Windup 工作台"
@@ -168,6 +167,7 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
               <WaveText playId={wave.entry === 'brand' ? wave.playId : 0} text="Windup" />
             </strong>
           </Link>
+          <PageBackButton />
         </div>
 
         <nav

--- a/frontend/src/app/layout/page-back-button.tsx
+++ b/frontend/src/app/layout/page-back-button.tsx
@@ -1,4 +1,8 @@
+import { ArrowLeft } from '@phosphor-icons/react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router'
+
+const backTransitionDurationMs = 230
 
 function fallbackPath(pathname: string): string {
   if (/^\/quick-start\/[^/]+$/.test(pathname)) return '/quick-start'
@@ -21,8 +25,18 @@ function hasInternalHistory(): boolean {
 export function PageBackButton() {
   const { pathname } = useLocation()
   const navigate = useNavigate()
+  const [transitioning, setTransitioning] = useState(false)
+  const transitioningRef = useRef(false)
+  const fallbackTimerRef = useRef<number | null>(null)
 
-  function goBack() {
+  useEffect(
+    () => () => {
+      if (fallbackTimerRef.current !== null) window.clearTimeout(fallbackTimerRef.current)
+    },
+    [],
+  )
+
+  function navigateBack() {
     if (hasInternalHistory()) {
       navigate(-1)
       return
@@ -30,16 +44,42 @@ export function PageBackButton() {
     navigate(fallbackPath(pathname), { replace: true })
   }
 
+  function finishTransition() {
+    if (!transitioningRef.current) return
+    transitioningRef.current = false
+    if (fallbackTimerRef.current !== null) window.clearTimeout(fallbackTimerRef.current)
+    fallbackTimerRef.current = null
+    setTransitioning(false)
+    navigateBack()
+  }
+
+  function requestBack() {
+    if (transitioningRef.current) return
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      navigateBack()
+      return
+    }
+
+    transitioningRef.current = true
+    setTransitioning(true)
+    fallbackTimerRef.current = window.setTimeout(finishTransition, backTransitionDurationMs)
+  }
+
   return (
     <button
       type="button"
       aria-label="返回上一页"
       title="返回上一页"
-      onClick={goBack}
-      className="inline-grid h-9 w-9 shrink-0 place-items-center rounded-md border border-app-accent/12 bg-app-surface-raised/35 text-app-ink-soft transition-[background-color,color,transform] duration-150 hover:bg-app-surface-raised/75 hover:text-app-accent-hover active:translate-y-px active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent motion-reduce:transform-none"
+      onClick={requestBack}
+      className={`inline-grid h-9 w-9 shrink-0 place-items-center rounded-md bg-transparent text-app-muted transition-[background-color,color] duration-150 hover:bg-app-surface-raised/55 hover:text-app-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ${
+        transitioning ? 'app-header-back-in-flight' : ''
+      }`}
     >
-      <span aria-hidden="true" className="text-[1.2rem] leading-none">
-        ←
+      <span aria-hidden="true" className="relative block h-[18px] w-[18px] overflow-hidden">
+        <span className="app-header-back-strip absolute inset-y-0 left-0 flex items-center gap-2">
+          <ArrowLeft className="shrink-0" size={18} weight="regular" />
+          <ArrowLeft className="shrink-0" size={18} weight="regular" />
+        </span>
       </span>
     </button>
   )

--- a/frontend/src/app/layout/page-back-button.tsx
+++ b/frontend/src/app/layout/page-back-button.tsx
@@ -45,9 +45,7 @@ export function PageBackButton() {
   }
 
   function finishTransition() {
-    if (!transitioningRef.current) return
     transitioningRef.current = false
-    if (fallbackTimerRef.current !== null) window.clearTimeout(fallbackTimerRef.current)
     fallbackTimerRef.current = null
     setTransitioning(false)
     navigateBack()

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -28,6 +28,24 @@ body,
   animation: app-header-glyph-wave 380ms cubic-bezier(0.2, 0.75, 0.25, 1) both;
 }
 
+@keyframes app-header-back-strip {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(-26px, 0, 0);
+  }
+}
+
+.app-header-back-strip {
+  transform: translate3d(0, 0, 0);
+  will-change: transform;
+}
+
+.app-header-back-in-flight .app-header-back-strip {
+  animation: app-header-back-strip 220ms cubic-bezier(0.65, 0, 0.35, 1) both;
+}
+
 @keyframes app-header-account-menu-in {
   0% {
     opacity: 0;
@@ -78,6 +96,11 @@ body,
 @media (prefers-reduced-motion: reduce) {
   .app-header-text-wave .app-header-wave-glyph {
     animation: none;
+  }
+
+  .app-header-back-in-flight .app-header-back-strip {
+    animation-duration: 0.01ms;
+    animation-delay: 0ms;
   }
 
   .app-header-account-menu-in {


### PR DESCRIPTION
调整全局顶栏的品牌与返回入口，并补充平滑的方向过渡。

## Why

原返回按钮位于品牌前且带边框，与顶栏层级割裂。

## Changes

- 将 Logo 与 Windup 放在左侧，返回入口移至品牌右侧并去除边框。
- 使用连续箭头轨道表达返回方向，保留 reduced-motion 降级。

## Verification

- [x] `npm run test:coverage -- src/app/layout/app-header.test.tsx`：29/29 通过，返回按钮实现定向覆盖 100%
- [x] `npm run typecheck`：通过
- [x] `npx oxfmt --check ...`：通过
- [x] `git diff --check main...HEAD`：通过

## Related Issues

Fixes #428
