### PR TITLE
fix(stream): reconcile generation state after SSE reconnect

### DIFF
--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -5,7 +5,11 @@ import {
   createGenerationApis,
   GenerationApiError,
 } from '@/entities'
-import { EventStreamError, type EventStreamOptions } from '@/shared/api/stream'
+import {
+  createEventStreamSubscriber,
+  EventStreamError,
+  type EventStreamOptions,
+} from '@/shared/api/stream'
 
 import type { MediaReference } from '../media'
 
@@ -399,6 +403,105 @@ describe('createGenerationApis', () => {
 
     unsubscribe()
     expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it('SSE 重连后补拉一次任务状态，交付断线窗口内错过的终态', async () => {
+    let streamOptions: EventStreamOptions | undefined
+    const request = vi.fn(async () => success(taskData()))
+    const apis = createGenerationApis({
+      baseUrl: 'https://api.test',
+      transport: {
+        request,
+        stream: vi.fn((_url: string, options: NonNullable<typeof streamOptions>) => {
+          streamOptions = options
+          return vi.fn()
+        }),
+      },
+    })
+    const onEvent = vi.fn()
+
+    apis.subscribe('42', '91', { type: 'character_template' }, onEvent, vi.fn())
+    expect(request).not.toHaveBeenCalled()
+
+    streamOptions?.onReconnect?.()
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledOnce())
+
+    expect(request).toHaveBeenCalledOnce()
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: '91', status: 'completed' }),
+    )
+  })
+
+  it('任务在 SSE 断线窗口内结束时，重连后仍然交付终态', async () => {
+    const encoder = new TextEncoder()
+    const runningThenDrop = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              `event: task_update\ndata: ${JSON.stringify(taskData({ status: 'running', result: null }))}\n\n`,
+            ),
+          )
+          controller.close()
+        },
+      }),
+      { headers: { 'content-type': 'text/event-stream' } },
+    )
+    // 重连后建立的流一直沉默：断线期间产生的终态事件不会被补发。
+    const silent = new Response(new ReadableStream<Uint8Array>({ start: () => undefined }), {
+      headers: { 'content-type': 'text/event-stream' },
+    })
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(runningThenDrop)
+      .mockResolvedValueOnce(silent)
+    const apis = createGenerationApis({
+      baseUrl: 'https://api.test',
+      transport: {
+        request: vi.fn(async () => success(taskData())),
+        stream: createEventStreamSubscriber({
+          fetchFn,
+          getAccessToken: () => null,
+          reconnectDelayMs: 0,
+        }),
+      },
+    })
+    const statuses: string[] = []
+
+    apis.subscribe(
+      '42',
+      '91',
+      { type: 'character_template' },
+      (event) => statuses.push(event.status),
+      vi.fn(),
+    )
+
+    await vi.waitFor(() => expect(statuses).toContain('completed'))
+    expect(statuses).toEqual(['running', 'completed'])
+  })
+
+  it('重连补拉遇到错误时报告，不把任务当作已结束', async () => {
+    let streamOptions: EventStreamOptions | undefined
+    const apis = createGenerationApis({
+      baseUrl: 'https://api.test',
+      transport: {
+        request: vi.fn(async () => {
+          throw new Error('network down')
+        }),
+        stream: vi.fn((_url: string, options: NonNullable<typeof streamOptions>) => {
+          streamOptions = options
+          return vi.fn()
+        }),
+      },
+    })
+    const onEvent = vi.fn()
+    const onError = vi.fn()
+
+    apis.subscribe('42', '91', { type: 'character_template' }, onEvent, onError)
+    streamOptions?.onReconnect?.()
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce())
+
+    expect(onEvent).not.toHaveBeenCalled()
   })
 
   it('从查询结果推断前端阶段，并允许现有三参数订阅继续使用', async () => {

--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -504,6 +504,148 @@ describe('createGenerationApis', () => {
     expect(onEvent).not.toHaveBeenCalled()
   })
 
+  it('取消订阅后忽略尚未开始的重连对账', async () => {
+    let streamOptions: EventStreamOptions | undefined
+    const request = vi.fn(async () => success(taskData()))
+    const apis = createGenerationApis({
+      baseUrl: 'https://api.test',
+      transport: {
+        request,
+        stream: vi.fn((_url: string, options: NonNullable<typeof streamOptions>) => {
+          streamOptions = options
+          return vi.fn()
+        }),
+      },
+    })
+    const onEvent = vi.fn()
+    const unsubscribe = apis.subscribe('42', '91', { type: 'character_template' }, onEvent, vi.fn())
+
+    unsubscribe()
+    streamOptions?.onReconnect?.()
+    await Promise.resolve()
+
+    expect(request).not.toHaveBeenCalled()
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('重连对账请求完成前取消订阅时不再交付结果', async () => {
+    let streamOptions: EventStreamOptions | undefined
+    let resolveRequest: ((response: Response) => void) | undefined
+    const request = vi.fn(
+      async () =>
+        new Promise<Response>((resolve) => {
+          resolveRequest = resolve
+        }),
+    )
+    const apis = createGenerationApis({
+      baseUrl: 'https://api.test',
+      transport: {
+        request,
+        stream: vi.fn((_url: string, options: NonNullable<typeof streamOptions>) => {
+          streamOptions = options
+          return vi.fn()
+        }),
+      },
+    })
+    const onEvent = vi.fn()
+    const unsubscribe = apis.subscribe('42', '91', { type: 'character_template' }, onEvent, vi.fn())
+
+    streamOptions?.onReconnect?.()
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce())
+    unsubscribe()
+    resolveRequest?.(success(taskData()))
+    await Promise.resolve()
+
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('重连对账请求失败前取消订阅时不再报告错误', async () => {
+    let streamOptions: EventStreamOptions | undefined
+    let rejectRequest: ((reason: unknown) => void) | undefined
+    const request = vi.fn(
+      async () =>
+        new Promise<Response>((_resolve, reject) => {
+          rejectRequest = reject
+        }),
+    )
+    const apis = createGenerationApis({
+      baseUrl: 'https://api.test',
+      transport: {
+        request,
+        stream: vi.fn((_url: string, options: NonNullable<typeof streamOptions>) => {
+          streamOptions = options
+          return vi.fn()
+        }),
+      },
+    })
+    const onError = vi.fn()
+    const unsubscribe = apis.subscribe('42', '91', { type: 'character_template' }, vi.fn(), onError)
+
+    streamOptions?.onReconnect?.()
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce())
+    unsubscribe()
+    rejectRequest?.(new Error('network down'))
+    await Promise.resolve()
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('重连对账把非 Error 异常归一化后报告', async () => {
+    let streamOptions: EventStreamOptions | undefined
+    const apis = createGenerationApis({
+      baseUrl: 'https://api.test',
+      transport: {
+        request: vi.fn(async () => {
+          throw 'network down'
+        }),
+        stream: vi.fn((_url: string, options: NonNullable<typeof streamOptions>) => {
+          streamOptions = options
+          return vi.fn()
+        }),
+      },
+    })
+    const onError = vi.fn()
+
+    apis.subscribe('42', '91', { type: 'character_template' }, vi.fn(), onError)
+    streamOptions?.onReconnect?.()
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce())
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: '重连后任务对账失败' }))
+  })
+
+  it.each([
+    ['running', false],
+    ['failed', true],
+  ] as const)('重连对账到 %s 状态时按终态决定是否停流', async (status, shouldStop) => {
+    let streamOptions: EventStreamOptions | undefined
+    const stopStream = vi.fn()
+    const apis = createGenerationApis({
+      baseUrl: 'https://api.test',
+      transport: {
+        request: vi.fn(async () =>
+          success(
+            taskData({
+              status,
+              result: null,
+              error_message: status === 'failed' ? 'generation failed' : null,
+            }),
+          ),
+        ),
+        stream: vi.fn((_url: string, options: NonNullable<typeof streamOptions>) => {
+          streamOptions = options
+          return stopStream
+        }),
+      },
+    })
+    const onEvent = vi.fn()
+
+    apis.subscribe('42', '91', { type: 'character_template' }, onEvent, vi.fn())
+    streamOptions?.onReconnect?.()
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledOnce())
+
+    expect(stopStream).toHaveBeenCalledTimes(shouldStop ? 1 : 0)
+  })
+
   it('从查询结果推断前端阶段，并允许现有三参数订阅继续使用', async () => {
     let streamOptions: EventStreamOptions | undefined
     const task = taskData({

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -624,6 +624,25 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
         }
       }
 
+      const reconcileAfterReconnect = async () => {
+        if (pollingController.signal.aborted) return
+        try {
+          const generation = await apis.get(projectId, id, expectation)
+          if (pollingController.signal.aborted) return
+          onEvent({
+            taskId: generation.id,
+            type: generation.type,
+            status: generation.status,
+            result: generation.result,
+            error: generation.error,
+          } as GenerationEvent)
+          if (generation.status === 'completed' || generation.status === 'failed') stopStream()
+        } catch (cause) {
+          if (pollingController.signal.aborted) return
+          onError(cause instanceof Error ? cause : new GenerationApiError('重连后任务对账失败'))
+        }
+      }
+
       stopStream = stream(
         endpoint(
           config.baseUrl,
@@ -652,6 +671,11 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
               return
             }
             onError(error)
+          },
+          // 断线窗口内的事件不会被补发，重连后必须自己查一次当前状态，
+          // 否则恰在窗口内结束的任务会永远停在最后一次收到的中间态。
+          onReconnect() {
+            void reconcileAfterReconnect()
           },
         },
       )

--- a/frontend/src/shared/api/stream.test.ts
+++ b/frontend/src/shared/api/stream.test.ts
@@ -255,6 +255,75 @@ describe('createEventStreamSubscriber', () => {
     expect(fetchFn).toHaveBeenCalledTimes(2)
   })
 
+  it('重新建立连接时通知业务层，首次连接不通知', async () => {
+    const onReconnect = vi.fn()
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError('connection reset'))
+      .mockResolvedValueOnce(eventStreamResponse('{"status":"completed"}'))
+    const subscriber = createEventStreamSubscriber({
+      fetchFn,
+      getAccessToken: () => null,
+      reconnectDelayMs: 0,
+    })
+
+    await new Promise<void>((resolve) => {
+      subscriber('https://api.test/stream', {
+        eventName: 'task_update',
+        onEvent() {
+          resolve()
+          return true
+        },
+        onError: () => undefined,
+        onReconnect,
+      })
+    })
+
+    expect(onReconnect).toHaveBeenCalledOnce()
+  })
+
+  it('连续重连时延迟指数增长并带抖动，不再固定间隔', async () => {
+    const delays: number[] = []
+    const originalSetTimeout = globalThis.setTimeout
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+      handler: TimerHandler,
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      delays.push(Number(ms))
+      return originalSetTimeout(handler as () => void, 0, ...rest)
+    }) as typeof globalThis.setTimeout)
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError('connection reset'))
+      .mockRejectedValueOnce(new TypeError('connection reset'))
+      .mockRejectedValueOnce(new TypeError('connection reset'))
+      .mockResolvedValueOnce(eventStreamResponse('{"status":"completed"}'))
+    const subscriber = createEventStreamSubscriber({
+      fetchFn,
+      getAccessToken: () => null,
+      reconnectDelayMs: 100,
+    })
+
+    try {
+      await new Promise<void>((resolve) => {
+        subscriber('https://api.test/stream', {
+          eventName: 'task_update',
+          onEvent() {
+            resolve()
+            return true
+          },
+          onError: () => undefined,
+        })
+      })
+
+      expect(delays).toEqual([75, 150, 300])
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
+
   it('把匹配到的实际事件名交给业务解析器', async () => {
     const onEvent = vi.fn((_data: string, _eventName: string) => true)
     const subscriber = createEventStreamSubscriber({

--- a/frontend/src/shared/api/stream.ts
+++ b/frontend/src/shared/api/stream.ts
@@ -7,6 +7,11 @@ export interface EventStreamOptions {
   onEvent(data: string, eventName: string): boolean
   /** 包含连接中断、非法响应和业务解析器抛出的错误。 */
   onError(error: Error): void
+  /**
+   * 断线后重新建立连接时触发，首次连接不触发。
+   * 传输层不补发断线窗口内的事件，业务层收到后应自行对账当前状态。
+   */
+  onReconnect?(): void
 }
 
 export type EventStreamSubscriber = (url: string, options: EventStreamOptions) => () => void
@@ -116,6 +121,18 @@ async function readEventStream(response: Response, options: EventStreamOptions):
   }
 }
 
+const MAX_RECONNECT_DELAY_MS = 30_000
+
+/**
+ * 指数退避加抖动。服务端整体不可用时，固定间隔会让所有在线页面以同一节奏
+ * 持续重试；抖动把它们的重连时刻打散，退避把总量压下来。
+ */
+function reconnectDelay(baseDelayMs: number, failures: number): number {
+  if (baseDelayMs <= 0) return 0
+  const backoff = Math.min(baseDelayMs * 2 ** failures, MAX_RECONNECT_DELAY_MS)
+  return Math.round(backoff * (0.5 + Math.random() * 0.5))
+}
+
 function waitForReconnect(delayMs: number, signal: AbortSignal): Promise<void> {
   if (delayMs <= 0 || signal.aborted) return Promise.resolve()
   return new Promise((resolve) => {
@@ -142,9 +159,15 @@ export function createEventStreamSubscriber(
   return (url, options) => {
     const controller = new AbortController()
     let attemptedUnauthorizedRecovery = false
+    let attempted = false
+    let failures = 0
 
     const run = async () => {
       while (!controller.signal.aborted) {
+        // 重连判定放在发起请求之前：首次连接就失败、由重试建立起来的流，
+        // 同样错过了断线窗口内的事件。
+        const reconnecting = attempted
+        attempted = true
         try {
           const headers = new Headers({ Accept: 'text/event-stream' })
           const accessToken = config.getAccessToken()
@@ -181,6 +204,9 @@ export function createEventStreamSubscriber(
             throw new EventStreamError('SSE 响应类型无效')
           }
           attemptedUnauthorizedRecovery = false
+          if (reconnecting) options.onReconnect?.()
+          // 流建立成功即视为服务端恢复，退避从头算起。
+          failures = 0
           const terminal = await readEventStream(response, options)
           if (terminal || controller.signal.aborted) return
           throw connectionError()
@@ -189,7 +215,8 @@ export function createEventStreamSubscriber(
           const error = asError(cause)
           options.onError(error)
           if (!(error instanceof EventStreamError) || !error.retryable) return
-          await waitForReconnect(reconnectDelayMs, controller.signal)
+          await waitForReconnect(reconnectDelay(reconnectDelayMs, failures), controller.signal)
+          failures += 1
         }
       }
     }


### PR DESCRIPTION
SSE 断线重连后补拉一次生成任务状态，修复任务在断线窗口内结束时节点永远停在中间态的问题；重连间隔同时改为指数退避加抖动。

## Why

传输层重连是静默的：断线期间产生的事件不会被补发，请求也不带 `Last-Event-ID`，服务端无从续传。`watchGeneration` 的「先订阅、再查一次」只在首次建立订阅时执行，因此任务恰在断线窗口内结束时，前端收到的最后一个事件停在 `running`，节点一直卡在 `phase: 'generating'`，只有刷新页面走 `resume()` 才能恢复。

切换标签页、WiFi 转移动网络、笔记本合盖唤醒都会触发重连，生成耗时以分钟计，命中概率不低。

## Changes

- SSE 断线重连成功后，生成任务订阅会补拉一次当前状态并交付给业务层；断线窗口内结束的任务不再需要刷新页面。
- 重连间隔由固定 1s 改为指数退避加抖动，上限 30s；连接建立成功后退避重新计数。

## Implementation

- `shared/api/stream.ts` 的 `EventStreamOptions` 增加可选 `onReconnect`。重连判定放在发起请求之前，首次连接就失败、由重试建立起来的流同样视为重连——它一样错过了窗口内的事件。传输层只负责通知，不理解业务语义。
- `entities/generation/api.ts` 在 `onReconnect` 中调用既有 `apis.get` 补拉，复用与轮询兜底相同的事件形状。补拉到终态时主动停流；失败走 `onError`，不会把任务当作已结束。
- 未采用 `Last-Event-ID`：它需要服务端保存事件序列并支持续传，成本更高。补拉方案不依赖服务端，事件丢失只会导致延迟，不会导致状态错误。
- `features/workflow-controller` 无需改动，节点推进沿用既有的 `settleGeneration` 路径。

## Verification

- [x] `npm run format:check`：All matched files use the correct format
- [x] `npm run lint`：通过，无输出
- [x] `npm run typecheck`：通过
- [x] `npm run test:coverage`：58 files / 757 tests 全部通过，`stream.ts` 行覆盖 98.98%
- [x] `npm run build`：通过（chunk size 警告为既有情况，与本 PR 无关）
- [x] 回归验证：临时摘掉 `onReconnect` 中的补拉调用后，端到端用例失败于 `expected [ 'running' ] to include 'completed'`，与 Issue 描述的症状一致

## Scope

- 本 PR 不包含：`Last-Event-ID` 续传、SSE 之外的轮询兜底路径调整、工作流控制器改动。
- 后续事项：#464 为进行中的生成任务保留返回入口。

## Related Issues

Closes #463
