### PR TITLE
fix(generation): 生图出口补一次抠图并落主体数读数

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy.orm import Session
 
 from windup_ai_engine.ports import PromptRejected
+from windup_ai_engine.slicing.quality import subject_blobs
 from windup_common.models import ActionSpec, ActionType as EngineActionType, CharacterCard
 from windup_framework.config.quality_gate import settings as gate_settings
 
@@ -536,11 +537,13 @@ class ImageTaskExecutor:
         self,
         *,
         image=None,                                      # None → 懒加载 SufyImageProvider
+        matte: MatteProvider | None = None,              # None → 懒加载 OnnxU2NetMatteProvider
         upload: Callable[[bytes], str] | None = None,    # None → 真实对象存储上传
         fetch_ref: Callable[[str], bytes] | None = None, # None → 下载 reference_image_url
         session_factory: Callable[[], Session] | None = None,
     ) -> None:
         self._image = image
+        self._matte = matte
         self._upload = upload
         self._fetch_ref = fetch_ref
         self._session_factory = session_factory
@@ -560,10 +563,11 @@ class ImageTaskExecutor:
             if own:
                 session.commit()
             cons = _load_constraints(session, project_id)   # 角色图也受项目约束
-            urls = self._produce_image(input, cons)
+            urls, quality = self._produce_image(input, cons)
             task_repo.update_result(session, task_id, _IMAGE_RESULT, {
                 "type": "character_image",
                 "image_urls": urls,
+                "quality": quality,
             })
             _settle_credit(session, task_id, success=True)
             if own:
@@ -579,8 +583,10 @@ class ImageTaskExecutor:
             if own:
                 session.close()
 
-    def _produce_image(self, input: CharacterImageInput, cons: ProjectConstraints) -> list[str]:
-        """根据项目约束决定生成模式,返回 URL 列表。
+    def _produce_image(
+        self, input: CharacterImageInput, cons: ProjectConstraints,
+    ) -> tuple[list[str], dict]:
+        """根据项目约束决定生成模式,返回 (URL 列表, 成色读数)。
 
         模式判断:
           - 项目有 sprite_sample_url → **图生图**: 风格参考图 + 提示词
@@ -624,16 +630,30 @@ class ImageTaskExecutor:
 
         prompt = " ".join(parts)
 
+        import io
+
+        from PIL import Image
+
         image_gen = self._get_image()
+        matte = self._get_matte()
         upload = self._upload or self._upload_image
         urls: list[str] = []
+        cut: list[Image.Image] = []
         for _ in range(max(1, input.num_images)):
             img = image_gen.gen_image(prompt, refs)
+            # 提示词要的是浅灰底,交付的母版却必须是透明底:不在这里抠,灰底会一路带进
+            # 预览、也会成为下一次图生图的参考底色(#430)。抠在缩放之前 —— u2netp 按模型
+            # 原始分辨率分割,先缩再抠等于把一半可用像素丢掉再让它猜。
+            # 抠不动时让它抛:静默交一张带灰底的母版,正是"看起来成功的错产物"。
             # 请求里的 width/height 此前被丢掉:入口收下并校验过它们(_validate_project_size),
             # 而 ImageProvider.gen_image 没有尺寸参数,模型出多大就返多大 —— 又一个"接了不
             # 履约"的字段。模型本身不吃宽高,所以在这里落实。
-            urls.append(upload(_fit_to(img, input.width, input.height, smooth=True)))
-        return urls
+            png = _fit_to(matte.cutout(img), input.width, input.height, smooth=True)
+            cut.append(Image.open(io.BytesIO(png)).convert("RGBA"))
+            urls.append(upload(png))
+        # 同一份 alpha 顺手数一次主体数(#427):此前多主体母版要等下一个动作任务才留痕,
+        # 而那时钱已经花在错的母版上了。只记账,不在此处判成败 —— 与动作那条同一立场。
+        return urls, {"subject_blobs": list(subject_blobs(cut))}
 
     def _get_image(self):
         if self._image is None:
@@ -641,6 +661,13 @@ class ImageTaskExecutor:
 
             self._image = SufyImageProvider()
         return self._image
+
+    def _get_matte(self):
+        if self._matte is None:
+            from windup_framework.providers import OnnxU2NetMatteProvider
+
+            self._matte = OnnxU2NetMatteProvider()
+        return self._matte
 
     def _download(self, url: str) -> bytes:
         # 同 _download_master:参考图 URL 由调用方给,必须走白名单取图。

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -107,6 +107,10 @@ class CharacterImageOutput:
 
     type: str = "character_image"
     image_urls: list[str] = field(default_factory=list)
+    # 出图当场量的主体数(``ai_engine.slicing.quality.subject_blobs`` 的逐张读数)。与动作
+    # 结果那份 ``quality`` 同键同语义:只落库、不参与前端回填,本层不据此判成败。
+    # ``None`` = **没量过**,不是"量了没问题"。
+    quality: dict | None = None
 
 
 @dataclass

--- a/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
@@ -255,6 +255,7 @@ def _deserialize_result(
         return CharacterImageOutput(
             type=raw.get("type", "character_image"),
             image_urls=raw.get("image_urls", []),
+            quality=raw.get("quality"),
         )
     if result_type == "character_action":
         from windup_app.server.orchestrator.model import CharacterActionFrame

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -406,7 +406,9 @@ def test_image_success_captures_reserved_credit(session_factory):
         upload=lambda _png: "https://cdn.example.com/img.png",
         session_factory=session_factory,
     )
-    executor._produce_image = lambda _input, _cons: ["https://cdn.example.com/img.png"]
+    executor._produce_image = lambda _input, _cons: (
+        ["https://cdn.example.com/img.png"], {"subject_blobs": [1]},
+    )
     image_input = CharacterImageInput(prompt="勇者", width=64, height=64)
     with session_factory() as session:
         task = AiGenerationService().generate_character_image(

--- a/backend/tests/test_master_cutout.py
+++ b/backend/tests/test_master_cutout.py
@@ -1,0 +1,174 @@
+"""母版出图那一步的抠图与主体数读数(#430 / #427)。
+
+两条 issue 改的是同一处出口,共用同一次 ``cutout()``:抠出来的 alpha 既是交付物,
+也是数主体数的依据。分两次插 matte 会让同一张图被抠两遍,还可能抠出两份不同的 alpha。
+
+抠图 provider 在这里桩替。真实那份走 u2netp(``test_matte_provider.py`` 校准),
+本文件要锁的是**生产路径确实过了它**,以及读数确实落到任务结果里 —— 这正是
+"端点看着可用、实际没接上"那类事故的防线。
+"""
+
+import io
+
+import numpy as np
+import pytest
+from PIL import Image
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from windup_app.server.orchestrator.executor import ImageTaskExecutor, ProjectConstraints
+from windup_app.server.orchestrator.model import CharacterImageInput, TaskStatus
+from windup_app.server.orchestrator.service import AiGenerationService
+from windup_framework.db.base import Base
+from windup_framework.mq.model import MqMessage  # noqa: F401 — register metadata
+
+from conftest import seed_credit_account
+
+_BG = (200, 200, 200)  # 提示词里那句 "Plain light-gray background"
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _master(size: int = 64, *, subjects: int = 1) -> bytes:
+    """模型刚出的母版:浅灰底 + 若干互不相连的主体块,**整幅不透明**。"""
+    arr = np.zeros((size, size, 4), "uint8")
+    arr[:, :, :3] = _BG
+    arr[:, :, 3] = 255
+    for i in range(subjects):
+        x = 6 + i * (size // 2)
+        arr[20:44, x:x + 18, :3] = (30, 60, 200)
+    buf = io.BytesIO()
+    Image.fromarray(arr, "RGBA").save(buf, "PNG")
+    return buf.getvalue()
+
+
+class _BackgroundMatte:
+    """把浅灰底判成背景。真 provider 按显著性分割,这里只需要一份确定的 alpha。"""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def cutout(self, png: bytes) -> bytes:
+        self.calls += 1
+        arr = np.asarray(Image.open(io.BytesIO(png)).convert("RGBA")).copy()
+        bg = np.all(np.abs(arr[:, :, :3].astype(int) - np.array(_BG)) <= 8, axis=-1)
+        arr[bg, 3] = 0
+        buf = io.BytesIO()
+        Image.fromarray(arr, "RGBA").save(buf, "PNG")
+        return buf.getvalue()
+
+
+class _Gen:
+    def __init__(self, png: bytes) -> None:
+        self._png = png
+
+    def gen_image(self, prompt, refs):
+        return self._png
+
+
+def _constraints() -> ProjectConstraints:
+    return ProjectConstraints(sprite_w=64, sprite_h=64)
+
+
+def _run(png: bytes, *, matte=None, num_images: int = 1):
+    got: list[bytes] = []
+    ex = ImageTaskExecutor(
+        image=_Gen(png),
+        matte=matte or _BackgroundMatte(),
+        upload=lambda b: (got.append(b), f"u{len(got)}")[1],
+    )
+    urls, quality = ex._produce_image(
+        CharacterImageInput(prompt="勇者", width=64, height=64, num_images=num_images),
+        _constraints(),
+    )
+    return got, urls, quality
+
+
+def _alpha(png: bytes) -> np.ndarray:
+    return np.asarray(Image.open(io.BytesIO(png)).convert("RGBA"))[:, :, 3]
+
+
+def test_delivered_master_has_no_background_left():
+    """#430:交上去的那份必须是抠过的,不是模型原样。
+
+    断言落在**上传拿到的字节**上,而不是"抠图被调用过"—— 调用了却把原图传上去
+    同样能让调用计数通过,而用户看到的仍是灰底。
+    """
+    raw = _master()
+    assert _alpha(raw)[0, 0] == 255, "仪器自检:模型出的图本就该是不透明的"
+
+    got, _, _ = _run(raw)
+
+    assert _alpha(got[0])[0, 0] == 0
+    assert _alpha(got[0])[20:44, 6:24].min() == 255, "主体不能被一起抠掉"
+
+
+def test_multi_subject_master_is_counted_at_the_image_exit():
+    """#427:两个主体在出图当场就留痕,不必等下一个动作任务。"""
+    _, _, quality = _run(_master(subjects=2))
+
+    assert quality["subject_blobs"] == [2]
+
+
+def test_single_subject_master_counts_one():
+    _, _, quality = _run(_master(subjects=1))
+
+    assert quality["subject_blobs"] == [1]
+
+
+def test_each_image_gets_its_own_reading():
+    """读数逐张给,不压成均值:一次出四张里只有一张是双主体,均值会把它抹平。"""
+    _, urls, quality = _run(_master(subjects=2), num_images=3)
+
+    assert len(urls) == 3
+    assert quality["subject_blobs"] == [2, 2, 2]
+
+
+def test_cutout_failure_fails_the_task_instead_of_delivering_gray():
+    """抠不动时任务该红。静默交一张带灰底的母版正是 #430 本身,而且不可检测。"""
+    class _Broken:
+        def cutout(self, png: bytes) -> bytes:
+            raise RuntimeError("onnxruntime 不可用")
+
+    with pytest.raises(RuntimeError):
+        _run(_master(), matte=_Broken())
+
+
+def test_quality_reaches_the_task_result_over_http(session_factory):
+    """从建任务到读任务走真实链路:读数必须能被前端拿到。
+
+    直接构造 ``CharacterImageOutput`` 的测试证明不了这条 —— 它绕过了 executor 落库
+    与 ``task_repo`` 反序列化那两段,而字段漏在哪一段都会让接口那头恒为空。
+    """
+    with session_factory() as session:
+        seed_credit_account(session, 1)
+        session.commit()
+
+    image_input = CharacterImageInput(prompt="勇者", width=64, height=64)
+    with session_factory() as session:
+        task = AiGenerationService().generate_character_image(
+            session, user_id=1, input=image_input,
+        )
+        session.commit()
+        task_id = task.id
+
+    ImageTaskExecutor(
+        image=_Gen(_master(subjects=2)),
+        matte=_BackgroundMatte(),
+        upload=lambda _b: "https://cdn.example.com/m.png",
+        session_factory=session_factory,
+    ).run_image_task(task_id, image_input)
+
+    with session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=1, task_id=task_id)
+
+    assert done.status is TaskStatus.COMPLETED
+    assert done.result.quality == {"subject_blobs": [2]}

--- a/backend/tests/test_orchestrator_hardening.py
+++ b/backend/tests/test_orchestrator_hardening.py
@@ -555,6 +555,13 @@ def _png(w: int, h: int) -> bytes:
     return buf.getvalue()
 
 
+class _PassthroughMatte:
+    """本文件量的是尺寸,不是抠图。原样返回,让 alpha 不参与断言。"""
+
+    def cutout(self, png: bytes) -> bytes:
+        return png
+
+
 @pytest.mark.parametrize(("want_w", "want_h"), [(512, 512), (256, 384), (1024, 1024)])
 def test_requested_image_size_is_actually_applied(want_w, want_h):
     """入口收下 width/height 并校验过，但 ImageProvider.gen_image 没有尺寸参数。
@@ -574,7 +581,10 @@ def test_requested_image_size_is_actually_applied(want_w, want_h):
             return _png(1024, 1024)          # 模型固定出 1024²
 
     got: list[bytes] = []
-    ex = ImageTaskExecutor(image=_Gen(), upload=lambda b: (got.append(b), "u")[1])
+    ex = ImageTaskExecutor(
+        image=_Gen(), matte=_PassthroughMatte(),
+        upload=lambda b: (got.append(b), "u")[1],
+    )
     ex._produce_image(
         CharacterImageInput(prompt="knight", width=want_w, height=want_h, num_images=1),
         _constraints(),


### PR DESCRIPTION
## 变更内容

`ImageTaskExecutor._produce_image` 在出图后、上传前插一次 `MatteProvider.cutout()`,交付透明底母版;同一份 alpha 顺手过一次 `subject_blobs()`,读数随任务结果落库。抠图 provider 与动作那条一样可注入,缺省惰性建 `OnnxU2NetMatteProvider`。

抠在缩放之前:u2netp 按模型原始分辨率分割,先缩再抠等于丢掉一半可用像素再让它猜。

## 关联

Closes #430
Closes #427

两条 issue 改的是同一处出口,共用同一次 `cutout()`。分两个 PR 会让同一张图被抠两遍,还可能抠出两份不同的 alpha,所以合成一个。

两者当前 milestone 不同(#430 在 MS4、#427 在 MS3),归置请组长定。

## 为什么这么做

`_produce_image` 里那句 `Plain light-gray background, no shadow.` 让模型必然出灰底,而这一步之后没有任何环节去背,灰底就成了交付物本身。动作那条路线的 `VideoFrameStrategy` / `PerFrameStrategy` 早就带 matte,只有生图出口是空的。

主体数同理:`subject_blobs` 挂在 `ActionQuality` 上,而多主体是在生图这一步产生的。等到下一个动作任务才读出 3,钱已经花在错的母版上了。

备选是让前端在展示时去背 —— 不取,因为母版还会作为下一次图生图的参考图回到模型,底色会继续传递。

抠不动时让异常上抛、任务转 FAILED(积分随现有 `_settle_credit` 解冻),不静默交一张带灰底的母版:那是不可检测的错产物。

## 本地验证

跑的是 CI 的原样命令,全树非单文件。

- `uv sync --frozen` → 0
- `uv run ruff check .` → 0,All checks passed
- `uv run python -m scripts.export_openapi` → 0,`openapi.json` 无差异(`result` 是 `dict`,新字段不改契约)
- `uv run lint-imports` → 0,2 kept / 0 broken
- `uv run pytest -q --cov=packages ...` → 0,**1132 passed, 14 skipped**
- 前端五项(`format:check` / `lint` / `typecheck` / `test:coverage` / `build`)退出码均为 0

真实样本:拿 #416 那批生产母版(8 张,走的就是本函数)过新代码,读数与此前离线手接 `原图→cutout()→subject_blobs()` 那条链完全一致 —— 旧文案臂 3/3/1/3、新文案臂 1/1/1/1。也就是说这 8 张里有 3 张是多主体,而在此之前生产链路看不见它们。交付图四角 alpha 全 0,入口与出口 sha256 不同。

新用例做过变异对照,不是写完就绿:把 `cutout()` 换成直通 → 5 条红;把主体数改成恒报 1 → 3 条红。

## 待对齐

- 与 #449 必然文本冲突:那条也改 `_produce_image`(加朝向)与 `run_image_task` 的结果 dict,只是没碰抠图这条接缝。它先提,谁先合我跟着 rebase。
- `subject_blobs` 有已知假阴性:多个主体被横贯画面的光束一类元素连成一个连通块时读 1(#427 有样本)。所以这里只记账、不设阈值,别当放行判据用。
