### PR TITLE
feat(agent): add single-tool Quick Start planner core

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,10 @@
       "name": "windup-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@ai-sdk/openai-compatible": "^3.0.31",
         "@phosphor-icons/react": "^2.1.10",
         "@xyflow/react": "^12.11.2",
+        "ai": "^7.0.68",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router": "^8.3.0"
@@ -30,6 +32,70 @@
         "typescript": "~6.0.2",
         "vite": "^8.1.1",
         "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.54",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.54.tgz",
+      "integrity": "sha512-x4fAXDqCtYzB/M5vsIQLYcyrzpJuaRgcIwDSw+lpTMMbgH19fU3ds75GSlHNLzfx6Z5yL4Z9+EMr0GJcqVy9QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible": {
+      "version": "3.0.31",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-3.0.31.tgz",
+      "integrity": "sha512-g6kbWJzI1mfHoZp2vXPyb/fiMrK8pNRU2dbum8rBHxemx+ryBJWFAwTndBaVefm+gx9A6fK7J/hSrdfRdVJlQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.27"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
+      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.27.tgz",
+      "integrity": "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.7",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1446,7 +1512,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -2178,6 +2243,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
@@ -2348,6 +2422,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@xyflow/react": {
       "version": "12.11.2",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
@@ -2388,6 +2468,23 @@
         "d3-interpolate": "^3.0.1",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.68",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.68.tgz",
+      "integrity": "sha512-9QuZOT77wzoxxUC0NcueXhCo3HUHA/1pApIJ9VRyE+9/K+3Innkq4kVhrd9aEnwIviJz2Nga063m+UTsPSdOyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.54",
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.27"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -2731,6 +2828,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2939,6 +3045,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3839,7 +3951,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -4110,6 +4221,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/zustand": {
       "version": "4.5.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,10 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
+    "@ai-sdk/openai-compatible": "^3.0.31",
     "@phosphor-icons/react": "^2.1.10",
     "@xyflow/react": "^12.11.2",
+    "ai": "^7.0.68",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router": "^8.3.0"

--- a/frontend/src/features/quick-start-agent/boundaries.test.ts
+++ b/frontend/src/features/quick-start-agent/boundaries.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { extname, join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const featureDirectory = resolve(import.meta.dirname)
+const quickStartPageDirectory = resolve(import.meta.dirname, '../../pages/quick-start')
+
+function productionFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return productionFiles(path)
+    if (!['.ts', '.tsx'].includes(extname(entry.name)) || entry.name.includes('.test.')) return []
+    return [path]
+  })
+}
+
+function moduleSpecifiers(source: string): string[] {
+  return [...source.matchAll(/(?:from\s+|import\s*\()(['"])([^'"]+)\1/gu)].map((match) => match[2]!)
+}
+
+describe('quick-start-agent architecture boundary', () => {
+  it('accepts business actions through injection instead of importing business modules', () => {
+    const forbidden = ['@/pages', '@/entities', '@/shared/api', '@/features']
+    const featureDependencies = productionFiles(featureDirectory).flatMap((file) =>
+      moduleSpecifiers(readFileSync(file, 'utf8')),
+    )
+
+    expect(
+      featureDependencies.filter((dependency) =>
+        forbidden.some((prefix) => dependency === prefix || dependency.startsWith(`${prefix}/`)),
+      ),
+    ).toEqual([])
+  })
+
+  it('keeps prompts, Tool schema, and SDK runtime out of the page directory', () => {
+    const pageSource = productionFiles(quickStartPageDirectory)
+      .map((file) => readFileSync(file, 'utf8'))
+      .join('\n')
+
+    expect(pageSource).not.toContain('start_character_generation')
+    expect(pageSource).not.toContain('generateText(')
+    expect(pageSource).not.toContain('quickStartPlannerInstructions')
+  })
+})

--- a/frontend/src/features/quick-start-agent/index.ts
+++ b/frontend/src/features/quick-start-agent/index.ts
@@ -1,0 +1,22 @@
+export { createAiSdkQuickStartPlanner, quickStartPlannerInstructions } from './planner'
+export type { CreateAiSdkQuickStartPlannerOptions, QuickStartGenerateText } from './planner'
+export {
+  createQuickStartAgent,
+  parseCharacterGenerationPlan,
+  START_CHARACTER_GENERATION_TOOL,
+  validatePlannerTerminal,
+} from './runtime'
+export type {
+  CharacterGenerationPlan,
+  CreateQuickStartAgentOptions,
+  PlannerInput,
+  PlannerMessage,
+  PlannerResult,
+  PlannerToolCall,
+  QuickStartAgent,
+  QuickStartAgentResult,
+  QuickStartAgentTurnOptions,
+  QuickStartPlanner,
+  StartCharacterGenerationAction,
+  ValidatedPlannerTerminal,
+} from './runtime'

--- a/frontend/src/features/quick-start-agent/planner.protocol.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.protocol.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createAiSdkQuickStartPlanner } from './planner'
+
+function completion(choice: Record<string, unknown>) {
+  return Response.json({
+    id: 'chatcmpl-fixture',
+    object: 'chat.completion',
+    created: 1,
+    model: 'server-model',
+    choices: [{ index: 0, ...choice }],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  })
+}
+
+describe('AI SDK OpenAI-compatible protocol fixture', () => {
+  it('parses a standard text completion without a custom response parser', async () => {
+    let requestBody: Record<string, unknown> | null = null
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      fetch: vi.fn(async (input, init) => {
+        requestBody = JSON.parse(await new Request(input, init).text())
+        return completion({
+          message: { role: 'assistant', content: '请补充一个外观特征。' },
+          finish_reason: 'stop',
+        })
+      }),
+    })
+
+    await expect(
+      planner({
+        messages: [{ role: 'user', content: '一个角色' }],
+        clarificationUsed: false,
+      }),
+    ).resolves.toEqual({
+      text: '请补充一个外观特征。',
+      finishReason: 'stop',
+      toolCalls: [],
+    })
+    const captured = requestBody as unknown as Record<string, unknown>
+    expect(captured).toMatchObject({
+      model: 'quick-start-planner',
+      tool_choice: 'auto',
+    })
+    expect(captured.stream).toBeUndefined()
+    expect((captured.tools as unknown[] | undefined)?.length).toBe(1)
+  })
+
+  it('parses one standard Tool Call and normalizes its finish reason', async () => {
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      fetch: vi.fn(async () =>
+        completion({
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call-1',
+                type: 'function',
+                function: {
+                  name: 'start_character_generation',
+                  arguments:
+                    '{"optimizedPrompt":"银发像素骑士全身像","assumptions":["默认单角色"]}',
+                },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        }),
+      ),
+    })
+
+    await expect(
+      planner({
+        messages: [{ role: 'user', content: '直接生成银发骑士' }],
+        clarificationUsed: false,
+      }),
+    ).resolves.toEqual({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'start_character_generation',
+          input: { optimizedPrompt: '银发像素骑士全身像', assumptions: ['默认单角色'] },
+        },
+      ],
+    })
+  })
+
+  it('surfaces a standard 401 and honors cancellation', async () => {
+    const unauthorized = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      fetch: vi.fn(async () =>
+        Response.json(
+          { error: { message: 'expired', type: 'authentication_error' } },
+          { status: 401 },
+        ),
+      ),
+    })
+    await expect(
+      unauthorized({
+        messages: [{ role: 'user', content: '一个角色' }],
+        clarificationUsed: false,
+      }),
+    ).rejects.toThrow()
+
+    const abortController = new AbortController()
+    const pending = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      fetch: vi.fn(
+        async (input, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            const signal = new Request(input, init).signal
+            if (signal.aborted) {
+              reject(new DOMException('aborted', 'AbortError'))
+              return
+            }
+            signal.addEventListener('abort', () =>
+              reject(new DOMException('aborted', 'AbortError')),
+            )
+          }),
+      ),
+    })
+    const request = pending({
+      messages: [{ role: 'user', content: '一个角色' }],
+      clarificationUsed: false,
+      signal: abortController.signal,
+    })
+    abortController.abort()
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+  })
+})

--- a/frontend/src/features/quick-start-agent/planner.protocol.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.protocol.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { createAiSdkQuickStartPlanner } from './planner'
+import { validatePlannerTerminal } from './runtime'
 
 function completion(choice: Record<string, unknown>) {
   return Response.json({
@@ -86,6 +87,38 @@ describe('AI SDK OpenAI-compatible protocol fixture', () => {
         },
       ],
     })
+  })
+
+  it('rejects a Tool Call whose arguments fail the declared schema', async () => {
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      fetch: vi.fn(async () =>
+        completion({
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call-invalid',
+                type: 'function',
+                function: {
+                  name: 'start_character_generation',
+                  arguments: '{"optimizedPrompt":"","assumptions":[]}',
+                },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        }),
+      ),
+    })
+
+    const result = await planner({
+      messages: [{ role: 'user', content: '直接生成' }],
+      clarificationUsed: false,
+    })
+
+    expect(() => validatePlannerTerminal(result)).toThrow('生成 Tool 的 optimizedPrompt 无效')
   })
 
   it('surfaces a standard 401 and honors cancellation', async () => {

--- a/frontend/src/features/quick-start-agent/planner.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createAiSdkQuickStartPlanner,
+  quickStartPlannerInstructions,
+  type QuickStartGenerateText,
+} from './planner'
+
+describe('quickStartPlannerInstructions', () => {
+  it('keeps readiness, direct-generation, negative intent, and one-question rules in the model', () => {
+    const firstTurn = quickStartPlannerInstructions(false)
+    const laterTurn = quickStartPlannerInstructions(true)
+
+    expect(firstTurn).toContain('最多追问一个')
+    expect(firstTurn).toContain('直接生成')
+    expect(firstTurn).toContain('不要生成')
+    expect(firstTurn).toContain('不得依赖关键词匹配')
+    expect(firstTurn).toContain('动作将在角色母版确认后处理')
+    expect(laterTurn).toContain('追问额度已经用完')
+    expect(laterTurn).toContain('默认假设')
+  })
+})
+
+describe('createAiSdkQuickStartPlanner', () => {
+  it('uses one schema-only Tool, non-streaming generateText, and no SDK retries', async () => {
+    const signal = new AbortController().signal
+    const generate = vi.fn<QuickStartGenerateText>(async () => ({
+      text: '',
+      finishReason: 'tool-calls' as const,
+      toolCalls: [
+        {
+          toolName: 'start_character_generation',
+          input: { optimizedPrompt: '银发像素骑士全身像', assumptions: ['默认单角色'] },
+        },
+      ],
+    }))
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      modelId: 'quick-start-planner',
+      fetch: vi.fn(),
+      generateText: generate,
+    })
+
+    await expect(
+      planner({
+        messages: [{ role: 'user', content: '直接生成银发骑士' }],
+        clarificationUsed: false,
+        signal,
+      }),
+    ).resolves.toEqual({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'start_character_generation',
+          input: { optimizedPrompt: '银发像素骑士全身像', assumptions: ['默认单角色'] },
+        },
+      ],
+    })
+
+    const options = generate.mock.calls[0]?.[0]
+    expect(options?.maxRetries).toBe(0)
+    expect(options?.abortSignal).toBe(signal)
+    expect(options?.toolChoice).toBe('auto')
+    expect(Object.keys(options?.tools ?? {})).toEqual(['start_character_generation'])
+    expect(options?.tools?.start_character_generation?.execute).toBeUndefined()
+    expect(options?.messages).toEqual([{ role: 'user', content: '直接生成银发骑士' }])
+  })
+})

--- a/frontend/src/features/quick-start-agent/planner.ts
+++ b/frontend/src/features/quick-start-agent/planner.ts
@@ -1,0 +1,140 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { generateText as aiGenerateText, jsonSchema, tool } from 'ai'
+
+import {
+  parseCharacterGenerationPlan,
+  START_CHARACTER_GENERATION_TOOL,
+  type PlannerInput,
+  type PlannerResult,
+  type QuickStartPlanner,
+} from './runtime'
+
+interface GenerateTextResultLike {
+  text: string
+  finishReason: string
+  toolCalls: readonly { toolName: string; input: unknown }[]
+}
+
+interface GenerateTextOptionsLike {
+  model: unknown
+  instructions: string
+  messages: PlannerInput['messages']
+  tools: Record<string, { execute?: unknown }>
+  toolChoice: 'auto'
+  maxRetries: 0
+  abortSignal?: AbortSignal
+}
+
+export type QuickStartGenerateText = (
+  options: GenerateTextOptionsLike,
+) => Promise<GenerateTextResultLike>
+
+export interface CreateAiSdkQuickStartPlannerOptions {
+  baseURL: string
+  modelId?: string
+  fetch?: typeof globalThis.fetch
+  /** 仅用于协议级测试；生产默认调用 AI SDK Core generateText。 */
+  generateText?: QuickStartGenerateText
+}
+
+interface StartCharacterGenerationToolInput {
+  optimizedPrompt: string
+  assumptions: string[]
+}
+
+const startCharacterGenerationTool = tool({
+  description:
+    '当角色母版信息已经足够，或用户明确要求跳过追问并直接生成时，提交唯一一次角色母版生成。',
+  inputSchema: jsonSchema<StartCharacterGenerationToolInput>(
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        optimizedPrompt: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 4_000,
+          description: '实际提交给角色母版生成器的完整单角色全身提示词。',
+        },
+        assumptions: {
+          type: 'array',
+          maxItems: 6,
+          items: { type: 'string', minLength: 1, maxLength: 200 },
+          description: '为了立即生成而采用、且需要向用户明确展示的默认假设。',
+        },
+      },
+      required: ['optimizedPrompt', 'assumptions'],
+    },
+    {
+      validate(value) {
+        try {
+          const plan = parseCharacterGenerationPlan(value)
+          return {
+            success: true,
+            value: { optimizedPrompt: plan.optimizedPrompt, assumptions: [...plan.assumptions] },
+          }
+        } catch (error) {
+          return {
+            success: false,
+            error: error instanceof Error ? error : new Error('生成 Tool 参数无效'),
+          }
+        }
+      },
+    },
+  ),
+})
+
+export function quickStartPlannerInstructions(clarificationUsed: boolean): string {
+  const clarificationRule = clarificationUsed
+    ? '追问额度已经用完。除非仍存在硬冲突，否则不得再提问题；请采用明确的默认假设并调用 Tool。'
+    : '追问额度尚未使用。只有缺少会实质改变角色母版的关键信息时，才最多追问一个问题。'
+  return `你是 Windup Quick Start 的轻量 Planner。用户已经通过“生成角色”主操作授予本页面会话一次角色母版生成权限。你只判断信息是否足够，并且最多调用一次 ${START_CHARACTER_GENERATION_TOOL}；你不参与生成后的任何流程。
+
+当前能力只生成一个角色的角色母版：单角色、完整身体、清楚轮廓，适合后续动作生成。保留用户明确给出的身份、外观、服装、气质和美术风格，把口语整理成可直接生成的 optimizedPrompt。用户描述的动态动作不要写进角色母版 Prompt；需要时在 assumptions 中明确“动作将在角色母版确认后处理”。
+
+决策规则：
+1. 信息足够时立即调用唯一 Tool，不要再次确认。
+2. 用户在语义上明确要求“跳过、不用问、直接生成”时，基于已有信息与可见默认假设立即调用 Tool。
+3. 用户明确表示“不要生成、只润色、先讨论”等否定意图时不得调用 Tool。引用、假设或否定语境也不得被误判；不得依赖关键词匹配，必须理解整句语义。
+4. 信息不足且仍有追问额度时，只问一个最关键、最容易回答的问题，不得列问卷。
+5. 输入有明显自相矛盾、违反内容政策，或超出当前单角色母版能力的硬冲突时，简短说明需要修改的具体内容，不调用 Tool。Planner 的提醒只是交互提示，最终安全、配额与计费仍由生成后端负责。
+6. 调用 Tool 时，optimizedPrompt 必须是最终实际使用的提示词；assumptions 只列确实采用的默认值，可以为空。不得产生第二个 Tool Call。
+
+${clarificationRule}
+
+不调用 Tool 时，只输出一条简短的中文追问或修改提醒。调用 Tool 后不再输出后续计划。`
+}
+
+export function createAiSdkQuickStartPlanner({
+  baseURL,
+  modelId = 'quick-start-planner',
+  fetch,
+  generateText = aiGenerateText as unknown as QuickStartGenerateText,
+}: CreateAiSdkQuickStartPlannerOptions): QuickStartPlanner {
+  const provider = createOpenAICompatible({
+    name: 'windup-agent-proxy',
+    baseURL: baseURL.replace(/\/+$/u, ''),
+    fetch,
+  })
+  const model = provider.chatModel(modelId)
+
+  return async ({ messages, clarificationUsed, signal }): Promise<PlannerResult> => {
+    const result = await generateText({
+      model,
+      instructions: quickStartPlannerInstructions(clarificationUsed),
+      messages,
+      tools: { [START_CHARACTER_GENERATION_TOOL]: startCharacterGenerationTool },
+      toolChoice: 'auto',
+      maxRetries: 0,
+      abortSignal: signal,
+    })
+    return {
+      text: result.text,
+      finishReason: result.finishReason,
+      toolCalls: result.toolCalls.map((call) => ({
+        toolName: call.toolName,
+        input: call.input,
+      })),
+    }
+  }
+}

--- a/frontend/src/features/quick-start-agent/runtime.test.ts
+++ b/frontend/src/features/quick-start-agent/runtime.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createQuickStartAgent,
+  validatePlannerTerminal,
+  type PlannerResult,
+  type QuickStartPlanner,
+  type StartCharacterGenerationAction,
+} from './runtime'
+
+function plannerResult(overrides: Partial<PlannerResult> = {}): PlannerResult {
+  return {
+    text: '',
+    finishReason: 'tool-calls',
+    toolCalls: [
+      {
+        toolName: 'start_character_generation',
+        input: { optimizedPrompt: '完整身体的银发像素骑士', assumptions: ['默认单角色'] },
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function fixture(result: PlannerResult = plannerResult()) {
+  const planner = vi.fn<QuickStartPlanner>(async () => result)
+  const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>(async () => ({
+    runId: 'run-1',
+  }))
+  const agent = createQuickStartAgent({ planner, startCharacterGeneration })
+  return { agent, planner, startCharacterGeneration }
+}
+
+describe('validatePlannerTerminal', () => {
+  it('accepts one complete, schema-valid write Tool Call', () => {
+    expect(validatePlannerTerminal(plannerResult())).toEqual({
+      kind: 'tool',
+      optimizedPrompt: '完整身体的银发像素骑士',
+      assumptions: ['默认单角色'],
+    })
+  })
+
+  it('accepts a complete text response without treating it as an action', () => {
+    expect(
+      validatePlannerTerminal(
+        plannerResult({
+          text: '请补充角色的身份或外观特征。',
+          finishReason: 'stop',
+          toolCalls: [],
+        }),
+      ),
+    ).toEqual({ kind: 'message', message: '请补充角色的身份或外观特征。' })
+  })
+
+  it.each([
+    ['unknown Tool', plannerResult({ toolCalls: [{ toolName: 'other_tool', input: {} }] })],
+    [
+      'multiple Tools',
+      plannerResult({
+        toolCalls: [plannerResult().toolCalls[0]!, plannerResult().toolCalls[0]!],
+      }),
+    ],
+    [
+      'invalid Tool input',
+      plannerResult({
+        toolCalls: [
+          {
+            toolName: 'start_character_generation',
+            input: { optimizedPrompt: ' ', assumptions: ['默认单角色'] },
+          },
+        ],
+      }),
+    ],
+    ['unfinished Tool response', plannerResult({ finishReason: 'stop' })],
+  ])('fails closed for %s', (_label, result) => {
+    expect(() => validatePlannerTerminal(result)).toThrow()
+  })
+})
+
+describe('createQuickStartAgent', () => {
+  it('dispatches the injected write action once after exposing the final prompt', async () => {
+    const { agent, startCharacterGeneration } = fixture()
+    const events: string[] = []
+    startCharacterGeneration.mockImplementation(async () => {
+      events.push('action')
+      return { runId: 'run-1' }
+    })
+
+    await expect(
+      agent.start('银发骑士', {
+        onBeforeDispatch: async (plan) => {
+          events.push(`visible:${plan.optimizedPrompt}`)
+        },
+      }),
+    ).resolves.toEqual({
+      kind: 'generated',
+      runId: 'run-1',
+      optimizedPrompt: '完整身体的银发像素骑士',
+      assumptions: ['默认单角色'],
+    })
+
+    expect(events).toEqual(['visible:完整身体的银发像素骑士', 'action'])
+    expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: '完整身体的银发像素骑士',
+    })
+  })
+
+  it('keeps a text-only response side-effect free and spends at most one clarification', async () => {
+    const { agent, planner, startCharacterGeneration } = fixture(
+      plannerResult({ text: '最希望保留什么外观特征？', finishReason: 'stop', toolCalls: [] }),
+    )
+
+    await expect(agent.start('一个角色')).resolves.toEqual({
+      kind: 'message',
+      message: '最希望保留什么外观特征？',
+    })
+    vi.mocked(planner).mockResolvedValueOnce(plannerResult())
+    await agent.continue('银色卷发')
+
+    expect(planner).toHaveBeenNthCalledWith(2, expect.objectContaining({ clarificationUsed: true }))
+    expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dispatch an unknown, duplicate, invalid, or text-only terminal result', async () => {
+    const cases = [
+      plannerResult({ toolCalls: [{ toolName: 'unknown', input: {} }] }),
+      plannerResult({
+        toolCalls: [plannerResult().toolCalls[0]!, plannerResult().toolCalls[0]!],
+      }),
+      plannerResult({
+        toolCalls: [
+          {
+            toolName: 'start_character_generation',
+            input: { optimizedPrompt: '', assumptions: [] },
+          },
+        ],
+      }),
+    ]
+
+    for (const result of cases) {
+      const { agent, startCharacterGeneration } = fixture(result)
+      await expect(agent.start('直接生成')).rejects.toThrow()
+      expect(startCharacterGeneration).not.toHaveBeenCalled()
+    }
+
+    const textOnly = fixture(
+      plannerResult({
+        text: '这个请求目前不能生成，请修改。',
+        finishReason: 'stop',
+        toolCalls: [],
+      }),
+    )
+    await expect(textOnly.agent.start('不要生成，只润色')).resolves.toEqual({
+      kind: 'message',
+      message: '这个请求目前不能生成，请修改。',
+    })
+    expect(textOnly.startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch when cancellation happens before the write starts', async () => {
+    const { agent, startCharacterGeneration } = fixture()
+    const abortController = new AbortController()
+
+    await expect(
+      agent.start('直接生成', {
+        signal: abortController.signal,
+        onBeforeDispatch: async () => abortController.abort(),
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('does not pretend a dispatched action was cancelled', async () => {
+    let resolveWrite: ((result: { runId: string }) => void) | undefined
+    const { agent, startCharacterGeneration } = fixture()
+    startCharacterGeneration.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveWrite = resolve
+        }),
+    )
+    const abortController = new AbortController()
+
+    const result = agent.start('直接生成', { signal: abortController.signal })
+    await vi.waitFor(() => expect(startCharacterGeneration).toHaveBeenCalledTimes(1))
+    abortController.abort()
+    resolveWrite?.({ runId: 'run-accepted' })
+
+    await expect(result).resolves.toMatchObject({ kind: 'generated', runId: 'run-accepted' })
+  })
+
+  it('revokes unused authorization and never calls the action afterwards', async () => {
+    const { agent, startCharacterGeneration } = fixture()
+    agent.revoke()
+
+    await expect(agent.start('直接生成')).rejects.toThrow('生成授权已失效')
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('never retries or replays the write action after an uncertain failure', async () => {
+    const { agent, startCharacterGeneration } = fixture()
+    startCharacterGeneration.mockRejectedValueOnce(new Error('generation response lost'))
+
+    await expect(agent.start('直接生成')).rejects.toThrow('generation response lost')
+    await expect(agent.continue('再试一次')).rejects.toThrow('生成授权已使用')
+    expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/features/quick-start-agent/runtime.test.ts
+++ b/frontend/src/features/quick-start-agent/runtime.test.ts
@@ -188,6 +188,28 @@ describe('createQuickStartAgent', () => {
     expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
   })
 
+  it('ends an unresolved conversation after the single clarification turn', async () => {
+    const textResult = plannerResult({
+      text: '这个请求仍有冲突，请修改后重新开始。',
+      finishReason: 'stop',
+      toolCalls: [],
+    })
+    const { agent, planner, startCharacterGeneration } = fixture(textResult)
+
+    await expect(agent.start('一个角色')).resolves.toEqual({
+      kind: 'message',
+      message: '这个请求仍有冲突，请修改后重新开始。',
+    })
+    await expect(agent.continue('补充说明')).resolves.toEqual({
+      kind: 'message',
+      message: '这个请求仍有冲突，请修改后重新开始。',
+    })
+    await expect(agent.continue('再追问一次')).rejects.toThrow('生成授权已失效')
+
+    expect(planner).toHaveBeenCalledTimes(2)
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
   it('does not dispatch an unknown, duplicate, invalid, or text-only terminal result', async () => {
     const cases = [
       plannerResult({ toolCalls: [{ toolName: 'unknown', input: {} }] }),

--- a/frontend/src/features/quick-start-agent/runtime.test.ts
+++ b/frontend/src/features/quick-start-agent/runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   createQuickStartAgent,
+  parseCharacterGenerationPlan,
   validatePlannerTerminal,
   type PlannerResult,
   type QuickStartPlanner,
@@ -75,9 +76,74 @@ describe('validatePlannerTerminal', () => {
   ])('fails closed for %s', (_label, result) => {
     expect(() => validatePlannerTerminal(result)).toThrow()
   })
+
+  it('rejects an incomplete text terminal result', () => {
+    expect(() =>
+      validatePlannerTerminal(plannerResult({ text: '', finishReason: 'stop', toolCalls: [] })),
+    ).toThrow('Planner 未返回完整的文字响应')
+  })
+})
+
+describe('parseCharacterGenerationPlan', () => {
+  it.each([
+    [
+      'unknown fields',
+      { optimizedPrompt: '像素骑士', assumptions: [], unexpected: true },
+      '生成 Tool 参数字段无效',
+    ],
+    [
+      'non-array assumptions',
+      { optimizedPrompt: '像素骑士', assumptions: '默认单角色' },
+      '生成 Tool 的 assumptions 无效',
+    ],
+    [
+      'empty assumption',
+      { optimizedPrompt: '像素骑士', assumptions: [' '] },
+      '生成 Tool 的 assumptions 无效',
+    ],
+  ])('rejects %s', (_label, input, message) => {
+    expect(() => parseCharacterGenerationPlan(input)).toThrow(message)
+  })
 })
 
 describe('createQuickStartAgent', () => {
+  it('revokes authorization when the request is already cancelled', async () => {
+    const { agent, planner, startCharacterGeneration } = fixture()
+    const abortController = new AbortController()
+    abortController.abort()
+
+    await expect(agent.start('直接生成', { signal: abortController.signal })).rejects.toMatchObject(
+      { name: 'AbortError' },
+    )
+    await expect(agent.continue('再试一次')).rejects.toThrow('生成授权已失效')
+    expect(planner).not.toHaveBeenCalled()
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('revokes authorization when cancellation happens while planning', async () => {
+    let resolvePlanner: ((result: PlannerResult) => void) | undefined
+    const planner = vi.fn<QuickStartPlanner>(
+      () =>
+        new Promise((resolve) => {
+          resolvePlanner = resolve
+        }),
+    )
+    const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>(async () => ({
+      runId: 'run-should-not-exist',
+    }))
+    const agent = createQuickStartAgent({ planner, startCharacterGeneration })
+    const abortController = new AbortController()
+
+    const request = agent.start('直接生成', { signal: abortController.signal })
+    await vi.waitFor(() => expect(planner).toHaveBeenCalledTimes(1))
+    abortController.abort()
+    resolvePlanner?.(plannerResult())
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+    await expect(agent.continue('再试一次')).rejects.toThrow('生成授权已失效')
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
   it('dispatches the injected write action once after exposing the final prompt', async () => {
     const { agent, startCharacterGeneration } = fixture()
     const events: string[] = []

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -168,6 +168,7 @@ export function createQuickStartAgent({
 
       if (terminal.kind === 'message') {
         messages = [...nextMessages, { role: 'assistant', content: terminal.message }]
+        if (clarificationUsed) revoked = true
         clarificationUsed = true
         return terminal
       }

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -1,0 +1,211 @@
+export const START_CHARACTER_GENERATION_TOOL = 'start_character_generation' as const
+
+const MAX_PROMPT_LENGTH = 4_000
+const MAX_ASSUMPTIONS = 6
+const MAX_ASSUMPTION_LENGTH = 200
+
+export interface PlannerMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export interface PlannerToolCall {
+  toolName: string
+  input: unknown
+}
+
+export interface PlannerResult {
+  text: string
+  finishReason: string
+  toolCalls: readonly PlannerToolCall[]
+}
+
+export interface PlannerInput {
+  messages: readonly PlannerMessage[]
+  clarificationUsed: boolean
+  signal?: AbortSignal
+}
+
+export type QuickStartPlanner = (input: PlannerInput) => Promise<PlannerResult>
+
+export interface CharacterGenerationPlan {
+  optimizedPrompt: string
+  assumptions: readonly string[]
+}
+
+export type ValidatedPlannerTerminal =
+  | { kind: 'message'; message: string }
+  | ({ kind: 'tool' } & CharacterGenerationPlan)
+
+export type QuickStartAgentResult =
+  | { kind: 'message'; message: string }
+  | ({ kind: 'generated'; runId: string } & CharacterGenerationPlan)
+
+export interface QuickStartAgentTurnOptions {
+  signal?: AbortSignal
+  /** 页面在此处先渲染实际 Prompt 与默认假设；回调完成前不得发起付费写操作。 */
+  onBeforeDispatch?: (plan: CharacterGenerationPlan) => void | Promise<void>
+}
+
+export interface QuickStartAgent {
+  start(input: string, options?: QuickStartAgentTurnOptions): Promise<QuickStartAgentResult>
+  continue(input: string, options?: QuickStartAgentTurnOptions): Promise<QuickStartAgentResult>
+  revoke(): void
+}
+
+/** 宿主从现有 WorkflowController 绑定出的单次生成动作；本 Feature 不拥有业务对象。 */
+export type StartCharacterGenerationAction = (input: {
+  prompt: string
+}) => Promise<{ runId: string }>
+
+export interface CreateQuickStartAgentOptions {
+  planner: QuickStartPlanner
+  startCharacterGeneration: StartCharacterGenerationAction
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function parseCharacterGenerationPlan(value: unknown): CharacterGenerationPlan {
+  if (!isRecord(value)) throw new Error('生成 Tool 参数必须是对象')
+  const keys = Object.keys(value)
+  if (
+    keys.some((key) => key !== 'optimizedPrompt' && key !== 'assumptions') ||
+    !keys.includes('optimizedPrompt') ||
+    !keys.includes('assumptions')
+  ) {
+    throw new Error('生成 Tool 参数字段无效')
+  }
+
+  const optimizedPrompt =
+    typeof value.optimizedPrompt === 'string' ? value.optimizedPrompt.trim() : ''
+  if (!optimizedPrompt || optimizedPrompt.length > MAX_PROMPT_LENGTH) {
+    throw new Error('生成 Tool 的 optimizedPrompt 无效')
+  }
+  if (!Array.isArray(value.assumptions) || value.assumptions.length > MAX_ASSUMPTIONS) {
+    throw new Error('生成 Tool 的 assumptions 无效')
+  }
+  const assumptions = value.assumptions.map((assumption) => {
+    const normalized = typeof assumption === 'string' ? assumption.trim() : ''
+    if (!normalized || normalized.length > MAX_ASSUMPTION_LENGTH) {
+      throw new Error('生成 Tool 的 assumptions 无效')
+    }
+    return normalized
+  })
+  return { optimizedPrompt, assumptions }
+}
+
+/** SDK 完整返回后再做一次 fail-closed 终态校验，校验通过前不触发业务 action。 */
+export function validatePlannerTerminal(result: PlannerResult): ValidatedPlannerTerminal {
+  if (result.toolCalls.length === 0) {
+    const message = result.text.trim()
+    if (result.finishReason !== 'stop' || !message) {
+      throw new Error('Planner 未返回完整的文字响应')
+    }
+    return { kind: 'message', message }
+  }
+
+  if (result.finishReason !== 'tool-calls') {
+    throw new Error('Planner 的 Tool Call 响应未完整结束')
+  }
+  if (result.toolCalls.length !== 1) {
+    throw new Error('Planner 每轮必须且只能调用一个 Tool')
+  }
+  const [call] = result.toolCalls
+  if (call?.toolName !== START_CHARACTER_GENERATION_TOOL) {
+    throw new Error('Planner 调用了未知 Tool')
+  }
+  return { kind: 'tool', ...parseCharacterGenerationPlan(call.input) }
+}
+
+function abortError(): DOMException {
+  return new DOMException('操作已取消', 'AbortError')
+}
+
+export function createQuickStartAgent({
+  planner,
+  startCharacterGeneration,
+}: CreateQuickStartAgentOptions): QuickStartAgent {
+  let started = false
+  let revoked = false
+  let consumed = false
+  let clarificationUsed = false
+  let running = false
+  let messages: PlannerMessage[] = []
+
+  function assertAuthorized() {
+    if (revoked) throw new Error('生成授权已失效')
+    if (consumed) throw new Error('生成授权已使用')
+  }
+
+  async function runTurn(
+    input: string,
+    { signal, onBeforeDispatch }: QuickStartAgentTurnOptions = {},
+  ): Promise<QuickStartAgentResult> {
+    assertAuthorized()
+    if (running) throw new Error('Planner 正在处理上一条输入')
+    const normalizedInput = input.trim()
+    if (!normalizedInput) throw new Error('请先描述想要创建的角色')
+    if (signal?.aborted) {
+      revoked = true
+      throw abortError()
+    }
+
+    running = true
+    try {
+      const nextMessages: PlannerMessage[] = [
+        ...messages,
+        { role: 'user', content: normalizedInput },
+      ]
+      const terminal = validatePlannerTerminal(
+        await planner({ messages: nextMessages, clarificationUsed, signal }),
+      )
+      if (signal?.aborted) {
+        revoked = true
+        throw abortError()
+      }
+
+      if (terminal.kind === 'message') {
+        messages = [...nextMessages, { role: 'assistant', content: terminal.message }]
+        clarificationUsed = true
+        return terminal
+      }
+
+      const plan: CharacterGenerationPlan = {
+        optimizedPrompt: terminal.optimizedPrompt,
+        assumptions: terminal.assumptions,
+      }
+      await onBeforeDispatch?.(plan)
+      if (signal?.aborted) {
+        revoked = true
+        throw abortError()
+      }
+      assertAuthorized()
+
+      // 写权限在调用前消费。即使响应丢失，也不得自动重放可能已经计费的 action。
+      consumed = true
+      const { runId } = await startCharacterGeneration({
+        prompt: plan.optimizedPrompt,
+      })
+      return { kind: 'generated', runId, ...plan }
+    } finally {
+      running = false
+    }
+  }
+
+  return {
+    start(input, options) {
+      if (started) return Promise.reject(new Error('Agent 已开始，请继续当前输入'))
+      started = true
+      return runTurn(input, options)
+    },
+    continue(input, options) {
+      if (!started) return Promise.reject(new Error('Agent 尚未开始'))
+      return runTurn(input, options)
+    },
+    revoke() {
+      if (!consumed) revoked = true
+    },
+  }
+}


### PR DESCRIPTION
本 PR 增加 Quick Start 的轻量 Plan-and-Solve Agent Core：模型最多追问一次，或返回唯一生成 Tool；终态校验完成后，运行时只调用宿主注入的单个 action，不新增业务 Controller 或 Service。

## Why

此前方案要么自行维护 AgentTransport 与 function-call 协议，要么移除 Tool 后只能给出提示词建议，无法执行“直接生成”。本次使用 AI SDK 的标准协议能力补齐最小 Action，同时保持现有 `WorkflowController` 是唯一业务执行边界。

## Changes

- 引入 AI SDK Core 与 OpenAI-compatible Provider。
- 增加单 Tool Planner，覆盖信息充分、一次追问、直接生成、否定意图和硬冲突规则。
- 增加完整终态校验、一次生成授权、dispatch 前撤权及写操作不重放。
- 暴露 `StartCharacterGenerationAction` 函数注入点；Agent Core 不依赖页面、Controller 实现、Entity API、业务 HTTP 或 DOM。

## Implementation

- Tool 只声明 Schema，不配置 SDK `execute`，也不实现流式 parser 或 Tool Loop。
- 只有 `finishReason === 'tool-calls'`、Tool 数量为一且参数合法时才执行 action。
- 最终 Prompt 与默认假设先通过 `onBeforeDispatch` 交给宿主展示，再消费一次写权限。
- 架构测试阻止 Agent Feature 反向依赖业务模块，并阻止协议细节进入 Quick Start 页面。

## Verification

- [x] `npm run format:check`：181 个文件格式检查通过。
- [x] `npm run lint`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run test:coverage`：62 个测试文件、757 项测试通过；Codecov 确认本 PR 所有可覆盖改动行均已覆盖。
- [x] `npm run build`：通过；仅有仓库既有的主包体积提示。
- [x] `npm audit --omit=dev --json`：生产依赖漏洞 0。

## Scope

- 本 PR 不包含 Quick Start 页面接入、React Hook、视觉改动或截图。
- 本 PR 不修改 `WorkflowController`，不新增 `QuickStartWorkflowController`、Service 或第二套业务状态机。
- 本 PR 不实现后端 Agent；真实 `/ai/chat` 模型代理由 #450 处理，页面接入由 #443 后续完成。

## Related Issues

Closes #452

Refs #443

Refs #450
