### PR TITLE
fix(ci): 发 Release 时显式给出 tagger 身份

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,10 @@ jobs:
           fi
           # tag 可能是上一次跑到一半留下的。已存在且指向同一个提交就沿用,指向别处则是
           # 真冲突,必须报错而不是悄悄挪走别人的 tag。
+          # 附注 tag 要写进 tagger 身份,而 runner 的主机名是 `.(none)`,git 推不出邮箱,
+          # 直接以 128 退出。身份必须显式给,不能指望自动探测。
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git rev-parse -q --verify "refs/tags/$NEXT" >/dev/null; then
             if [ "$(git rev-parse "refs/tags/$NEXT^{commit}")" != "$(git rev-parse HEAD)" ]; then
               echo "::error::$NEXT 已指向别的提交,不覆盖"; exit 1


### PR DESCRIPTION
## 改动

`release.yml` 的 `Tag and publish` 步骤在打 tag 前显式配置 `user.name` / `user.email`（`github-actions[bot]`）。版本号推导、幂等判据、Release 正文与触发条件均不变，净增 4 行。

## 它修的是哪个真实坏例

`release.yml` 自 #387 合入（08-19 03:27）起运行 13 次，**全部失败，成功 0 次**，失败点始终是这一步。抽取最近 4 次，报错一致：

```
run 32241886981  fatal: unable to auto-detect email address (got 'runner@runnervm76f27.(none)')
run 32240309172  fatal: empty ident name (for <runner@runnervm76f27...cloudapp.net>) not allowed
run 32239091064  fatal: empty ident name (for <runner@runnervmzvulz...cloudapp.net>) not allowed
run 32237805936  fatal: empty ident name (for <runner@runnervmzvulz...cloudapp.net>) not allowed
```

`git tag -a` 要把 tagger 写进附注 tag，runner 主机名带 `.(none)` 时 git 推不出邮箱，以 128 退出。

## 关于验证的说明

这一处**无法在本地复现**：macOS 能从系统全名与可解析主机名自动推出身份，同一条 `git tag -a` 在本地直接成功。所以本 PR 不附合成复现，判据取生产数据（上面 13 次运行）。修复是否生效，以合入后 main 上的下一次 release 运行为准。

## 不包含

- 不改版本号推导、幂等判据与 Release 正文。
- 不改触发条件。

Closes #447
