### PR TITLE
ci(backend): OpenAPI 漂移时打印修复命令

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -41,7 +41,14 @@ jobs:
       - name: OpenAPI contract drift
         run: |
           uv run python -m scripts.export_openapi
-          git diff --exit-code -- ../openapi.json
+          if ! git diff --quiet -- ../openapi.json; then
+            echo "::error::openapi.json 与代码对不上：改了 API 模型但没重新导出。"
+            echo "在 backend/ 下跑这一条，然后把 openapi.json 一起提交："
+            echo "    uv run python -m scripts.export_openapi && git add ../openapi.json"
+            echo "--- 实际差异 ---"
+            git --no-pager diff -- ../openapi.json
+            exit 1
+          fi
 
       - name: Import-linter (分层契约)
         run: uv run lint-imports


### PR DESCRIPTION
## 改动

`backend.yml` 的 OpenAPI contract drift 步骤：判定为漂移时先打印 `::error::` 注解与修复命令，再打印差异，然后以 1 退出。判定方式与退出码均不变。

## 这道提示拦住了哪个真实坏例

`feat/directional-generation-pipeline` 的 `394bdef`（run #871）新增了 `ActionDirection` 枚举，没有重新导出 `openapi.json`。在该提交上跑改后的这一步，输出：

```
::error::openapi.json 与代码对不上：改了 API 模型但没重新导出。
在 backend/ 下跑这一条，然后把 openapi.json 一起提交：
    uv run python -m scripts.export_openapi && git add ../openapi.json
--- 实际差异 ---
diff --git a/openapi.json b/openapi.json
@@ -1,6 +1,20 @@
+      "ActionDirection": {
+        "enum": [
+          "east",
...
```

退出码 1。同一段脚本在无漂移的主干上退出码 0，两者都实测过。

改之前，同一个提交的 CI 输出只有那段 `diff`，没有任何一句说明该做什么。

## 不包含

- 不改导出脚本，也不改比对方式。
- 不自动提交 `openapi.json`。

Closes #445
