### PR TITLE
feat(app-header): keep a way back to the running generation

### DIFF
--- a/frontend/src/app/layout/active-run-monitor.test.tsx
+++ b/frontend/src/app/layout/active-run-monitor.test.tsx
@@ -70,6 +70,32 @@ describe('ActiveRunMonitor', () => {
     expect(harness.service.open).not.toHaveBeenCalled()
   })
 
+  it('open 在监控卸载后才返回时只释放 session', async () => {
+    const opened = deferred<Awaited<ReturnType<ActiveRunMonitorService['open']>>>()
+    const harness = monitorService()
+    const service: ActiveRunMonitorService = { open: vi.fn(() => opened.promise) }
+    rememberActiveRun('7', '42')
+    const view = render(<ActiveRunMonitor userId="7" pathname="/workspace" service={service} />)
+    await waitFor(() => expect(service.open).toHaveBeenCalledOnce())
+
+    view.unmount()
+    await act(async () => opened.resolve(harness.session))
+
+    expect(harness.dispose).toHaveBeenCalledOnce()
+    expect(harness.session.resume).not.toHaveBeenCalled()
+  })
+
+  it('初始快照已经结束时立即清除入口并释放 session', async () => {
+    const harness = monitorService(run('selecting'))
+    rememberActiveRun('7', '42')
+
+    render(<ActiveRunMonitor userId="7" pathname="/workspace" service={harness.service} />)
+
+    await waitFor(() => expect(readActiveRun('7')).toBeNull())
+    expect(harness.dispose).toHaveBeenCalledOnce()
+    expect(harness.session.resume).not.toHaveBeenCalled()
+  })
+
   it('后端确认任务不存在时清除旧指针', async () => {
     rememberActiveRun('7', '42')
     const service: ActiveRunMonitorService = {

--- a/frontend/src/app/layout/active-run-monitor.test.tsx
+++ b/frontend/src/app/layout/active-run-monitor.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiError } from '@/shared/api'
+import { readActiveRun, rememberActiveRun, type ActiveRunSnapshot } from '@/features/active-run'
+import { ActiveRunMonitor, type ActiveRunMonitorService } from './active-run-monitor'
+
+function run(phase: string): ActiveRunSnapshot {
+  return { id: '42', nodes: [{ status: 'active', phase, deletedAt: null }] }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
+function monitorService(initial = run('generating')) {
+  let publish: ((snapshot: ActiveRunSnapshot) => void) | null = null
+  const dispose = vi.fn()
+  const session = {
+    getWorkflow: vi.fn(() => initial),
+    subscribe: vi.fn((listener: (snapshot: ActiveRunSnapshot) => void) => {
+      publish = listener
+      return () => {
+        publish = null
+      }
+    }),
+    resume: vi.fn(async () => initial),
+    dispose,
+  }
+  const service: ActiveRunMonitorService = { open: vi.fn(async () => session) }
+  return {
+    service,
+    session,
+    dispose,
+    publish(snapshot: ActiveRunSnapshot) {
+      publish?.(snapshot)
+    },
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+})
+
+describe('ActiveRunMonitor', () => {
+  it('离开 Quick Start 后继续对齐终态并清除入口', async () => {
+    const harness = monitorService()
+    rememberActiveRun('7', '42')
+    render(<ActiveRunMonitor userId="7" pathname="/workspace" service={harness.service} />)
+
+    await waitFor(() => expect(harness.service.open).toHaveBeenCalledWith('42'))
+    act(() => harness.publish(run('selecting')))
+
+    await waitFor(() => expect(readActiveRun('7')).toBeNull())
+    expect(harness.dispose).toHaveBeenCalledOnce()
+  })
+
+  it('当前任务页面自己持有 session 时不重复恢复', async () => {
+    const harness = monitorService()
+    rememberActiveRun('7', '42')
+    render(<ActiveRunMonitor userId="7" pathname="/quick-start/42" service={harness.service} />)
+
+    await act(async () => Promise.resolve())
+    expect(harness.service.open).not.toHaveBeenCalled()
+  })
+
+  it('后端确认任务不存在时清除旧指针', async () => {
+    rememberActiveRun('7', '42')
+    const service: ActiveRunMonitorService = {
+      open: vi.fn(async () => {
+        throw new ApiError('执行记录不存在', { kind: 'business', code: 404, status: 200 })
+      }),
+    }
+
+    render(<ActiveRunMonitor userId="7" pathname="/workspace" service={service} />)
+
+    await waitFor(() => expect(readActiveRun('7')).toBeNull())
+  })
+
+  it('网络错误时保留入口供用户稍后重试', async () => {
+    rememberActiveRun('7', '42')
+    const service: ActiveRunMonitorService = {
+      open: vi.fn(async () => {
+        throw new ApiError('网络请求失败', { kind: 'network' })
+      }),
+    }
+
+    render(<ActiveRunMonitor userId="7" pathname="/workspace" service={service} />)
+
+    await waitFor(() => expect(service.open).toHaveBeenCalledOnce())
+    expect(readActiveRun('7')).toBe('42')
+  })
+
+  it('旧任务恢复结果晚到时不覆盖用户刚开始的新任务', async () => {
+    const resumed = deferred<ActiveRunSnapshot>()
+    const harness = monitorService()
+    harness.session.resume.mockReturnValue(resumed.promise)
+    rememberActiveRun('7', '42')
+    const view = render(
+      <ActiveRunMonitor userId="7" pathname="/workspace" service={harness.service} />,
+    )
+    await waitFor(() => expect(harness.session.resume).toHaveBeenCalledOnce())
+
+    act(() => {
+      rememberActiveRun('7', '99')
+      view.unmount()
+    })
+    await act(async () => resumed.resolve(run('generating')))
+
+    expect(readActiveRun('7')).toBe('99')
+  })
+})

--- a/frontend/src/app/layout/active-run-monitor.tsx
+++ b/frontend/src/app/layout/active-run-monitor.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react'
+
+import {
+  forgetActiveRun,
+  isMissingActiveRunError,
+  readActiveRun,
+  subscribeActiveRun,
+  syncActiveRun,
+  type ActiveRunSnapshot,
+} from '@/features/active-run'
+import { quickStartService } from '@/pages/quick-start/service'
+
+interface ActiveRunMonitorSession {
+  getWorkflow(): ActiveRunSnapshot
+  subscribe(listener: (run: ActiveRunSnapshot) => void): () => void
+  resume(): Promise<ActiveRunSnapshot>
+  dispose(): void
+}
+
+export interface ActiveRunMonitorService {
+  open(runId: string): Promise<ActiveRunMonitorSession>
+}
+
+export interface ActiveRunMonitorProps {
+  userId: string
+  pathname: string
+  service?: ActiveRunMonitorService
+}
+
+/**
+ * Quick Start 离页后由产品外壳接管生成订阅，直到后端终态落进 WorkflowRun。
+ * 当前任务页仍由页面自己的 session 持有，避免两个 Controller 同时写同一条 Run。
+ */
+export function ActiveRunMonitor({
+  userId,
+  pathname,
+  service = quickStartService,
+}: ActiveRunMonitorProps) {
+  const [runId, setRunId] = useState(() => readActiveRun(userId))
+
+  useEffect(() => {
+    const refresh = () => setRunId(readActiveRun(userId))
+    refresh()
+    return subscribeActiveRun(userId, refresh)
+  }, [userId])
+
+  useEffect(() => {
+    if (!runId || pathname === `/quick-start/${encodeURIComponent(runId)}`) return
+
+    let active = true
+    let session: ActiveRunMonitorSession | null = null
+    let unsubscribe: () => void = () => undefined
+    const isCurrent = () => active && readActiveRun(userId) === runId
+    const sync = (snapshot: ActiveRunSnapshot) => {
+      if (isCurrent()) syncActiveRun(userId, snapshot)
+    }
+
+    void service
+      .open(runId)
+      .then(async (nextSession) => {
+        if (!isCurrent()) {
+          nextSession.dispose()
+          return
+        }
+        session = nextSession
+        sync(nextSession.getWorkflow())
+        if (!isCurrent()) {
+          nextSession.dispose()
+          session = null
+          return
+        }
+        unsubscribe = nextSession.subscribe(sync)
+        const resumed = await nextSession.resume()
+        if (isCurrent()) sync(resumed)
+      })
+      .catch((error: unknown) => {
+        if (active && isMissingActiveRunError(error)) forgetActiveRun(userId, runId)
+      })
+
+    return () => {
+      active = false
+      unsubscribe()
+      session?.dispose()
+    }
+  }, [pathname, runId, service, userId])
+
+  return null
+}

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 
 import type { AuthTokens, CreditAccount, QuotaApis, UserApis } from '@/entities'
+import { forgetActiveRun, rememberActiveRun } from '@/features/active-run'
 import { AuthSessionProvider } from '@/features/auth-session'
 import { AppHeader } from './app-header'
 
@@ -117,6 +118,84 @@ afterEach(() => {
   window.localStorage.clear()
   window.sessionStorage.clear()
   window.history.replaceState({ idx: 0 }, '')
+})
+
+describe('AppHeader 进行中任务入口', () => {
+  it('没有进行中的任务时，创作仍是直达新建的链接', () => {
+    renderHeader('/workspace')
+
+    expect(screen.getByRole('link', { name: '创作' }).getAttribute('href')).toBe('/quick-start')
+    expect(screen.queryByRole('button', { name: /创作/ })).toBeNull()
+  })
+
+  it('存在进行中的任务时，创作入口带标记并可展开', () => {
+    rememberActiveRun('77')
+
+    renderHeader('/workspace')
+
+    const entry = screen.getByRole('button', { name: '创作，有任务进行中' })
+    expect(entry.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByRole('link', { name: '创作' })).toBeNull()
+  })
+
+  it('任务在同一标签页开始后，入口无需刷新就出现', () => {
+    renderHeader('/quick-start')
+    expect(screen.queryByRole('button', { name: /创作/ })).toBeNull()
+
+    act(() => rememberActiveRun('77'))
+
+    expect(screen.getByRole('button', { name: '创作，有任务进行中' })).toBeTruthy()
+  })
+
+  it('任务进行期间文字旁跟一个张望的小机器人，红点自己不动', () => {
+    renderHeader('/workspace')
+    expect(document.querySelector('[data-active-run-bot]')).toBeNull()
+
+    act(() => rememberActiveRun('77'))
+    const entry = screen.getByRole('button', { name: '创作，有任务进行中' })
+    const bot = entry.querySelector('[data-active-run-bot]')
+    expect(bot).toBeTruthy()
+    // 文字保留：这一项不该在图标和文字之间换形态。
+    expect(entry.textContent).toContain('创作')
+    // 只有眼睛会动；脸和红点都挂在静止的层上。
+    expect(bot?.querySelector('.app-header-bot-gaze')).toBeTruthy()
+    expect(bot?.querySelector('.app-header-bot-blink')).toBeTruthy()
+    expect(bot?.querySelector('[data-active-run-dot]')).toBeNull()
+    expect(entry.querySelector('[data-active-run-dot]')).toBeTruthy()
+
+    act(() => forgetActiveRun('77'))
+    expect(document.querySelector('[data-active-run-bot]')).toBeNull()
+  })
+
+  it('任务结束后入口随即收起', () => {
+    rememberActiveRun('77')
+    renderHeader('/quick-start')
+
+    act(() => forgetActiveRun('77'))
+
+    expect(screen.getByRole('link', { name: '创作' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /创作/ })).toBeNull()
+  })
+
+  it('展开后可以返回那条进行中的任务', () => {
+    rememberActiveRun('77')
+    renderHeader('/workspace')
+
+    fireEvent.click(screen.getByRole('button', { name: '创作，有任务进行中' }))
+    fireEvent.click(screen.getByRole('link', { name: '返回进行中的任务' }))
+
+    expect(screen.getByTestId('location').textContent).toBe('/quick-start/77')
+  })
+
+  it('展开后仍然可以开始新的创作', () => {
+    rememberActiveRun('77')
+    renderHeader('/workspace')
+
+    fireEvent.click(screen.getByRole('button', { name: '创作，有任务进行中' }))
+    fireEvent.click(screen.getByRole('link', { name: '开始新的创作' }))
+
+    expect(screen.getByTestId('location').textContent).toBe('/quick-start')
+  })
 })
 
 describe('AppHeader', () => {

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -107,6 +107,11 @@ function renderHeader(
   }
 }
 
+function renderAuthenticatedHeader(entry = '/') {
+  window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+  return renderHeader(entry)
+}
+
 function finishBackAnimation() {
   act(() => vi.advanceTimersByTime(240))
 }
@@ -128,30 +133,32 @@ describe('AppHeader 进行中任务入口', () => {
     expect(screen.queryByRole('button', { name: /创作/ })).toBeNull()
   })
 
-  it('存在进行中的任务时，创作入口带标记并可展开', () => {
-    rememberActiveRun('77')
+  it('存在进行中的任务时，创作入口带标记并可展开', async () => {
+    rememberActiveRun('7', '77')
 
-    renderHeader('/workspace')
+    renderAuthenticatedHeader('/workspace')
 
-    const entry = screen.getByRole('button', { name: '创作，有任务进行中' })
+    const entry = await screen.findByRole('button', { name: '创作，有任务进行中' })
     expect(entry.getAttribute('aria-expanded')).toBe('false')
     expect(screen.queryByRole('link', { name: '创作' })).toBeNull()
   })
 
-  it('任务在同一标签页开始后，入口无需刷新就出现', () => {
-    renderHeader('/quick-start')
+  it('任务在同一标签页开始后，入口无需刷新就出现', async () => {
+    renderAuthenticatedHeader('/quick-start')
+    await screen.findByRole('button', { name: '打开账号菜单' })
     expect(screen.queryByRole('button', { name: /创作/ })).toBeNull()
 
-    act(() => rememberActiveRun('77'))
+    act(() => rememberActiveRun('7', '77'))
 
     expect(screen.getByRole('button', { name: '创作，有任务进行中' })).toBeTruthy()
   })
 
-  it('任务进行期间文字旁跟一个张望的小机器人，红点自己不动', () => {
-    renderHeader('/workspace')
+  it('任务进行期间文字旁跟一个张望的小机器人，红点自己不动', async () => {
+    renderAuthenticatedHeader('/workspace')
+    await screen.findByRole('button', { name: '打开账号菜单' })
     expect(document.querySelector('[data-active-run-bot]')).toBeNull()
 
-    act(() => rememberActiveRun('77'))
+    act(() => rememberActiveRun('7', '77'))
     const entry = screen.getByRole('button', { name: '创作，有任务进行中' })
     const bot = entry.querySelector('[data-active-run-bot]')
     expect(bot).toBeTruthy()
@@ -163,35 +170,36 @@ describe('AppHeader 进行中任务入口', () => {
     expect(bot?.querySelector('[data-active-run-dot]')).toBeNull()
     expect(entry.querySelector('[data-active-run-dot]')).toBeTruthy()
 
-    act(() => forgetActiveRun('77'))
+    act(() => forgetActiveRun('7', '77'))
     expect(document.querySelector('[data-active-run-bot]')).toBeNull()
   })
 
-  it('任务结束后入口随即收起', () => {
-    rememberActiveRun('77')
-    renderHeader('/quick-start')
+  it('任务结束后入口随即收起', async () => {
+    rememberActiveRun('7', '77')
+    renderAuthenticatedHeader('/quick-start')
+    await screen.findByRole('button', { name: '创作，有任务进行中' })
 
-    act(() => forgetActiveRun('77'))
+    act(() => forgetActiveRun('7', '77'))
 
     expect(screen.getByRole('link', { name: '创作' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: /创作/ })).toBeNull()
   })
 
-  it('展开后可以返回那条进行中的任务', () => {
-    rememberActiveRun('77')
-    renderHeader('/workspace')
+  it('展开后可以返回那条进行中的任务', async () => {
+    rememberActiveRun('7', '77')
+    renderAuthenticatedHeader('/workspace')
 
-    fireEvent.click(screen.getByRole('button', { name: '创作，有任务进行中' }))
+    fireEvent.click(await screen.findByRole('button', { name: '创作，有任务进行中' }))
     fireEvent.click(screen.getByRole('link', { name: '返回进行中的任务' }))
 
     expect(screen.getByTestId('location').textContent).toBe('/quick-start/77')
   })
 
-  it('展开后仍然可以开始新的创作', () => {
-    rememberActiveRun('77')
-    renderHeader('/workspace')
+  it('展开后仍然可以开始新的创作', async () => {
+    rememberActiveRun('7', '77')
+    renderAuthenticatedHeader('/workspace')
 
-    fireEvent.click(screen.getByRole('button', { name: '创作，有任务进行中' }))
+    fireEvent.click(await screen.findByRole('button', { name: '创作，有任务进行中' }))
     fireEvent.click(screen.getByRole('link', { name: '开始新的创作' }))
 
     expect(screen.getByTestId('location').textContent).toBe('/quick-start')

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router'
 
 import { quotaApis as defaultQuotaApis } from '@/entities'
 import type { QuotaApis } from '@/entities'
+import { readActiveRun, subscribeActiveRun } from '@/features/active-run'
 import { AUTH_SESSION_STORAGE_PREFIX, useAuthSession } from '@/features/auth-session'
 import { useQuotaBalance } from '@/features/quota'
 import { PageBackButton } from './page-back-button'
@@ -40,19 +41,50 @@ const productNavigation: ProductNavigationItem[] = [
     isActive: (pathname) => pathname.startsWith('/projects'),
   },
   {
+    motionKey: 'playtest',
+    to: '/playtest',
+    label: '预览台',
+    isActive: (pathname) => pathname.startsWith('/playtest'),
+  },
+  // 排在末位：有任务在跑时这一项会换成小机器人，夹在导航中间会把另外三项挤开。
+  {
     motionKey: 'create',
     to: '/quick-start',
     label: '创作',
     isActive: (pathname) =>
       pathname.startsWith('/quick-start') || pathname.startsWith('/workflow-editor'),
   },
-  {
-    motionKey: 'playtest',
-    to: '/playtest',
-    label: '预览台',
-    isActive: (pathname) => pathname.startsWith('/playtest'),
-  },
 ]
+
+function navItemClassName(active: boolean, waving: boolean): string {
+  return `relative inline-flex min-h-11 items-center px-1.5 text-[12px] font-medium whitespace-nowrap transition-colors after:absolute after:inset-x-1.5 after:bottom-0 after:h-[2px] after:origin-center after:bg-app-accent after:transition-transform focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent sm:px-3 sm:text-[13px] sm:after:inset-x-3 ${
+    active
+      ? 'text-app-accent after:scale-x-100'
+      : 'text-app-muted after:scale-x-0 hover:text-app-accent'
+  } ${waving ? 'app-header-text-wave' : ''}`
+}
+
+/**
+ * 有任务在跑时跟在"创作"右边的小机器人：圆脸加两只眼，眼睛左右张望。
+ * 顶掉文字试过一版：这一项会在图标和文字之间来回换形态，读起来像换了个入口。
+ * 颜色继承文字色，所以选中态和 hover 都不用另外配色。
+ */
+function ActiveRunBot() {
+  return (
+    <span aria-hidden="true" data-active-run-bot className="inline-flex shrink-0 align-middle">
+      <svg viewBox="0 0 24 24" className="h-[1.15rem] w-[1.15rem]" fill="none">
+        <rect x="4" y="5" width="16" height="14" stroke="currentColor" strokeWidth="2" />
+        {/* 两层分开：外层管看哪儿，内层管眨眼，合在一起会互相覆盖 transform。 */}
+        <g className="app-header-bot-gaze">
+          <g className="app-header-bot-blink" fill="currentColor">
+            <rect x="8" y="10" width="3" height="3" />
+            <rect x="13" y="10" width="3" height="3" />
+          </g>
+        </g>
+      </svg>
+    </span>
+  )
+}
 
 function WaveText({ playId, text }: { playId: number; text: string }) {
   return (
@@ -87,10 +119,15 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
     quotaApis,
   )
   const [wave, setWave] = useState({ entry: '', playId: 0 })
+  const [activeRunId, setActiveRunId] = useState(readActiveRun)
+  const [activeRunMenuState, setActiveRunMenuState] = useState<AccountMenuState>('closed')
+  const activeRunMenuOpen = activeRunMenuState === 'open'
   const accountEntry = `/?${new URLSearchParams({
     account: 'login',
     returnTo: `${pathname}${search}${hash}`,
   })}`
+
+  useEffect(() => subscribeActiveRun(() => setActiveRunId(readActiveRun())), [])
 
   useEffect(() => {
     if (accountMenuState !== 'closing') {
@@ -141,6 +178,20 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
     }
   }
 
+  function toggleActiveRunMenu() {
+    setActiveRunMenuState((state) => (state === 'open' ? 'closing' : 'open'))
+  }
+
+  function closeActiveRunMenu() {
+    setActiveRunMenuState((state) => (state === 'open' ? 'closing' : state))
+  }
+
+  function finishActiveRunMenuMotion() {
+    if (activeRunMenuState === 'closing') {
+      setActiveRunMenuState('closed')
+    }
+  }
+
   function playTextWave(entry: string) {
     setWave(({ playId }) => ({ entry, playId: playId + 1 }))
   }
@@ -176,6 +227,87 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
         >
           {productNavigation.map((item) => {
             const active = item.isActive(pathname)
+            const playId = wave.entry === item.motionKey ? wave.playId : 0
+            const label = item.compactLabel ? (
+              <>
+                <span className="hidden md:inline">
+                  <WaveText playId={playId} text={item.label} />
+                </span>
+                <span className="md:hidden">
+                  <WaveText playId={playId} text={item.compactLabel} />
+                </span>
+              </>
+            ) : (
+              <WaveText playId={playId} text={item.label} />
+            )
+            const className = navItemClassName(active, wave.entry === item.motionKey)
+
+            // 有任务在跑时，创作入口先展开一层：新建和返回各占一项，
+            // 直接跳回旧任务会让用户没有开始下一次创作的地方。
+            if (item.motionKey === 'create' && activeRunId) {
+              return (
+                <div key={item.to} className="relative flex items-stretch">
+                  <button
+                    type="button"
+                    aria-label="创作，有任务进行中"
+                    aria-expanded={activeRunMenuOpen}
+                    aria-current={active ? 'page' : undefined}
+                    data-motion="text-wave"
+                    onClick={() => {
+                      playTextWave(item.motionKey)
+                      toggleActiveRunMenu()
+                    }}
+                    className={className}
+                  >
+                    {/* 红点贴内容而不是贴按钮：按钮左右有 padding，挂在按钮上会飘到相邻项那边去。 */}
+                    <span className="relative inline-flex items-center gap-1.5">
+                      {label}
+                      <ActiveRunBot />
+                      <span
+                        aria-hidden="true"
+                        data-active-run-dot
+                        className="absolute -top-0.5 -right-1.5 h-1.5 w-1.5 rounded-full bg-app-danger"
+                      />
+                    </span>
+                  </button>
+
+                  <div
+                    data-testid="active-run-menu"
+                    data-state={activeRunMenuState}
+                    data-motion="scale-fade"
+                    aria-hidden={activeRunMenuOpen ? undefined : true}
+                    inert={!activeRunMenuOpen}
+                    onAnimationEnd={finishActiveRunMenuMotion}
+                    className={`absolute top-[calc(100%+0.5rem)] left-1/2 grid min-w-44 origin-top -translate-x-1/2 overflow-hidden rounded-lg border border-app-ink/12 bg-app-surface-raised p-1.5 shadow-app-menu ${
+                      activeRunMenuState === 'open'
+                        ? 'visible app-header-account-menu-in'
+                        : activeRunMenuState === 'closing'
+                          ? 'visible pointer-events-none app-header-account-menu-out'
+                          : 'invisible pointer-events-none -translate-y-2 scale-[0.82] opacity-0'
+                    }`}
+                  >
+                    <Link
+                      to={`/quick-start/${encodeURIComponent(activeRunId)}`}
+                      onClick={closeActiveRunMenu}
+                      className="flex min-h-11 items-center gap-2 rounded-md px-3 text-[13px] text-app-ink-soft transition-colors hover:bg-app-accent-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                    >
+                      <span
+                        aria-hidden="true"
+                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-app-danger"
+                      />
+                      返回进行中的任务
+                    </Link>
+                    <Link
+                      to={item.to}
+                      onClick={closeActiveRunMenu}
+                      className="flex min-h-11 items-center rounded-md px-3 text-[13px] text-app-ink-soft transition-colors hover:bg-app-accent-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                    >
+                      开始新的创作
+                    </Link>
+                  </div>
+                </div>
+              )
+            }
 
             return (
               <Link
@@ -185,33 +317,9 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
                 aria-current={active ? 'page' : undefined}
                 data-motion="text-wave"
                 onClick={() => playTextWave(item.motionKey)}
-                className={`relative inline-flex min-h-11 items-center px-1.5 text-[12px] font-medium whitespace-nowrap transition-colors after:absolute after:inset-x-1.5 after:bottom-0 after:h-[2px] after:origin-center after:bg-app-accent after:transition-transform focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent sm:px-3 sm:text-[13px] sm:after:inset-x-3 ${
-                  active
-                    ? 'text-app-accent after:scale-x-100'
-                    : 'text-app-muted after:scale-x-0 hover:text-app-accent'
-                } ${wave.entry === item.motionKey ? 'app-header-text-wave' : ''}`}
+                className={className}
               >
-                {item.compactLabel ? (
-                  <>
-                    <span className="hidden md:inline">
-                      <WaveText
-                        playId={wave.entry === item.motionKey ? wave.playId : 0}
-                        text={item.label}
-                      />
-                    </span>
-                    <span className="md:hidden">
-                      <WaveText
-                        playId={wave.entry === item.motionKey ? wave.playId : 0}
-                        text={item.compactLabel}
-                      />
-                    </span>
-                  </>
-                ) : (
-                  <WaveText
-                    playId={wave.entry === item.motionKey ? wave.playId : 0}
-                    text={item.label}
-                  />
-                )}
+                {label}
               </Link>
             )
           })}

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -119,7 +119,8 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
     quotaApis,
   )
   const [wave, setWave] = useState({ entry: '', playId: 0 })
-  const [activeRunId, setActiveRunId] = useState(readActiveRun)
+  const activeRunUserId = session.state.status === 'authenticated' ? session.state.user.id : null
+  const [activeRunId, setActiveRunId] = useState<string | null>(null)
   const [activeRunMenuState, setActiveRunMenuState] = useState<AccountMenuState>('closed')
   const activeRunMenuOpen = activeRunMenuState === 'open'
   const accountEntry = `/?${new URLSearchParams({
@@ -127,7 +128,15 @@ export function AppHeader({ quotaApis = defaultQuotaApis }: AppHeaderProps = {})
     returnTo: `${pathname}${search}${hash}`,
   })}`
 
-  useEffect(() => subscribeActiveRun(() => setActiveRunId(readActiveRun())), [])
+  useEffect(() => {
+    if (!activeRunUserId) {
+      setActiveRunId(null)
+      return
+    }
+    const refresh = () => setActiveRunId(readActiveRun(activeRunUserId))
+    refresh()
+    return subscribeActiveRun(activeRunUserId, refresh)
+  }, [activeRunUserId])
 
   useEffect(() => {
     if (accountMenuState !== 'closing') {

--- a/frontend/src/app/layout/index.tsx
+++ b/frontend/src/app/layout/index.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from 'react'
-import { Outlet } from 'react-router'
+import { Outlet, useLocation } from 'react-router'
 
 import { AccountPanel } from '@/features/account-panel'
 import { SessionExpiredNotice } from '@/features/auth-guard'
+import { useAuthSession } from '@/features/auth-session'
+import { ActiveRunMonitor } from './active-run-monitor'
 import { AppHeader } from './app-header'
 
 export interface AppShellProps {
@@ -12,8 +14,13 @@ export interface AppShellProps {
 
 /** 登录产品外壳；只服务工作台与受保护业务页。 */
 export function AppShell({ children }: AppShellProps) {
+  const { pathname } = useLocation()
+  const session = useAuthSession()
   return (
     <div className="min-h-screen bg-app-canvas text-app-ink">
+      {session.state.status === 'authenticated' ? (
+        <ActiveRunMonitor userId={session.state.user.id} pathname={pathname} />
+      ) : null}
       <AppHeader />
       {/*
         外壳只管顶栏。页面自己决定宽度与留白，不在这里统一夹到屏幕中间，

--- a/frontend/src/features/account-panel/index.test.tsx
+++ b/frontend/src/features/account-panel/index.test.tsx
@@ -213,7 +213,9 @@ describe('AccountPanel', () => {
     )
     // 断言"进入冷却"，不断言"还剩 60 秒"：这条用例走真实计时器，点击到断言之间过掉
     // 一秒钟标签就成了 59s。近 30 小时里三个人的四条分支都栽在这一行。
-    expect(screen.getByRole('button', { name: /^\d+s$/u }).hasAttribute('disabled')).toBe(true)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /^\d+s$/u }).hasAttribute('disabled')).toBe(true),
+    )
 
     fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: 'new@example.com' } })
     expect(screen.getByRole('button', { name: '发送验证码' }).hasAttribute('disabled')).toBe(false)

--- a/frontend/src/features/active-run/index.test.ts
+++ b/frontend/src/features/active-run/index.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  forgetActiveRun,
+  readActiveRun,
+  rememberActiveRun,
+  syncActiveRun,
+  type ActiveRunNodeSnapshot,
+} from './index'
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+describe('活跃生成任务的本地指针', () => {
+  it('记住后可以在任意页面读回同一个 runId', () => {
+    rememberActiveRun('42')
+
+    expect(readActiveRun()).toBe('42')
+  })
+
+  it('只清除仍指向同一条任务的指针，晚到的旧任务回调不误伤新任务', () => {
+    rememberActiveRun('42')
+    rememberActiveRun('99')
+
+    forgetActiveRun('42')
+
+    expect(readActiveRun()).toBe('99')
+  })
+
+  it('清除当前任务后不再提供返回入口', () => {
+    rememberActiveRun('42')
+
+    forgetActiveRun('42')
+
+    expect(readActiveRun()).toBeNull()
+  })
+
+  it('没有记录时返回空', () => {
+    expect(readActiveRun()).toBeNull()
+  })
+})
+
+function node(overrides: Partial<ActiveRunNodeSnapshot> = {}): ActiveRunNodeSnapshot {
+  return { status: 'active', phase: 'generating', deletedAt: null, ...overrides }
+}
+
+describe('按工作流快照同步指针', () => {
+  it('有节点正在生成时记住这条任务', () => {
+    syncActiveRun({ id: '42', nodes: [node({ phase: 'ready' }), node()] })
+
+    expect(readActiveRun()).toBe('42')
+  })
+
+  it('没有节点在生成时清除这条任务', () => {
+    rememberActiveRun('42')
+
+    syncActiveRun({ id: '42', nodes: [node({ phase: 'selecting' })] })
+
+    expect(readActiveRun()).toBeNull()
+  })
+
+  it('已归档的生成节点不算进行中', () => {
+    syncActiveRun({ id: '42', nodes: [node({ deletedAt: '2026-08-20T00:00:00Z' })] })
+
+    expect(readActiveRun()).toBeNull()
+  })
+
+  it('还没有工作流时不动已有指针', () => {
+    rememberActiveRun('42')
+
+    syncActiveRun(null)
+
+    expect(readActiveRun()).toBe('42')
+  })
+})

--- a/frontend/src/features/active-run/index.test.ts
+++ b/frontend/src/features/active-run/index.test.ts
@@ -6,6 +6,7 @@ import {
   forgetActiveRun,
   readActiveRun,
   rememberActiveRun,
+  subscribeActiveRun,
   syncActiveRun,
   type ActiveRunNodeSnapshot,
 } from './index'
@@ -66,6 +67,63 @@ describe('活跃生成任务的本地指针', () => {
     expect(storage.read('7')).toBe('42')
     expect(() => storage.forget('7', '42')).not.toThrow()
     expect(storage.read('7')).toBeNull()
+  })
+
+  it('首次读取被拒绝时也从空内存开始', () => {
+    const storage = createActiveRunStorage({
+      getItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    })
+
+    expect(storage.read('7')).toBeNull()
+    storage.remember('7', '42')
+    expect(storage.read('7')).toBe('42')
+  })
+
+  it('删除被拒绝时仍清掉本标签页的内存指针', () => {
+    const storage = createActiveRunStorage({
+      getItem: vi.fn(() => '42'),
+      setItem: vi.fn(),
+      removeItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+    })
+
+    expect(storage.forget('7', '42')).toBe(true)
+    expect(storage.read('7')).toBeNull()
+  })
+
+  it('取得 localStorage 本身抛错时返回空而不泄漏异常', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage')
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('blocked', 'SecurityError')
+      },
+    })
+
+    try {
+      expect(createActiveRunStorage().read('7')).toBeNull()
+    } finally {
+      if (descriptor) Object.defineProperty(globalThis, 'localStorage', descriptor)
+      else delete (globalThis as { localStorage?: Storage }).localStorage
+    }
+  })
+
+  it('只响应当前用户的跨标签 storage 变化', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeActiveRun('7', listener)
+
+    window.dispatchEvent(new StorageEvent('storage', { key: 'windup.quick-start.active-run.v2.8' }))
+    window.dispatchEvent(new StorageEvent('storage', { key: 'windup.quick-start.active-run.v2.7' }))
+    window.dispatchEvent(new StorageEvent('storage', { key: null }))
+    unsubscribe()
+    window.dispatchEvent(new StorageEvent('storage', { key: null }))
+
+    expect(listener).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/frontend/src/features/active-run/index.test.ts
+++ b/frontend/src/features/active-run/index.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  createActiveRunStorage,
   forgetActiveRun,
   readActiveRun,
   rememberActiveRun,
@@ -15,30 +16,56 @@ afterEach(() => {
 
 describe('活跃生成任务的本地指针', () => {
   it('记住后可以在任意页面读回同一个 runId', () => {
-    rememberActiveRun('42')
+    rememberActiveRun('7', '42')
 
-    expect(readActiveRun()).toBe('42')
+    expect(readActiveRun('7')).toBe('42')
   })
 
   it('只清除仍指向同一条任务的指针，晚到的旧任务回调不误伤新任务', () => {
-    rememberActiveRun('42')
-    rememberActiveRun('99')
+    rememberActiveRun('7', '42')
+    rememberActiveRun('7', '99')
 
-    forgetActiveRun('42')
+    forgetActiveRun('7', '42')
 
-    expect(readActiveRun()).toBe('99')
+    expect(readActiveRun('7')).toBe('99')
   })
 
   it('清除当前任务后不再提供返回入口', () => {
-    rememberActiveRun('42')
+    rememberActiveRun('7', '42')
 
-    forgetActiveRun('42')
+    forgetActiveRun('7', '42')
 
-    expect(readActiveRun()).toBeNull()
+    expect(readActiveRun('7')).toBeNull()
   })
 
   it('没有记录时返回空', () => {
-    expect(readActiveRun()).toBeNull()
+    expect(readActiveRun('7')).toBeNull()
+  })
+
+  it('不同登录用户不会读到彼此的任务', () => {
+    rememberActiveRun('7', '42')
+
+    expect(readActiveRun('8')).toBeNull()
+  })
+
+  it('浏览器拒绝 localStorage 时退回内存指针', () => {
+    const storage = createActiveRunStorage({
+      getItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+      setItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+      removeItem: vi.fn(() => {
+        throw new DOMException('blocked', 'SecurityError')
+      }),
+    })
+
+    storage.remember('7', '42')
+
+    expect(storage.read('7')).toBe('42')
+    expect(() => storage.forget('7', '42')).not.toThrow()
+    expect(storage.read('7')).toBeNull()
   })
 })
 
@@ -48,30 +75,33 @@ function node(overrides: Partial<ActiveRunNodeSnapshot> = {}): ActiveRunNodeSnap
 
 describe('按工作流快照同步指针', () => {
   it('有节点正在生成时记住这条任务', () => {
-    syncActiveRun({ id: '42', nodes: [node({ phase: 'ready' }), node()] })
+    syncActiveRun('7', { id: '42', nodes: [node({ phase: 'ready' }), node()] })
 
-    expect(readActiveRun()).toBe('42')
+    expect(readActiveRun('7')).toBe('42')
   })
 
   it('没有节点在生成时清除这条任务', () => {
-    rememberActiveRun('42')
+    rememberActiveRun('7', '42')
 
-    syncActiveRun({ id: '42', nodes: [node({ phase: 'selecting' })] })
+    syncActiveRun('7', { id: '42', nodes: [node({ phase: 'selecting' })] })
 
-    expect(readActiveRun()).toBeNull()
+    expect(readActiveRun('7')).toBeNull()
   })
 
   it('已归档的生成节点不算进行中', () => {
-    syncActiveRun({ id: '42', nodes: [node({ deletedAt: '2026-08-20T00:00:00Z' })] })
+    syncActiveRun('7', {
+      id: '42',
+      nodes: [node({ deletedAt: '2026-08-20T00:00:00Z' })],
+    })
 
-    expect(readActiveRun()).toBeNull()
+    expect(readActiveRun('7')).toBeNull()
   })
 
   it('还没有工作流时不动已有指针', () => {
-    rememberActiveRun('42')
+    rememberActiveRun('7', '42')
 
-    syncActiveRun(null)
+    syncActiveRun('7', null)
 
-    expect(readActiveRun()).toBe('42')
+    expect(readActiveRun('7')).toBe('42')
   })
 })

--- a/frontend/src/features/active-run/index.ts
+++ b/frontend/src/features/active-run/index.ts
@@ -1,11 +1,13 @@
+import { ApiError } from '@/shared/api'
+
 /**
  * 进行中生成任务的本地指针。
  *
  * runId 本身只活在 `/quick-start/:runId` 的 URL 里，用户离开那个地址后就没有
- * 任何地方记得它。这里只存"最近一条还没结束的任务"这一个指针，供 Header 提供
- * 返回入口；它不是任务状态的副本，真相仍然是后端的 WorkflowRun。
+ * 任何地方记得它。这里只存“当前用户最近一条还没结束的任务”这个指针，供 Header
+ * 提供返回入口；它不是任务状态的副本，真相仍然是后端的 WorkflowRun。
  */
-const storageKey = 'windup.quick-start.active-run.v1'
+const storageKeyPrefix = 'windup.quick-start.active-run.v2.'
 
 /**
  * `storage` 事件只在其他标签页写入时触发，本标签页自己写不会收到。
@@ -13,31 +15,96 @@ const storageKey = 'windup.quick-start.active-run.v1'
  */
 const changeEvent = 'windup:active-run-change'
 
-function broadcast(): void {
-  window.dispatchEvent(new Event(changeEvent))
+type ActiveRunStorageTarget = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+export interface ActiveRunStorage {
+  remember(userId: string, runId: string): void
+  read(userId: string): string | null
+  forget(userId: string, runId: string): boolean
 }
 
-export function rememberActiveRun(runId: string): void {
-  window.localStorage.setItem(storageKey, runId)
-  broadcast()
+function storageKey(userId: string): string {
+  return `${storageKeyPrefix}${encodeURIComponent(userId)}`
 }
 
-export function readActiveRun(): string | null {
-  return window.localStorage.getItem(storageKey)
+function getLocalStorage(): ActiveRunStorageTarget | null {
+  try {
+    return globalThis.localStorage
+  } catch {
+    return null
+  }
+}
+
+/** localStorage 是跨刷新增强能力；被浏览器拒绝时，本标签页继续用内存指针。 */
+export function createActiveRunStorage(storage?: ActiveRunStorageTarget | null): ActiveRunStorage {
+  const memory = new Map<string, string>()
+  let memoryOnly = false
+  const resolveStorage = () => (storage === undefined ? getLocalStorage() : storage)
+
+  return {
+    remember(userId, runId) {
+      const key = storageKey(userId)
+      memory.set(key, runId)
+      if (memoryOnly) return
+      try {
+        resolveStorage()?.setItem(key, runId)
+      } catch {
+        memoryOnly = true
+      }
+    },
+    read(userId) {
+      const key = storageKey(userId)
+      if (memoryOnly) return memory.get(key) ?? null
+      try {
+        const stored = resolveStorage()?.getItem(key) ?? null
+        if (stored === null) memory.delete(key)
+        else memory.set(key, stored)
+      } catch {
+        memoryOnly = true
+      }
+      return memory.get(key) ?? null
+    },
+    forget(userId, runId) {
+      const key = storageKey(userId)
+      if (this.read(userId) !== runId) return false
+      memory.delete(key)
+      if (!memoryOnly) {
+        try {
+          resolveStorage()?.removeItem(key)
+        } catch {
+          memoryOnly = true
+        }
+      }
+      return true
+    },
+  }
+}
+
+const activeRunStorage = createActiveRunStorage()
+
+function broadcast(userId: string): void {
+  window.dispatchEvent(new CustomEvent(changeEvent, { detail: { userId } }))
+}
+
+export function rememberActiveRun(userId: string, runId: string): void {
+  activeRunStorage.remember(userId, runId)
+  broadcast(userId)
+}
+
+export function readActiveRun(userId: string): string | null {
+  return activeRunStorage.read(userId)
 }
 
 /**
  * 只在指针仍指向 runId 时才清除。用户可能已经开始了下一条任务，而上一条的
  * 结束回调这时才到；无条件清除会把新任务的入口一起抹掉。
  */
-export function forgetActiveRun(runId: string): void {
-  if (window.localStorage.getItem(storageKey) !== runId) return
-  window.localStorage.removeItem(storageKey)
-  broadcast()
+export function forgetActiveRun(userId: string, runId: string): void {
+  if (activeRunStorage.forget(userId, runId)) broadcast(userId)
 }
 
 /**
- * 只取判断"是否还在生成"所需的最小形状，不引 entities 的 WorkflowRun：
+ * 只取判断“是否还在生成”所需的最小形状，不引 entities 的 WorkflowRun：
  * 这个 feature 只认指针，不认工作流语义。
  */
 export interface ActiveRunNodeSnapshot {
@@ -53,24 +120,40 @@ export interface ActiveRunSnapshot {
 }
 
 /**
- * 按最新的工作流快照对齐指针。"进行中"取的是节点层面的生成态，与 Header 上
- * "有任务进行中"的说法同义；整条 Run 是否走完不在这里判断，那是用户自己的节奏。
+ * 按最新的工作流快照对齐指针。“进行中”取的是节点层面的生成态，与 Header 上
+ * “有任务进行中”的说法同义；整条 Run 是否走完不在这里判断，那是用户自己的节奏。
  */
-export function syncActiveRun(run: ActiveRunSnapshot | null): void {
+export function syncActiveRun(userId: string, run: ActiveRunSnapshot | null): void {
   if (!run) return
   const generating = run.nodes.some(
     (node) => !node.deletedAt && node.status === 'active' && node.phase === 'generating',
   )
-  if (generating) rememberActiveRun(run.id)
-  else forgetActiveRun(run.id)
+  if (generating) rememberActiveRun(userId, run.id)
+  else forgetActiveRun(userId, run.id)
 }
 
-/** 订阅指针变化；同时覆盖本标签页写入和其他标签页的 `storage` 事件。 */
-export function subscribeActiveRun(listener: () => void): () => void {
-  window.addEventListener(changeEvent, listener)
-  window.addEventListener('storage', listener)
+/** 只有后端明确确认无权访问或记录不存在时，旧入口才应被丢弃。 */
+export function isMissingActiveRunError(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    (error.code === 403 || error.code === 404 || error.status === 403 || error.status === 404)
+  )
+}
+
+/** 订阅当前用户的指针变化；同时覆盖本标签页写入和其他标签页的 `storage` 事件。 */
+export function subscribeActiveRun(userId: string, listener: () => void): () => void {
+  const key = storageKey(userId)
+  const onChange = (event: Event) => {
+    if (event instanceof StorageEvent) {
+      if (event.key === key || event.key === null) listener()
+      return
+    }
+    if (event instanceof CustomEvent && event.detail?.userId === userId) listener()
+  }
+  window.addEventListener(changeEvent, onChange)
+  window.addEventListener('storage', onChange)
   return () => {
-    window.removeEventListener(changeEvent, listener)
-    window.removeEventListener('storage', listener)
+    window.removeEventListener(changeEvent, onChange)
+    window.removeEventListener('storage', onChange)
   }
 }

--- a/frontend/src/features/active-run/index.ts
+++ b/frontend/src/features/active-run/index.ts
@@ -1,0 +1,76 @@
+/**
+ * 进行中生成任务的本地指针。
+ *
+ * runId 本身只活在 `/quick-start/:runId` 的 URL 里，用户离开那个地址后就没有
+ * 任何地方记得它。这里只存"最近一条还没结束的任务"这一个指针，供 Header 提供
+ * 返回入口；它不是任务状态的副本，真相仍然是后端的 WorkflowRun。
+ */
+const storageKey = 'windup.quick-start.active-run.v1'
+
+/**
+ * `storage` 事件只在其他标签页写入时触发，本标签页自己写不会收到。
+ * Header 与写入方在同一个标签页里，因此另开一条同页广播。
+ */
+const changeEvent = 'windup:active-run-change'
+
+function broadcast(): void {
+  window.dispatchEvent(new Event(changeEvent))
+}
+
+export function rememberActiveRun(runId: string): void {
+  window.localStorage.setItem(storageKey, runId)
+  broadcast()
+}
+
+export function readActiveRun(): string | null {
+  return window.localStorage.getItem(storageKey)
+}
+
+/**
+ * 只在指针仍指向 runId 时才清除。用户可能已经开始了下一条任务，而上一条的
+ * 结束回调这时才到；无条件清除会把新任务的入口一起抹掉。
+ */
+export function forgetActiveRun(runId: string): void {
+  if (window.localStorage.getItem(storageKey) !== runId) return
+  window.localStorage.removeItem(storageKey)
+  broadcast()
+}
+
+/**
+ * 只取判断"是否还在生成"所需的最小形状，不引 entities 的 WorkflowRun：
+ * 这个 feature 只认指针，不认工作流语义。
+ */
+export interface ActiveRunNodeSnapshot {
+  status: string
+  phase: string
+  /** 归档时间；实体里是可选字段，未归档的节点可能整个缺省。 */
+  deletedAt?: string | null
+}
+
+export interface ActiveRunSnapshot {
+  id: string
+  nodes: readonly ActiveRunNodeSnapshot[]
+}
+
+/**
+ * 按最新的工作流快照对齐指针。"进行中"取的是节点层面的生成态，与 Header 上
+ * "有任务进行中"的说法同义；整条 Run 是否走完不在这里判断，那是用户自己的节奏。
+ */
+export function syncActiveRun(run: ActiveRunSnapshot | null): void {
+  if (!run) return
+  const generating = run.nodes.some(
+    (node) => !node.deletedAt && node.status === 'active' && node.phase === 'generating',
+  )
+  if (generating) rememberActiveRun(run.id)
+  else forgetActiveRun(run.id)
+}
+
+/** 订阅指针变化；同时覆盖本标签页写入和其他标签页的 `storage` 事件。 */
+export function subscribeActiveRun(listener: () => void): () => void {
+  window.addEventListener(changeEvent, listener)
+  window.addEventListener('storage', listener)
+  return () => {
+    window.removeEventListener(changeEvent, listener)
+    window.removeEventListener('storage', listener)
+  }
+}

--- a/frontend/src/features/auth-session/index.tsx
+++ b/frontend/src/features/auth-session/index.tsx
@@ -397,6 +397,11 @@ export function useAuthSession(): AuthSessionValue {
   return session
 }
 
+/** 允许可独立渲染的业务页读取会话；生产外壳存在时仍返回同一份 AuthSession。 */
+export function useOptionalAuthSession(): AuthSessionValue | null {
+  return useContext(AuthSessionContext)
+}
+
 function getRefreshTime(accessToken: string | null): number | null {
   const payload = accessToken?.split('.')[1]
   if (!payload) return null

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -28,6 +28,65 @@ body,
   animation: app-header-glyph-wave 380ms cubic-bezier(0.2, 0.75, 0.25, 1) both;
 }
 
+/*
+ * 生成中那个小机器人。方脸方眼是照产品本体的像素语汇画的——圆脸圆眼是通用
+ * emoji 语汇，跟"做像素角色资产"这件事没关系，排在中文字旁边像贴上去的。
+ *
+ * 动的只有瞳孔，脸不动：脸跟着晃就成了摇头，那是"不同意"不是"在张望"。
+ * 视线和眨眼分成两条动画，周期故意不整除（3.6s / 4.3s），合起来的节奏不重复。
+ * 每次移动占约 8% 周期（≈290ms）滑过去，到位后停住十几个百分点再走下一步。
+ */
+@keyframes app-header-bot-gaze {
+  0%,
+  22% {
+    transform: translate(0, 0);
+  }
+  /* 瞟左边 */
+  30%,
+  44% {
+    transform: translate(-2px, 0);
+  }
+  /* 扫到右边 */
+  52%,
+  64% {
+    transform: translate(2px, 0);
+  }
+  /* 抬头想一下 */
+  72%,
+  84% {
+    transform: translate(0, -2px);
+  }
+  92%,
+  100% {
+    transform: translate(0, 0);
+  }
+}
+
+@keyframes app-header-bot-blink {
+  0%,
+  92% {
+    transform: scaleY(1);
+  }
+  94.5% {
+    transform: scaleY(0.15);
+  }
+  97%,
+  100% {
+    transform: scaleY(1);
+  }
+}
+
+.app-header-bot-gaze {
+  animation: app-header-bot-gaze 3600ms cubic-bezier(0.5, 0, 0.15, 1) infinite;
+}
+
+.app-header-bot-blink {
+  /* SVG 默认绕用户坐标原点缩放，不套 fill-box 的话眨眼会把眼睛甩出脸外。 */
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: app-header-bot-blink 4300ms cubic-bezier(0.4, 0, 0.55, 1) infinite;
+}
+
 @keyframes app-header-back-strip {
   from {
     transform: translate3d(0, 0, 0);
@@ -94,7 +153,9 @@ body,
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .app-header-text-wave .app-header-wave-glyph {
+  .app-header-text-wave .app-header-wave-glyph,
+  .app-header-bot-gaze,
+  .app-header-bot-blink {
     animation: none;
   }
 

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -5,8 +5,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { QuickStartEntryService, QuickStartSession } from './service'
 import { WorkflowRunConflictError, type WorkflowRun } from '@/entities'
+import { ApiError } from '@/shared/api'
 import type { ExportPackageModel } from '@/features/export-package'
-import { readActiveRun } from '@/features/active-run'
+import { readActiveRun, rememberActiveRun } from '@/features/active-run'
 import { QuickStartPage } from './index'
 
 afterEach(() => {
@@ -158,8 +159,14 @@ function renderAt(path: string, service: QuickStartEntryService) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/quick-start" element={<QuickStartPage service={service} />} />
-        <Route path="/quick-start/:runId" element={<QuickStartPage service={service} />} />
+        <Route
+          path="/quick-start"
+          element={<QuickStartPage service={service} activeRunUserId="7" />}
+        />
+        <Route
+          path="/quick-start/:runId"
+          element={<QuickStartPage service={service} activeRunUserId="7" />}
+        />
         <Route path="/projects/:projectId/assets" element={<PlaytestLocation />} />
         <Route path="/playtest/:characterId/:outfitId" element={<PlaytestLocation />} />
       </Routes>
@@ -189,7 +196,10 @@ function renderWithRunSwitcher(
     <MemoryRouter initialEntries={[`/quick-start/${initialRunId}`]}>
       <Controls />
       <Routes>
-        <Route path="/quick-start/:runId" element={<QuickStartPage service={service} />} />
+        <Route
+          path="/quick-start/:runId"
+          element={<QuickStartPage service={service} activeRunUserId="7" />}
+        />
       </Routes>
     </MemoryRouter>,
   )
@@ -448,14 +458,14 @@ describe('QuickStartPage', () => {
   it('生成进行中时为 Header 留下返回入口，走完就清掉', async () => {
     renderStateFixture('template-generating')
 
-    await waitFor(() => expect(readActiveRun()).toBe('run-1'))
+    await waitFor(() => expect(readActiveRun('7')).toBe('run-1'))
   })
 
   it('没有节点在生成时不留返回入口', async () => {
     renderStateFixture('template-selecting')
 
     await screen.findByTestId('quick-start-transcript')
-    expect(readActiveRun()).toBeNull()
+    expect(readActiveRun('7')).toBeNull()
   })
 
   it('presents Agent replies as restrained product copy without display typography or avatars', async () => {
@@ -968,6 +978,20 @@ describe('QuickStartPage', () => {
     expect(await screen.findByRole('heading', { name: '无法恢复这次创作' })).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: '返回快速开始' }))
     expect(screen.getByRole('textbox', { name: '创作指令' })).toBeTruthy()
+  })
+
+  it('clears the saved entry when the backend confirms that run is missing', async () => {
+    rememberActiveRun('7', 'missing')
+    const service = serviceFor(null, {
+      open: vi.fn(async () => {
+        throw new ApiError('执行记录不存在', { kind: 'business', code: 404, status: 200 })
+      }),
+    })
+
+    renderAt('/quick-start/missing', service)
+
+    expect(await screen.findByRole('heading', { name: '无法恢复这次创作' })).toBeTruthy()
+    expect(readActiveRun('7')).toBeNull()
   })
 
   it('opens a recoverable run once and accepts its session update', async () => {

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -6,10 +6,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { QuickStartEntryService, QuickStartSession } from './service'
 import { WorkflowRunConflictError, type WorkflowRun } from '@/entities'
 import type { ExportPackageModel } from '@/features/export-package'
+import { readActiveRun } from '@/features/active-run'
 import { QuickStartPage } from './index'
 
 afterEach(() => {
   cleanup()
+  window.localStorage.clear()
   vi.useRealTimers()
 })
 
@@ -441,6 +443,19 @@ describe('QuickStartPage', () => {
     expect(screen.queryByText('WORKFLOW RUN')).toBeNull()
     expect(screen.queryByText(/STEPS PASSED/u)).toBeNull()
     expect(screen.getByRole('button', { name: '中断自动制作' })).toBeTruthy()
+  })
+
+  it('生成进行中时为 Header 留下返回入口，走完就清掉', async () => {
+    renderStateFixture('template-generating')
+
+    await waitFor(() => expect(readActiveRun()).toBe('run-1'))
+  })
+
+  it('没有节点在生成时不留返回入口', async () => {
+    renderStateFixture('template-selecting')
+
+    await screen.findByTestId('quick-start-transcript')
+    expect(readActiveRun()).toBeNull()
   })
 
   it('presents Agent replies as restrained product copy without display typography or avatars', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -18,6 +18,7 @@ import {
   type WorkflowRun,
   WorkflowRunConflictError,
 } from '@/entities'
+import { syncActiveRun } from '@/features/active-run'
 import { ExportButton, type ExportPackageModel } from '@/features/export-package'
 import { PixelMatrix } from '@/shared/ui'
 import { KineticCopyCycle, type KineticCopyMessage } from './kinetic-copy-cycle'
@@ -636,6 +637,9 @@ function QuickStartRun({
       activeSessionRef.current = null
     }
   }, [])
+
+  // 用户会在生成的几分钟里离开这个页面，Header 靠这个指针提供返回入口。
+  useEffect(() => syncActiveRun(run), [run])
 
   useEffect(() => {
     let active = true

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -18,7 +18,8 @@ import {
   type WorkflowRun,
   WorkflowRunConflictError,
 } from '@/entities'
-import { syncActiveRun } from '@/features/active-run'
+import { forgetActiveRun, isMissingActiveRunError, syncActiveRun } from '@/features/active-run'
+import { useOptionalAuthSession } from '@/features/auth-session'
 import { ExportButton, type ExportPackageModel } from '@/features/export-package'
 import { PixelMatrix } from '@/shared/ui'
 import { KineticCopyCycle, type KineticCopyMessage } from './kinetic-copy-cycle'
@@ -121,12 +122,21 @@ export interface QuickStartPageProps {
    * 未注入时，Quick Start 自己装配真实实体接口，避免 app 层承担流程细节。
    */
   service?: QuickStartEntryService
+  /** 直渲染页面测试可显式提供；生产中取当前认证用户。 */
+  activeRunUserId?: string
 }
 
 /** Quick Start 独立完成 AI 入口；它不跳转 Workflow Editor。 */
-export function QuickStartPage({ service }: QuickStartPageProps) {
+export function QuickStartPage({
+  service,
+  activeRunUserId: providedActiveRunUserId,
+}: QuickStartPageProps) {
   const { runId } = useParams()
   const [searchParams] = useSearchParams()
+  const authSession = useOptionalAuthSession()
+  const activeRunUserId =
+    providedActiveRunUserId ??
+    (authSession?.state.status === 'authenticated' ? authSession.state.user.id : null)
   const activeService = useMemo(() => {
     return service ?? quickStartService
   }, [service])
@@ -144,6 +154,7 @@ export function QuickStartPage({ service }: QuickStartPageProps) {
       initialSession={createdSession?.runId === runId ? createdSession : null}
       onSessionCreated={setCreatedSession}
       onInitialSessionConsumed={consumeCreatedSession}
+      activeRunUserId={activeRunUserId}
     />
   ) : characterId && outfitId ? (
     <QuickStartActionInput
@@ -583,12 +594,14 @@ function QuickStartRun({
   initialSession,
   onSessionCreated,
   onInitialSessionConsumed,
+  activeRunUserId,
 }: {
   service: QuickStartEntryService
   runId: string
   initialSession: QuickStartSession | null
   onSessionCreated: (session: QuickStartSession) => void
   onInitialSessionConsumed: (session: QuickStartSession) => void
+  activeRunUserId: string | null
 }) {
   const navigate = useNavigate()
   const location = useLocation()
@@ -639,7 +652,9 @@ function QuickStartRun({
   }, [])
 
   // 用户会在生成的几分钟里离开这个页面，Header 靠这个指针提供返回入口。
-  useEffect(() => syncActiveRun(run), [run])
+  useEffect(() => {
+    if (activeRunUserId) syncActiveRun(activeRunUserId, run)
+  }, [activeRunUserId, run])
 
   useEffect(() => {
     let active = true
@@ -686,6 +701,9 @@ function QuickStartRun({
       }
     })().catch((cause) => {
       if (active) {
+        if (activeRunUserId && isMissingActiveRunError(cause)) {
+          forgetActiveRun(activeRunUserId, runId)
+        }
         reportWorkflowError(cause, '恢复生成任务失败')
         setRestoring(false)
       }
@@ -706,7 +724,14 @@ function QuickStartRun({
         pendingDisposeRef.current = { session: sessionToDispose, timer }
       }
     }
-  }, [clearWorkflowError, onInitialSessionConsumed, reportWorkflowError, runId, service])
+  }, [
+    activeRunUserId,
+    clearWorkflowError,
+    onInitialSessionConsumed,
+    reportWorkflowError,
+    runId,
+    service,
+  ])
 
   useEffect(() => {
     if (!run || !session) {


### PR DESCRIPTION
生成过程中离开页面后，Header 的「创作」会展开成两项：返回那条进行中的任务，或开始新的创作。入口带静态红点，文字旁跟一个左右张望的小机器人，任务结束后一并收起。

## Why

runId 只存在于 `/quick-start/:runId` 的 URL 里，用户离开该地址后前端没有任何位置记录它。`app/layout/app-header.tsx` 的「创作」硬编码指向 `/quick-start`，点下去回到空白输入页，进行中的任务无从返回。

生成耗时以分钟计，用户必然会切走看别的。恢复能力本身是完整的——进入 `/quick-start/:runId` 会调用 `resume()` 重建节点状态与订阅——缺的只是让用户找回那个地址的入口。

## Changes

- 存在进行中的生成任务时，「创作」变为可展开入口，两项分别回到该任务和开始新的创作。
- 入口显示静态红点，并在文字右侧跟一个眼睛左右张望的小机器人，任务结束后入口与动效一并收起。
- 「创作」移到导航末位：这一项在有任务时会变宽，排在中间会把其余三项挤开。
- 没有进行中的任务时，「创作」保持原样，仍是直达新建页的链接。

## Implementation

- 新增 `features/active-run`：只存"最近一条未结束任务"这一个指针，不复制任务状态，真相仍是后端的 WorkflowRun。`forgetActiveRun(runId)` 只在指针仍指向该 runId 时清除——用户可能已经开始了下一条任务，而上一条的结束回调这时才到。
- `syncActiveRun(run)` 按工作流快照对齐指针，"进行中"取节点层面的生成态，与界面上"有任务进行中"的说法同义；整条 Run 是否走完不在这里判断。Quick Start 页面在 run 变化时调用它。
- 指针变化通过一条同页事件广播：`storage` 事件只在其他标签页写入时触发，而 Header 与写入方在同一个标签页里。订阅同时覆盖两者。
- 「创作」不改跳转目标而是展开一层：该入口语义是"开始新的创作"，直接劫持回旧任务会让用户没有新建的地方。菜单复用账号菜单既有的三态与出入场动效。
- 小机器人用方脸方眼，取产品本体的像素语汇；圆脸圆眼是通用 emoji 语汇，排在中文字旁边像贴上去的。只有瞳孔会动，脸不动——脸跟着晃读起来是摇头。
- 视线与眨眼拆成两条动画，周期 3.6s 与 4.3s 不整除，合起来的节奏不重复，盯久了不会看出是一段固定循环。`prefers-reduced-motion` 下两条都关闭。

## Verification

- [x] `npm run format:check`：All matched files use the correct format
- [x] `npm run lint`：通过，无输出
- [x] `npm run typecheck`：通过
- [x] `npm run test:coverage`：59 files / 769 tests 全部通过
- [x] `npm run build`：通过
- [x] 端到端：用 `renderStateFixture('template-generating')` 的真实 WorkflowRun 走完页面 effect，断言指针落到 localStorage；`template-selecting` 场景断言不留指针。摘掉页面里的 `syncActiveRun` 调用后该用例失败于 `expected null to be 'run-1'`
- [x] 字段核对：`phase: 'generating'` 全仓只在 `attachGenerationReference` 中设置，该函数对生成节点以外的类型直接抛错，因此 `phase === 'generating'` 已蕴含 controller 那侧 `generationRoleForNode(node) !== null` 的条件，两处判断等价
- [x] 真实浏览器：本地 dev 起 Header 预览，逐轮确认无任务时为链接、有任务时红点与机器人一同出现、`/quick-start` 高亮态下不与下划线冲突、菜单居中展开、任务结束后入口收起；采样 `getComputedStyle` 确认两条动画的 name / duration / 实际 transform 变化

## Scope

- 本 PR 不包含：跨设备同步（后端 `GET /workflow-runs` 需要 `project_id` 且无状态筛选，"生成中"属于前端节点图语义，后端不理解）、多条任务的并列展示、工作台内的任务区块。
- 后续事项：#463 修复 SSE 重连后不补拉状态（PR #466）。

## Related Issues

Closes #464
