### PR TITLE
fix(generation): restore image candidate request range

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -59,7 +59,7 @@ class CharacterImageInput:
     negative_prompt: str = ""
     width: int = 1024
     height: int = 1024
-    # 角色母版和动作首帧统一返回两张候选；API 层也会把这个值限制为 2。
+    # 候选数量由调用方决定；API 默认请求 3 张，并把可付费调用次数限制在 1–4。
     num_images: int = 2
     direction: ActionDirection = ActionDirection.EAST
 
@@ -105,7 +105,7 @@ class CharacterActionInput:
 class CharacterImageOutput:
     """角色图片生成结果。
 
-    前端拿到 ``image_urls`` 后把两张候选交给工作流节点选择；只有被确认的图片
+    前端拿到 ``image_urls`` 后把候选图交给工作流节点选择；只有被确认的图片
     才写入 ``Character.reference_image_url``。
     """
 

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -174,7 +174,7 @@ class CharacterImageGenerateRequest(BaseModel):
     # (2026-08-10 机器审逮到)。宽高上界按当前 i2v 与像素化管线的实际处理范围取。
     width: int = Field(default=1024, ge=64, le=2048)
     height: int = Field(default=1024, ge=64, le=2048)
-    num_images: int = Field(default=2, ge=2, le=2)
+    num_images: int = Field(default=3, ge=1, le=4)
     direction: ActionDirection = ActionDirection.EAST
 
 

--- a/backend/tests/test_orchestrator_hardening.py
+++ b/backend/tests/test_orchestrator_hardening.py
@@ -500,10 +500,12 @@ def test_num_images_is_bounded_at_the_contract_layer():
     绕过按请求计的限流，把成本拉到无上限。
     """
     with pytest.raises(ValueError):
-        CharacterImageGenerateRequest(project_id=42, prompt="x", num_images=10_000)
+        CharacterImageGenerateRequest(project_id=42, prompt="x", num_images=5)
     with pytest.raises(ValueError):
         CharacterImageGenerateRequest(project_id=42, prompt="x", num_images=0)
-    assert CharacterImageGenerateRequest(project_id=42, prompt="x", num_images=2).num_images == 2
+    assert CharacterImageGenerateRequest(project_id=42, prompt="x").num_images == 3
+    assert CharacterImageGenerateRequest(project_id=42, prompt="x", num_images=1).num_images == 1
+    assert CharacterImageGenerateRequest(project_id=42, prompt="x", num_images=4).num_images == 4
 
 
 def test_image_dimensions_are_bounded():

--- a/openapi.json
+++ b/openapi.json
@@ -471,9 +471,9 @@
             "type": "string"
           },
           "num_images": {
-            "default": 2,
-            "maximum": 2.0,
-            "minimum": 2.0,
+            "default": 3,
+            "maximum": 4.0,
+            "minimum": 1.0,
             "title": "Num Images",
             "type": "integer"
           },


### PR DESCRIPTION
恢复图片生成请求的兼容候选数量范围，保留默认三张候选，解除 Workflow Editor 生成角色母版和动作首帧时的请求校验失败。

## Why

PR #449 将共享图片生成接口的 `num_images` 限制为固定 `2`，但现有前端仍按既定契约请求 `3` 张候选，导致请求被 Pydantic 在进入生成流程前拒绝。

## Changes

- 将 `CharacterImageGenerateRequest.num_images` 恢复为默认 `3`、合法范围 `1–4`。
- 同步导出的 OpenAPI 最小值、最大值与默认值。
- 增加边界回归覆盖，锁定默认值、合法边界和越界拒绝行为。

## Implementation

- 只调整图片生成请求模型及其对外契约，不修改前端、生成执行器或多方向 WorkflowRun。
- 同步清理编排模型中“固定两张候选”的过期注释。

## Verification

- [x] `pytest -q tests/test_orchestrator_hardening.py --no-cov`：41 passed。
- [x] `ruff check packages/app/src/windup_app/web/api/generation.py packages/app/src/windup_app/server/orchestrator/model.py tests/test_orchestrator_hardening.py`：通过。
- [x] `python -m scripts.export_openapi` 后与已提交 `openapi.json` 比较：无漂移。
- [x] `git diff --check upstream/main...HEAD`：通过。

## Scope

- 本 PR 不包含：多方向候选状态、Workflow Editor 改造或完整撤销 #449。
- 后续事项：方向化工作流应在前后端契约同步落地时另行处理。

## Related Issues

Closes #471
Refs #449
