### PR TITLE
fix(test): 项目卡缩略图断言等待 src 落定

### DIFF
--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -52,9 +52,13 @@ describe('ProjectsPage', () => {
     )
 
     const preview = await screen.findByRole('img', { name: '点灯人 · MVP的项目预览' })
-    expect(preview.getAttribute('src')).toBe(
-      'https://cdn.windup.test/media/outfit-preview/messenger.card.webp',
-    )
+    // findByRole 只等到 img 挂上，不等 src 落定：缩略图地址要等角色请求回来后的那次状态
+    // 更新才写进去。裸断言在 CI 这类慢环境上会取到写入前的值，随机把无关 PR 染红。
+    await waitFor(() => {
+      expect(preview.getAttribute('src')).toBe(
+        'https://cdn.windup.test/media/outfit-preview/messenger.card.webp',
+      )
+    })
 
     fireEvent.error(preview)
 


### PR DESCRIPTION
## 变更内容

把 `projects/index.test.tsx` 里判断缩略图地址的那个裸断言包进 `waitFor`。

## 关联

Closes #473

## 为什么这么做

`findByRole` 只等到 `<img>` 挂上，不等 `src` 落定。缩略图地址要等 `/characters?project_id=42` 回来后的那次状态更新才写进去，在那之前 `src` 是回退用的原图地址。慢环境下断言跑在写回之前，取到的是 `messenger.source.png` 而不是 `messenger.card.webp` —— CI 日志里那两个字符串被截断成看起来一样，差别在末段。

同一用例后半段那个回退断言本来就在 `waitFor` 里，只有这一处是裸的。

## 本地验证

- 前端五项均为 0：`format:check` / `lint` / `typecheck` / `test:coverage` / `build`
- 该文件单跑 16 passed

本机复现不出这条 flaky（20 次连跑 0 失败），所以改完不能只看它变绿。用变异确认这条断言不是空的：把期望值改成回退地址 `messenger.source.png`，结果 `1 failed | 15 passed`，还原后文件 sha256 与改前一致。

## 待对齐

`#272` 记的是 `workflow-editor/index.test.tsx` 那条同型问题。在 `ee00fdf` 上对它连跑 42 次 0 失败（该 issue 记的复现率 1/6，42 次期望失败约 7 次），目前复现不出来。本 PR 不覆盖它，是否已被后续改动顺带修掉需要另行确认。
