### PR TITLE
feat(quick-start): add single-tool generation agent

### DIFF
--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -15,6 +15,7 @@ import { QuickStartPage } from '@/pages/quick-start'
 import { WorkspacePage } from '@/pages/workspace'
 import { ProtectedRoute } from '@/features/auth-guard'
 import { AppShellRoute, MarketingShellRoute } from './layout'
+import { productionQuickStartAgentDependencies } from '@/features/quick-start-agent/production'
 
 const WorkflowEditorPage = lazy(() =>
   import('@/pages/workflow-editor').then(({ WorkflowEditorPage: Page }) => ({ default: Page })),
@@ -42,6 +43,10 @@ function LazyWorkflowEditorPage() {
   )
 }
 
+function QuickStartRoute() {
+  return <QuickStartPage agent={productionQuickStartAgentDependencies} />
+}
+
 /** 路由声明独立导出，测试用 MemoryRouter 验证直达地址。 */
 export function AppRoutes() {
   return (
@@ -54,8 +59,8 @@ export function AppRoutes() {
         <Route element={<AppShellRoute />}>
           <Route path="/workspace" element={<WorkspacePage />} />
           <Route path="/account" element={<AccountPage />} />
-          <Route path="/quick-start" element={<QuickStartPage />} />
-          <Route path="/quick-start/:runId" element={<QuickStartPage />} />
+          <Route path="/quick-start" element={<QuickStartRoute />} />
+          <Route path="/quick-start/:runId" element={<QuickStartRoute />} />
           <Route path="/projects" element={<ProjectsPage />} />
           <Route path="/projects/new" element={<ProjectCreatePage />} />
           <Route path="/workflow-editor/:runId" element={<LazyWorkflowEditorPage />} />

--- a/frontend/src/features/quick-start-agent/boundaries.test.ts
+++ b/frontend/src/features/quick-start-agent/boundaries.test.ts
@@ -19,11 +19,11 @@ function moduleSpecifiers(source: string): string[] {
 }
 
 describe('quick-start-agent architecture boundary', () => {
-  it('accepts business actions through injection instead of importing business modules', () => {
+  it('keeps business imports out of the Agent core', () => {
     const forbidden = ['@/pages', '@/entities', '@/shared/api', '@/features']
-    const featureDependencies = productionFiles(featureDirectory).flatMap((file) =>
-      moduleSpecifiers(readFileSync(file, 'utf8')),
-    )
+    const featureDependencies = productionFiles(featureDirectory)
+      .filter((file) => !file.endsWith('/production.ts'))
+      .flatMap((file) => moduleSpecifiers(readFileSync(file, 'utf8')))
 
     expect(
       featureDependencies.filter((dependency) =>

--- a/frontend/src/features/quick-start-agent/production.test.ts
+++ b/frontend/src/features/quick-start-agent/production.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { GenerationApis, WorkflowRunApis } from '@/entities'
+import type {
+  CreateWorkflowControllerOptions,
+  PrepareQuickStartProject,
+  WorkflowController,
+} from '@/features/workflow-controller'
+import {
+  createAgentProxyFetch,
+  createProductionQuickStartAgentDependencies,
+  resolveAgentProxyBaseUrl,
+} from './production'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('Quick Start Agent composition', () => {
+  it('turns the production relative API path into an absolute AI SDK base URL', () => {
+    expect(resolveAgentProxyBaseUrl('/api', 'https://windup.test/quick-start')).toBe(
+      'https://windup.test/api/ai',
+    )
+  })
+
+  it('rejects an Agent API address when no browser origin is available', () => {
+    expect(() => resolveAgentProxyBaseUrl('/api', '')).toThrow('当前环境无法解析 Agent API 地址')
+  })
+
+  it('rejects SDK requests outside the Chat Completions endpoint', async () => {
+    const fetchFn = vi.fn<typeof fetch>()
+    const proxyFetch = createAgentProxyFetch({ fetchFn })
+
+    await expect(
+      proxyFetch('https://windup.test/api/ai/responses', { method: 'POST' }),
+    ).rejects.toThrow('AI SDK 请求未命中 Chat Completions 路径')
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('rewrites the AI SDK chat path, attaches JWT, and replays only an auth rejection', async () => {
+    let token = 'expired-token'
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json(
+          { error: { message: 'expired', type: 'authentication_error' } },
+          { status: 401 },
+        ),
+      )
+      .mockResolvedValueOnce(Response.json({ choices: [] }))
+    const recoverUnauthorized = vi.fn(async () => {
+      token = 'fresh-token'
+      return true
+    })
+    const proxyFetch = createAgentProxyFetch({
+      fetchFn,
+      getAccessToken: () => token,
+      recoverUnauthorized,
+    })
+
+    const response = await proxyFetch('https://windup.test/api/ai/chat/completions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"messages":[]}',
+    })
+
+    expect(response.status).toBe(200)
+    expect(recoverUnauthorized).toHaveBeenCalledTimes(1)
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    const [firstRequest] = fetchFn.mock.calls[0] as [Request]
+    const [secondRequest] = fetchFn.mock.calls[1] as [Request]
+    expect(firstRequest.url).toBe('https://windup.test/api/ai/chat')
+    expect(firstRequest.headers.get('authorization')).toBe('Bearer expired-token')
+    expect(secondRequest.headers.get('authorization')).toBe('Bearer fresh-token')
+  })
+
+  it('forwards a tokenless GET response without invoking auth recovery', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () => Response.json({ choices: [] }))
+    const recoverUnauthorized = vi.fn(async () => true)
+    const proxyFetch = createAgentProxyFetch({
+      fetchFn,
+      getAccessToken: () => null,
+      recoverUnauthorized,
+    })
+
+    const response = await proxyFetch('https://windup.test/api/ai/chat/completions', {
+      method: 'GET',
+    })
+
+    expect(response.status).toBe(200)
+    expect(recoverUnauthorized).not.toHaveBeenCalled()
+    const [request] = fetchFn.mock.calls[0] as [Request]
+    expect(request.headers.has('authorization')).toBe(false)
+    expect(await request.text()).toBe('')
+  })
+
+  it('returns an auth rejection without replay when session recovery declines', async () => {
+    const unauthorized = Response.json(
+      { error: { message: 'expired', type: 'authentication_error' } },
+      { status: 401 },
+    )
+    const fetchFn = vi.fn<typeof fetch>(async () => unauthorized)
+    const recoverUnauthorized = vi.fn(async () => false)
+    const proxyFetch = createAgentProxyFetch({ fetchFn, recoverUnauthorized })
+
+    await expect(
+      proxyFetch('https://windup.test/api/ai/chat/completions', { method: 'POST' }),
+    ).resolves.toBe(unauthorized)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(recoverUnauthorized).toHaveBeenCalledTimes(1)
+  })
+
+  it('loads the production AI SDK Planner once and reuses it across turns', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+    vi.stubGlobal('location', { origin: 'https://app.windup.test' })
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input)
+      expect(request.url).toBe('https://api.windup.test/ai/chat')
+      const payload = (await request.clone().json()) as Record<string, unknown>
+      expect(payload).toMatchObject({ model: 'quick-start-planner' })
+      expect(payload.stream).toBeUndefined()
+      return Response.json({
+        id: 'chatcmpl-planner',
+        object: 'chat.completion',
+        created: 1,
+        model: 'planner-model',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: '请补充角色风格。' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+      })
+    })
+    vi.stubGlobal('fetch', fetchFn)
+    const dependencies = createProductionQuickStartAgentDependencies()
+    const input = {
+      messages: [{ role: 'user' as const, content: '一个骑士' }],
+      clarificationUsed: false,
+    }
+
+    await expect(dependencies.planner(input)).resolves.toMatchObject({
+      text: '请补充角色风格。',
+      finishReason: 'stop',
+      toolCalls: [],
+    })
+    await expect(dependencies.planner(input)).resolves.toMatchObject({
+      text: '请补充角色风格。',
+    })
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('creates an injected Planner once and reuses it across turns', async () => {
+    const planner = vi.fn(async () => ({
+      text: '请补充角色风格。',
+      finishReason: 'stop',
+      toolCalls: [],
+    }))
+    const createPlanner = vi.fn(() => planner)
+    const dependencies = createProductionQuickStartAgentDependencies({ createPlanner })
+    const input = {
+      messages: [{ role: 'user' as const, content: '一个骑士' }],
+      clarificationUsed: false,
+    }
+
+    await dependencies.planner(input)
+    await dependencies.planner(input)
+
+    expect(createPlanner).toHaveBeenCalledTimes(1)
+    expect(planner).toHaveBeenCalledTimes(2)
+  })
+
+  it('binds the Agent write action directly to one existing WorkflowController command', async () => {
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const dispose = vi.fn()
+    const controller = {
+      startCharacterGeneration,
+      dispose,
+    } as unknown as WorkflowController
+    const createController = vi.fn((_options: CreateWorkflowControllerOptions) => controller)
+    const planner = vi.fn(async () => ({
+      text: 'not used',
+      finishReason: 'stop',
+      toolCalls: [],
+    }))
+    const prepareProject = vi.fn<PrepareQuickStartProject>()
+    const dependencies = createProductionQuickStartAgentDependencies({
+      createPlanner: () => planner,
+      createController,
+      prepareProject,
+      workflowRunApis: {} as WorkflowRunApis,
+      generationApis: {} as GenerationApis,
+    })
+
+    await expect(
+      dependencies.startCharacterGeneration({ prompt: '银发像素骑士' }),
+    ).resolves.toEqual({ runId: 'run-agent' })
+
+    expect(createController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prepareProject,
+        workflowRunApis: expect.anything(),
+        generationApis: expect.anything(),
+      }),
+    )
+    expect(startCharacterGeneration).toHaveBeenCalledWith({ prompt: '银发像素骑士' })
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('disposes the Controller when its write command fails', async () => {
+    const failure = new Error('generation failed')
+    const dispose = vi.fn()
+    const controller = {
+      startCharacterGeneration: vi.fn(async () => Promise.reject(failure)),
+      dispose,
+    } as unknown as WorkflowController
+    const dependencies = createProductionQuickStartAgentDependencies({
+      createPlanner: () => vi.fn(),
+      createController: () => controller,
+      prepareProject: vi.fn<PrepareQuickStartProject>(),
+      workflowRunApis: {} as WorkflowRunApis,
+      generationApis: {} as GenerationApis,
+    })
+
+    await expect(dependencies.startCharacterGeneration({ prompt: '银发像素骑士' })).rejects.toBe(
+      failure,
+    )
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces background Controller failures through the default error reporter', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let controllerOptions: CreateWorkflowControllerOptions | undefined
+    const controller = {
+      startCharacterGeneration: vi.fn(async () => ({ runId: 'run-agent' })),
+      dispose: vi.fn(),
+    } as unknown as WorkflowController
+    const dependencies = createProductionQuickStartAgentDependencies({
+      createPlanner: () => vi.fn(),
+      createController: (options) => {
+        controllerOptions = options
+        return controller
+      },
+      prepareProject: vi.fn<PrepareQuickStartProject>(),
+      workflowRunApis: {} as WorkflowRunApis,
+      generationApis: {} as GenerationApis,
+    })
+    const failure = new Error('subscription failed')
+
+    await dependencies.startCharacterGeneration({ prompt: '银发像素骑士' })
+    controllerOptions?.onAsyncError?.(failure)
+
+    expect(consoleError).toHaveBeenCalledWith('[quick-start-agent] 工作流错误', failure)
+  })
+})

--- a/frontend/src/features/quick-start-agent/production.ts
+++ b/frontend/src/features/quick-start-agent/production.ts
@@ -1,0 +1,135 @@
+import {
+  createAuthenticatedGenerationApis,
+  projectApis,
+  workflowRunApis,
+  type GenerationApis,
+  type WorkflowRunApis,
+} from '@/entities'
+import {
+  type CreateQuickStartAgentOptions,
+  type QuickStartPlanner,
+} from '@/features/quick-start-agent/runtime'
+import {
+  createAutoPrepareProject,
+  createWorkflowController,
+  type CreateWorkflowControllerOptions,
+  type PrepareQuickStartProject,
+  type WorkflowController,
+} from '@/features/workflow-controller'
+import { getApiAccessToken, recoverApiUnauthorized, resolveApiBaseUrl } from '@/shared/api'
+
+interface CreateAgentProxyFetchOptions {
+  fetchFn?: typeof globalThis.fetch
+  getAccessToken?: () => string | null | undefined
+  recoverUnauthorized?: () => Promise<boolean>
+}
+
+function rewriteAgentProxyUrl(value: string): string {
+  const url = new URL(value)
+  const sdkPath = '/chat/completions'
+  if (!url.pathname.endsWith(sdkPath)) {
+    throw new Error('AI SDK 请求未命中 Chat Completions 路径')
+  }
+  url.pathname = `${url.pathname.slice(0, -sdkPath.length)}/chat`
+  return url.toString()
+}
+
+export function resolveAgentProxyBaseUrl(
+  apiBaseUrl: string,
+  origin = globalThis.location?.origin,
+): string {
+  if (!origin) throw new Error('当前环境无法解析 Agent API 地址')
+  const normalizedApiBase = apiBaseUrl.replace(/\/+$/u, '')
+  return new URL(`${normalizedApiBase}/ai`, `${origin}/`).toString().replace(/\/+$/u, '')
+}
+
+/** AI SDK 负责协议；此适配器补 Windup JWT 并把固定 SDK 路径接到既有 /ai/chat。 */
+export function createAgentProxyFetch({
+  fetchFn = globalThis.fetch,
+  getAccessToken = getApiAccessToken,
+  recoverUnauthorized: recover = recoverApiUnauthorized,
+}: CreateAgentProxyFetchOptions = {}): typeof globalThis.fetch {
+  return async (input, init) => {
+    const original = new Request(input, init)
+
+    async function send(): Promise<Response> {
+      const headers = new Headers(original.headers)
+      const accessToken = getAccessToken()
+      if (accessToken) headers.set('authorization', `Bearer ${accessToken}`)
+      const body =
+        original.method === 'GET' || original.method === 'HEAD'
+          ? undefined
+          : await original.clone().arrayBuffer()
+      return fetchFn(
+        new Request(rewriteAgentProxyUrl(original.url), {
+          method: original.method,
+          headers,
+          body,
+          signal: original.signal,
+          credentials: 'include',
+        }),
+      )
+    }
+
+    const response = await send()
+    if (response.status !== 401 || !(await recover())) return response
+    return send()
+  }
+}
+
+interface CreateProductionQuickStartAgentDependenciesOptions {
+  createPlanner?: () => QuickStartPlanner
+  createController?: (options: CreateWorkflowControllerOptions) => WorkflowController
+  prepareProject?: PrepareQuickStartProject
+  workflowRunApis?: WorkflowRunApis
+  generationApis?: GenerationApis
+  onAsyncError?: (error: Error) => void
+}
+
+export function createProductionQuickStartAgentDependencies(
+  options: CreateProductionQuickStartAgentDependenciesOptions = {},
+): CreateQuickStartAgentOptions {
+  let planner: QuickStartPlanner | null = null
+  let plannerLoading: Promise<QuickStartPlanner> | null = null
+  let generationApis = options.generationApis ?? null
+  const prepareProject = options.prepareProject ?? createAutoPrepareProject(projectApis)
+  const createController = options.createController ?? createWorkflowController
+  const runApis = options.workflowRunApis ?? workflowRunApis
+  const reportError =
+    options.onAsyncError ??
+    ((error: Error) => console.error('[quick-start-agent] 工作流错误', error))
+
+  return {
+    async planner(input) {
+      if (!planner) {
+        plannerLoading ??= options.createPlanner
+          ? Promise.resolve(options.createPlanner())
+          : import('@/features/quick-start-agent/planner').then(
+              ({ createAiSdkQuickStartPlanner }) =>
+                createAiSdkQuickStartPlanner({
+                  baseURL: resolveAgentProxyBaseUrl(resolveApiBaseUrl()),
+                  fetch: createAgentProxyFetch(),
+                }),
+            )
+        planner = await plannerLoading
+      }
+      return planner(input)
+    },
+    async startCharacterGeneration(input) {
+      generationApis ??= createAuthenticatedGenerationApis()
+      const controller = createController({
+        workflowRunApis: runApis,
+        generationApis,
+        prepareProject,
+        onAsyncError: reportError,
+      })
+      try {
+        return await controller.startCharacterGeneration(input)
+      } finally {
+        controller.dispose()
+      }
+    },
+  }
+}
+
+export const productionQuickStartAgentDependencies = createProductionQuickStartAgentDependencies()

--- a/frontend/src/features/quick-start-agent/react.test.tsx
+++ b/frontend/src/features/quick-start-agent/react.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { PlannerResult } from './runtime'
+import { useQuickStartAgent } from './react'
+
+afterEach(cleanup)
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('useQuickStartAgent', () => {
+  it('keeps one clarification inline and presents the final plan before dispatch', async () => {
+    const presentation = deferred()
+    const plannerResults: PlannerResult[] = [
+      { text: '请补充角色的美术风格。', finishReason: 'stop', toolCalls: [] },
+      {
+        text: '',
+        finishReason: 'tool-calls',
+        toolCalls: [
+          {
+            toolName: 'start_character_generation',
+            input: {
+              optimizedPrompt: '银发像素骑士，全身像',
+              assumptions: ['默认单角色', '默认横版视角'],
+            },
+          },
+        ],
+      },
+    ]
+    const planner = vi.fn(async () => plannerResults.shift()!)
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() =>
+      useQuickStartAgent({
+        planner,
+        startCharacterGeneration,
+        waitForPresentation: () => presentation.promise,
+      }),
+    )
+
+    await act(async () => {
+      await result.current.submit('一个银发骑士')
+    })
+    expect(result.current.state).toEqual({
+      status: 'awaiting-input',
+      message: '请补充角色的美术风格。',
+    })
+
+    let secondTurn!: Promise<unknown>
+    act(() => {
+      secondTurn = result.current.submit('16-bit 像素风，请直接生成')
+    })
+    await waitFor(() =>
+      expect(result.current.state).toEqual({
+        status: 'dispatching',
+        optimizedPrompt: '银发像素骑士，全身像',
+        assumptions: ['默认单角色', '默认横版视角'],
+      }),
+    )
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+
+    presentation.resolve()
+    await act(async () => {
+      await secondTurn
+    })
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: '银发像素骑士，全身像',
+    })
+  })
+
+  it('revokes pending authorization when the host unmounts', async () => {
+    const planner = vi.fn(
+      async ({ signal }: { signal?: AbortSignal }) =>
+        new Promise<PlannerResult>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+        }),
+    )
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result, unmount } = renderHook(() =>
+      useQuickStartAgent({ planner, startCharacterGeneration }),
+    )
+
+    let pending!: Promise<unknown>
+    act(() => {
+      pending = result.current.submit('银发骑士')
+    })
+    unmount()
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/features/quick-start-agent/react.test.tsx
+++ b/frontend/src/features/quick-start-agent/react.test.tsx
@@ -2,10 +2,14 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { PlannerResult } from './runtime'
+import type { PlannerInput, PlannerResult } from './runtime'
 import { useQuickStartAgent } from './react'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
 
 function deferred() {
   let resolve!: () => void
@@ -34,7 +38,7 @@ describe('useQuickStartAgent', () => {
         ],
       },
     ]
-    const planner = vi.fn(async () => plannerResults.shift()!)
+    const planner = vi.fn(async (_input: PlannerInput) => plannerResults.shift()!)
     const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
     const { result } = renderHook(() =>
       useQuickStartAgent({
@@ -94,5 +98,145 @@ describe('useQuickStartAgent', () => {
 
     await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
     expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('rejects overlapping turns while the current Planner request is pending', async () => {
+    let resolvePlanner!: (result: PlannerResult) => void
+    const planner = vi.fn(
+      async () =>
+        new Promise<PlannerResult>((resolve) => {
+          resolvePlanner = resolve
+        }),
+    )
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+
+    let firstTurn!: Promise<unknown>
+    act(() => {
+      firstTurn = result.current.submit('银发骑士')
+    })
+    await waitFor(() => expect(planner).toHaveBeenCalledTimes(1))
+
+    await expect(result.current.submit('再发一条')).rejects.toThrow('Planner 正在处理上一条输入')
+
+    resolvePlanner({ text: '请补充角色风格。', finishReason: 'stop', toolCalls: [] })
+    await act(async () => {
+      await firstTurn
+    })
+    expect(result.current.state).toEqual({
+      status: 'awaiting-input',
+      message: '请补充角色风格。',
+    })
+  })
+
+  it('shows the safe fallback message for a non-Error Planner rejection', async () => {
+    const planner = vi.fn(async () => Promise.reject('offline'))
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+    let rejection: unknown
+
+    await act(async () => {
+      try {
+        await result.current.submit('银发骑士')
+      } catch (cause) {
+        rejection = cause
+      }
+    })
+
+    expect(rejection).toBe('offline')
+    expect(result.current.state).toEqual({
+      status: 'error',
+      message: 'Agent 暂时不可用，请稍后重试',
+    })
+  })
+
+  it('keeps the first successful clarification available after an initial Planner failure', async () => {
+    const planner = vi
+      .fn<(input: PlannerInput) => Promise<PlannerResult>>()
+      .mockRejectedValueOnce(new Error('network unavailable'))
+      .mockResolvedValueOnce({
+        text: '请补充角色风格。',
+        finishReason: 'stop',
+        toolCalls: [],
+      })
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+
+    await act(async () => {
+      await expect(result.current.submit('一个骑士')).rejects.toThrow('network unavailable')
+    })
+    await act(async () => {
+      await result.current.submit('重试')
+    })
+
+    expect(result.current.state).toEqual({
+      status: 'awaiting-input',
+      message: '请补充角色风格。',
+    })
+  })
+
+  it('dispatches without a presentation delay when animation frames are unavailable', async () => {
+    vi.stubGlobal('requestAnimationFrame', undefined)
+    const planner = vi.fn(
+      async (): Promise<PlannerResult> => ({
+        text: '',
+        finishReason: 'tool-calls',
+        toolCalls: [
+          {
+            toolName: 'start_character_generation',
+            input: { optimizedPrompt: '银发像素骑士，全身像', assumptions: [] },
+          },
+        ],
+      }),
+    )
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+
+    await act(async () => {
+      await result.current.submit('请直接生成银发骑士')
+    })
+
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: '银发像素骑士，全身像',
+    })
+  })
+
+  it('requires an explicit restart after the one clarification is exhausted', async () => {
+    const plannerResults: PlannerResult[] = [
+      { text: '请补充角色风格。', finishReason: 'stop', toolCalls: [] },
+      { text: '描述仍有冲突，请修改后重新开始。', finishReason: 'stop', toolCalls: [] },
+      {
+        text: '',
+        finishReason: 'tool-calls',
+        toolCalls: [
+          {
+            toolName: 'start_character_generation',
+            input: { optimizedPrompt: '银发像素骑士，全身像', assumptions: [] },
+          },
+        ],
+      },
+    ]
+    const planner = vi.fn(async (_input: PlannerInput) => plannerResults.shift()!)
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+
+    await act(async () => {
+      await result.current.submit('一个骑士')
+      await result.current.submit('仍然缺少明确风格')
+    })
+    expect(result.current.state).toEqual({
+      status: 'restart-required',
+      message: '描述仍有冲突，请修改后重新开始。',
+    })
+
+    await act(async () => {
+      await result.current.submit('16-bit 银发像素骑士，请直接生成')
+    })
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: '银发像素骑士，全身像',
+    })
+    expect(planner.mock.calls[2]?.[0].messages).toEqual([
+      { role: 'user', content: '16-bit 银发像素骑士，请直接生成' },
+    ])
   })
 })

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import {
+  createQuickStartAgent,
+  type CharacterGenerationPlan,
+  type CreateQuickStartAgentOptions,
+  type QuickStartAgentResult,
+} from './runtime'
+
+export type QuickStartAgentState =
+  | { status: 'idle' }
+  | { status: 'planning' }
+  | { status: 'awaiting-input'; message: string }
+  | ({ status: 'dispatching' } & CharacterGenerationPlan)
+  | { status: 'error'; message: string }
+
+export interface UseQuickStartAgentOptions extends CreateQuickStartAgentOptions {
+  /** 测试可替换；生产至少等待一帧，保证最终 Prompt 先于付费写操作可见。 */
+  waitForPresentation?: () => Promise<void>
+}
+
+async function waitForBrowserPresentation(): Promise<void> {
+  if (typeof requestAnimationFrame !== 'function') return
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  )
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error && cause.message ? cause.message : 'Agent 暂时不可用，请稍后重试'
+}
+
+export function useQuickStartAgent({
+  planner,
+  startCharacterGeneration,
+  waitForPresentation = waitForBrowserPresentation,
+}: UseQuickStartAgentOptions) {
+  const [state, setState] = useState<QuickStartAgentState>({ status: 'idle' })
+  const agent = useRef<ReturnType<typeof createQuickStartAgent> | null>(null)
+  const started = useRef(false)
+  const running = useRef(false)
+  const abortController = useRef<AbortController | null>(null)
+  const mounted = useRef(true)
+
+  useEffect(() => {
+    mounted.current = true
+    started.current = false
+    return () => {
+      mounted.current = false
+      abortController.current?.abort()
+      agent.current?.revoke()
+      agent.current = null
+      started.current = false
+    }
+  }, [planner, startCharacterGeneration])
+
+  const submit = useCallback(
+    async (input: string): Promise<QuickStartAgentResult> => {
+      if (running.current) throw new Error('Planner 正在处理上一条输入')
+      running.current = true
+      const controller = new AbortController()
+      abortController.current = controller
+      if (mounted.current) setState({ status: 'planning' })
+
+      try {
+        agent.current ??= createQuickStartAgent({ planner, startCharacterGeneration })
+        const activeAgent = agent.current
+        const runTurn = started.current ? activeAgent.continue : activeAgent.start
+        started.current = true
+        const result = await runTurn(input, {
+          signal: controller.signal,
+          async onBeforeDispatch(plan) {
+            if (mounted.current) setState({ status: 'dispatching', ...plan })
+            await waitForPresentation()
+          },
+        })
+        if (result.kind === 'message' && mounted.current) {
+          setState({ status: 'awaiting-input', message: result.message })
+        }
+        return result
+      } catch (cause) {
+        if (mounted.current && !(cause instanceof Error && cause.name === 'AbortError')) {
+          setState({ status: 'error', message: errorMessage(cause) })
+        }
+        throw cause
+      } finally {
+        running.current = false
+        if (abortController.current === controller) abortController.current = null
+      }
+    },
+    [planner, startCharacterGeneration, waitForPresentation],
+  )
+
+  return {
+    state,
+    busy: state.status === 'planning' || state.status === 'dispatching',
+    submit,
+  }
+}

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -11,6 +11,7 @@ export type QuickStartAgentState =
   | { status: 'idle' }
   | { status: 'planning' }
   | { status: 'awaiting-input'; message: string }
+  | { status: 'restart-required'; message: string }
   | ({ status: 'dispatching' } & CharacterGenerationPlan)
   | { status: 'error'; message: string }
 
@@ -38,6 +39,8 @@ export function useQuickStartAgent({
   const [state, setState] = useState<QuickStartAgentState>({ status: 'idle' })
   const agent = useRef<ReturnType<typeof createQuickStartAgent> | null>(null)
   const started = useRef(false)
+  const clarificationReceived = useRef(false)
+  const restartRequired = useRef(false)
   const running = useRef(false)
   const abortController = useRef<AbortController | null>(null)
   const mounted = useRef(true)
@@ -51,12 +54,21 @@ export function useQuickStartAgent({
       agent.current?.revoke()
       agent.current = null
       started.current = false
+      clarificationReceived.current = false
+      restartRequired.current = false
     }
   }, [planner, startCharacterGeneration])
 
   const submit = useCallback(
     async (input: string): Promise<QuickStartAgentResult> => {
       if (running.current) throw new Error('Planner 正在处理上一条输入')
+      if (restartRequired.current) {
+        agent.current?.revoke()
+        agent.current = null
+        started.current = false
+        clarificationReceived.current = false
+        restartRequired.current = false
+      }
       running.current = true
       const controller = new AbortController()
       abortController.current = controller
@@ -65,7 +77,8 @@ export function useQuickStartAgent({
       try {
         agent.current ??= createQuickStartAgent({ planner, startCharacterGeneration })
         const activeAgent = agent.current
-        const runTurn = started.current ? activeAgent.continue : activeAgent.start
+        const continuing = started.current
+        const runTurn = continuing ? activeAgent.continue : activeAgent.start
         started.current = true
         const result = await runTurn(input, {
           signal: controller.signal,
@@ -75,7 +88,13 @@ export function useQuickStartAgent({
           },
         })
         if (result.kind === 'message' && mounted.current) {
-          setState({ status: 'awaiting-input', message: result.message })
+          const clarificationExhausted = clarificationReceived.current
+          clarificationReceived.current = true
+          restartRequired.current = clarificationExhausted
+          setState({
+            status: clarificationExhausted ? 'restart-required' : 'awaiting-input',
+            message: result.message,
+          })
         }
         return result
       } catch (cause) {

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -258,6 +258,59 @@ async function flushAsyncWork() {
 }
 
 describe('WorkflowController', () => {
+  it('从角色描述创建两节点 Run 并提交母版生成', async () => {
+    const workflow = createWorkflowApis()
+    const generation = createGenerationHarness()
+    const prepareProject = vi.fn(async () => ({
+      id: 'project-agent',
+      spriteSize: { width: 256, height: 256 },
+    }))
+    const controller = createWorkflowController({
+      workflowRunApis: workflow.apis,
+      generationApis: generation.apis,
+      prepareProject,
+      onAsyncError: () => undefined,
+    })
+
+    await expect(
+      controller.startCharacterGeneration({ prompt: '  银发像素骑士  ' }),
+    ).resolves.toEqual({ runId: 'run-1' })
+
+    expect(prepareProject).toHaveBeenCalledWith('银发像素骑士')
+    expect(workflow.apis.create).toHaveBeenCalledWith({
+      projectId: 'project-agent',
+      nodes: [
+        expect.objectContaining({
+          id: 'character-setup',
+          type: 'character-setup',
+          input: { prompt: '银发像素骑士', referenceMedia: [] },
+        }),
+        expect.objectContaining({
+          id: 'character-template',
+          type: 'character-template',
+          dependsOnNodeIds: ['character-setup'],
+        }),
+      ],
+    })
+    expect(generation.apis.create).toHaveBeenCalledWith({
+      type: 'character_template',
+      projectId: 'project-agent',
+      prompt: '银发像素骑士',
+      referenceMedia: [],
+      spriteWidth: 256,
+      spriteHeight: 256,
+      direction: 'east',
+    })
+  })
+
+  it('未注入项目准备能力时拒绝 Quick Start 生成命令', async () => {
+    const { controller } = createController()
+
+    await expect(controller.startCharacterGeneration({ prompt: '银发像素骑士' })).rejects.toThrow(
+      'WorkflowController 未配置 Quick Start 项目准备能力',
+    )
+  })
+
   it('只在角色设定节点仍处于配置阶段时更新提示词和参考媒体', async () => {
     const { controller } = createController()
 

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -16,6 +16,8 @@ import type {
   GenerationExpectation,
   GeneratedImage,
   MediaReference,
+  Project,
+  ProjectApis,
   ReviewWorkflowNode,
   WorkflowActionInput,
   WorkflowCharacterInput,
@@ -26,10 +28,16 @@ import type {
   WorkflowRunApis,
   DirectionalMovement,
 } from '@/entities'
-import { getDirectionProfile } from '@/entities'
-import { IMAGE_CANDIDATE_COUNT, WorkflowRunConflictError } from '@/entities'
+import {
+  getDirectionProfile,
+  IMAGE_CANDIDATE_COUNT,
+  ProjectNameConflictError,
+  WorkflowRunConflictError,
+} from '@/entities'
 
 const COMPLETE_ANIMATION_FRAME_COUNT = 32
+const PROJECT_NAME_MAX_LENGTH = 20
+const QUICK_START_PROJECT_NAME_ATTEMPTS = 100
 
 export interface AddActionInput {
   /** 首帧节点 ID；完整动画和审核节点在此 ID 后追加稳定后缀。 */
@@ -92,6 +100,18 @@ export interface ApplyGenerationResultInput {
   generation: Generation
 }
 
+export type PrepareQuickStartProject = (
+  prompt: string,
+) => Promise<Pick<Project, 'id' | 'spriteSize'> & Partial<Pick<Project, 'directionalMovement'>>>
+
+export interface StartCharacterGenerationInput {
+  prompt: string
+}
+
+export interface StartCharacterGenerationResult {
+  runId: WorkflowRun['id']
+}
+
 export interface CreateWorkflowControllerOptions {
   /** 已从 WorkflowRunApis.get 取回的运行记录；不传时只能先调用 create。 */
   workflow?: WorkflowRun
@@ -99,6 +119,8 @@ export interface CreateWorkflowControllerOptions {
   generationApis: GenerationApis
   createId?: () => string
   now?: () => string
+  /** 只有纯文本入口需要；调用时机仍由 Controller 的生成命令持有。 */
+  prepareProject?: PrepareQuickStartProject
   /** SSE 回调无法 await，异步保存错误通过此处交给装配层展示或记录。 */
   onAsyncError: (error: Error) => void
   /** 项目方向模式；缺省按旧单向 WorkflowRun 兼容。 */
@@ -113,6 +135,10 @@ export interface CreateWorkflowControllerOptions {
  */
 export interface WorkflowController {
   create(input: CreateWorkflowRunInput): Promise<void>
+  /** 从纯文本入口创建一条 Run 并提交角色母版生成；提交后不参与后续流程。 */
+  startCharacterGeneration(
+    input: StartCharacterGenerationInput,
+  ): Promise<StartCharacterGenerationResult>
   /** 页面首次读取当前快照；后续变化统一通过 subscribe 接收。 */
   getWorkflow(): WorkflowRun
   subscribe(listener: (workflow: WorkflowRun) => void): () => void
@@ -205,12 +231,54 @@ interface PendingGenerationAttachment {
   generation: Generation
 }
 
+function boundedProjectName(value: string, maxLength: number): string {
+  const characters = Array.from(value)
+  return characters.length > maxLength
+    ? `${characters.slice(0, maxLength - 1).join('')}…`
+    : characters.join('')
+}
+
+export function createAutoPrepareProject(
+  projectApis: Pick<ProjectApis, 'create'>,
+): PrepareQuickStartProject {
+  return async (prompt) => {
+    const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
+    let lastConflict: unknown
+
+    for (let sequence = 1; sequence <= QUICK_START_PROJECT_NAME_ATTEMPTS; sequence += 1) {
+      const suffix = sequence === 1 ? '' : ` ${sequence}`
+      const maxBaseLength = PROJECT_NAME_MAX_LENGTH - Array.from(suffix).length
+      const base = boundedProjectName(normalizedPrompt, maxBaseLength)
+
+      try {
+        const project = await projectApis.create({
+          name: `${base}${suffix}`,
+          perspective: 'side',
+          directionalMovement: 'single',
+          spriteSize: { width: 256, height: 256 },
+        })
+        return {
+          id: project.id,
+          spriteSize: project.spriteSize,
+          directionalMovement: project.directionalMovement,
+        }
+      } catch (error) {
+        if (!(error instanceof ProjectNameConflictError)) throw error
+        lastConflict = error
+      }
+    }
+
+    throw lastConflict
+  }
+}
+
 export function createWorkflowController({
   workflow,
   workflowRunApis,
   generationApis,
   createId = createBrowserSafeId,
   now = () => new Date().toISOString(),
+  prepareProject,
   onAsyncError,
   directionalMovement = 'single',
 }: CreateWorkflowControllerOptions): WorkflowController {
@@ -313,6 +381,47 @@ export function createWorkflowController({
 
   function getWorkflow() {
     return snapshot()
+  }
+
+  async function startCharacterGeneration({
+    prompt,
+  }: StartCharacterGenerationInput): Promise<StartCharacterGenerationResult> {
+    ensureRunning()
+    if (!prepareProject) {
+      throw new Error('WorkflowController 未配置 Quick Start 项目准备能力')
+    }
+    const normalizedPrompt = nonEmpty(prompt, '角色描述')
+    const project = await prepareProject(normalizedPrompt)
+    await create({
+      projectId: project.id,
+      nodes: [
+        {
+          id: 'character-setup',
+          type: 'character-setup',
+          status: 'active',
+          phase: 'configuring',
+          dependsOnNodeIds: [],
+          generations: [],
+          error: null,
+          input: { prompt: normalizedPrompt, referenceMedia: [] },
+        },
+        {
+          id: 'character-template',
+          type: 'character-template',
+          status: 'locked',
+          phase: 'ready',
+          dependsOnNodeIds: ['character-setup'],
+          generations: [],
+          error: null,
+          selectedImageUrl: null,
+        },
+      ],
+    })
+    await generateCharacterTemplate('character-setup', {
+      spriteWidth: project.spriteSize.width,
+      spriteHeight: project.spriteSize.height,
+    })
+    return { runId: requireWorkflow().id }
   }
 
   function setCharacterName(
@@ -1580,6 +1689,7 @@ export function createWorkflowController({
 
   return {
     create: asCommand(create),
+    startCharacterGeneration,
     getWorkflow,
     subscribe,
     setCharacterName: asCommand(setCharacterName),

--- a/frontend/src/features/workflow-controller/index.ts
+++ b/frontend/src/features/workflow-controller/index.ts
@@ -1,9 +1,12 @@
-export { createWorkflowController } from './controller'
+export { createAutoPrepareProject, createWorkflowController } from './controller'
 export type {
   AddActionInput,
   ApplyGenerationResultInput,
   CreateWorkflowControllerOptions,
   GenerateActionOptions,
   GenerateCharacterTemplateOptions,
+  PrepareQuickStartProject,
+  StartCharacterGenerationInput,
+  StartCharacterGenerationResult,
   WorkflowController,
 } from './controller'

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -8,6 +8,11 @@ import { WorkflowRunConflictError, type WorkflowRun } from '@/entities'
 import { ApiError } from '@/shared/api'
 import type { ExportPackageModel } from '@/features/export-package'
 import { readActiveRun, rememberActiveRun } from '@/features/active-run'
+import type {
+  CreateQuickStartAgentOptions,
+  PlannerInput,
+  PlannerResult,
+} from '@/features/quick-start-agent'
 import { QuickStartPage } from './index'
 
 afterEach(() => {
@@ -157,7 +162,30 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
-function renderAt(path: string, service: QuickStartEntryService) {
+function agentFor(
+  overrides: Partial<CreateQuickStartAgentOptions> = {},
+): CreateQuickStartAgentOptions {
+  return {
+    planner: vi.fn(async ({ messages }) => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'start_character_generation',
+          input: { optimizedPrompt: messages.at(-1)?.content ?? '', assumptions: [] },
+        },
+      ],
+    })),
+    startCharacterGeneration: vi.fn(async () => ({ runId: 'run-new' })),
+    ...overrides,
+  }
+}
+
+function renderAt(
+  path: string,
+  service: QuickStartEntryService,
+  agent: CreateQuickStartAgentOptions = agentFor(),
+) {
   function PlaytestLocation() {
     const location = useLocation()
     return <h1>{`${location.pathname}${location.search}`}</h1>
@@ -167,11 +195,11 @@ function renderAt(path: string, service: QuickStartEntryService) {
       <Routes>
         <Route
           path="/quick-start"
-          element={<QuickStartPage service={service} activeRunUserId="7" />}
+          element={<QuickStartPage service={service} activeRunUserId="7" agent={agent} />}
         />
         <Route
           path="/quick-start/:runId"
-          element={<QuickStartPage service={service} activeRunUserId="7" />}
+          element={<QuickStartPage service={service} activeRunUserId="7" agent={agent} />}
         />
         <Route path="/projects/:projectId/assets" element={<PlaytestLocation />} />
         <Route path="/playtest/:characterId/:outfitId" element={<PlaytestLocation />} />
@@ -185,6 +213,7 @@ function renderWithRunSwitcher(
   initialRunId: string,
   nextRunId: string,
 ) {
+  const agent = agentFor()
   function Controls() {
     const navigate = useNavigate()
     const location = useLocation()
@@ -204,7 +233,7 @@ function renderWithRunSwitcher(
       <Routes>
         <Route
           path="/quick-start/:runId"
-          element={<QuickStartPage service={service} activeRunUserId="7" />}
+          element={<QuickStartPage service={service} activeRunUserId="7" agent={agent} />}
         />
       </Routes>
     </MemoryRouter>,
@@ -722,18 +751,26 @@ describe('QuickStartPage', () => {
   it('hands the creation entry off to the generating canvas instead of hard-cutting routes', async () => {
     vi.useFakeTimers()
     const createdRun = workflow(setupAndTemplate({ phase: 'generating' }), 'run-created')
-    const service = serviceFor(null, {
+    const service = serviceFor(createdRun, {
       runId: 'run-created',
       getWorkflow: vi.fn(() => createdRun),
       resume: vi.fn(async () => createdRun),
     })
-    renderAt('/quick-start', service)
+    renderAt(
+      '/quick-start',
+      service,
+      agentFor({
+        startCharacterGeneration: vi.fn(async () => ({ runId: 'run-created' })),
+      }),
+    )
 
     fireEvent.change(screen.getByLabelText('创作指令'), {
       target: { value: '提着风灯的森林守夜人' },
     })
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
     await act(async () => undefined)
+    expect(screen.getByText('提着风灯的森林守夜人')).toBeTruthy()
+    await act(async () => vi.advanceTimersByTimeAsync(32))
 
     const entry = screen.getByLabelText('创作指令').closest('[data-layout="quick-start-entry"]')
     expect(entry?.getAttribute('data-transition')).toBe('leaving')
@@ -854,7 +891,7 @@ describe('QuickStartPage', () => {
   it('keeps the natural-language creation entry visible when no run is selected', () => {
     render(
       <MemoryRouter>
-        <QuickStartPage />
+        <QuickStartPage service={serviceFor(null)} agent={agentFor()} />
       </MemoryRouter>,
     )
 
@@ -864,6 +901,87 @@ describe('QuickStartPage', () => {
       '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',
     )
     expect(screen.queryByRole('button', { name: /暗黑哥特像素/u })).toBeNull()
+  })
+
+  it('asks once, then shows the optimized description and assumptions before the Controller action', async () => {
+    const action = deferred<{ runId: string }>()
+    const plannerResults: PlannerResult[] = [
+      { text: '请补充角色的美术风格。', finishReason: 'stop', toolCalls: [] },
+      {
+        text: '',
+        finishReason: 'tool-calls',
+        toolCalls: [
+          {
+            toolName: 'start_character_generation',
+            input: {
+              optimizedPrompt: '银发骑士，16-bit 像素风，全身像',
+              assumptions: ['默认单角色', '动作稍后处理'],
+            },
+          },
+        ],
+      },
+    ]
+    const planner = vi.fn(async (_input: PlannerInput) => plannerResults.shift()!)
+    const startCharacterGeneration = vi.fn(() => action.promise)
+    renderAt('/quick-start', serviceFor(null), { planner, startCharacterGeneration })
+
+    fireEvent.change(screen.getByLabelText('创作指令'), { target: { value: '银发骑士' } })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    expect(await screen.findByText('请补充角色的美术风格。')).toBeTruthy()
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByLabelText('创作指令'), {
+      target: { value: '16-bit 像素风，请直接生成' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '继续' }))
+    expect(await screen.findByText('优化后描述')).toBeTruthy()
+    expect(await screen.findByText('银发骑士，16-bit 像素风，全身像')).toBeTruthy()
+    expect(screen.getByText('默认单角色')).toBeTruthy()
+    expect(screen.getByText('动作稍后处理')).toBeTruthy()
+    await waitFor(() => expect(startCharacterGeneration).toHaveBeenCalledTimes(1))
+
+    action.resolve({ runId: 'run-new' })
+  })
+
+  it('restarts with a fresh Agent session after the clarification budget is exhausted', async () => {
+    const plannerResults: PlannerResult[] = [
+      { text: '请补充角色风格。', finishReason: 'stop', toolCalls: [] },
+      { text: '描述仍有冲突，请修改后重新开始。', finishReason: 'stop', toolCalls: [] },
+      {
+        text: '',
+        finishReason: 'tool-calls',
+        toolCalls: [
+          {
+            toolName: 'start_character_generation',
+            input: { optimizedPrompt: '银发像素骑士，全身像', assumptions: [] },
+          },
+        ],
+      },
+    ]
+    const planner = vi.fn(async (_input: PlannerInput) => plannerResults.shift()!)
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-new' }))
+    renderAt('/quick-start', serviceFor(null), { planner, startCharacterGeneration })
+
+    fireEvent.change(screen.getByLabelText('创作指令'), { target: { value: '一个骑士' } })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    expect(await screen.findByText('请补充角色风格。')).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('创作指令'), {
+      target: { value: '仍然缺少明确风格' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '继续' }))
+    expect(await screen.findByText('描述仍有冲突，请修改后重新开始。')).toBeTruthy()
+    expect(screen.getByRole('button', { name: '重新开始' })).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('创作指令'), {
+      target: { value: '16-bit 银发像素骑士，请直接生成' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '重新开始' }))
+
+    await waitFor(() => expect(startCharacterGeneration).toHaveBeenCalledTimes(1))
+    expect(planner.mock.calls[2]?.[0].messages).toEqual([
+      { role: 'user', content: '16-bit 银发像素骑士，请直接生成' },
+    ])
   })
 
   it('shows first-frame confirmation instead of stale character candidates after a template is confirmed', async () => {
@@ -890,14 +1008,18 @@ describe('QuickStartPage', () => {
 
   it('submits both text and uploaded-template creation from the natural-language entry', async () => {
     const service = serviceFor(null)
-    const view = renderAt('/quick-start', service)
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-new' }))
+    const agent = agentFor({ startCharacterGeneration })
+    const view = renderAt('/quick-start', service, agent)
 
     fireEvent.click(screen.getByRole('button', { name: /16-bit 日式 RPG/u }))
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
     await waitFor(() =>
-      expect(service.start).toHaveBeenCalledWith('16-bit 日式 RPG 像素风，清晰轮廓，明亮配色'),
+      expect(startCharacterGeneration).toHaveBeenCalledWith({
+        prompt: '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',
+      }),
     )
-    expect(service.open).not.toHaveBeenCalled()
+    expect(service.start).not.toHaveBeenCalled()
 
     view.unmount()
     renderAt('/quick-start', service)
@@ -917,13 +1039,21 @@ describe('QuickStartPage', () => {
   })
 
   it('hands the created session to the run page under the production StrictMode lifecycle', async () => {
-    const service = serviceFor(null)
+    const run = workflow(setupAndTemplate({ phase: 'generating' }), 'run-new')
+    const service = serviceFor(run)
+    const agent = agentFor()
     const view = render(
       <StrictMode>
         <MemoryRouter initialEntries={['/quick-start']}>
           <Routes>
-            <Route path="/quick-start" element={<QuickStartPage service={service} />} />
-            <Route path="/quick-start/:runId" element={<QuickStartPage service={service} />} />
+            <Route
+              path="/quick-start"
+              element={<QuickStartPage service={service} agent={agent} />}
+            />
+            <Route
+              path="/quick-start/:runId"
+              element={<QuickStartPage service={service} agent={agent} />}
+            />
           </Routes>
         </MemoryRouter>
       </StrictMode>,
@@ -933,18 +1063,20 @@ describe('QuickStartPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
 
     await waitFor(() => expect(service.resume).toHaveBeenCalled())
-    expect(service.open).not.toHaveBeenCalled()
-    expect(service.dispose).not.toHaveBeenCalled()
+    expect(service.open).toHaveBeenCalledWith('run-new')
+    expect(service.start).not.toHaveBeenCalled()
+    expect(service.dispose).toHaveBeenCalledTimes(1)
 
     view.unmount()
-    await waitFor(() => expect(service.dispose).toHaveBeenCalledOnce())
+    await waitFor(() => expect(service.dispose).toHaveBeenCalledTimes(2))
   })
 
   it('shows entry errors and supports removing an uploaded template', async () => {
-    const service = serviceFor(null, {
-      start: vi.fn(async () => Promise.reject(new Error('服务繁忙'))),
+    const service = serviceFor(null)
+    const agent = agentFor({
+      startCharacterGeneration: vi.fn(async () => Promise.reject(new Error('服务繁忙'))),
     })
-    renderAt('/quick-start', service)
+    renderAt('/quick-start', service, agent)
     const file = new File(['pixels'], 'hero.png', { type: 'image/png' })
     fireEvent.change(screen.getByLabelText('上传角色母版'), { target: { files: [file] } })
     fireEvent.click(screen.getByRole('button', { name: '移除图片' }))

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -21,6 +21,8 @@ import {
 import { forgetActiveRun, isMissingActiveRunError, syncActiveRun } from '@/features/active-run'
 import { useOptionalAuthSession } from '@/features/auth-session'
 import { ExportButton, type ExportPackageModel } from '@/features/export-package'
+import { useQuickStartAgent, type QuickStartAgentState } from '@/features/quick-start-agent/react'
+import type { CreateQuickStartAgentOptions } from '@/features/quick-start-agent/runtime'
 import {
   GenerationPreviewCard,
   GenerationProgressCopy,
@@ -142,12 +144,15 @@ export interface QuickStartPageProps {
   service?: QuickStartEntryService
   /** 直渲染页面测试可显式提供；生产中取当前认证用户。 */
   activeRunUserId?: string
+  /** app 组合层注入 Planner 与绑定到现有 WorkflowController 的唯一写 action。 */
+  agent: CreateQuickStartAgentOptions
 }
 
 /** Quick Start 独立完成 AI 入口；它不跳转 Workflow Editor。 */
 export function QuickStartPage({
   service,
   activeRunUserId: providedActiveRunUserId,
+  agent,
 }: QuickStartPageProps) {
   const { runId } = useParams()
   const [searchParams] = useSearchParams()
@@ -181,7 +186,7 @@ export function QuickStartPage({
       onSessionCreated={setCreatedSession}
     />
   ) : (
-    <QuickStartInput service={activeService} onSessionCreated={setCreatedSession} />
+    <QuickStartInput service={activeService} agent={agent} onSessionCreated={setCreatedSession} />
   )
 }
 
@@ -267,11 +272,65 @@ function QuickStartActionInput({
   )
 }
 
+function QuickStartAgentInlineState({ state }: { state: QuickStartAgentState }) {
+  if (state.status === 'idle') return null
+  if (state.status === 'planning') {
+    return (
+      <p role="status" className="mb-3 px-1 text-sm text-app-muted">
+        正在判断信息是否足够…
+      </p>
+    )
+  }
+  if (state.status === 'awaiting-input' || state.status === 'restart-required') {
+    return (
+      <p
+        role="status"
+        className="mb-3 rounded-xl border border-app-line bg-app-surface/80 px-4 py-3 text-sm text-app-ink-soft"
+      >
+        {state.message}
+      </p>
+    )
+  }
+  if (state.status === 'error') {
+    return (
+      <p
+        role="alert"
+        className="mb-3 rounded-xl bg-app-danger px-4 py-3 text-sm text-app-danger-soft"
+      >
+        {state.message}
+      </p>
+    )
+  }
+  return (
+    <div
+      role="status"
+      className="mb-3 rounded-xl border border-app-line-strong bg-app-surface/90 px-4 py-3"
+    >
+      <p className="font-mono text-[10px] font-bold tracking-[0.12em] text-app-muted">优化后描述</p>
+      <p className="mt-1 text-sm leading-6 text-app-ink">{state.optimizedPrompt}</p>
+      {state.assumptions.length > 0 ? (
+        <ul className="mt-2 flex flex-wrap gap-1.5" aria-label="本次生成采用的默认假设">
+          {state.assumptions.map((assumption) => (
+            <li
+              key={assumption}
+              className="rounded-md bg-app-surface-muted px-2 py-1 text-xs text-app-muted"
+            >
+              {assumption}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  )
+}
+
 function QuickStartInput({
   service,
+  agent,
   onSessionCreated,
 }: {
   service: QuickStartEntryService
+  agent: CreateQuickStartAgentOptions
   onSessionCreated: (session: QuickStartSession) => void
 }) {
   const navigate = useNavigate()
@@ -283,9 +342,11 @@ function QuickStartInput({
   const fileInput = useRef<HTMLInputElement>(null)
   const submitAbortController = useRef<AbortController | null>(null)
   const handoffTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const agentSession = useQuickStartAgent(agent)
   const unavailableReason = service.unavailableReason
+  const entryBusy = submitting || agentSession.busy
   const hasPrompt = Boolean(prompt.trim())
-  const showStylePrompts = !hasPrompt && !templateFile
+  const showStylePrompts = !hasPrompt && !templateFile && agentSession.state.status === 'idle'
 
   useEffect(
     () => () => {
@@ -296,6 +357,7 @@ function QuickStartInput({
   )
 
   function selectTemplateFile(event: ChangeEvent<HTMLInputElement>) {
+    if (entryBusy) return
     const selected = event.target.files?.[0] ?? null
     setTemplateFile(selected)
     setError(null)
@@ -309,7 +371,31 @@ function QuickStartInput({
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const normalizedPrompt = prompt.trim()
-    if ((!normalizedPrompt && !templateFile) || submitting || unavailableReason) return
+    if ((!normalizedPrompt && !templateFile) || entryBusy || unavailableReason) return
+
+    if (!templateFile) {
+      setError(null)
+      try {
+        const result = await agentSession.submit(normalizedPrompt)
+        if (result.kind === 'message') {
+          setPrompt('')
+          return
+        }
+        setEntryTransition('leaving')
+        await new Promise<void>((resolve) => {
+          handoffTimer.current = setTimeout(() => {
+            handoffTimer.current = null
+            resolve()
+          }, ENTRY_HANDOFF_MS)
+        })
+        navigate(`/quick-start/${encodeURIComponent(result.runId)}`)
+      } catch (cause) {
+        if (!(cause instanceof Error && cause.name === 'AbortError')) {
+          setEntryTransition('idle')
+        }
+      }
+      return
+    }
 
     const abortController = new AbortController()
     submitAbortController.current = abortController
@@ -317,9 +403,11 @@ function QuickStartInput({
     setEntryTransition('leaving')
     setError(null)
     try {
-      const sessionPromise = templateFile
-        ? service.startWithUploadedTemplate(templateFile, normalizedPrompt, abortController.signal)
-        : service.start(normalizedPrompt)
+      const sessionPromise = service.startWithUploadedTemplate(
+        templateFile,
+        normalizedPrompt,
+        abortController.signal,
+      )
       const handoffPromise = new Promise<void>((resolve) => {
         handoffTimer.current = setTimeout(() => {
           handoffTimer.current = null
@@ -362,7 +450,7 @@ function QuickStartInput({
           }`}
         >
           <KineticCopyCycle
-            active={!templateFile && !submitting}
+            active={!templateFile && !entryBusy}
             as="h1"
             ariaLabel="想做一个什么角色？"
             motionMode="characters"
@@ -399,6 +487,7 @@ function QuickStartInput({
         </div>
 
         <div data-layout="quick-start-composer" className="mx-auto w-full max-w-3xl self-end">
+          {!templateFile ? <QuickStartAgentInlineState state={agentSession.state} /> : null}
           <form
             onSubmit={(event) => void submit(event)}
             className="grid items-center gap-1.5 rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)] sm:grid-cols-[1fr_auto_auto]"
@@ -411,6 +500,7 @@ function QuickStartInput({
                 aria-label="创作指令"
                 value={prompt}
                 onChange={(event) => setPrompt(event.target.value)}
+                disabled={entryBusy}
                 placeholder={
                   templateFile ? '描述动作，可留空生成待机动作…' : '描述角色的外形、身份和气质…'
                 }
@@ -423,6 +513,7 @@ function QuickStartInput({
               type="file"
               accept="image/*"
               aria-label="上传角色母版"
+              disabled={entryBusy}
               className="sr-only"
               onChange={selectTemplateFile}
             />
@@ -431,6 +522,7 @@ function QuickStartInput({
                 <button
                   type="button"
                   aria-label={`更换母版 ${templateFile.name}`}
+                  disabled={entryBusy}
                   onClick={() => fileInput.current?.click()}
                   className="inline-flex h-full min-w-0 items-center gap-2 rounded-l-lg px-2.5 font-semibold transition hover:bg-app-surface hover:text-app-accent focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
                 >
@@ -440,6 +532,7 @@ function QuickStartInput({
                 <button
                   type="button"
                   aria-label="移除图片"
+                  disabled={entryBusy}
                   onClick={removeTemplateFile}
                   className="grid size-8 shrink-0 place-items-center rounded-md text-app-muted transition hover:bg-app-surface hover:text-app-accent focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
                 >
@@ -449,6 +542,7 @@ function QuickStartInput({
             ) : (
               <button
                 type="button"
+                disabled={entryBusy}
                 onClick={() => fileInput.current?.click()}
                 className="inline-flex h-10 items-center gap-2 rounded-lg px-3 text-xs font-semibold whitespace-nowrap text-app-muted transition hover:bg-app-surface-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
               >
@@ -459,12 +553,22 @@ function QuickStartInput({
             <button
               type="submit"
               disabled={
-                (!prompt.trim() && !templateFile) || submitting || Boolean(unavailableReason)
+                (!prompt.trim() && !templateFile) || entryBusy || Boolean(unavailableReason)
               }
               className="inline-flex h-10 items-center gap-2 rounded-lg bg-app-accent px-4 text-sm font-bold whitespace-nowrap text-app-on-accent transition hover:bg-app-accent-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-45"
             >
-              {submitting ? '正在创建…' : '生成角色'}
-              {!submitting ? <ArrowUp aria-hidden="true" size={16} weight="bold" /> : null}
+              {templateFile && submitting
+                ? '正在创建…'
+                : agentSession.state.status === 'planning'
+                  ? '正在判断…'
+                  : agentSession.state.status === 'dispatching'
+                    ? '正在开始生成…'
+                    : agentSession.state.status === 'restart-required'
+                      ? '重新开始'
+                      : agentSession.state.status === 'awaiting-input'
+                        ? '继续'
+                        : '生成角色'}
+              {!entryBusy ? <ArrowUp aria-hidden="true" size={16} weight="bold" /> : null}
             </button>
           </form>
 

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -3,7 +3,6 @@ import {
   createGenerationApis,
   createMediaApis,
   projectApis,
-  ProjectNameConflictError,
   workflowRunApis,
   characterTemplateImages,
   characterTemplatesFromImages,
@@ -24,14 +23,17 @@ import {
 } from '@/entities'
 import { getApiAccessToken, recoverApiUnauthorized, resolveApiBaseUrl } from '@/shared/api'
 import { createEventStreamSubscriber } from '@/shared/api/stream'
-import { createWorkflowController, type WorkflowController } from '@/features/workflow-controller'
+import {
+  createAutoPrepareProject,
+  createWorkflowController,
+  type PrepareQuickStartProject,
+  type WorkflowController,
+} from '@/features/workflow-controller'
 import { createProgressiveExportModel, type ExportPackageModel } from '@/features/export-package'
 import { createActionSequences } from '@/features/export'
 
-/** 页面不直接拼接后端字段；只负责准备项目约束。 */
-export type PrepareQuickStartProject = (
-  prompt: string,
-) => Promise<Pick<Project, 'id' | 'spriteSize'> & Partial<Pick<Project, 'directionalMovement'>>>
+export { createAutoPrepareProject }
+export type { PrepareQuickStartProject }
 
 export interface QuickStartFrame {
   index: number
@@ -120,8 +122,6 @@ export interface CreateQuickStartServiceOptions {
 
 type GeneratableActionType = 'idle' | 'walk' | 'jump' | 'attack' | 'custom'
 
-const PROJECT_NAME_MAX_LENGTH = 20
-const QUICK_START_PROJECT_NAME_ATTEMPTS = 100
 const ACTION_DISPLAY_NAME_MAX_LENGTH = 20
 
 function boundedDisplayName(value: string, maxLength: number): string {
@@ -1062,39 +1062,6 @@ export function createQuickStartService({
       projectDirectionalMovements.set(project.id, project.directionalMovement)
       return createSession(createController(run, project.directionalMovement), project.spriteSize)
     },
-  }
-}
-
-export function createAutoPrepareProject(projectApis: ProjectApis): PrepareQuickStartProject {
-  return async (prompt) => {
-    const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
-    let lastConflict: unknown
-
-    for (let sequence = 1; sequence <= QUICK_START_PROJECT_NAME_ATTEMPTS; sequence += 1) {
-      // 首次名称不预留编号空间；只有重名时才缩短前缀，为可读编号让出 20 字上限。
-      const suffix = sequence === 1 ? '' : ` ${sequence}`
-      const maxBaseLength = PROJECT_NAME_MAX_LENGTH - Array.from(suffix).length
-      const base = boundedDisplayName(normalizedPrompt, maxBaseLength)
-
-      try {
-        const project = await projectApis.create({
-          name: `${base}${suffix}`,
-          perspective: 'side',
-          directionalMovement: 'single',
-          spriteSize: { width: 256, height: 256 },
-        })
-        return {
-          id: project.id,
-          spriteSize: project.spriteSize,
-          directionalMovement: project.directionalMovement,
-        }
-      } catch (error) {
-        if (!(error instanceof ProjectNameConflictError)) throw error
-        lastConflict = error
-      }
-    }
-
-    throw lastConflict
   }
 }
 


### PR DESCRIPTION
本 PR 把已合入的 Agent Core 和模型代理接入 Quick Start：LLM 最多追问一次，信息充分或用户明确要求直接生成时，通过唯一 Tool 进入现有 `WorkflowController`，创建 `WorkflowRun` 并提交角色母版生成。

## Why

此前方案要么自行维护 AgentTransport，要么移除 Tool 后只能给提示、无法执行生成。当前 Quick Start 需要一个受限、可维护的 Agent，同时保持所有生成业务仍由既有 `WorkflowController` 负责。

## Changes

- 将 Agent action 接到现有 `WorkflowController`，补齐从项目准备、Run 创建到角色母版生成提交的单一命令。
- 增加生产组合层：同源 API 地址解析、JWT 恢复、AI SDK Planner 懒加载，以及 Controller 生命周期释放。
- 增加 React 适配器和页面接线：信息不足时最多追问一次；第二次仍无法生成时明确要求重新开始，新会话不继承旧上下文。
- 在现有 Quick Start 输入器内展示追问、优化后描述、默认假设和生成状态，不采用旧版聊天布局。

## Implementation

- 唯一调用链为 `Agent → app 薄装配 callback → WorkflowController → WorkflowRun / Generation`。
- 页面只依赖 React adapter/runtime 类型；不新增页面内业务 HTTP 或绕过 Controller 的生成路径。
- AI SDK Planner 首次使用时懒加载；生产 API 地址解析为同源绝对地址，再适配到 `/ai/chat`。
- 写权限在调用前消费，Planner 与写 action 都不自动重试；dispatch 前取消不会产生写操作。

## Verification

- [x] `npm run format:check`：通过。
- [x] `npm run lint`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run test:coverage`：66 个文件、844 项通过；Agent 组合与 React adapter 均为 100% 行覆盖。
- [x] `npm run build`：通过；仅有既存 chunk size warning。
- [x] 独立验收：通过；完整 diff 仍为本 PR 的 11 个集成文件。

## Scope

- 本 PR 不包含：生成后的候选选择、动作生成、审核、发布、Memory、RAG、MCP、多 Agent 或 Tool Loop。
- 本 PR 不包含：上传母版的 Agent 路径、跨刷新 exactly-once、新 Controller、Service 或通用 Tool 平台。
- 本 PR 不重复包含 #456/#457 的实现；两者已合入 `main`，本分支已 rebase 到最新基线。

## Related Issues

Closes #443

Refs #450

Refs #452
