### PR TITLE
feat(workflow-editor): refine visual hierarchy

### DIFF
--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import type { ReactNode } from 'react'
+import { createElement, type ComponentType, type ReactNode } from 'react'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Link, MemoryRouter, Route, Routes } from 'react-router'
@@ -61,7 +61,8 @@ interface TestCanvasNode {
   deletable?: boolean
   draggable?: boolean
   dragHandle?: string
-  data: { title: string; content: ReactNode }
+  position: { x: number; y: number }
+  data: { eyebrow: string; title: string; content: ReactNode }
 }
 
 interface TestFlowProps extends Record<string, unknown> {
@@ -191,6 +192,102 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     expect(await screen.findByLabelText('当前项目')).toBeTruthy()
     expect(screen.queryByText('真实 WorkflowRun 接口')).toBeNull()
     expect(defaultSessionLoader).toHaveBeenCalledWith('42')
+  })
+
+  it('节点抬头只显示流程序号，不附加英文阶段名', async () => {
+    defaultSessionLoader.mockResolvedValue(createSession(reviewingActionWorkflow()))
+
+    renderEditor('/workflow-editor/42')
+
+    await waitFor(() => expect(latestFlowProps().nodes).toHaveLength(6))
+    expect(latestFlowProps().nodes.map((node) => node.data.eyebrow)).toEqual([
+      '01',
+      '02',
+      '03',
+      '04',
+      '05',
+      '06',
+    ])
+  })
+
+  it('用紧凑卡片和更短的节点间距呈现完整工作流', async () => {
+    defaultSessionLoader.mockResolvedValue(
+      createSession(reviewingActionWorkflow('action-a', 'action-b')),
+    )
+
+    renderEditor('/workflow-editor/42')
+
+    await waitFor(() => expect(latestFlowProps().nodes).toHaveLength(10))
+    const nodes = latestFlowProps().nodes
+    const xValues = nodes.map((node) => node.position.x)
+    expect(Math.max(...xValues) - Math.min(...xValues)).toBeLessThanOrEqual(1700)
+
+    const actionRoots = nodes.filter((node) => node.data.title === '动作首帧')
+    expect(actionRoots[1]!.position.y - actionRoots[0]!.position.y).toBeLessThanOrEqual(400)
+
+    const Card = (
+      latestFlowProps().nodeTypes as Record<string, ComponentType<Record<string, unknown>>>
+    )['workflow-card']!
+    const cardView = render(
+      createElement(Card, {
+        id: 'compact-card',
+        selected: false,
+        data: {
+          eyebrow: '01',
+          title: '角色设定',
+          status: 'active',
+          content: <span>内容</span>,
+        },
+      }),
+    )
+    expect(cardView.container.querySelector('article')?.className).toContain('w-[296px]')
+    const header = cardView.container.querySelector('header')
+    expect(header).not.toBeNull()
+    expect(header?.textContent).toContain('01')
+    expect(header?.textContent).toContain('角色设定')
+    expect(header?.className).not.toContain('border-b')
+    expect(header?.className).not.toContain('bg-app-surface')
+    expect(header?.querySelector('span')?.className).not.toContain('bg-app-accent-muted')
+  })
+
+  it('图片加载时保留版面并在完成后淡入', async () => {
+    defaultSessionLoader.mockResolvedValue(createSession(completedTemplateWorkflow('42')))
+
+    renderEditor('/workflow-editor/42')
+
+    const image = await screen.findByRole('img', { name: '已确认身份母版' })
+    expect(screen.getByRole('status', { name: '正在加载已确认身份母版' })).toBeTruthy()
+    expect(image.className).toContain('opacity-0')
+
+    fireEvent.load(image)
+
+    expect(screen.queryByRole('status', { name: '正在加载已确认身份母版' })).toBeNull()
+    expect(image.className).toContain('opacity-100')
+  })
+
+  it('导出是次要动作，当前节点推进仍是主要动作', async () => {
+    const character = characterFixture()
+    character.outfits[0] = {
+      ...character.outfits[0]!,
+      previewUrl: 'https://assets.windup.test/42.png',
+    }
+    defaultSessionLoader.mockResolvedValue(
+      createSession(reviewingActionWorkflow(), {
+        character,
+        generationApis: generationApisFixture({
+          get: vi.fn().mockResolvedValue(completeAnimationGeneration()),
+        }),
+      }),
+    )
+
+    renderEditor('/workflow-editor/42')
+
+    const exportButtons = await screen.findAllByRole('button', { name: /导出角色母版/ })
+    expect(exportButtons.length).toBeGreaterThan(0)
+    expect(
+      exportButtons.every((button) => button.className.includes('border-app-line-strong')),
+    ).toBe(true)
+    expect(screen.getByRole('button', { name: '审核通过' }).className).toContain('bg-app-accent')
   })
 
   it('会话加载失败时展示恢复错误', async () => {

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -265,6 +265,66 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     expect(image.className).toContain('opacity-100')
   })
 
+  it('图片加载失败时在原位显示错误状态', async () => {
+    defaultSessionLoader.mockResolvedValue(createSession(completedTemplateWorkflow('42')))
+
+    renderEditor('/workflow-editor/42')
+
+    const image = await screen.findByRole('img', { name: '已确认身份母版' })
+    fireEvent.error(image)
+
+    expect(screen.getByText('图片加载失败')).toBeTruthy()
+    expect(screen.queryByRole('status', { name: '正在加载已确认身份母版' })).toBeNull()
+    expect(image.className).toContain('opacity-0')
+  })
+
+  it('生成任务运行时显示动态状态', async () => {
+    defaultSessionLoader.mockResolvedValue(
+      createSession(generatingTemplateWorkflow(), {
+        generationApis: generationApisFixture({
+          get: vi.fn().mockResolvedValue({
+            id: 'in-flight-task',
+            projectId: '1',
+            type: 'character_template',
+            status: 'running',
+            result: null,
+            error: null,
+          } satisfies Generation),
+        }),
+      }),
+    )
+
+    renderEditor('/workflow-editor/42')
+
+    expect((await screen.findByRole('status')).textContent).toContain('生成中…')
+  })
+
+  it('动作首帧等待候选结果时显示处理中状态', async () => {
+    const workflow = completedTemplateWorkflow('42')
+    workflow.nodes.push({
+      id: 'action-walk',
+      type: 'action-first-frame',
+      status: 'active',
+      phase: 'selecting',
+      dependsOnNodeIds: ['character-template'],
+      generations: [],
+      error: null,
+      input: {
+        outfitId: 'day',
+        name: '行走',
+        type: 'walk',
+        prompt: null,
+        fps: 12,
+      },
+      selectedFirstFrameUrl: null,
+    })
+    defaultSessionLoader.mockResolvedValue(createSession(workflow))
+
+    renderEditor('/workflow-editor/42')
+
+    expect((await screen.findByText('处理中…')).getAttribute('role')).toBe('status')
+  })
+
   it('导出是次要动作，当前节点推进仍是主要动作', async () => {
     const character = characterFixture()
     character.outfits[0] = {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -72,30 +72,34 @@ const SHARED_BRANCH = 'shared'
   搬成工具类后写在这里，好处是能看见哪些元素共用同一套外观，而不是被选择器隐式波及。
   nodrag/nopan/nowheel 是 React Flow 的约定类：让卡片内的交互不被画布手势吞掉。
 */
-const CARD_STACK = 'grid gap-[17px] nodrag nopan nowheel'
+const CARD_STACK = 'grid gap-3 nodrag nopan nowheel'
+
+const CARD_BUTTON_BASE =
+  'min-h-9 rounded-lg border px-3 py-2 text-[11px] font-semibold transition-[color,background-color,border-color,transform,box-shadow] ' +
+  'duration-150 ease-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ' +
+  'enabled:active:translate-y-px enabled:active:scale-[0.98] motion-reduce:transform-none disabled:cursor-not-allowed ' +
+  'disabled:border-app-line disabled:bg-app-surface-muted disabled:text-app-faint'
 
 const CARD_BUTTON =
-  'min-h-[42px] rounded-lg border border-app-accent bg-app-accent px-3 py-[9px] text-[11px] ' +
-  'font-[750] text-app-on-accent enabled:hover:border-app-accent-hover enabled:hover:bg-app-accent-hover ' +
-  'aria-pressed:border-app-accent-hover aria-pressed:bg-app-accent-hover disabled:cursor-not-allowed ' +
-  'disabled:border-app-line disabled:bg-app-surface-muted disabled:text-app-faint'
+  `${CARD_BUTTON_BASE} border-app-accent bg-app-accent text-app-on-accent ` +
+  'enabled:hover:border-app-accent-hover enabled:hover:bg-app-accent-hover enabled:hover:shadow-app-menu ' +
+  'aria-pressed:border-app-accent-hover aria-pressed:bg-app-accent-hover'
+
+const CARD_BUTTON_SECONDARY =
+  `${CARD_BUTTON_BASE} border-app-line-strong bg-app-surface-raised text-app-ink-soft ` +
+  'enabled:hover:border-app-accent enabled:hover:bg-app-accent-muted enabled:hover:text-app-accent'
 
 /** 缩略图按钮：沿用卡片按钮的尺寸约定，但换成浅底，让图片自己当主角。 */
 const THUMB_BUTTON =
   'min-h-[42px] rounded-lg border border-[var(--color-app-line)] bg-app-surface-raised p-1 ' +
-  'aria-pressed:border-[var(--color-app-ink)] aria-pressed:bg-app-surface-raised ' +
-  'aria-pressed:shadow-app-pulse disabled:cursor-not-allowed'
-
-const THUMB_IMAGE = 'block aspect-square w-full rounded-lg object-cover'
-
-/** 已确认的母版/首帧：像素资产按原样放大，不做平滑。 */
-const MASTER_IMAGE =
-  'block aspect-square w-full rounded-xl border border-[var(--color-app-line)] bg-app-surface ' +
-  'object-cover [image-rendering:pixelated]'
+  'transition-[border-color,background-color,transform,box-shadow] duration-150 ease-out ' +
+  'hover:border-app-line-strong active:scale-[0.98] focus-visible:outline-2 focus-visible:outline-offset-2 ' +
+  'focus-visible:outline-app-accent motion-reduce:transform-none aria-pressed:border-app-accent ' +
+  'aria-pressed:bg-app-surface-raised aria-pressed:shadow-[0_0_0_2px_var(--color-app-accent-soft)] ' +
+  'disabled:cursor-not-allowed'
 
 const CARD_SUMMARY =
-  'm-0 rounded-[10px] border border-[var(--color-app-line)] bg-app-surface px-3 py-2.5 ' +
-  'text-[11px] leading-[1.6] text-[var(--color-app-muted)]'
+  'm-0 rounded-lg bg-app-accent-muted px-3 py-2 text-[11px] leading-[1.55] text-app-ink-soft'
 
 const CARD_TEXT = 'm-0 text-[11px] leading-[1.6] text-[var(--color-app-muted)]'
 
@@ -309,7 +313,7 @@ interface ProjectionInput {
 
 function NodeExportButton({ model }: { model: ExportPackageModel | undefined }) {
   return model ? (
-    <ExportButton model={model} className={`${CARD_BUTTON} nodrag nopan nowheel`} />
+    <ExportButton model={model} className={`${CARD_BUTTON_SECONDARY} nodrag nopan nowheel`} />
   ) : null
 }
 
@@ -376,6 +380,58 @@ function contentFor(node: WorkflowNode, input: ProjectionInput): ReactNode {
   if (node.type === 'action-generation-method') return <MethodContent node={node} input={input} />
   if (node.type === 'action-full-frame') return <AnimationContent node={node} input={input} />
   return <ReviewContent node={node} input={input} />
+}
+
+type WorkflowImageVariant = 'master' | 'thumbnail' | 'frame'
+
+/** 图片先占住最终版面，再从骨架淡入，避免远程资产到达时把节点和连线一起顶动。 */
+function WorkflowImage({
+  src,
+  alt,
+  variant,
+}: {
+  src: string
+  alt: string
+  variant: WorkflowImageVariant
+}) {
+  const [state, setState] = useState<'loading' | 'loaded' | 'failed'>('loading')
+
+  useEffect(() => setState('loading'), [src])
+
+  const frameClass =
+    variant === 'master'
+      ? 'aspect-[4/3] rounded-lg border border-app-line bg-app-surface'
+      : variant === 'thumbnail'
+        ? 'aspect-square rounded-md bg-app-surface'
+        : 'aspect-square rounded border border-app-line bg-app-surface'
+  const imageClass =
+    variant === 'master' ? 'object-contain p-2 [image-rendering:pixelated]' : 'object-cover'
+
+  return (
+    <span className={`relative block w-full overflow-hidden ${frameClass}`}>
+      {state === 'loading' ? (
+        <span
+          role="status"
+          aria-label={`正在加载${alt}`}
+          className="workflow-image-skeleton absolute inset-0"
+        />
+      ) : null}
+      {state === 'failed' ? (
+        <span className="absolute inset-0 grid place-items-center px-2 text-center text-[10px] text-app-faint">
+          图片加载失败
+        </span>
+      ) : null}
+      <img
+        className={`absolute inset-0 block h-full w-full transition-opacity duration-200 ease-out motion-reduce:transition-none ${imageClass} ${
+          state === 'loaded' ? 'opacity-100' : 'opacity-0'
+        }`}
+        src={src}
+        alt={alt}
+        onLoad={() => setState('loaded')}
+        onError={() => setState('failed')}
+      />
+    </span>
+  )
 }
 
 function CharacterSetupContent({
@@ -548,7 +604,7 @@ function CharacterTemplateContent({
                 }))
               }
             >
-              <img className={THUMB_IMAGE} src={image.url} alt={`角色候选 ${index + 1}`} />
+              <WorkflowImage src={image.url} alt={`角色候选 ${index + 1}`} variant="thumbnail" />
             </button>
           ))}
         </div>
@@ -575,7 +631,7 @@ function CharacterTemplateContent({
       ) ?? input.character?.outfits[0]
     return (
       <div className={CARD_STACK}>
-        <img className={MASTER_IMAGE} src={node.selectedImageUrl} alt="已确认身份母版" />
+        <WorkflowImage src={node.selectedImageUrl} alt="已确认身份母版" variant="master" />
         <span className="text-center text-[11px] text-[var(--color-app-muted)]">身份已锁定</span>
         {outfit ? <NodeExportButton model={input.exportModels.get(outfit.id)} /> : null}
         <div className="grid gap-2">
@@ -643,7 +699,7 @@ function CharacterTemplateContent({
         </div>
         <button
           type="button"
-          className="absolute -bottom-4 -right-4 z-8 grid h-8 min-h-8 w-8 place-items-center rounded-full border border-[var(--color-app-ink)] bg-app-surface-raised p-0 text-[15px] leading-none text-[var(--color-app-ink)] shadow-[var(--shadow-app-panel)] hover:bg-[var(--color-app-ink)] hover:text-app-on-accent"
+          className="absolute -bottom-3.5 -right-3.5 z-8 grid h-8 min-h-8 w-8 place-items-center rounded-full border border-app-line-strong bg-app-surface-raised p-0 text-[15px] leading-none text-app-accent shadow-app-menu transition-[color,background-color,border-color,transform,box-shadow] duration-150 ease-out hover:border-app-accent hover:bg-app-accent-muted hover:shadow-app-card active:translate-y-px active:scale-[0.94] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent motion-reduce:transform-none"
           aria-label="添加动作分支"
           onClick={() => {
             input.setActionMenuLevel('root')
@@ -898,7 +954,11 @@ function FirstFrameContent({
                 }))
               }
             >
-              <img className={THUMB_IMAGE} src={image.url} alt={`动作首帧候选 ${index + 1}`} />
+              <WorkflowImage
+                src={image.url}
+                alt={`动作首帧候选 ${index + 1}`}
+                variant="thumbnail"
+              />
             </button>
           ))}
         </div>
@@ -920,7 +980,7 @@ function FirstFrameContent({
   if (node.phase === 'completed' && node.selectedFirstFrameUrl) {
     return (
       <div className={CARD_STACK}>
-        <img className={MASTER_IMAGE} src={node.selectedFirstFrameUrl} alt="已确认动作首帧" />
+        <WorkflowImage src={node.selectedFirstFrameUrl} alt="已确认动作首帧" variant="master" />
         <div className="grid gap-2">
           <button
             type="button"
@@ -1017,7 +1077,7 @@ function MethodContent({
       >
         视频裁剪
       </button>
-      <button type="button" className={CARD_BUTTON} disabled title="后端接口尚未提供">
+      <button type="button" className={CARD_BUTTON_SECONDARY} disabled title="后端接口尚未提供">
         3D 转 2D · 尚未开放
       </button>
     </div>
@@ -1073,11 +1133,11 @@ function AnimationContent({
       <div className={CARD_STACK}>
         <div className="nodrag nopan nowheel grid max-h-40 grid-cols-8 gap-[3px] overflow-auto">
           {frames.map((frame, index) => (
-            <img
+            <WorkflowImage
               key={`${frame.url}-${index}`}
-              className="block aspect-square w-full rounded border border-[var(--color-app-line)] object-cover"
               src={frame.url}
               alt={`动画帧 ${index + 1}`}
+              variant="frame"
             />
           ))}
         </div>
@@ -1130,23 +1190,29 @@ function ReviewContent({ node, input }: { node: ReviewWorkflowNode; input: Proje
   )
 }
 
-function WorkflowCard({ data }: NodeProps<WorkflowCardNode>) {
+function WorkflowCard({ data, selected }: NodeProps<WorkflowCardNode>) {
   return (
     <article
+      aria-label={data.title}
       className={[
-        'w-[368px] overflow-visible rounded-xl border border-[var(--color-app-line)] bg-app-surface-raised/98 shadow-[var(--shadow-app-panel)]',
+        'w-[296px] overflow-visible rounded-[10px] border bg-app-surface-raised/98 transition-[border-color,box-shadow,opacity] duration-150 ease-out',
+        selected
+          ? 'border-app-accent shadow-app-card'
+          : 'border-app-line shadow-app-menu hover:border-app-line-strong',
         data.status === 'failed' ? 'border-dashed' : 'border-solid',
-        data.status === 'locked' ? 'opacity-45' : '',
+        data.status === 'locked' ? 'opacity-60' : '',
       ].join(' ')}
     >
       <Handle type="target" position={Position.Left} isConnectable={false} />
-      <header className="workflow-card__handle grid min-h-[62px] cursor-grab select-none content-center gap-0.5 rounded-t-[11px] bg-app-accent px-[18px] py-3 text-app-on-accent active:cursor-grabbing">
-        <span className="text-[8px] font-extrabold tracking-[0.12em] text-app-line">
+      <header className="workflow-card__handle flex min-h-[50px] cursor-grab select-none items-center gap-2 px-3.5 py-2.5 active:cursor-grabbing">
+        <span className="font-mono text-[9px] font-bold leading-none text-app-muted">
           {data.eyebrow}
         </span>
-        <strong className="text-sm font-bold">{data.title}</strong>
+        <strong className="text-[13px] font-semibold text-app-ink-soft">{data.title}</strong>
       </header>
-      <div className="rounded-b-[11px] bg-app-surface-raised/98 p-[21px]">{data.content}</div>
+      <div className="rounded-b-[9px] bg-app-surface-raised/98 px-3.5 pb-3.5 pt-1">
+        {data.content}
+      </div>
       <Handle type="source" position={Position.Right} isConnectable={false} />
     </article>
   )
@@ -1179,6 +1245,14 @@ function StatusText({ node, input }: { node: WorkflowNode; input: ProjectionInpu
   }
   const label =
     node.status === 'locked' ? '等待上游节点' : node.phase === 'generating' ? '生成中…' : '处理中…'
+  if (node.phase === 'generating' || (node.status === 'active' && label === '处理中…')) {
+    return (
+      <p role="status" className={`${CARD_SUMMARY} flex items-center gap-2`}>
+        <span className="workflow-status-pulse h-1.5 w-1.5 shrink-0 rounded-full bg-app-accent" />
+        {label}
+      </p>
+    )
+  }
   return <p className={CARD_SUMMARY}>{label}</p>
 }
 
@@ -1226,28 +1300,28 @@ function branchIndexFor(branchKey: string, actionRootIds: string[]): number {
 
 function positionFor(type: WorkflowNode['type'], branchIndex: number) {
   const x: Record<WorkflowNode['type'], number> = {
-    'character-setup': 70,
-    'character-template': 510,
-    'action-first-frame': 950,
-    'action-generation-method': 1390,
-    'action-full-frame': 1820,
-    review: 2250,
+    'character-setup': 60,
+    'character-template': 400,
+    'action-first-frame': 740,
+    'action-generation-method': 1080,
+    'action-full-frame': 1420,
+    review: 1760,
   }
   const isActionBranch = type.startsWith('action') || type === 'review'
   return {
     x: x[type],
-    y: isActionBranch ? 60 + branchIndex * 510 : 280,
+    y: isActionBranch ? 48 + branchIndex * 380 : 218,
   }
 }
 
 /** 卡片抬头文案。序号是流程顺序，与 positionFor 的横向排布一致。 */
 const CARD_LABELS: Record<WorkflowNode['type'], { eyebrow: string; title: string }> = {
-  'character-setup': { eyebrow: '01 · ORIGIN', title: '角色设定' },
-  'character-template': { eyebrow: '02 · MASTER', title: '身份母版' },
-  'action-first-frame': { eyebrow: '03 · FIRST FRAME', title: '动作首帧' },
-  'action-generation-method': { eyebrow: '04 · METHOD', title: '生产方式' },
-  'action-full-frame': { eyebrow: '05 · ANIMATION', title: '完整动画' },
-  review: { eyebrow: '06 · REVIEW', title: '动画审核' },
+  'character-setup': { eyebrow: '01', title: '角色设定' },
+  'character-template': { eyebrow: '02', title: '身份母版' },
+  'action-first-frame': { eyebrow: '03', title: '动作首帧' },
+  'action-generation-method': { eyebrow: '04', title: '生产方式' },
+  'action-full-frame': { eyebrow: '05', title: '完整动画' },
+  review: { eyebrow: '06', title: '动画审核' },
 }
 
 /**

--- a/frontend/src/pages/workflow-editor/workflow-editor-view.tsx
+++ b/frontend/src/pages/workflow-editor/workflow-editor-view.tsx
@@ -64,17 +64,15 @@ export function WorkflowEditorView({
   return (
     <div className="workflow-editor-shell fixed inset-0 z-30 overflow-hidden bg-[var(--color-app-canvas)] text-[var(--color-app-ink)]">
       <aside
-        className="pointer-events-none absolute bottom-[18px] left-[18px] z-15 grid min-w-[250px] max-w-[min(380px,calc(100vw-112px))] gap-1 rounded-[10px] border border-app-line bg-app-surface-raised/90 px-[15px] py-3 shadow-app-menu backdrop-blur-[14px]"
+        className="pointer-events-none absolute bottom-4 left-4 z-15 grid min-w-[220px] max-w-[min(340px,calc(100vw-104px))] gap-1 rounded-lg border border-app-line bg-app-surface-raised/92 px-3.5 py-3 shadow-app-menu backdrop-blur-xl"
         aria-label="当前项目"
       >
         <div>
-          <p className="m-0 mb-[5px] text-[8px] font-extrabold tracking-[0.12em] text-app-faint">
-            PROJECT
-          </p>
+          <p className="m-0 mb-1 text-[9px] font-semibold text-app-muted">当前项目</p>
           <h1 className="m-0 text-sm font-bold text-app-ink-soft">{project.name}</h1>
         </div>
         <p className="m-0 overflow-hidden text-ellipsis whitespace-nowrap text-[9px] leading-[1.5] text-app-faint">
-          {constraints.join(' · ')}
+          {constraints.join(' / ')}
         </p>
         <div className="mt-1 flex justify-end">
           <small className="font-mono text-[8px] font-bold text-[var(--color-app-muted)]">
@@ -120,7 +118,7 @@ export function WorkflowEditorView({
           elementsSelectable
           deleteKeyCode={null}
           fitView
-          fitViewOptions={{ padding: 0.14, maxZoom: 0.82 }}
+          fitViewOptions={{ padding: 0.16, maxZoom: 0.92 }}
           minZoom={0.3}
           maxZoom={1.2}
         >
@@ -138,7 +136,7 @@ function FitViewOnNodeSetChange({ nodeIds }: { nodeIds: string[] }) {
   useEffect(() => {
     if (!signature) return
     const timer = window.setTimeout(() => {
-      void fitView({ padding: 0.14, maxZoom: 0.82, duration: 180 })
+      void fitView({ padding: 0.16, maxZoom: 0.92, duration: 180 })
     }, 32)
     return () => window.clearTimeout(timer)
   }, [fitView, signature])

--- a/frontend/src/pages/workflow-editor/workflow-editor.css
+++ b/frontend/src/pages/workflow-editor/workflow-editor.css
@@ -31,13 +31,26 @@
   border-color: var(--color-app-line);
   color: var(--color-app-ink);
   background: color-mix(in srgb, var(--color-app-surface-raised) 76%, transparent);
+  transition:
+    color 150ms ease,
+    background-color 150ms ease,
+    transform 150ms ease;
+}
+
+.workflow-editor-canvas .react-flow__controls-button:hover {
+  color: var(--color-app-accent);
+  background: var(--color-app-accent-muted);
+}
+
+.workflow-editor-canvas .react-flow__controls-button:active {
+  transform: scale(0.94);
 }
 
 .workflow-editor-canvas .react-flow__handle {
-  top: 38px;
-  width: 22px;
-  height: 22px;
-  border: 4px solid var(--color-app-surface);
+  top: 25px;
+  width: 16px;
+  height: 16px;
+  border: 3px solid var(--color-app-surface);
   background: var(--color-app-line-strong);
   box-shadow: 0 0 0 1px var(--color-app-accent);
 }
@@ -48,25 +61,67 @@
 */
 .workflow-editor-canvas .workflow-edge--confirmed path {
   stroke: var(--color-app-line-strong);
-  stroke-width: 3;
+  stroke-width: 2;
 }
 
 .workflow-editor-canvas .workflow-edge--flowing path {
   stroke: color-mix(in srgb, var(--color-app-accent) 42%, transparent);
-  stroke-width: 3;
-  stroke-dasharray: 9 8;
+  stroke-width: 2;
+  stroke-dasharray: 7 7;
   animation: workflow-edge-flow 900ms linear infinite;
   will-change: stroke-dashoffset;
 }
 
+.workflow-image-skeleton {
+  background: linear-gradient(
+    100deg,
+    var(--color-app-surface-muted) 18%,
+    var(--color-app-surface-raised) 46%,
+    var(--color-app-surface-muted) 74%
+  );
+  background-size: 220% 100%;
+  animation: workflow-image-shimmer 1.2s ease-in-out infinite;
+}
+
+.workflow-status-pulse {
+  animation: workflow-status-pulse 1.2s ease-in-out infinite;
+}
+
 @keyframes workflow-edge-flow {
   to {
-    stroke-dashoffset: -17;
+    stroke-dashoffset: -14;
+  }
+}
+
+@keyframes workflow-image-shimmer {
+  from {
+    background-position: 100% 0;
+  }
+  to {
+    background-position: -100% 0;
+  }
+}
+
+@keyframes workflow-status-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.82);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .workflow-editor-canvas .workflow-edge--flowing path {
+  .workflow-editor-canvas .workflow-edge--flowing path,
+  .workflow-image-skeleton,
+  .workflow-status-pulse {
     animation: none;
+  }
+
+  .workflow-editor-canvas .react-flow__controls-button {
+    transition: none;
   }
 }


### PR DESCRIPTION
收紧 Workflow Editor 的卡片与画布布局，简化标题层级，并补齐图片加载和按钮交互反馈，让完整工作流更容易浏览和操作。

## Why

原有卡片尺寸和节点间距过大，标题底色、英文阶段名与多种按钮样式同时争夺注意力；远程图片出现时缺少过程反馈，也容易让用户误判页面状态。

## Changes

- 将卡片宽度收紧至 296px，并缩短横向节点与动作分支间距。
- 标题只保留流程序号和中文名称，移除英文阶段名、标题底色、数字色块与分隔线。
- 区分主要推进动作和次要导出动作，统一 hover、active、focus-visible 反馈。
- 为候选图、母版、动作首帧和动画帧增加固定版面、加载骨架、淡入与失败状态。
- 收细连线与连接点，并为画布控件和处理中状态补充轻量反馈。

## Implementation

- 保持 `WorkflowController`、`WorkflowRun` 和 React Flow 交互约束不变，只调整页面投影和视觉组件。
- 动画统一响应 `prefers-reduced-motion`。
- 在最新 `upstream/main` 上移植，保留现有自定义动作、重新生成、微调和冲突恢复能力。

## Verification

- [x] `npm test -- src/pages/workflow-editor/index.test.tsx`：50/50 通过。
- [x] `npm run test:coverage -- src/pages/workflow-editor/index.test.tsx`：图片失败、生成中与处理中分支均命中。
- [x] `npm run typecheck`：通过。
- [x] `npx oxlint src/pages/workflow-editor/index.tsx src/pages/workflow-editor/index.test.tsx src/pages/workflow-editor/workflow-editor-view.tsx`：通过。
- [x] `npx oxfmt --check src/pages/workflow-editor/index.tsx src/pages/workflow-editor/index.test.tsx src/pages/workflow-editor/workflow-editor-view.tsx src/pages/workflow-editor/workflow-editor.css`：通过。
- [x] `VITE_API_BASE_URL=/api npm run build`：通过。

## Scope

- 本 PR 不修改工作流业务状态机、生成接口、发布流程或其他页面。
- 编辑器路由 fallback、WorkflowRun 初次恢复和参考图上传反馈仍由 #437 跟踪。

## Related Issues

Closes #442
Refs #437
