### PR TITLE
feat(quick-start): add character generation controller

### DIFF
--- a/frontend/src/features/workflow-controller/index.ts
+++ b/frontend/src/features/workflow-controller/index.ts
@@ -7,3 +7,15 @@ export type {
   GenerateCharacterTemplateOptions,
   WorkflowController,
 } from './controller'
+export {
+  createAutoPrepareProject,
+  createQuickStartCharacterNodes,
+  createQuickStartWorkflowController,
+} from './quick-start-controller'
+export type {
+  CreateQuickStartWorkflowControllerOptions,
+  PrepareQuickStartProject,
+  QuickStartWorkflowController,
+  StartCharacterGenerationInput,
+  StartCharacterGenerationResult,
+} from './quick-start-controller'

--- a/frontend/src/features/workflow-controller/quick-start-controller.test.ts
+++ b/frontend/src/features/workflow-controller/quick-start-controller.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { GenerationApis, ProjectApis, WorkflowRunApis } from '@/entities'
+
+import type { WorkflowController } from './controller'
+import { createQuickStartWorkflowController } from './quick-start-controller'
+
+function fixture() {
+  let run = {
+    id: 'run-1',
+    projectId: 'project-1',
+    version: 1,
+    storageStatus: 'active' as const,
+    nodes: [],
+  }
+  const workflowController = {
+    create: vi.fn(async (input) => {
+      run = { ...run, projectId: input.projectId, nodes: input.nodes }
+    }),
+    generateCharacterTemplate: vi.fn(async () => undefined),
+    getWorkflow: vi.fn(() => structuredClone(run)),
+    dispose: vi.fn(),
+  } as unknown as WorkflowController
+  const createController = vi.fn(() => workflowController)
+  const projectApis = {
+    create: vi.fn(async (input) => ({
+      id: 'project-1',
+      ...input,
+      description: null,
+      createdAt: '2026-08-19T00:00:00Z',
+      updatedAt: '2026-08-19T00:00:00Z',
+    })),
+  } as unknown as ProjectApis
+  const controller = createQuickStartWorkflowController({
+    projectApis,
+    workflowRunApis: {} as WorkflowRunApis,
+    generationApis: {} as GenerationApis,
+    createController,
+    onAsyncError: vi.fn(),
+  })
+  return { controller, createController, projectApis, workflowController }
+}
+
+describe('createQuickStartWorkflowController', () => {
+  it('rejects an empty prompt before provisioning business resources', async () => {
+    const { controller, createController, projectApis } = fixture()
+
+    await expect(controller.startCharacterGeneration({ prompt: '   ' })).rejects.toThrow(
+      '请先描述想要创建的角色',
+    )
+
+    expect(projectApis.create).not.toHaveBeenCalled()
+    expect(createController).not.toHaveBeenCalled()
+  })
+
+  it('provisions one project and starts one persisted character-template generation', async () => {
+    const { controller, createController, projectApis, workflowController } = fixture()
+
+    await expect(
+      controller.startCharacterGeneration({ prompt: '  银发的像素骑士  ' }),
+    ).resolves.toEqual({ runId: 'run-1' })
+
+    expect(projectApis.create).toHaveBeenCalledTimes(1)
+    expect(projectApis.create).toHaveBeenCalledWith({
+      name: '银发的像素骑士',
+      perspective: 'side',
+      directionalMovement: 'single',
+      spriteSize: { width: 256, height: 256 },
+    })
+    expect(createController).toHaveBeenCalledTimes(1)
+    expect(workflowController.create).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      nodes: [
+        {
+          id: 'character-setup',
+          type: 'character-setup',
+          status: 'active',
+          phase: 'configuring',
+          dependsOnNodeIds: [],
+          generations: [],
+          error: null,
+          input: { prompt: '银发的像素骑士', referenceMedia: [] },
+        },
+        {
+          id: 'character-template',
+          type: 'character-template',
+          status: 'locked',
+          phase: 'ready',
+          dependsOnNodeIds: ['character-setup'],
+          generations: [],
+          error: null,
+          selectedImageUrl: null,
+        },
+      ],
+    })
+    expect(workflowController.generateCharacterTemplate).toHaveBeenCalledTimes(1)
+    expect(workflowController.generateCharacterTemplate).toHaveBeenCalledWith('character-setup', {
+      spriteWidth: 256,
+      spriteHeight: 256,
+    })
+    expect(workflowController.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry the paid write when generation submission fails', async () => {
+    const { controller, projectApis, workflowController } = fixture()
+    vi.mocked(workflowController.generateCharacterTemplate).mockRejectedValueOnce(
+      new Error('generation response lost'),
+    )
+
+    await expect(controller.startCharacterGeneration({ prompt: '像素骑士' })).rejects.toThrow(
+      'generation response lost',
+    )
+
+    expect(projectApis.create).toHaveBeenCalledTimes(1)
+    expect(workflowController.generateCharacterTemplate).toHaveBeenCalledTimes(1)
+    expect(workflowController.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts a host project provisioner so other Quick Start paths can share naming policy', async () => {
+    const { createController, workflowController } = fixture()
+    const prepareProject = vi.fn(async () => ({
+      id: 'project-shared',
+      spriteSize: { width: 128, height: 96 },
+    }))
+    const controller = createQuickStartWorkflowController({
+      prepareProject,
+      workflowRunApis: {} as WorkflowRunApis,
+      generationApis: {} as GenerationApis,
+      createController,
+      onAsyncError: vi.fn(),
+    })
+
+    await controller.startCharacterGeneration({ prompt: '  共享项目策略  ' })
+
+    expect(prepareProject).toHaveBeenCalledWith('共享项目策略')
+    expect(workflowController.create).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'project-shared' }),
+    )
+    expect(workflowController.generateCharacterTemplate).toHaveBeenCalledWith('character-setup', {
+      spriteWidth: 128,
+      spriteHeight: 96,
+    })
+  })
+})

--- a/frontend/src/features/workflow-controller/quick-start-controller.ts
+++ b/frontend/src/features/workflow-controller/quick-start-controller.ts
@@ -1,0 +1,165 @@
+import {
+  ProjectNameConflictError,
+  type GenerationApis,
+  type MediaReference,
+  type Project,
+  type ProjectApis,
+  type WorkflowNode,
+  type WorkflowRun,
+  type WorkflowRunApis,
+} from '@/entities'
+
+import {
+  createWorkflowController,
+  type CreateWorkflowControllerOptions,
+  type WorkflowController,
+} from './controller'
+
+const PROJECT_NAME_MAX_LENGTH = 20
+const QUICK_START_PROJECT_NAME_ATTEMPTS = 100
+
+export type PrepareQuickStartProject = (
+  prompt: string,
+) => Promise<Pick<Project, 'id' | 'spriteSize'>>
+
+export interface StartCharacterGenerationInput {
+  prompt: string
+}
+
+export interface StartCharacterGenerationResult {
+  runId: WorkflowRun['id']
+}
+
+export interface QuickStartWorkflowController {
+  startCharacterGeneration(
+    input: StartCharacterGenerationInput,
+  ): Promise<StartCharacterGenerationResult>
+}
+
+interface QuickStartWorkflowControllerDependencies {
+  workflowRunApis: WorkflowRunApis
+  generationApis: GenerationApis
+  onAsyncError?: (error: Error) => void
+  /** 单测可替换装配点；生产始终使用现有的一 Run 一 Controller 实现。 */
+  createController?: (options: CreateWorkflowControllerOptions) => WorkflowController
+}
+
+export type CreateQuickStartWorkflowControllerOptions = QuickStartWorkflowControllerDependencies &
+  (
+    | {
+        projectApis: Pick<ProjectApis, 'create'>
+        prepareProject?: never
+      }
+    | {
+        /** 已有 Quick Start 路径可注入同一项目命名策略，Controller 仍拥有调用时机。 */
+        prepareProject: PrepareQuickStartProject
+        projectApis?: never
+      }
+  )
+
+function boundedDisplayName(value: string, maxLength: number): string {
+  const characters = Array.from(value)
+  return characters.length > maxLength
+    ? `${characters.slice(0, maxLength - 1).join('')}…`
+    : characters.join('')
+}
+
+/** Quick Start 的两节点入口图；上传母版与纯文本入口共用同一份结构。 */
+export function createQuickStartCharacterNodes(
+  prompt: string,
+  referenceMedia: readonly MediaReference[] = [],
+): WorkflowNode[] {
+  return [
+    {
+      id: 'character-setup',
+      type: 'character-setup',
+      status: 'active',
+      phase: 'configuring',
+      dependsOnNodeIds: [],
+      generations: [],
+      error: null,
+      input: { prompt, referenceMedia: [...referenceMedia] },
+    },
+    {
+      id: 'character-template',
+      type: 'character-template',
+      status: 'locked',
+      phase: 'ready',
+      dependsOnNodeIds: ['character-setup'],
+      generations: [],
+      error: null,
+      selectedImageUrl: null,
+    },
+  ]
+}
+
+export function createAutoPrepareProject(
+  projectApis: Pick<ProjectApis, 'create'>,
+): PrepareQuickStartProject {
+  return async (prompt) => {
+    const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
+    let lastConflict: unknown
+
+    for (let sequence = 1; sequence <= QUICK_START_PROJECT_NAME_ATTEMPTS; sequence += 1) {
+      const suffix = sequence === 1 ? '' : ` ${sequence}`
+      const maxBaseLength = PROJECT_NAME_MAX_LENGTH - Array.from(suffix).length
+      const base = boundedDisplayName(normalizedPrompt, maxBaseLength)
+
+      try {
+        const project = await projectApis.create({
+          name: `${base}${suffix}`,
+          perspective: 'side',
+          directionalMovement: 'single',
+          spriteSize: { width: 256, height: 256 },
+        })
+        return { id: project.id, spriteSize: project.spriteSize }
+      } catch (error) {
+        if (!(error instanceof ProjectNameConflictError)) throw error
+        lastConflict = error
+      }
+    }
+
+    throw lastConflict
+  }
+}
+
+/**
+ * 纯文本 Quick Start 的唯一写入口。
+ *
+ * 它只负责准备 Project、创建一条 Run 并通过现有 Controller 提交角色母版任务。
+ * Generation 引用持久化后立即释放本地订阅；后续页面会按 runId 重新打开同一条 Run。
+ */
+export function createQuickStartWorkflowController({
+  projectApis,
+  prepareProject: providedPrepareProject,
+  workflowRunApis,
+  generationApis,
+  onAsyncError = (error) => console.error('[quick-start-controller] 异步工作流错误', error),
+  createController = createWorkflowController,
+}: CreateQuickStartWorkflowControllerOptions): QuickStartWorkflowController {
+  const prepareProject =
+    providedPrepareProject ?? createAutoPrepareProject(projectApis as Pick<ProjectApis, 'create'>)
+
+  return {
+    async startCharacterGeneration({ prompt }) {
+      const normalizedPrompt = prompt.trim()
+      if (!normalizedPrompt) throw new Error('请先描述想要创建的角色')
+
+      const project = await prepareProject(normalizedPrompt)
+      const controller = createController({ workflowRunApis, generationApis, onAsyncError })
+      try {
+        await controller.create({
+          projectId: project.id,
+          nodes: createQuickStartCharacterNodes(normalizedPrompt),
+        })
+        await controller.generateCharacterTemplate('character-setup', {
+          spriteWidth: project.spriteSize.width,
+          spriteHeight: project.spriteSize.height,
+        })
+        return { runId: controller.getWorkflow().id }
+      } finally {
+        controller.dispose()
+      }
+    },
+  }
+}

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -474,6 +474,25 @@ describe('createQuickStartService', () => {
     )
   })
 
+  it('returns the accepted generation without adding a fallible post-write run read', async () => {
+    const workflowRunApis = createWorkflowRunApis()
+    vi.spyOn(workflowRunApis, 'get').mockRejectedValue(new Error('run read unavailable'))
+    const service = createQuickStartService({
+      workflowRunApis,
+      generationApis: pendingGenerationApis(),
+      prepareProject: async () => ({ id: 'project-1', spriteSize: { width: 256, height: 256 } }),
+      projectApis: projectReader(),
+    })
+
+    const session = await service.start('像素骑士')
+
+    expect(session.getWorkflow().nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'character-template', phase: 'generating' }),
+      ]),
+    )
+  })
+
   it('creates the character without a name so the backend derives it from the description', async () => {
     const longPrompt = '一位穿着红色斗篷的像素风格女骑士手持长剑站立'
     let savedCharacter = characterFixture({

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -3,7 +3,6 @@ import {
   createGenerationApis,
   createMediaApis,
   projectApis,
-  ProjectNameConflictError,
   workflowRunApis,
   type Action,
   type Character,
@@ -20,13 +19,18 @@ import {
 } from '@/entities'
 import { getApiAccessToken, recoverApiUnauthorized, resolveApiBaseUrl } from '@/shared/api'
 import { createEventStreamSubscriber } from '@/shared/api/stream'
-import { createWorkflowController, type WorkflowController } from '@/features/workflow-controller'
+import {
+  createAutoPrepareProject,
+  createQuickStartCharacterNodes,
+  createQuickStartWorkflowController,
+  createWorkflowController,
+  type PrepareQuickStartProject,
+  type WorkflowController,
+} from '@/features/workflow-controller'
 import { createProgressiveExportModel, type ExportPackageModel } from '@/features/export-package'
 
-/** 页面不直接拼接后端字段；只负责准备项目约束。 */
-export type PrepareQuickStartProject = (
-  prompt: string,
-) => Promise<Pick<Project, 'id' | 'spriteSize'>>
+export { createAutoPrepareProject } from '@/features/workflow-controller'
+export type { PrepareQuickStartProject } from '@/features/workflow-controller'
 
 export interface QuickStartFrame {
   index: number
@@ -93,8 +97,6 @@ export interface CreateQuickStartServiceOptions {
 
 type GeneratableActionType = 'idle' | 'walk' | 'jump' | 'attack' | 'custom'
 
-const PROJECT_NAME_MAX_LENGTH = 20
-const QUICK_START_PROJECT_NAME_ATTEMPTS = 100
 const ACTION_DISPLAY_NAME_MAX_LENGTH = 20
 
 function boundedDisplayName(value: string, maxLength: number): string {
@@ -134,7 +136,6 @@ export function createQuickStartService({
       report(error: Error): void
     }
   >()
-
   async function shouldRollbackWorkflowChange(
     runId: WorkflowRun['id'],
     isPersisted: (latest: WorkflowRun) => boolean,
@@ -223,34 +224,6 @@ export function createQuickStartService({
           item.dependsOnNodeIds.includes(fullFrameNodeId),
       ) ?? null
     )
-  }
-
-  function workflowNodes(
-    prompt: string,
-    referenceMedia: readonly MediaReference[] = [],
-  ): WorkflowNode[] {
-    return [
-      {
-        id: 'character-setup',
-        type: 'character-setup',
-        status: 'active',
-        phase: 'configuring',
-        dependsOnNodeIds: [],
-        generations: [],
-        error: null,
-        input: { prompt, referenceMedia },
-      },
-      {
-        id: 'character-template',
-        type: 'character-template',
-        status: 'locked',
-        phase: 'ready',
-        dependsOnNodeIds: ['character-setup'],
-        generations: [],
-        error: null,
-        selectedImageUrl: null,
-      },
-    ]
   }
 
   function existingCharacterNodes(
@@ -772,7 +745,10 @@ export function createQuickStartService({
       if (!normalizedPrompt) throw new Error('请先描述想要创建的角色')
       const project = await prepareProject(normalizedPrompt)
       projectSpriteSizes.set(project.id, project.spriteSize)
-      const controller = await createRun(project.id, workflowNodes(normalizedPrompt))
+      const controller = await createRun(
+        project.id,
+        createQuickStartCharacterNodes(normalizedPrompt),
+      )
       await controller.generateCharacterTemplate('character-setup', {
         spriteWidth: project.spriteSize.width,
         spriteHeight: project.spriteSize.height,
@@ -787,7 +763,10 @@ export function createQuickStartService({
       const project = await prepareProject(prompt)
       projectSpriteSizes.set(project.id, project.spriteSize)
       const templateReference = await mediaApis.upload(file, 'reference-image', signal)
-      const controller = await createRun(project.id, workflowNodes(prompt, [templateReference]))
+      const controller = await createRun(
+        project.id,
+        createQuickStartCharacterNodes(prompt, [templateReference]),
+      )
       await controller.updateCharacterSetup('character-setup', {
         prompt,
         referenceMedia: [templateReference],
@@ -808,35 +787,6 @@ export function createQuickStartService({
       const run = await workflowRunApis.get(runId)
       return createSession(createController(run), projectSpriteSizes.get(run.projectId))
     },
-  }
-}
-
-export function createAutoPrepareProject(projectApis: ProjectApis): PrepareQuickStartProject {
-  return async (prompt) => {
-    const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
-    let lastConflict: unknown
-
-    for (let sequence = 1; sequence <= QUICK_START_PROJECT_NAME_ATTEMPTS; sequence += 1) {
-      // 首次名称不预留编号空间；只有重名时才缩短前缀，为可读编号让出 20 字上限。
-      const suffix = sequence === 1 ? '' : ` ${sequence}`
-      const maxBaseLength = PROJECT_NAME_MAX_LENGTH - Array.from(suffix).length
-      const base = boundedDisplayName(normalizedPrompt, maxBaseLength)
-
-      try {
-        const project = await projectApis.create({
-          name: `${base}${suffix}`,
-          perspective: 'side',
-          directionalMovement: 'single',
-          spriteSize: { width: 256, height: 256 },
-        })
-        return { id: project.id, spriteSize: project.spriteSize }
-      } catch (error) {
-        if (!(error instanceof ProjectNameConflictError)) throw error
-        lastConflict = error
-      }
-    }
-
-    throw lastConflict
   }
 }
 
@@ -889,11 +839,21 @@ const generationApis = createGenerationApis({
   },
 })
 
-/** Quick Start 的生产实例；身份仅由会话 token 提供。 */
-export const quickStartService = createRealQuickStartService({
+const productionPrepareProject = createAutoPrepareProject(projectApis)
+
+/** Agent 只拿这一项写能力；页面服务与 Agent 不互相调用。 */
+export const quickStartWorkflowController = createQuickStartWorkflowController({
+  prepareProject: productionPrepareProject,
+  workflowRunApis,
+  generationApis,
+})
+
+/** Quick Start 的生产实例；上传母版与生成后的确定性流程仍由它负责。 */
+export const quickStartService = createQuickStartService({
   projectApis,
   characterApis,
   generationApis,
+  prepareProject: productionPrepareProject,
   mediaApis: createMediaApis(),
   workflowRunApis,
 })


### PR DESCRIPTION
为 Quick Start 抽出一个独立的角色母版生成入口，让后续规划器只能通过现有 `WorkflowController` 提交一次生成，同时保持当前纯文本与上传母版流程不变。

## Why

Quick Start 目前把 Project 准备、WorkflowRun 创建和角色母版提交组合在页面 Service 内。后续接入规划器时，如果直接复用 Service 或调用 Entity API，会让生成写入绕过 Controller 边界，也更容易在响应不确定时重复提交付费任务。

## Changes

- 新增 `QuickStartWorkflowController.startCharacterGeneration()`，统一准备 Project、创建 Run 并提交角色母版 Generation。
- 将项目命名策略和 Quick Start 两节点入口图移入 Controller feature，现有纯文本与上传母版路径继续复用同一实现。
- Generation 被现有 Controller 接受后直接返回内存 WorkflowRun 的 `runId`，不增加一次易失败的写后读取。
- 成功或失败都会释放本地 Controller 订阅，付费写操作不自动重试。

## Implementation

- 入口 Controller 内部装配现有一 Run 一实例的 `WorkflowController`，不建立第二套工作流状态机。
- 页面 Service 仍负责上传母版与生成后的确定性流程；本次只抽取纯文本角色母版启动所需的写入口。
- Controller 可注入已有项目准备策略，避免生产路径出现两套项目命名规则。

## Verification

- [x] `npm test -- src/features/workflow-controller/quick-start-controller.test.ts src/pages/quick-start/service.test.ts src/pages/quick-start/index.test.tsx`：3 个文件、102 项测试通过。
- [x] `npx oxfmt --check src/features/workflow-controller/index.ts src/features/workflow-controller/quick-start-controller.ts src/features/workflow-controller/quick-start-controller.test.ts src/pages/quick-start/service.ts src/pages/quick-start/service.test.ts`：5 个变更文件通过。
- [x] `npx oxlint src/features/workflow-controller/index.ts src/features/workflow-controller/quick-start-controller.ts src/features/workflow-controller/quick-start-controller.test.ts src/pages/quick-start/service.ts src/pages/quick-start/service.test.ts`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run build`：通过；保留现有大于 500 kB 的 chunk 提示。

## Scope

- 本 PR 不包含 LLM、AI SDK、Agent runtime、Quick Start 页面交互或后端改动。
- #452 只会在本 PR 合并后从新的 `main` 开始，不创建依赖 PR。

## Related Issues

Closes #451

Refs #443
