### PR TITLE
perf(asset-library): load character summaries

### DIFF
--- a/backend/packages/app/src/windup_app/web/api/character.py
+++ b/backend/packages/app/src/windup_app/web/api/character.py
@@ -64,6 +64,19 @@ class CharacterOut(BaseModel):
     status: int
 
 
+class CharacterSummaryOut(BaseModel):
+    """角色集合的卡片投影；不携带完整资产树。"""
+
+    id: int
+    project_id: int
+    name: str | None
+    status: int
+    preview_url: str | None
+    outfit_name: str | None
+    outfit_count: int
+    action_count: int
+
+
 # ── 辅助函数 ─────────────────────────────────────────────────────────────────
 
 
@@ -208,6 +221,49 @@ def list_characters(
     )
     return ListResponse.success(
         [CharacterOut.model_validate(c) for c in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+def _character_summary(character: Character) -> CharacterSummaryOut:
+    outfits = (character.character_data or {}).get("outfits", [])
+    first_outfit = outfits[0] if outfits else None
+    return CharacterSummaryOut(
+        id=character.id,
+        project_id=character.project_id,
+        name=character.name,
+        status=character.status,
+        preview_url=first_outfit.get("preview_url") if first_outfit else None,
+        outfit_name=first_outfit.get("name") if first_outfit else None,
+        outfit_count=len(outfits),
+        action_count=sum(len(outfit.get("actions", [])) for outfit in outfits),
+    )
+
+
+@router.get("/summaries", response_model=ListResponse[CharacterSummaryOut])
+def list_character_summaries(
+    project_id: int = Query(..., gt=0),
+    request: Request = None,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    status: int | None = Query(
+        None, ge=0, le=1, description="按发布状态过滤: 0=草稿, 1=已发布"
+    ),
+    session: Session = Depends(get_session),
+) -> ListResponse[CharacterSummaryOut]:
+    user_id = request.state.current_user.id
+    _get_project_or_raise(session, project_id, user_id)
+    items, total = character_service.list_characters(
+        session,
+        project_id=project_id,
+        page=page,
+        page_size=page_size,
+        status=status,
+    )
+    return ListResponse.success(
+        [_character_summary(character) for character in items],
         total=total,
         page=page,
         page_size=page_size,

--- a/backend/tests/test_character_api.py
+++ b/backend/tests/test_character_api.py
@@ -698,6 +698,88 @@ def test_list_characters_without_status_returns_all(auth_client):
     assert len(data["data"]) == 2
 
 
+def test_list_character_summaries_omits_asset_tree(auth_client):
+    project = _create_project(auth_client)
+    auth_client.post(
+        "/characters",
+        json=_payload_with_frames(
+            project["id"],
+            workflow_run_id=12,
+            character_data={
+                "version": 1,
+                "outfits": [
+                    {
+                        "id": "outfit-1",
+                        "name": "常态",
+                        "preview_url": "https://example.com/preview.png",
+                        "actions": [
+                            {
+                                "id": "idle",
+                                "type": "idle",
+                                "name": "待机",
+                                "frame_count": 1,
+                                "frames": [
+                                    {
+                                        "index": 0,
+                                        "image_url": "https://example.com/private-frame.png",
+                                    }
+                                ],
+                            },
+                            {
+                                "id": "walk",
+                                "type": "walk",
+                                "name": "行走",
+                                "frame_count": 1,
+                                "frames": [
+                                    {
+                                        "index": 0,
+                                        "image_url": "https://example.com/private-walk.png",
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+        ),
+    )
+
+    body = auth_client.get(
+        "/characters/summaries",
+        params={"project_id": project["id"], "status": 1},
+    ).json()
+
+    assert body["code"] == 200
+    assert body["total"] == 1
+    assert body["data"] == [
+        {
+            "id": body["data"][0]["id"],
+            "project_id": project["id"],
+            "name": "有帧角色",
+            "status": 1,
+            "preview_url": "https://example.com/preview.png",
+            "outfit_name": "常态",
+            "outfit_count": 1,
+            "action_count": 2,
+        }
+    ]
+    assert "character_data" not in body["data"][0]
+    assert "private-frame.png" not in str(body)
+
+
+def test_list_character_summaries_preserves_project_ownership(
+    auth_client, auth_client_b
+):
+    project = _create_project(auth_client)
+
+    body = auth_client_b.get(
+        "/characters/summaries", params={"project_id": project["id"]}
+    ).json()
+
+    assert body["code"] == 404
+    assert body["message"] == "项目不存在"
+
+
 def test_update_character_data_recalculates_status(auth_client):
     """更新 character_data 后应自动重新计算 status。"""
     project = _create_project(auth_client)

--- a/frontend/src/entities/character/index.test.ts
+++ b/frontend/src/entities/character/index.test.ts
@@ -83,6 +83,58 @@ function jsonResponse(data: unknown) {
 }
 
 describe('characterApis', () => {
+  it('maps lightweight Character summaries without a Character asset tree', async () => {
+    let requestUrl = ''
+    const characterApis = await loadCharacterApis(async (input) => {
+      requestUrl = String(input)
+      return new Response(
+        JSON.stringify({
+          code: 200,
+          message: 'success',
+          data: [
+            {
+              id: 51,
+              project_id: 42,
+              name: '轻装信使',
+              status: 1,
+              preview_url: 'https://cdn.windup.test/outfit.png',
+              outfit_name: '常态造型',
+              outfit_count: 1,
+              action_count: 2,
+            },
+          ],
+          total: 1,
+          page: 1,
+          page_size: 24,
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      )
+    })
+
+    await expect(
+      characterApis.listSummariesByProject('42', { page: 1, pageSize: 24, status: 1 }),
+    ).resolves.toEqual({
+      items: [
+        {
+          id: '51',
+          projectId: '42',
+          name: '轻装信使',
+          status: 1,
+          previewUrl: 'https://cdn.windup.test/outfit.png',
+          outfitName: '常态造型',
+          outfitCount: 1,
+          actionCount: 2,
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 24,
+    })
+    expect(requestUrl).toBe(
+      'https://api.windup.test/characters/summaries?project_id=42&page=1&page_size=24&status=1',
+    )
+  })
+
   it('maps an explicit draft publication status', async () => {
     const characterApis = await loadCharacterApis(async () =>
       jsonResponse({ ...characterDto, status: 0 }),

--- a/frontend/src/entities/character/index.ts
+++ b/frontend/src/entities/character/index.ts
@@ -91,6 +91,18 @@ export interface Character {
   outfits: Outfit[]
 }
 
+/** 角色列表卡片只消费摘要；完整资产树通过 get 或旧列表边界读取。 */
+export interface CharacterSummary {
+  id: string
+  projectId: string
+  name: string | null
+  status: CharacterStatus
+  previewUrl: string | null
+  outfitName: string | null
+  outfitCount: number
+  actionCount: number
+}
+
 /** 创建 Character 记录的字段；生成流程由 Workflow Editor 负责。 */
 export interface CreateCharacterInput {
   projectId: string
@@ -110,6 +122,14 @@ export interface CharacterApis {
   create(input: CreateCharacterInput): Promise<Character>
   update(character: Character): Promise<Character>
   remove(id: Character['id']): Promise<void>
+}
+
+/** 卡片集合的轻量读取边界，不扩大生成流程依赖的 CharacterApis。 */
+export interface CharacterSummaryApis {
+  listSummariesByProject(
+    projectId: string,
+    query?: CharacterPageQuery,
+  ): Promise<Paged<CharacterSummary>>
 }
 
 export interface CharacterPageQuery extends PageQuery {
@@ -173,6 +193,17 @@ interface CharacterDto {
   reference_image_url: string | null
   character_data: CharacterDataDto
   status: number
+}
+
+interface CharacterSummaryDto {
+  id: number
+  project_id: number
+  name: string | null
+  status: number
+  preview_url: string | null
+  outfit_name: string | null
+  outfit_count: number
+  action_count: number
 }
 
 function toBackendId(value: string, field: string): number {
@@ -372,6 +403,19 @@ function mapCharacter(dto: CharacterDto): Character {
   }
 }
 
+function mapCharacterSummary(dto: CharacterSummaryDto): CharacterSummary {
+  return {
+    id: String(dto.id),
+    projectId: String(dto.project_id),
+    name: dto.name,
+    status: mapCharacterStatus(dto.status),
+    previewUrl: dto.preview_url,
+    outfitName: dto.outfit_name,
+    outfitCount: dto.outfit_count,
+    actionCount: dto.action_count,
+  }
+}
+
 function toFrameDto(frame: Frame): CharacterFrameDto {
   return {
     index: frame.index,
@@ -418,7 +462,7 @@ function getApiClient() {
   return createApiClient({ getAccessToken: getApiAccessToken })
 }
 
-export const characterApis: CharacterApis = {
+export const characterApis: CharacterApis & CharacterSummaryApis = {
   async get(id) {
     return mapCharacter(
       await getApiClient().request<CharacterDto>(`/characters/${encodeURIComponent(id)}`),
@@ -436,6 +480,18 @@ export const characterApis: CharacterApis = {
       },
     })
     return { ...result, items: result.items.map(mapCharacter) }
+  },
+
+  async listSummariesByProject(projectId, query = {}) {
+    const result = await getApiClient().requestList<CharacterSummaryDto>('/characters/summaries', {
+      query: {
+        project_id: toBackendId(projectId, 'projectId'),
+        page: query.page,
+        page_size: query.pageSize,
+        status: query.status,
+      },
+    })
+    return { ...result, items: result.items.map(mapCharacterSummary) }
   },
 
   async create(input) {

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -46,6 +46,8 @@ export type {
   ActionType,
   Character,
   CharacterApis,
+  CharacterSummaryApis,
+  CharacterSummary,
   CharacterPageQuery,
   CharacterPublicationStatus,
   CharacterStatus,

--- a/frontend/src/pages/asset-library/index.test.tsx
+++ b/frontend/src/pages/asset-library/index.test.tsx
@@ -17,18 +17,19 @@ function renderRoute(route: string) {
   const backend = createProjectAssetsBackend()
   vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
   vi.stubGlobal('fetch', backend.fetch)
-  return render(
+  const view = render(
     <AuthenticatedAuthSession>
       <MemoryRouter initialEntries={[route]}>
         <AppRoutes />
       </MemoryRouter>
     </AuthenticatedAuthSession>,
   )
+  return { backend, view }
 }
 
 describe('AssetLibraryPage', () => {
   it('hides draft characters from the published asset list', async () => {
-    renderRoute('/projects/42/assets')
+    const { backend } = renderRoute('/projects/42/assets')
 
     expect(await screen.findByRole('heading', { name: '点灯人 · MVP' })).toBeTruthy()
     expect(await screen.findAllByRole('link', { name: /查看角色/ })).toHaveLength(1)
@@ -43,6 +44,14 @@ describe('AssetLibraryPage', () => {
     expect(screen.getByText('2 个动作')).toBeTruthy()
     expect(screen.queryByRole('searchbox')).toBeNull()
     expect(screen.queryByRole('button', { name: '导出全部角色资产' })).toBeNull()
+    expect(
+      backend.requests.some((request) =>
+        new URL(request.url).pathname.endsWith('/characters/summaries'),
+      ),
+    ).toBe(true)
+    expect(
+      backend.requests.some((request) => new URL(request.url).pathname === '/characters'),
+    ).toBe(false)
   })
 
   it('renders the real empty state without creating a local Character', async () => {
@@ -59,7 +68,7 @@ describe('AssetLibraryPage', () => {
     vi.stubGlobal('fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
       const request = new Request(input, init)
       const response = await backend.fetch(input, init)
-      if (!request.url.includes('/characters?project_id=42')) return response
+      if (!request.url.includes('/characters/summaries?project_id=42')) return response
 
       const payload = (await response.json()) as {
         data: Array<Record<string, unknown>>
@@ -73,8 +82,11 @@ describe('AssetLibraryPage', () => {
         name: '无造型角色',
         description: null,
         reference_image_url: null,
-        character_data: { version: 1, outfits: [] },
         status: 1,
+        preview_url: null,
+        outfit_name: null,
+        outfit_count: 0,
+        action_count: 0,
       })
       payload.total += 1
       return new Response(JSON.stringify(payload), {
@@ -109,7 +121,7 @@ describe('AssetLibraryPage', () => {
 
     expect(await screen.findAllByRole('link', { name: /查看角色/ })).toHaveLength(24)
     const requestsBeforePaging = backend.requests.filter((request) =>
-      request.url.includes('/characters?project_id=42'),
+      request.url.includes('/characters/summaries?project_id=42'),
     ).length
     fireEvent.click(screen.getByRole('button', { name: '下一页' }))
 
@@ -117,7 +129,7 @@ describe('AssetLibraryPage', () => {
       expect(screen.getAllByRole('link', { name: /查看角色/ })).toHaveLength(1)
     })
     const characterRequests = backend.requests.filter((request) =>
-      request.url.includes('/characters?project_id=42'),
+      request.url.includes('/characters/summaries?project_id=42'),
     )
     expect(characterRequests).toHaveLength(requestsBeforePaging + 1)
     expect(characterRequests.at(-1)?.url).toContain('page=2&page_size=24&status=1')

--- a/frontend/src/pages/asset-library/index.tsx
+++ b/frontend/src/pages/asset-library/index.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react'
 import { Link, useOutletContext, useParams } from 'react-router'
 
-import { CHARACTER_STATUS, characterApis, type Character, type Project } from '@/entities'
+import { CHARACTER_STATUS, characterApis, type CharacterSummary, type Project } from '@/entities'
 import type { Paged } from '@/shared/pagination'
 import { AssetPreviewCard, Pagination } from '@/shared/ui'
 
 const CHARACTER_PAGE_SIZE = 24
 
-function characterName(character: Character) {
+function characterName(character: CharacterSummary) {
   return character.name ?? '未命名角色'
 }
 
@@ -15,7 +15,7 @@ export function AssetLibraryPage() {
   const { projectId } = useParams()
   const project = useOutletContext<Project>()
   const [pageNumber, setPageNumber] = useState(1)
-  const [charactersPage, setCharactersPage] = useState<Paged<Character> | null>(null)
+  const [charactersPage, setCharactersPage] = useState<Paged<CharacterSummary> | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -30,7 +30,7 @@ export function AssetLibraryPage() {
     setCharactersPage(null)
     setError(null)
     void characterApis
-      .listByProject(projectId, {
+      .listSummariesByProject(projectId, {
         page: pageNumber,
         pageSize: CHARACTER_PAGE_SIZE,
         status: CHARACTER_STATUS.PUBLISHED,
@@ -93,26 +93,30 @@ export function AssetLibraryPage() {
   )
 }
 
-function CharacterGrid({ projectId, characters }: { projectId: string; characters: Character[] }) {
+function CharacterGrid({
+  projectId,
+  characters,
+}: {
+  projectId: string
+  characters: CharacterSummary[]
+}) {
   if (characters.length === 0) return <EmptyState />
 
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(13rem,1fr))] gap-4">
       {characters.map((character, index) => {
         const name = characterName(character)
-        const outfit = character.outfits[0]
-        const actionCount = character.outfits.reduce((sum, item) => sum + item.actions.length, 0)
         return (
           <AssetPreviewCard
             key={character.id}
             to={`/projects/${projectId}/assets/${character.id}`}
             ariaLabel={`查看角色 ${name}`}
             title={name}
-            subtitle={outfit?.name ?? '尚未创建造型'}
+            subtitle={character.outfitName ?? '尚未创建造型'}
             trailing="↗"
-            footer={`${character.outfits.length} 套造型 · ${actionCount} 个动作`}
-            previewUrl={outfit?.previewUrl ?? null}
-            previewAlt={`${name}的${outfit?.name ?? '造型'}预览`}
+            footer={`${character.outfitCount} 套造型 · ${character.actionCount} 个动作`}
+            previewUrl={character.previewUrl}
+            previewAlt={`${name}的${character.outfitName ?? '造型'}预览`}
             thumbnail
             eager={index < 4}
             priority={index === 0}

--- a/frontend/src/test/project-assets-backend.ts
+++ b/frontend/src/test/project-assets-backend.ts
@@ -265,6 +265,37 @@ export function createProjectAssetsBackend({
       )
     }
 
+    if (request.method === 'GET' && url.pathname === '/characters/summaries') {
+      const projectId = Number(url.searchParams.get('project_id'))
+      const page = Number(url.searchParams.get('page') ?? 1)
+      const pageSize = Number(url.searchParams.get('page_size') ?? 20)
+      const status = url.searchParams.get('status')
+      const projectCharacters = characters.filter(
+        (item) =>
+          item.project_id === projectId && (status === null || item.status === Number(status)),
+      )
+      const summaries = projectCharacters.map((item) => {
+        const outfits = item.character_data.outfits
+        return {
+          id: item.id,
+          project_id: item.project_id,
+          name: item.name,
+          status: item.status,
+          preview_url: outfits[0]?.preview_url ?? null,
+          outfit_name: outfits[0]?.name ?? null,
+          outfit_count: outfits.length,
+          action_count: outfits.reduce((sum, outfit) => sum + outfit.actions.length, 0),
+        }
+      })
+      const start = (page - 1) * pageSize
+      return listResponse(
+        summaries.slice(start, start + pageSize),
+        page,
+        pageSize,
+        summaries.length,
+      )
+    }
+
     if (request.method === 'GET' && url.pathname.startsWith('/characters/')) {
       const characterId = Number(url.pathname.split('/').at(-1))
       const character = characters.find((item) => item.id === characterId)

--- a/openapi.json
+++ b/openapi.json
@@ -695,6 +695,76 @@
         "title": "CharacterStance",
         "type": "string"
       },
+      "CharacterSummaryOut": {
+        "description": "角色集合的卡片投影；不携带完整资产树。",
+        "properties": {
+          "action_count": {
+            "title": "Action Count",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "outfit_count": {
+            "title": "Outfit Count",
+            "type": "integer"
+          },
+          "outfit_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Outfit Name"
+          },
+          "preview_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preview Url"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "project_id",
+          "name",
+          "status",
+          "preview_url",
+          "outfit_name",
+          "outfit_count",
+          "action_count"
+        ],
+        "title": "CharacterSummaryOut",
+        "type": "object"
+      },
       "CharacterTemplateSequence": {
         "description": "角色母版的真实源方向或水平镜像关系。",
         "properties": {
@@ -1452,6 +1522,65 @@
           }
         },
         "title": "ListResponse[CharacterOut]",
+        "type": "object"
+      },
+      "ListResponse_CharacterSummaryOut_": {
+        "properties": {
+          "code": {
+            "default": 200,
+            "description": "业务状态码:成功 200,失败非 200",
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "description": "业务数据列表",
+            "items": {
+              "$ref": "#/components/schemas/CharacterSummaryOut"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "message": {
+            "default": "success",
+            "description": "提示信息",
+            "title": "Message",
+            "type": "string"
+          },
+          "page": {
+            "default": 1,
+            "description": "当前页码,从 1 开始",
+            "minimum": 1.0,
+            "title": "Page",
+            "type": "integer"
+          },
+          "page_size": {
+            "default": 0,
+            "description": "每页条数;0 表示不分页(全量)",
+            "minimum": 0.0,
+            "title": "Page Size",
+            "type": "integer"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "响应时间;默认不携带,不携带时省略",
+            "title": "Timestamp"
+          },
+          "total": {
+            "default": 0,
+            "description": "数据总数;分页时为查询条件总数,不分页时为 len(data)",
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "title": "ListResponse[CharacterSummaryOut]",
         "type": "object"
       },
       "ListResponse_CreditTransactionOut_": {
@@ -3535,6 +3664,92 @@
           }
         },
         "summary": "Create Character",
+        "tags": [
+          "characters"
+        ]
+      }
+    },
+    "/characters/summaries": {
+      "get": {
+        "operationId": "list_character_summaries_characters_summaries_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "exclusiveMinimum": 0,
+              "title": "Project Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "按发布状态过滤: 0=草稿, 1=已发布",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 1,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "按发布状态过滤: 0=草稿, 1=已发布",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_CharacterSummaryOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Character Summaries",
         "tags": [
           "characters"
         ]


### PR DESCRIPTION
新增轻量 Character Summary 集合并让资产库使用该投影，列表不再传输完整造型动作与帧 URL，同时保持生成流程依赖的完整 Character 接口不变。

## Why

资产库卡片只需要名称、预览和数量信息，原接口却返回每个角色的完整 `character_data`。角色与动作增长后，列表响应会携带大量当前页面不会使用的帧 URL。

## Changes

- 新增分页、可按发布状态筛选的 `/characters/summaries`。
- 摘要仅返回卡片需要的 8 个字段，不包含动作和帧树。
- 资产库迁移到摘要接口，卡片内容、空状态和分页行为保持不变。

## Implementation

- Summary 使用独立 DTO 和前端读取边界，不扩大 Workflow Editor 与 Quick Start 依赖的 `CharacterApis`。
- 权限、项目归属、分页和状态筛选复用当前 Character 服务边界。
- `/characters` 完整列表与 `/characters/:id` 详情契约保持不变。

## Verification

- [x] `UV_CACHE_DIR=/private/tmp/windup-uv-cache uv run pytest -q tests/test_character_api.py`：19 项通过。
- [x] `npm test -- src/entities/character/index.test.ts src/pages/asset-library/index.test.tsx src/pages/character-detail/index.test.tsx src/pages/workflow-editor/index.test.tsx src/pages/quick-start/service.test.ts`：93 项通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run build`：通过；仅有既存 chunk size 警告。
- [x] `uv run ruff check ...`：相关后端文件通过。
- [x] OpenAPI 重新生成后无漂移。

## Scope

- 本 PR 不包含：缩略图生成、图片格式、CDN、对象存储或 Release 调整。
- 项目中心请求瀑布由 #425 独立处理。

## Related Issues

Closes #426
Refs #425
