### PR TITLE
refactor(render3d): 成本展示只保留积分口径

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -167,7 +167,6 @@ class Render3DAssetOperations:
                 "model3d_credits": MODEL3D_CREDITS,
                 "autorig_credits": AUTORIG_CREDITS,
                 "total_credits": BUILD_CREDITS,
-                "total_cny": BUILD_CNY,
                 "billing": "postpaid",
                 "scope": "per_outfit_once",
             },

--- a/backend/tests/test_render3d_asset_endpoints.py
+++ b/backend/tests/test_render3d_asset_endpoints.py
@@ -152,7 +152,7 @@ def test_status_always_carries_the_cost_even_before_anything_is_built(api, rende
     assert data["cost"]["model3d_credits"] == 20
     assert data["cost"]["autorig_credits"] == 10
     assert data["cost"]["total_credits"] == BUILD_CREDITS
-    assert data["cost"]["total_cny"] == pytest.approx(3.60)
+    assert "total_cny" not in data["cost"], "人民币金额不出参 —— 那是我们的成本,不是用户的价钱"
     assert data["cost"]["scope"] == "per_outfit_once"
     assert render3d.test_model3d.calls == 0     # 看一眼状态不花钱
 
@@ -167,18 +167,12 @@ def test_reading_status_is_free_no_matter_how_often(api, render3d):
 def test_cost_numbers_come_from_the_billing_implementation(api):
     """成本不是前端抄的常量。改了计费实现而这里没跟着变,说明有人抄了一份数字 ——
     抄的那一份正是给用户看的,告知错的价钱比不告知更糟。"""
-    from windup_framework.providers.render3d.tencent import (
-        CREDIT_PRICE_CNY,
-        CREDITS,
-        RIG_CREDITS,
-    )
+    from windup_framework.providers.render3d.tencent import CREDITS, RIG_CREDITS
 
     cost = _data(api.get(_base()))["cost"]
     assert cost["model3d_credits"] == CREDITS["Normal"]
     assert cost["autorig_credits"] == RIG_CREDITS
-    assert cost["total_cny"] == pytest.approx(
-        (CREDITS["Normal"] + RIG_CREDITS) * CREDIT_PRICE_CNY, abs=0.005
-    )
+    assert cost["total_credits"] == CREDITS["Normal"] + RIG_CREDITS
 
 
 # ── ② 人工确认闸 ────────────────────────────────────────────────────────────

--- a/frontend/src/entities/render3d/api.test.ts
+++ b/frontend/src/entities/render3d/api.test.ts
@@ -25,7 +25,6 @@ const ASSET = {
     model3d_credits: 20,
     autorig_credits: 10,
     total_credits: 30,
-    total_cny: 3.6,
     billing: 'postpaid',
     scope: 'per_outfit_once',
   },
@@ -54,7 +53,7 @@ describe('三渲二资产适配器', () => {
     expect(asset.state).toBe('awaiting_review')
     expect(asset.reviewModelUrl).toBe('https://cdn.test/pending.glb')
     expect(asset.cost.totalCredits).toBe(30)
-    expect(asset.cost.totalCny).toBe(3.6)
+    expect('totalCny' in asset.cost).toBe(false) // 人民币金额不出参
   })
 
   it('四个动作各自打到自己的路径上', async () => {
@@ -81,7 +80,7 @@ describe('三渲二资产适配器', () => {
   })
 
   it('成本字段缺一个就拒收——界面拿它让用户做付费决定', async () => {
-    const { total_cny: _dropped, ...partial } = ASSET.cost
+    const { total_credits: _dropped, ...partial } = ASSET.cost
     const { client } = clientReturning({ ...ASSET, cost: partial })
     await expect(createRender3DApis(client).getOutfitAsset('7', 'a')).rejects.toBeInstanceOf(
       Render3DContractError,

--- a/frontend/src/entities/render3d/api.ts
+++ b/frontend/src/entities/render3d/api.ts
@@ -126,7 +126,6 @@ function parseCost(value: unknown): Render3DAssetCost {
     model3dCredits: requireNumber(cost.model3d_credits, 'cost.model3d_credits'),
     autorigCredits: requireNumber(cost.autorig_credits, 'cost.autorig_credits'),
     totalCredits: requireNumber(cost.total_credits, 'cost.total_credits'),
-    totalCny: requireNumber(cost.total_cny, 'cost.total_cny'),
     billing: requireString(cost.billing, 'cost.billing'),
     scope: requireString(cost.scope, 'cost.scope'),
   }

--- a/frontend/src/entities/render3d/index.ts
+++ b/frontend/src/entities/render3d/index.ts
@@ -61,7 +61,6 @@ export interface Render3DAssetCost {
   model3dCredits: number
   autorigCredits: number
   totalCredits: number
-  totalCny: number
   /** 后付费 / 预付费。 */
   billing: string
   /** per_outfit_once = 每造型一次性,不是每动作一次。 */

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -1458,17 +1458,17 @@ describe('建 3D 资产入口', () => {
     expect(buildOutfitAsset).not.toHaveBeenCalled()
   })
 
-  it('触发按次计费之前把积分和金额摆在按钮上', async () => {
+  it('触发按次计费之前把积分摆在按钮上，但不显示人民币金额', async () => {
     sessionWithConfirmedMaster(stubRender3DApis())
     renderEditor('/workflow-editor/42')
 
     const build = await screen.findByRole('button', {
-      name: '建 3D 资产（30 积分 · 约 ¥3.6）',
+      name: '建 3D 资产（30 积分）',
     })
     expect(build).toBeTruthy()
-    expect(
-      screen.getByText(/图生 3D 20 积分 \+ 绑骨 10 积分 = 30 积分（后付费约 ¥3.6）/),
-    ).toBeTruthy()
+    expect(screen.getByText(/图生 3D 20 积分 \+ 绑骨 10 积分 = 30 积分/)).toBeTruthy()
+    // 人民币金额是我们的成本口径，不该出现在用户界面上
+    expect(screen.queryByText(/¥/)).toBeNull()
     expect(screen.getByText(/每造型一次性/)).toBeTruthy()
   })
 
@@ -1481,7 +1481,6 @@ describe('建 3D 资产入口', () => {
               model3dCredits: 25,
               autorigCredits: 10,
               totalCredits: 35,
-              totalCny: 4.2,
               billing: 'postpaid',
               scope: 'per_outfit_once',
             },
@@ -1490,9 +1489,7 @@ describe('建 3D 资产入口', () => {
     )
     renderEditor('/workflow-editor/42')
 
-    expect(
-      await screen.findByRole('button', { name: '建 3D 资产（35 积分 · 约 ¥4.2）' }),
-    ).toBeTruthy()
+    expect(await screen.findByRole('button', { name: '建 3D 资产（35 积分）' })).toBeTruthy()
   })
 
   it('模型出来后停在确认闸上，没人点头就绝不绑骨', async () => {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -987,7 +987,7 @@ function Render3DAssetPanel({
   const cost = asset.cost
   const costLine =
     `图生 3D ${cost.model3dCredits} 积分 + 绑骨 ${cost.autorigCredits} 积分 = ` +
-    `${cost.totalCredits} 积分（后付费约 ¥${cost.totalCny}）。每造型一次性，做多少个动作都不再收。`
+    `${cost.totalCredits} 积分。每造型一次性，做多少个动作都不再收。`
 
   return (
     <section className={CARD_STACK} aria-label="三渲二 3D 资产">
@@ -1004,7 +1004,7 @@ function Render3DAssetPanel({
             disabled={busy}
             onClick={() => act(() => render3d.buildOutfitAsset(characterId, outfitId))}
           >
-            建 3D 资产（{cost.totalCredits} 积分 · 约 ¥{cost.totalCny}）
+            建 3D 资产（{cost.totalCredits} 积分）
           </button>
         </>
       ) : null}

--- a/frontend/src/test/render3d-apis.ts
+++ b/frontend/src/test/render3d-apis.ts
@@ -11,7 +11,6 @@ export const RENDER3D_COST: Render3DAsset['cost'] = {
   model3dCredits: 20,
   autorigCredits: 10,
   totalCredits: 30,
-  totalCny: 3.6,
   billing: 'postpaid',
   scope: 'per_outfit_once',
 }


### PR DESCRIPTION
## 变更内容

后端状态出参不再下发折算出来的货币金额字段，前端相应删掉类型与两处展示，只保留积分。

界面文案里的货币金额去掉，只留积分。

## 关联

Closes #480

## 为什么这么做

积分是产品自己的计价单位，展示没问题。那个字段由内部单价常量乘出来，属于成本口径，放在按钮上会把它暴露给用户，也会限制之后的定价空间。

## 本地验证

- 后端：`pytest -q` → **1180 passed, 14 skipped**
- 前端五项均为 0（`test:coverage` 连跑两次确认，首次那一红是 `projects/index.test.tsx` 的已知 flaky，另见 #473）

两处测试反过来锁住新契约：状态出参里断言该字段不存在，界面断言不出现货币符号。原先那条「成本字段缺一个就拒收」的用例改用 `total_credits` 作为被删字段，保持其原意。

