### PR TITLE
feat(projects): densify asset entry pages

### DIFF
--- a/frontend/src/pages/playtest/entry.test.tsx
+++ b/frontend/src/pages/playtest/entry.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -54,7 +54,8 @@ describe('PlaytestEntryPage', () => {
   it('does not call project or character APIs and points new users to the asset library', async () => {
     const fetch = renderEntry()
 
-    expect(await screen.findByRole('heading', { name: '预览台' })).toBeTruthy()
+    const pageTitle = await screen.findByRole('heading', { name: '预览台', level: 1 })
+    expect(pageTitle.classList.contains('sr-only')).toBe(true)
     expect(screen.getByText('还没有最近预览')).toBeTruthy()
     expect(screen.getByRole('link', { name: '从项目资产中选择' }).getAttribute('href')).toBe(
       '/projects',
@@ -69,12 +70,19 @@ describe('PlaytestEntryPage', () => {
 
     renderEntry()
 
-    expect(await screen.findByRole('heading', { name: '角色 4 · 造型 4' })).toBeTruthy()
+    expect(await screen.findByRole('heading', { name: '最近预览 · 03', level: 2 })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: '预览台', level: 1 })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: '角色 4 · 造型 4' })).toBeTruthy()
     expect(screen.getAllByRole('link', { name: /继续预览/ })).toHaveLength(3)
     expect(screen.queryByText('角色 1')).toBeNull()
     expect(screen.getByRole('link', { name: '从项目资产中选择' }).getAttribute('href')).toBe(
       '/projects',
     )
+    const recentSection = screen.getByRole('heading', { name: '最近预览 · 03' }).closest('section')
+    expect(recentSection).toBeTruthy()
+    expect(
+      within(recentSection as HTMLElement).queryByRole('link', { name: '从项目资产中选择' }),
+    ).toBeNull()
   })
 
   it('keeps the recent preview link on the existing parameterized workbench route', async () => {

--- a/frontend/src/pages/playtest/entry.tsx
+++ b/frontend/src/pages/playtest/entry.tsx
@@ -15,25 +15,9 @@ export function PlaytestEntryPage() {
   }, [recentOwnerId])
 
   return (
-    <div className="mx-auto w-full max-w-[1560px] px-4 pb-8 pt-[clamp(4.75rem,11vh,7rem)] sm:px-6 xl:px-8">
-      <section aria-labelledby="playtest-entry-title" className="pb-10">
-        <header className="flex flex-col gap-4 border-b border-app-line pb-6 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h1
-              id="playtest-entry-title"
-              className="font-serif text-[clamp(2.15rem,4.5vw,4rem)] leading-none font-medium tracking-[-0.055em] text-app-ink"
-            >
-              预览台
-            </h1>
-            <p className="mt-2 max-w-2xl text-sm leading-6 text-app-muted">
-              继续最近打开的角色造型，或回到项目资产库选择新的预览对象。
-            </p>
-          </div>
-          <p className="shrink-0 pb-0.5 font-mono text-[0.68rem] text-app-faint">
-            {recent.length > 0 ? `${recent.length} 条最近预览` : '等待第一次预览'}
-          </p>
-        </header>
-
+    <div className="mx-auto w-full max-w-[1560px] px-4 pb-8 pt-[4.5rem] sm:px-6 xl:px-8">
+      <section aria-label="角色预览入口" className="pb-10">
+        <h1 className="sr-only">预览台</h1>
         <AssetPickerEntry hasRecent={recent.length > 0} />
         {recent.length > 0 ? <RecentPreviewGrid previews={recent} /> : null}
       </section>
@@ -52,7 +36,7 @@ function RecentPreviewGrid({ previews }: { previews: RecentPreview[] }) {
           最近预览 · {String(previews.length).padStart(2, '0')}
         </h2>
       </div>
-      <div className="grid gap-x-4 gap-y-7 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid gap-x-4 gap-y-7 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
         {previews.map((preview, index) => (
           <RecentPreviewCard
             key={`${preview.characterId}:${preview.outfitId}`}
@@ -83,7 +67,7 @@ function RecentPreviewCard({ preview, priority }: { preview: RecentPreview; prio
 
 function AssetPickerEntry({ hasRecent }: { hasRecent: boolean }) {
   return (
-    <div className="mt-5">
+    <div>
       <Link
         to="/projects"
         aria-label="从项目资产中选择"

--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -279,7 +279,8 @@ describe('ProjectsPage', () => {
       </AuthenticatedAuthSession>,
     )
 
-    expect(await screen.findByRole('heading', { name: '项目中心' })).toBeTruthy()
+    const pageTitle = await screen.findByRole('heading', { name: '项目中心', level: 1 })
+    expect(pageTitle.classList.contains('sr-only')).toBe(true)
     const createLink = await screen.findByRole('link', { name: '新建项目' })
     const artwork = createLink.querySelector('img')
     expect(artwork).toBeTruthy()
@@ -303,9 +304,14 @@ describe('ProjectsPage', () => {
       expect(emptyProject.textContent).toContain('等待第一份角色资产')
     })
     expect(previewProject.textContent).toContain('08/04')
+    expect(previewProject.textContent).toContain('横版视角 · 四向')
+    expect(previewProject.textContent).toContain('64 × 64 px')
+    expect(previewProject.textContent).toContain('低饱和像素绘本')
     expect(screen.queryByText('项目名称')).toBeNull()
-    expect(screen.queryByText('视角 / 朝向')).toBeNull()
     expect(screen.queryByRole('link', { name: /查看角色/ })).toBeNull()
+    const gallery = screen.getByRole('heading', { name: '最近项目 · 02' }).closest('section')
+    expect(gallery).toBeTruthy()
+    expect(within(gallery as HTMLElement).queryByRole('link', { name: '新建项目' })).toBeNull()
     expect(
       backend.requests.every((request) =>
         ['/projects', '/characters'].includes(new URL(request.url).pathname),

--- a/frontend/src/pages/projects/index.tsx
+++ b/frontend/src/pages/projects/index.tsx
@@ -3,7 +3,9 @@ import { Link } from 'react-router'
 
 import assetLibraryArtwork from '@/assets/workspace/asset-library.png'
 import {
+  CHARACTER_PERSPECTIVE,
   characterApis,
+  DIRECTIONAL_MOVEMENT,
   projectApis,
   ProjectHasCharactersError,
   type Character,
@@ -208,20 +210,9 @@ export function ProjectsPage() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-[1560px] px-4 pb-8 pt-[clamp(4.75rem,11vh,7rem)] sm:px-6 xl:px-8">
-      <section aria-labelledby="projects-title">
-        <header data-projects-intro className="projects-intro border-b border-app-line pb-6">
-          <h1
-            id="projects-title"
-            className="font-serif text-[clamp(2.15rem,4.5vw,4rem)] leading-none font-medium tracking-[-0.055em] text-app-ink"
-          >
-            项目中心
-          </h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-app-muted">
-            项目隔离角色资产与生成规格；先选项目，再管理其资产。
-          </p>
-        </header>
-
+    <div className="mx-auto w-full max-w-[1560px] px-4 pb-8 pt-[4.5rem] sm:px-6 xl:px-8">
+      <section aria-label="项目资产">
+        <h1 className="sr-only">项目中心</h1>
         {error ? (
           <p
             role="alert"
@@ -234,7 +225,7 @@ export function ProjectsPage() {
           <p className="mt-6 text-sm text-app-muted">正在读取项目…</p>
         ) : null}
         {projectsPage ? (
-          <div className="mt-5">
+          <div>
             <ProjectCreateCard />
             {projectsPage.items.length > 0 ? (
               <ProjectGallery
@@ -340,7 +331,7 @@ function ProjectGallery({
   onDelete: (project: Project) => void
 }) {
   return (
-    <section aria-labelledby="project-gallery-title" className="mt-9">
+    <section aria-labelledby="project-gallery-title" className="mt-7">
       <div className="mb-4">
         <h2
           id="project-gallery-title"
@@ -349,7 +340,7 @@ function ProjectGallery({
           最近项目 · {String(total).padStart(2, '0')}
         </h2>
       </div>
-      <div className="grid gap-x-4 gap-y-7 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid gap-x-4 gap-y-7 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
         {projects.map((project, index) => (
           <ProjectGalleryTile
             key={project.id}
@@ -402,6 +393,14 @@ function ProjectGalleryTile({
           <h3 className="min-w-0 truncate text-sm font-semibold text-app-ink">{project.name}</h3>
           <span className="shrink-0 text-xs tabular-nums text-app-faint">{updatedAt}</span>
         </div>
+        <p className="mt-1.5 truncate px-0.5 text-xs text-app-muted">
+          {CHARACTER_PERSPECTIVE[project.perspective]} ·{' '}
+          {DIRECTIONAL_MOVEMENT[project.directionalMovement]} · {project.spriteSize.width} ×{' '}
+          {project.spriteSize.height} px
+        </p>
+        <p className="mt-1 truncate px-0.5 font-mono text-[0.65rem] tracking-[0.02em] text-app-faint">
+          {project.gameStyle || '未设置游戏风格'}
+        </p>
       </Link>
       <button
         type="button"


### PR DESCRIPTION
收紧项目中心与预览台的首屏信息密度，让资产和生产规格更早进入视野，同时保留既有的编辑风格与横向主动作入口。

## Why

两个入口页原先重复展示顶部导航已经表达的页面名称，并以三列大卡片承载较少信息。桌面端首屏留白较多，项目卡也没有展示已有的生成规格，难以形成专业资产生产工具应有的可扫描性。

## Changes

- 保留“新建一个项目”和“预览其他角色”横向主动作卡，统一两页顶部位置与列表间距。
- 移除重复的可见大标题，同时用视觉隐藏的 `h1` 保留页面语义。
- 项目卡展示视角、方向、Sprite 尺寸、游戏风格和更新时间。
- 资产网格按屏幕宽度逐级使用 1、2、3、4 列。

## Implementation

- 复用现有 `Project` 字段映射，不增加接口或额外请求。
- 保留当前主线的 `AssetThumbnailImage` 缩略图回退，以及现有空状态、动画和最近预览逻辑。
- 定向测试覆盖页面标题层级、横栏与列表边界、项目规格信息。

## Verification

- [x] `npx oxfmt --check src/pages/projects/index.tsx src/pages/projects/index.test.tsx src/pages/playtest/entry.tsx src/pages/playtest/entry.test.tsx`：通过。
- [x] `npx oxlint src/pages/projects/index.tsx src/pages/projects/index.test.tsx src/pages/playtest/entry.tsx src/pages/playtest/entry.test.tsx`：通过。
- [x] `npm test -- src/pages/projects/index.test.tsx src/pages/playtest/entry.test.tsx`：2 个文件、20 个测试通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run build`：通过；仅保留既有的大 chunk 提示。
- [x] 本地真实 API 环境：桌面与窄屏下两页横栏顶部均为 `72px`、列表间距均为 `28px`，控制台无警告或错误。

## Screenshots

### Desktop

<img width="2275" height="1280" alt="项目中心紧凑资产网格" src="https://github.com/user-attachments/assets/1f981a91-2f87-43cb-97e2-01459c55e33d" />

## Scope

- 本 PR 不包含：项目或角色 API、分页契约、最近预览存储上限、预览台运行时、空状态蒙版与动画调整。
- 后续事项：无。

## Related Issues

Closes #476
