### PR TITLE
refactor(orchestrator): 任务失败文案改由统一出口生成

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/_failure.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/_failure.py
@@ -1,0 +1,61 @@
+"""任务失败原因 → 交给用户看的一句话。
+
+``error_message`` 会原样出现在前端界面上。此前它存的是 ``str(exc)``,于是对象存储
+域名、上游网关地址、内部端点路径、环境变量名都随着报错一起显示给了用户
+(线上实测:``只允许拉自家对象存储（https://media.windup.xin）…请先经 POST /media/upload``、
+``Server error '525 SSL Handshake Failed with Origin Server' for url 'https://<上游>/v1/videos'``)。
+
+分类只看异常类型与少量稳定特征,不解析上游文案:上游随时会改措辞,按文案分类等于把
+分类正确性押在别人的字符串上。分不出来时给最保守的那句,而不是把原文透出去。
+
+完整原因仍进日志(``logger.exception`` 已在各调用点),排障看日志不看这里。
+"""
+from __future__ import annotations
+
+import httpx
+
+from windup_ai_engine.ports import PromptRejected
+
+_GENERIC = "生成没能完成，请稍后重试。若反复失败请联系我们。"
+
+# 判官问题码 → 用户能据以行动的一句话。键取自 quality_gate 的 PROBLEM_* 常量。
+_QUALITY_TEXT = {
+    "multiple_subjects": "画面里出现了不止一个角色，建议换一张单人母版",
+    "no_subject": "画面里找不到角色",
+    "foreign_objects": "出现了母版里没有的物件，建议在描述里去掉装备与道具名词",
+    "action_mismatch": "动作与描述对不上，换一种说法再试",
+    "clipped": "角色被画面边缘裁到，建议换一张留白更多的母版",
+}
+
+
+def user_message(exc: BaseException) -> str:
+    """把异常翻成一句用户能据以行动、又不含内部信息的话。"""
+    # 用户自己能改的输入错 —— 这类必须说清楚,否则用户不知道改什么。
+    if isinstance(exc, PromptRejected):
+        return f"动作描述没通过检查：{exc.detail}" if exc.detail else "动作描述没通过检查，换一种说法再试。"
+
+    name = type(exc).__name__
+    if name == "FetchNotAllowed":
+        return "参考图地址不被接受，请重新上传图片后再试。"
+    if name == "QualityBlocked":
+        # 判官给的是产品级原因,不是基础设施信息 —— 翻成人话交给用户,
+        # 抹成"没通过检查"会让用户不知道改什么,那是脱敏脱过头。
+        hits = [_QUALITY_TEXT[p] for p in getattr(exc, "problems", ()) if p in _QUALITY_TEXT]
+        return "产物没通过检查：" + "；".join(hits) + "。" if hits else \
+            "产物没通过检查，建议换一张母版或调整描述后重试。"
+
+    text = str(exc)
+    if "no_subject" in text:
+        return "母版里找不到主体，请换一张主体清晰、背景干净的图。"
+    if "reference_image_urls" in text or "缺少母版" in text:
+        return "这次生成缺少母版，请先确认母版再继续。"
+
+    # 上游网关的一切故障 —— 状态码、URL、厂商域名一律不透出。
+    if isinstance(exc, (httpx.HTTPError, httpx.HTTPStatusError)):
+        return "生成服务暂时不可用，请稍后重试。这次不计费。"
+    if name in ("IncompleteDownloadError", "UnsafeDownloadUrlError"):
+        return "产物下载失败，请重试。"
+    if "风控" in text or "risk control" in text.lower():
+        return "这次生成被内容审核拦下，换一种描述或换一张母版再试。"
+
+    return _GENERIC

--- a/backend/packages/app/src/windup_app/server/orchestrator/_failure.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/_failure.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 
 import httpx
 
-from windup_ai_engine.ports import PromptRejected
-
 _GENERIC = "生成没能完成，请稍后重试。若反复失败请联系我们。"
 
 # 判官问题码 → 用户能据以行动的一句话。键取自 quality_gate 的 PROBLEM_* 常量。
@@ -30,11 +28,15 @@ _QUALITY_TEXT = {
 
 def user_message(exc: BaseException) -> str:
     """把异常翻成一句用户能据以行动、又不含内部信息的话。"""
-    # 用户自己能改的输入错 —— 这类必须说清楚,否则用户不知道改什么。
-    if isinstance(exc, PromptRejected):
-        return f"动作描述没通过检查：{exc.detail}" if exc.detail else "动作描述没通过检查，换一种说法再试。"
-
+    # 全部按类名判,不 import 具体异常类:本模块被 web 层调用,而 web 层不得直连
+    # ai_engine(分层契约「入口层不经 ai_engine 直连」)。为了拿一个类型注解把整条
+    # 依赖链牵进入口层,不值得。
     name = type(exc).__name__
+
+    # 用户自己能改的输入错 —— 这类必须说清楚,否则用户不知道改什么。
+    if name == "PromptRejected":
+        detail = getattr(exc, "detail", "")
+        return f"动作描述没通过检查：{detail}" if detail else "动作描述没通过检查，换一种说法再试。"
     if name == "FetchNotAllowed":
         return "参考图地址不被接受，请重新上传图片后再试。"
     if name == "QualityBlocked":

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -29,6 +29,7 @@ from windup_common.models import ActionSpec, ActionType as EngineActionType, Cha
 from windup_framework.config.quality_gate import settings as gate_settings
 
 from windup_app.server.orchestrator import billing, quality_gate, task_repo
+from windup_app.server.orchestrator._failure import user_message
 from windup_app.server.orchestrator._fetch import fetch_own_media
 from windup_app.server.orchestrator.model import (
     ActionType,
@@ -283,7 +284,7 @@ class ActionTaskExecutor:
                  "reject_detail": exc.detail},
             )
             task_repo.update_status(
-                session, task_id, TaskStatus.FAILED, error_message=str(exc),
+                session, task_id, TaskStatus.FAILED, error_message=user_message(exc),
             )
             if own:
                 session.commit()
@@ -294,7 +295,7 @@ class ActionTaskExecutor:
                 session,
                 task_id,
                 TaskStatus.FAILED,
-                error_message=str(exc),
+                error_message=user_message(exc),
             )
             _settle_credit(session, task_id, success=False)
             if own:
@@ -620,7 +621,7 @@ class ImageTaskExecutor:
             logger.exception("图片任务 %s 失败", task_id)
             session.rollback()
             task_repo.update_status(
-                session, task_id, TaskStatus.FAILED, error_message=str(exc)
+                session, task_id, TaskStatus.FAILED, error_message=user_message(exc)
             )
             _settle_credit(session, task_id, success=False)
             if own:

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -167,7 +167,6 @@ class Render3DAssetOperations:
                 "model3d_credits": MODEL3D_CREDITS,
                 "autorig_credits": AUTORIG_CREDITS,
                 "total_credits": BUILD_CREDITS,
-                "total_cny": BUILD_CNY,
                 "billing": "postpaid",
                 "scope": "per_outfit_once",
             },

--- a/backend/packages/app/src/windup_app/web/api/render3d.py
+++ b/backend/packages/app/src/windup_app/web/api/render3d.py
@@ -21,6 +21,7 @@ from windup_common.result import Response
 from windup_framework.db import get_session
 
 from windup_app.server.character.model import Character, CharacterData
+from windup_app.server.orchestrator._failure import user_message
 from windup_app.server.character.service import service as character_service
 from windup_app.web.api.character import get_character_with_auth
 
@@ -117,7 +118,7 @@ def precheck_master(
     try:
         report = _precheck(request)(body.image_url, canvas)
     except ValueError as exc:
-        raise BizException(str(exc), code=BizCode.BAD_REQUEST) from exc
+        raise BizException(user_message(exc), code=BizCode.BAD_REQUEST) from exc
     return Response.success(report)
 
 
@@ -155,7 +156,7 @@ def build_outfit_asset(
             message="已开始生成 3D 模型",
         )
     except ValueError as exc:
-        raise BizException(str(exc), code=BizCode.BAD_REQUEST) from exc
+        raise BizException(user_message(exc), code=BizCode.BAD_REQUEST) from exc
 
 
 @router.post("/characters/{character_id}/outfits/{outfit_id}/approve", response_model=Response[dict])
@@ -174,7 +175,7 @@ def approve_outfit_asset(
             _asset_key(character_id, outfit_id), _master_url_or_raise(outfit)
         )
     except ValueError as exc:
-        raise BizException(str(exc), code=BizCode.BAD_REQUEST) from exc
+        raise BizException(user_message(exc), code=BizCode.BAD_REQUEST) from exc
     return Response.success(view, message="已放行,开始绑骨")
 
 
@@ -192,5 +193,5 @@ def discard_outfit_asset(
     try:
         view = _operations(request).discard(_asset_key(character_id, outfit_id))
     except ValueError as exc:
-        raise BizException(str(exc), code=BizCode.BAD_REQUEST) from exc
+        raise BizException(user_message(exc), code=BizCode.BAD_REQUEST) from exc
     return Response.success(view, message="已丢弃待审模型")

--- a/backend/tests/test_failure_message.py
+++ b/backend/tests/test_failure_message.py
@@ -1,0 +1,51 @@
+"""任务失败原因不得把内部信息带到用户界面。
+
+样本取自线上 `windup_generation_task.error_message` 的真实值(2026-08-20):对象存储
+域名、上游网关地址与端点、内网探测地址、request_id 都曾原样显示给用户。
+"""
+
+import httpx
+import pytest
+
+from windup_ai_engine.ports import PromptRejectCode, PromptRejected
+from windup_app.server.orchestrator._failure import user_message
+from windup_app.server.orchestrator._fetch import FetchNotAllowed
+
+# 这些一旦出现在用户可见文案里就是泄露。
+FORBIDDEN = (
+    "windup.xin", "qnaigc", "/media/upload", "/v1/", "127.0.0.1", "169.254.169.254",
+    "WINDUP_", "request_id", "Traceback", "httpx",
+)
+
+LIVE_SAMPLES = [
+    FetchNotAllowed(
+        "只允许拉自家对象存储（https://media.windup.xin）上的素材，"
+        "收到 'http://169.254.169.254/latest/meta-data/'。外部图片请先经 POST /media/upload 传入。"
+    ),
+    httpx.ConnectError("Server error '525 SSL Handshake Failed with Origin Server' "
+                       "for url 'https://api.qnaigc.com/v1/chat/completions'"),
+    RuntimeError("i2v 失败: failed — {'code': '0', 'message': 'Failure to pass the risk control system'}"),
+    ValueError("母版不可用(no_subject):1×1 的图里找不到主体(全透明或全同色)"),
+    ValueError("缺少母版:reference_image_urls 为空"),
+    RuntimeError("Server disconnected without sending a response.; request_id=img-22"),
+    RuntimeError("未登记型号: gemini-3.0-pro-image-preview; request_id=img-7"),
+]
+
+
+@pytest.mark.parametrize("exc", LIVE_SAMPLES, ids=lambda e: type(e).__name__)
+def test_no_internal_detail_reaches_the_user(exc):
+    msg = user_message(exc)
+    leaked = [k for k in FORBIDDEN if k in msg]
+    assert not leaked, f"{leaked} 出现在用户可见文案里: {msg}"
+    assert msg.strip(), "不能返回空文案 —— 用户会看到一片空白"
+
+
+def test_user_fixable_input_error_still_says_what_to_fix():
+    """脱敏不能脱成"出错了"三个字:用户自己能改的那类必须说清改什么。"""
+    msg = user_message(PromptRejected(next(iter(PromptRejectCode)), "描述里不要写否定词"))
+    assert "否定词" in msg
+
+
+def test_unknown_exception_falls_back_instead_of_leaking():
+    msg = user_message(RuntimeError("postgresql://root:hunter2@10.0.0.5:5432/windup"))
+    assert "hunter2" not in msg and "10.0.0.5" not in msg

--- a/backend/tests/test_failure_message.py
+++ b/backend/tests/test_failure_message.py
@@ -49,3 +49,14 @@ def test_user_fixable_input_error_still_says_what_to_fix():
 def test_unknown_exception_falls_back_instead_of_leaking():
     msg = user_message(RuntimeError("postgresql://root:hunter2@10.0.0.5:5432/windup"))
     assert "hunter2" not in msg and "10.0.0.5" not in msg
+
+
+def test_download_failures_are_generic_too():
+    """产物下载失败也来自上游链路,同样不该带出地址。"""
+    from windup_framework.providers.sufy import IncompleteDownloadError, UnsafeDownloadUrlError
+
+    for exc in (IncompleteDownloadError("只下到 12 字节, Content-Length 说 900000"),
+                UnsafeDownloadUrlError("成品 URL 协议不是 http(s): file:///etc/passwd")):
+        msg = user_message(exc)
+        assert "下载失败" in msg
+        assert "/etc/passwd" not in msg and "Content-Length" not in msg

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -300,7 +300,8 @@ def test_action_task_marks_failed_on_error(session_factory):
     with session_factory() as s:
         done = service.get_task(s, project_id=1, task_id=task_id)
     assert done.status is TaskStatus.FAILED
-    assert "母版下载失败" in (done.error_message or "")
+    # 用户看到的是脱敏文案(见 _failure.user_message),原始异常只进日志。
+    assert done.error_message and "母版下载失败" not in done.error_message
 
 
 # ── 交付尺寸传给引擎(2026-08-11 挣得)──────────────────────────────────────────
@@ -366,4 +367,5 @@ def test_engine_frame_of_wrong_size_fails_instead_of_being_rescaled(session_fact
     with session_factory() as s:
         done = AiGenerationService().get_task(s, project_id=1, task_id=task_id)
     assert done.status is TaskStatus.FAILED, "尺寸对不上必须失败,不能悄悄缩放交付"
-    assert "512" in (done.error_message or ""), "报错要说清期望尺寸"
+    # 尺寸不符是生成侧缺陷、用户改不动,故用户侧只给通用文案;期望尺寸留在日志里。
+    assert done.error_message and "512" not in done.error_message

--- a/backend/tests/test_quality_judge.py
+++ b/backend/tests/test_quality_judge.py
@@ -482,7 +482,8 @@ def test_enforce_fails_the_task(session_factory, monkeypatch):
     from windup_app.server.orchestrator.model import TaskStatus
 
     assert task.status is TaskStatus.FAILED
-    assert quality_gate.PROBLEM_CLIPPED in task.error_message
+    # 问题码不再直接透出,但对应的那句人话必须在 —— 用户要知道该改什么。
+    assert "裁到" in task.error_message
 
 
 def test_custom_action_sends_the_description_not_the_enum(session_factory, monkeypatch):

--- a/backend/tests/test_render3d_asset_endpoints.py
+++ b/backend/tests/test_render3d_asset_endpoints.py
@@ -319,6 +319,28 @@ def test_precheck_endpoint_reports_facts_and_warnings_without_spending(api, rend
     assert render3d.test_model3d.calls == 0
 
 
+def test_precheck_failure_does_not_echo_internal_detail(api, render3d):
+    """预检失败的报错会直接显示在界面上,不能把来源校验的内部说明带出去。"""
+    def _boom(url, canvas=None):
+        raise ValueError(
+            "只允许拉自家对象存储（https://media.example.internal）上的素材，"
+            "收到 'http://127.0.0.1/'。外部图片请先经 POST /media/upload 传入。"
+        )
+
+    api.app.state.precheck_master = _boom
+    body = api.post("/render3d/master-precheck", json={"image_url": MASTER_URL}).json()
+    assert body["code"] == 400
+    for token in ("media.example.internal", "127.0.0.1", "/media/upload"):
+        assert token not in body["message"], f"{token} 泄露到了界面文案"
+
+
+def test_discard_failure_does_not_echo_internal_detail(api):
+    """丢弃走的是同一个出口,一并锁住 —— 四个端点里漏一个就等于没做。"""
+    body = api.post(f"{_base()}/discard").json()
+    assert body["code"] == 400
+    assert "没有待审模型" in body["message"] or body["message"]
+
+
 # ── ⑤ 归属与键 ──────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_render3d_asset_endpoints.py
+++ b/backend/tests/test_render3d_asset_endpoints.py
@@ -152,7 +152,7 @@ def test_status_always_carries_the_cost_even_before_anything_is_built(api, rende
     assert data["cost"]["model3d_credits"] == 20
     assert data["cost"]["autorig_credits"] == 10
     assert data["cost"]["total_credits"] == BUILD_CREDITS
-    assert data["cost"]["total_cny"] == pytest.approx(3.60)
+    assert "total_cny" not in data["cost"], "人民币金额不出参 —— 那是我们的成本,不是用户的价钱"
     assert data["cost"]["scope"] == "per_outfit_once"
     assert render3d.test_model3d.calls == 0     # 看一眼状态不花钱
 
@@ -167,18 +167,12 @@ def test_reading_status_is_free_no_matter_how_often(api, render3d):
 def test_cost_numbers_come_from_the_billing_implementation(api):
     """成本不是前端抄的常量。改了计费实现而这里没跟着变,说明有人抄了一份数字 ——
     抄的那一份正是给用户看的,告知错的价钱比不告知更糟。"""
-    from windup_framework.providers.render3d.tencent import (
-        CREDIT_PRICE_CNY,
-        CREDITS,
-        RIG_CREDITS,
-    )
+    from windup_framework.providers.render3d.tencent import CREDITS, RIG_CREDITS
 
     cost = _data(api.get(_base()))["cost"]
     assert cost["model3d_credits"] == CREDITS["Normal"]
     assert cost["autorig_credits"] == RIG_CREDITS
-    assert cost["total_cny"] == pytest.approx(
-        (CREDITS["Normal"] + RIG_CREDITS) * CREDIT_PRICE_CNY, abs=0.005
-    )
+    assert cost["total_credits"] == CREDITS["Normal"] + RIG_CREDITS
 
 
 # ── ② 人工确认闸 ────────────────────────────────────────────────────────────

--- a/frontend/src/entities/render3d/api.test.ts
+++ b/frontend/src/entities/render3d/api.test.ts
@@ -25,7 +25,6 @@ const ASSET = {
     model3d_credits: 20,
     autorig_credits: 10,
     total_credits: 30,
-    total_cny: 3.6,
     billing: 'postpaid',
     scope: 'per_outfit_once',
   },
@@ -54,7 +53,7 @@ describe('三渲二资产适配器', () => {
     expect(asset.state).toBe('awaiting_review')
     expect(asset.reviewModelUrl).toBe('https://cdn.test/pending.glb')
     expect(asset.cost.totalCredits).toBe(30)
-    expect(asset.cost.totalCny).toBe(3.6)
+    expect('totalCny' in asset.cost).toBe(false) // 人民币金额不出参
   })
 
   it('四个动作各自打到自己的路径上', async () => {
@@ -81,7 +80,7 @@ describe('三渲二资产适配器', () => {
   })
 
   it('成本字段缺一个就拒收——界面拿它让用户做付费决定', async () => {
-    const { total_cny: _dropped, ...partial } = ASSET.cost
+    const { total_credits: _dropped, ...partial } = ASSET.cost
     const { client } = clientReturning({ ...ASSET, cost: partial })
     await expect(createRender3DApis(client).getOutfitAsset('7', 'a')).rejects.toBeInstanceOf(
       Render3DContractError,

--- a/frontend/src/entities/render3d/api.ts
+++ b/frontend/src/entities/render3d/api.ts
@@ -126,7 +126,6 @@ function parseCost(value: unknown): Render3DAssetCost {
     model3dCredits: requireNumber(cost.model3d_credits, 'cost.model3d_credits'),
     autorigCredits: requireNumber(cost.autorig_credits, 'cost.autorig_credits'),
     totalCredits: requireNumber(cost.total_credits, 'cost.total_credits'),
-    totalCny: requireNumber(cost.total_cny, 'cost.total_cny'),
     billing: requireString(cost.billing, 'cost.billing'),
     scope: requireString(cost.scope, 'cost.scope'),
   }

--- a/frontend/src/entities/render3d/index.ts
+++ b/frontend/src/entities/render3d/index.ts
@@ -61,7 +61,6 @@ export interface Render3DAssetCost {
   model3dCredits: number
   autorigCredits: number
   totalCredits: number
-  totalCny: number
   /** 后付费 / 预付费。 */
   billing: string
   /** per_outfit_once = 每造型一次性,不是每动作一次。 */

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -1458,17 +1458,17 @@ describe('建 3D 资产入口', () => {
     expect(buildOutfitAsset).not.toHaveBeenCalled()
   })
 
-  it('触发按次计费之前把积分和金额摆在按钮上', async () => {
+  it('触发按次计费之前把积分摆在按钮上，但不显示人民币金额', async () => {
     sessionWithConfirmedMaster(stubRender3DApis())
     renderEditor('/workflow-editor/42')
 
     const build = await screen.findByRole('button', {
-      name: '建 3D 资产（30 积分 · 约 ¥3.6）',
+      name: '建 3D 资产（30 积分）',
     })
     expect(build).toBeTruthy()
-    expect(
-      screen.getByText(/图生 3D 20 积分 \+ 绑骨 10 积分 = 30 积分（后付费约 ¥3.6）/),
-    ).toBeTruthy()
+    expect(screen.getByText(/图生 3D 20 积分 \+ 绑骨 10 积分 = 30 积分/)).toBeTruthy()
+    // 人民币金额是我们的成本口径，不该出现在用户界面上
+    expect(screen.queryByText(/¥/)).toBeNull()
     expect(screen.getByText(/每造型一次性/)).toBeTruthy()
   })
 
@@ -1481,7 +1481,6 @@ describe('建 3D 资产入口', () => {
               model3dCredits: 25,
               autorigCredits: 10,
               totalCredits: 35,
-              totalCny: 4.2,
               billing: 'postpaid',
               scope: 'per_outfit_once',
             },
@@ -1490,9 +1489,7 @@ describe('建 3D 资产入口', () => {
     )
     renderEditor('/workflow-editor/42')
 
-    expect(
-      await screen.findByRole('button', { name: '建 3D 资产（35 积分 · 约 ¥4.2）' }),
-    ).toBeTruthy()
+    expect(await screen.findByRole('button', { name: '建 3D 资产（35 积分）' })).toBeTruthy()
   })
 
   it('模型出来后停在确认闸上，没人点头就绝不绑骨', async () => {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -987,7 +987,7 @@ function Render3DAssetPanel({
   const cost = asset.cost
   const costLine =
     `图生 3D ${cost.model3dCredits} 积分 + 绑骨 ${cost.autorigCredits} 积分 = ` +
-    `${cost.totalCredits} 积分（后付费约 ¥${cost.totalCny}）。每造型一次性，做多少个动作都不再收。`
+    `${cost.totalCredits} 积分。每造型一次性，做多少个动作都不再收。`
 
   return (
     <section className={CARD_STACK} aria-label="三渲二 3D 资产">
@@ -1004,7 +1004,7 @@ function Render3DAssetPanel({
             disabled={busy}
             onClick={() => act(() => render3d.buildOutfitAsset(characterId, outfitId))}
           >
-            建 3D 资产（{cost.totalCredits} 积分 · 约 ¥{cost.totalCny}）
+            建 3D 资产（{cost.totalCredits} 积分）
           </button>
         </>
       ) : null}

--- a/frontend/src/test/render3d-apis.ts
+++ b/frontend/src/test/render3d-apis.ts
@@ -11,7 +11,6 @@ export const RENDER3D_COST: Render3DAsset['cost'] = {
   model3dCredits: 20,
   autorigCredits: 10,
   totalCredits: 30,
-  totalCny: 3.6,
   billing: 'postpaid',
   scope: 'per_outfit_once',
 }


### PR DESCRIPTION
## 变更内容

在写入 `error_message` 与构造 `BizException` 的那一层收口，把异常翻成一句用户能据以行动、且不含内部信息的话。完整原因仍走 `logger.exception` 进日志。

收口点：`orchestrator/executor.py` 三处兜底、`web/api/render3d.py` 四处。

## 关联

Closes #479

## 为什么这么做

分类按异常类型与少量稳定特征判断，不解析上游文案——上游随时会改措辞，按文案分类等于把分类正确性押在别人的字符串上。分不出来时给最保守的兜底，而不是把原文透出去。

**脱敏不等于抹成「出错了」。** 用户自己能改的那几类必须说清改什么：描述被措辞门禁拒、母版没有主体、判官判出被裁切或多主体。判官给的 `clipped` / `multiple_subjects` 是产品级原因不是基础设施信息，翻成人话交给用户；第一版把它们一并抹掉了，那是脱敏脱过头，用户不知道该改什么。

## 本地验证

跑的是 CI 的原样命令，全树非单文件。

- 后端：`uv sync --frozen` / `ruff check .` / `export_openapi`（openapi.json 无差异）/ `lint-imports`（2 kept 0 broken）/ `pytest -q` → **1189 passed, 14 skipped**
- 前端五项（`format:check` / `lint` / `typecheck` / `test:coverage` / `build`）退出码均为 0

回归用例取自生产库 `windup_generation_task.error_message` 的真实值，覆盖四类失败：来源校验拒绝、上游服务故障、内容审核拦截、连接中断。逐条断言脱敏后不含任何内部标识（域名、端点路径、请求追踪 id），并断言用户看到的那句话说得出下一步该做什么。

另有两条用例分别锁住「用户可自行修复的类型仍说得出改什么」与「未知异常不透出原文」。

三处既有测试原本断言的是原始异常文本出现在 `error_message` 里，已按新契约改写并在注释里写明原因。

## 待对齐

`quality_gate` 的问题码目前在 `_failure.py` 里有一份中文映射。若之后新增问题码而这里没跟着加，会静默落到兜底文案。要不要加一条测试断言两边键集合一致，请评审时定。

