### PR TITLE
fix(test): 体型用例改截建任务这一步

### DIFF
--- a/backend/tests/test_generation_api.py
+++ b/backend/tests/test_generation_api.py
@@ -254,14 +254,28 @@ def test_validation_error_message_tells_the_user_what_is_wrong(auth_client):
 # 永远触发不了它。这条测试从真实端点发起,断言的是"贯通"而不是"函数会不会算"。
 
 
+def _capture_action_input(gen_api, monkeypatch) -> list:
+    """截下建任务时的引擎入参。
+
+    挂在建任务这一步而不是投递那一步:投递只带 task_id,看不到入参,而这两条用例
+    要断言的正是"字段有没有从请求一路走到引擎入参"。
+    """
+    seen: list = []
+    real = gen_api.generation_service.generate_character_action
+
+    def spy(*args, **kwargs):
+        seen.append((kwargs.get("input"),))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(gen_api.generation_service, "generate_character_action", spy)
+    return seen
+
+
 def test_stance_from_request_reaches_the_engine(auth_client, monkeypatch):
     from windup_app.web.api import generation as gen_api
     from windup_app.server.orchestrator.model import CharacterActionInput
 
-    dispatched: list = []
-    monkeypatch.setattr(
-        gen_api, "_dispatch_after_commit", lambda *args: dispatched.append(args)
-    )
+    dispatched = _capture_action_input(gen_api, monkeypatch)
     project = _create_project(auth_client)
     character = _create_character(auth_client, project["id"])
 
@@ -281,10 +295,7 @@ def test_stance_omitted_stays_none_not_biped(auth_client, monkeypatch):
     from windup_app.web.api import generation as gen_api
     from windup_app.server.orchestrator.model import CharacterActionInput
 
-    dispatched: list = []
-    monkeypatch.setattr(
-        gen_api, "_dispatch_after_commit", lambda *args: dispatched.append(args)
-    )
+    dispatched = _capture_action_input(gen_api, monkeypatch)
     project = _create_project(auth_client)
     character = _create_character(auth_client, project["id"])
 


### PR DESCRIPTION
## 改动

- `test_generation_api.py` 新增 `_capture_action_input` 辅助函数，包住 `generation_service.generate_character_action` 并保留真实调用，两条体型用例改用它取引擎入参。

## 为什么不是改成新函数名

#399 之后的 `_publish_generation_after_commit` 只带 `task_id` / `task_type`，看不到 `CharacterActionInput`。照搬新名字能让用例跑通，但断言的东西会从"字段有没有走到引擎入参"退化成"有没有投递过"，正是这两条用例要防的那件事。

## 不包含

- 不改生产代码。
- 不改投递机制与消息形状。

## 验证

按 CI 原样命令在 `backend/` 下全树跑：`uv sync --frozen` / `ruff check .` / `export_openapi` 加 `git diff --exit-code` / `lint-imports` / `pytest` 五项退出码均为 0，1061 通过 14 跳过；`openapi.json` 无漂移。

改动前在同一棵树上跑同一条命令为 2 failed、14 passed。

Closes #440
