### PR TITLE
fix(workflow-editor): align generation feedback and controls

### DIFF
--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -298,6 +298,7 @@ describe('WorkflowEditorPage real runtime boundary', () => {
 
     const image = await screen.findByRole('img', { name: '已确认身份母版' })
     expect(image.parentElement?.getAttribute('data-workflow-image-shape')).toBe('square')
+    expect(image.parentElement?.className).toContain('rounded-[10px]')
     expect(screen.getByRole('status', { name: '正在加载已确认身份母版' })).toBeTruthy()
     expect(image.className).toContain('opacity-0')
 
@@ -375,6 +376,49 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     renderEditor('/workflow-editor/42')
 
     expect((await screen.findByText('处理中…')).getAttribute('role')).toBe('status')
+  })
+
+  it.each([
+    {
+      nodeType: 'action-first-frame' as const,
+      previewLabel: '动作首帧生成预览',
+      progressLabel: '动作首帧生成进度',
+      progressCopy: '摆好动作姿态',
+    },
+    {
+      nodeType: 'action-full-frame' as const,
+      previewLabel: '完整动作生成预览',
+      progressLabel: '完整动作生成进度',
+      progressCopy: '把动作连起来',
+    },
+  ])('$nodeType 生成时使用对应的共享预览语义', async (scenario) => {
+    const workflow = reviewingActionWorkflow()
+    const target = workflow.nodes.find((node) => node.type === scenario.nodeType)
+    if (!target) throw new Error(`missing ${scenario.nodeType}`)
+    target.status = 'active'
+    target.phase = 'generating'
+    if (target.type === 'action-first-frame') {
+      target.generations = [{ taskId: 'running-first-frame', role: 'first_frame' }]
+    }
+    defaultSessionLoader.mockResolvedValue(
+      createSession(workflow, {
+        generationApis: generationApisFixture({
+          get: vi.fn().mockResolvedValue({
+            id: `running-${scenario.nodeType}`,
+            projectId: '1',
+            type: scenario.nodeType === 'action-first-frame' ? 'first_frame' : 'complete_animation',
+            status: 'running',
+            result: null,
+            error: null,
+          } satisfies Generation),
+        }),
+      }),
+    )
+
+    renderEditor('/workflow-editor/42')
+
+    expect(await screen.findByRole('img', { name: scenario.previewLabel })).toBeTruthy()
+    expect(screen.getByLabelText(scenario.progressLabel).textContent).toBe(scenario.progressCopy)
   })
 
   it('导出是次要动作，当前节点推进仍是主要动作', async () => {
@@ -1366,6 +1410,7 @@ describe('母版确认闸', () => {
 
     const selectedCandidate = screen.getByRole('button', { name: '选择角色候选 1' })
     expect(selectedCandidate.getAttribute('aria-pressed')).toBe('true')
+    expect(selectedCandidate.className).toContain('rounded-[10px]')
     expect(screen.queryByRole('img', { name: '待确认定妆母版' })).toBeNull()
     expect(screen.getByRole('button', { name: '确认为定妆母版' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '重新生成三张' })).toBeTruthy()

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { createElement, type ComponentType, type ReactNode } from 'react'
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Link, MemoryRouter, Route, Routes } from 'react-router'
 
@@ -17,7 +17,7 @@ import {
   type WorkflowRunApis,
 } from '@/entities'
 import { createWorkflowController, type WorkflowController } from '@/features/workflow-controller'
-import { absentAsset, acceptedReport, stubRender3DApis } from '@/test/render3d-apis'
+import { acceptedReport, stubRender3DApis } from '@/test/render3d-apis'
 import { WorkflowEditorPage } from './index'
 import type { WorkflowEditorSession } from './runtime'
 
@@ -91,6 +91,35 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe('WorkflowEditorPage real runtime boundary', () => {
+  it('身份母版只展示现有操作，并让加号菜单专注于生成动作', async () => {
+    const character = characterFixture()
+    character.outfits[0] = {
+      ...character.outfits[0]!,
+      previewUrl: 'https://assets.windup.test/42.png',
+    }
+    defaultSessionLoader.mockResolvedValue(
+      createSession(completedTemplateWorkflow('42'), { character }),
+    )
+    renderEditor('/workflow-editor/42')
+
+    const primaryActions = await screen.findByRole('group', { name: '角色母版操作' })
+    expect(within(primaryActions).getByRole('button', { name: '导出角色母版' })).toBeTruthy()
+
+    const secondaryActions = within(primaryActions).getByRole('group', {
+      name: '调整角色母版',
+    })
+    expect(within(secondaryActions).getByRole('button', { name: '重新生成角色母版' })).toBeTruthy()
+    expect(within(secondaryActions).getByRole('button', { name: '微调角色母版' })).toBeTruthy()
+    expect(screen.queryByText(/3D 资产/)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: '添加动作分支' }))
+    const actionMenu = screen.getByRole('menu', { name: '新增节点' })
+    expect(within(actionMenu).getAllByRole('button')).toHaveLength(1)
+    expect(within(actionMenu).getByRole('button', { name: '生成动作 ›' })).toBeTruthy()
+    expect(within(actionMenu).queryByText('生成静态资产')).toBeNull()
+    expect(within(actionMenu).queryByText('导出')).toBeNull()
+  })
+
   it('角色母版完成后可以重新生成或提交微调描述', async () => {
     const session = createSession(completedTemplateWorkflow('42'))
     const regenerate = vi
@@ -268,6 +297,7 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     renderEditor('/workflow-editor/42')
 
     const image = await screen.findByRole('img', { name: '已确认身份母版' })
+    expect(image.parentElement?.getAttribute('data-workflow-image-shape')).toBe('square')
     expect(screen.getByRole('status', { name: '正在加载已确认身份母版' })).toBeTruthy()
     expect(image.className).toContain('opacity-0')
 
@@ -308,7 +338,17 @@ describe('WorkflowEditorPage real runtime boundary', () => {
 
     renderEditor('/workflow-editor/42')
 
-    expect((await screen.findByRole('status')).textContent).toContain('生成中…')
+    const preview = await screen.findByRole('img', { name: '身份母版生成预览' })
+    expect(preview.getAttribute('data-generation-preview')).toBe('true')
+    expect(preview.getAttribute('data-generation-preview-size')).toBe('candidate')
+    expect(preview.getAttribute('data-generation-preview-radius')).toBe('node')
+    expect(preview.getAttribute('data-generation-preview-fit')).toBe('container')
+    expect(preview.querySelectorAll('[data-pixel-matrix-dot]')).toHaveLength(432)
+    const progress = screen.getByLabelText('身份母版生成进度')
+    expect(progress.textContent).toBe('勾勒角色轮廓')
+    expect(progress.className).toContain('generation-progress-copy')
+    expect(progress.getAttribute('data-copy-motion-mode')).toBe('characters')
+    expect(screen.queryByText('生成中…')).toBeNull()
   })
 
   it('动作首帧等待候选结果时显示处理中状态', async () => {
@@ -1321,12 +1361,12 @@ describe('母版确认闸', () => {
     return session
   }
 
-  it('挑中候选后先展示放大的母版，不直接进入下一步', async () => {
+  it('挑中候选后只在缩略图上标记选择，不重复展示放大图', async () => {
     await openGate()
 
-    expect((await screen.findByRole('img', { name: '待确认定妆母版' })).getAttribute('src')).toBe(
-      'https://assets.windup.test/character.png',
-    )
+    const selectedCandidate = screen.getByRole('button', { name: '选择角色候选 1' })
+    expect(selectedCandidate.getAttribute('aria-pressed')).toBe('true')
+    expect(screen.queryByRole('img', { name: '待确认定妆母版' })).toBeNull()
     expect(screen.getByRole('button', { name: '确认为定妆母版' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '重新生成三张' })).toBeTruthy()
   })
@@ -1394,183 +1434,6 @@ describe('母版确认闸', () => {
     expect(generateCharacterTemplate.mock.calls[0]?.[0]).toBe('character-setup')
     // 复位后没有被选中的候选，闸自然收起来——旧选择不会被当成对新三张的选择。
     await waitFor(() => expect(screen.queryByRole('button', { name: '确认为定妆母版' })).toBeNull())
-  })
-})
-
-/**
- * 建 3D 资产入口。原本用户看得到"该造型暂无绑骨 3D 模型"，却没有任何地方能去建。
- *
- * 用例锁两件事：**按次计费的成本必须先说**，以及**人工确认闸不点头就不绑骨**。
- */
-describe('建 3D 资产入口', () => {
-  function sessionWithConfirmedMaster(render3d: Render3DApis) {
-    const character = characterFixture()
-    const session = createSession(completedTemplateWorkflow('42'), {
-      character: {
-        ...character,
-        outfits: [{ ...character.outfits[0]!, previewUrl: 'https://assets.windup.test/42.png' }],
-      },
-      render3d,
-    })
-    defaultSessionLoader.mockResolvedValue(session)
-    return session
-  }
-
-  it('资产就绪后当场解锁三渲二，不要求用户刷新页面', async () => {
-    // 造型初始没有 3D 模型，资产接口报 ready —— 也就是用户刚等完两段付费流程那一刻。
-    const character = characterFixture()
-    character.outfits[0]!.model3dUrl = null
-    const session = createSession(selectingGenerationMethodWorkflow(), {
-      character,
-      render3d: stubRender3DApis({
-        getOutfitAsset: async () =>
-          absentAsset({ state: 'ready', model3dUrl: 'https://assets.windup.test/day.glb' }),
-      }),
-    })
-    defaultSessionLoader.mockResolvedValue(session)
-    renderEditor('/workflow-editor/42')
-
-    // 三渲二能否选中读的是页面级 Character，轮询到 ready 必须把它一起带上；
-    // 不带的话这个按钮会一直是灰的，用户只能整页刷新。
-    await waitFor(() =>
-      expect((screen.getByRole('button', { name: '三渲二' }) as HTMLButtonElement).disabled).toBe(
-        false,
-      ),
-    )
-  })
-
-  it('母版还没确认时根本没有建 3D 资产这个入口', async () => {
-    const buildOutfitAsset = vi.fn()
-    const session = createSession(selectingTemplateWorkflow(3, 'character-task'), {
-      generationApis: generationApisFixture({
-        get: vi.fn().mockResolvedValue(characterGeneration('character')),
-      }),
-      render3d: stubRender3DApis({ buildOutfitAsset }),
-    })
-    defaultSessionLoader.mockResolvedValue(session)
-    renderEditor('/workflow-editor/42')
-
-    fireEvent.click(await screen.findByRole('button', { name: '选择角色候选 1' }))
-    await screen.findByRole('button', { name: '确认为定妆母版' })
-
-    expect(screen.queryByLabelText('三渲二 3D 资产')).toBeNull()
-    expect(screen.queryByRole('button', { name: /建 3D 资产/ })).toBeNull()
-    expect(buildOutfitAsset).not.toHaveBeenCalled()
-  })
-
-  it('触发按次计费之前把积分摆在按钮上，但不显示人民币金额', async () => {
-    sessionWithConfirmedMaster(stubRender3DApis())
-    renderEditor('/workflow-editor/42')
-
-    const build = await screen.findByRole('button', {
-      name: '建 3D 资产（30 积分）',
-    })
-    expect(build).toBeTruthy()
-    expect(screen.getByText(/图生 3D 20 积分 \+ 绑骨 10 积分 = 30 积分/)).toBeTruthy()
-    // 人民币金额是我们的成本口径，不该出现在用户界面上
-    expect(screen.queryByText(/¥/)).toBeNull()
-    expect(screen.getByText(/每造型一次性/)).toBeTruthy()
-  })
-
-  it('成本数字来自后端返回，不是前端写死的常量', async () => {
-    sessionWithConfirmedMaster(
-      stubRender3DApis({
-        getOutfitAsset: async () =>
-          absentAsset({
-            cost: {
-              model3dCredits: 25,
-              autorigCredits: 10,
-              totalCredits: 35,
-              billing: 'postpaid',
-              scope: 'per_outfit_once',
-            },
-          }),
-      }),
-    )
-    renderEditor('/workflow-editor/42')
-
-    expect(await screen.findByRole('button', { name: '建 3D 资产（35 积分）' })).toBeTruthy()
-  })
-
-  it('模型出来后停在确认闸上，没人点头就绝不绑骨', async () => {
-    const approveOutfitAsset = vi.fn(async () => absentAsset({ state: 'ready' }))
-    let asset = absentAsset()
-    sessionWithConfirmedMaster(
-      stubRender3DApis({
-        getOutfitAsset: async () => asset,
-        buildOutfitAsset: async () => {
-          asset = absentAsset({
-            state: 'awaiting_review',
-            reviewModelUrl: 'https://assets.windup.test/pending.glb',
-          })
-          return asset
-        },
-        approveOutfitAsset,
-      }),
-    )
-    renderEditor('/workflow-editor/42')
-
-    fireEvent.click(await screen.findByRole('button', { name: /建 3D 资产/ }))
-
-    expect(await screen.findByText(/模型已生成，等你确认/)).toBeTruthy()
-    expect(approveOutfitAsset).not.toHaveBeenCalled()
-
-    // 待审模型必须真的能打开——只躺在服务器上的话，"通过"就退化成一个必须点的步骤。
-    expect(
-      (screen.getByRole('link', { name: /下载待审模型/ }) as HTMLAnchorElement).getAttribute(
-        'href',
-      ),
-    ).toBe('https://assets.windup.test/pending.glb')
-
-    fireEvent.click(screen.getByRole('button', { name: /通过 · 继续绑骨/ }))
-    await waitFor(() => expect(approveOutfitAsset).toHaveBeenCalledWith('9', 'day'))
-  })
-
-  it('判不合格时走丢弃重做，并说清要再花一次图生 3D 的钱', async () => {
-    const discardOutfitAsset = vi.fn(async () => absentAsset())
-    const approveOutfitAsset = vi.fn(async () => absentAsset({ state: 'ready' }))
-    sessionWithConfirmedMaster(
-      stubRender3DApis({
-        getOutfitAsset: async () =>
-          absentAsset({
-            state: 'awaiting_review',
-            reviewModelUrl: 'https://assets.windup.test/pending.glb',
-          }),
-        approveOutfitAsset,
-        discardOutfitAsset,
-      }),
-    )
-    renderEditor('/workflow-editor/42')
-
-    fireEvent.click(
-      await screen.findByRole('button', { name: '不合格 · 重新生成（再花 20 积分）' }),
-    )
-
-    await waitFor(() => expect(discardOutfitAsset).toHaveBeenCalledWith('9', 'day'))
-    expect(approveOutfitAsset).not.toHaveBeenCalled()
-  })
-
-  it('在跑的两段付费调用给状态说明，不给一个和真实进度无关的进度条', async () => {
-    sessionWithConfirmedMaster(
-      stubRender3DApis({ getOutfitAsset: async () => absentAsset({ state: 'rigging' }) }),
-    )
-    renderEditor('/workflow-editor/42')
-
-    expect(await screen.findByText(/正在自动绑骨/)).toBeTruthy()
-    expect(screen.queryByRole('progressbar')).toBeNull()
-  })
-
-  it('上一次没建成时把原因摆出来，并允许重来', async () => {
-    sessionWithConfirmedMaster(
-      stubRender3DApis({
-        getOutfitAsset: async () =>
-          absentAsset({ state: 'failed', error: '绑骨轮询 10 分钟仍未出结果' }),
-      }),
-    )
-    renderEditor('/workflow-editor/42')
-
-    expect(await screen.findByText(/绑骨轮询 10 分钟仍未出结果/)).toBeTruthy()
-    expect(screen.getByRole('button', { name: /建 3D 资产/ })).toBeTruthy()
   })
 })
 

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -1463,21 +1463,24 @@ function StatusText({ node, input }: { node: WorkflowNode; input: ProjectionInpu
   return <p className={CARD_SUMMARY}>{label}</p>
 }
 
-function generationPreviewLabel(node: WorkflowNode) {
+type GenerationFeedbackNode = Extract<
+  WorkflowNode,
+  { type: 'character-template' | 'action-first-frame' | 'action-full-frame' }
+>
+
+function generationPreviewLabel(node: GenerationFeedbackNode) {
   if (node.type === 'character-template') return '身份母版生成预览'
   if (node.type === 'action-first-frame') return '动作首帧生成预览'
-  if (node.type === 'action-full-frame') return '完整动作生成预览'
-  return '生成任务预览'
+  return '完整动作生成预览'
 }
 
-function generationProgressLabel(node: WorkflowNode) {
+function generationProgressLabel(node: GenerationFeedbackNode) {
   if (node.type === 'character-template') return '身份母版生成进度'
   if (node.type === 'action-first-frame') return '动作首帧生成进度'
-  if (node.type === 'action-full-frame') return '完整动作生成进度'
-  return '生成任务进度'
+  return '完整动作生成进度'
 }
 
-function generationProgressKind(node: WorkflowNode): GenerationProgressKind {
+function generationProgressKind(node: GenerationFeedbackNode): GenerationProgressKind {
   if (node.type === 'action-first-frame') return 'action-first-frame'
   if (node.type === 'action-full-frame') return 'action-full-frame'
   return 'character-template'

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -80,7 +80,7 @@ const CARD_BUTTON_SECONDARY =
 
 /** 缩略图按钮：沿用卡片按钮的尺寸约定，但换成浅底，让图片自己当主角。 */
 const THUMB_BUTTON =
-  'min-h-[42px] rounded-lg border border-[var(--color-app-line)] bg-app-surface-raised p-1 ' +
+  'min-h-[42px] rounded-[10px] border border-[var(--color-app-line)] bg-app-surface-raised p-1 ' +
   'transition-[border-color,background-color,transform,box-shadow] duration-150 ease-out ' +
   'hover:border-app-line-strong active:scale-[0.98] focus-visible:outline-2 focus-visible:outline-offset-2 ' +
   'focus-visible:outline-app-accent motion-reduce:transform-none aria-pressed:border-app-accent ' +
@@ -417,7 +417,7 @@ function WorkflowImage({
 
   const frameClass =
     variant === 'master'
-      ? 'aspect-square rounded-lg border border-app-line bg-app-surface'
+      ? 'aspect-square rounded-[10px] border border-app-line bg-app-surface'
       : variant === 'thumbnail'
         ? 'aspect-square rounded-md bg-app-surface'
         : 'aspect-square rounded border border-app-line bg-app-surface'

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -35,11 +35,7 @@ import {
   ExportButton,
   type ExportPackageModel,
 } from '@/features/export-package'
-import {
-  GenerationPreviewCard,
-  GenerationProgressCopy,
-  type GenerationProgressKind,
-} from '@/shared/ui'
+import { GenerationPreviewCard, GenerationProgressCopy } from '@/shared/ui'
 import { loadDefaultActionPresets, type WorkflowEditorSession } from './runtime'
 import { useWorkflowEditorSession } from './use-workflow-editor-session'
 import { WorkflowEditorView, type WorkflowCardNode } from './workflow-editor-view'
@@ -1436,18 +1432,16 @@ function StatusText({ node, input }: { node: WorkflowNode; input: ProjectionInpu
     )
   }
   if (node.phase === 'generating') {
+    const feedback =
+      node.type === 'character-template'
+        ? (['character-template', '身份母版生成进度', '身份母版生成预览'] as const)
+        : node.type === 'action-first-frame'
+          ? (['action-first-frame', '动作首帧生成进度', '动作首帧生成预览'] as const)
+          : (['action-full-frame', '完整动作生成进度', '完整动作生成预览'] as const)
     return (
       <div className={`${CARD_STACK} justify-items-center`}>
-        <GenerationProgressCopy
-          kind={generationProgressKind(node)}
-          label={generationProgressLabel(node)}
-          placement="node"
-        />
-        <GenerationPreviewCard
-          label={generationPreviewLabel(node)}
-          radius="node"
-          size="candidate"
-        />
+        <GenerationProgressCopy kind={feedback[0]} label={feedback[1]} placement="node" />
+        <GenerationPreviewCard label={feedback[2]} radius="node" size="candidate" />
       </div>
     )
   }
@@ -1461,29 +1455,6 @@ function StatusText({ node, input }: { node: WorkflowNode; input: ProjectionInpu
     )
   }
   return <p className={CARD_SUMMARY}>{label}</p>
-}
-
-type GenerationFeedbackNode = Extract<
-  WorkflowNode,
-  { type: 'character-template' | 'action-first-frame' | 'action-full-frame' }
->
-
-function generationPreviewLabel(node: GenerationFeedbackNode) {
-  if (node.type === 'character-template') return '身份母版生成预览'
-  if (node.type === 'action-first-frame') return '动作首帧生成预览'
-  return '完整动作生成预览'
-}
-
-function generationProgressLabel(node: GenerationFeedbackNode) {
-  if (node.type === 'character-template') return '身份母版生成进度'
-  if (node.type === 'action-first-frame') return '动作首帧生成进度'
-  return '完整动作生成进度'
-}
-
-function generationProgressKind(node: GenerationFeedbackNode): GenerationProgressKind {
-  if (node.type === 'action-first-frame') return 'action-first-frame'
-  if (node.type === 'action-full-frame') return 'action-full-frame'
-  return 'character-template'
 }
 
 function EditorBoundary({ message }: { message: string }) {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -24,7 +24,6 @@ import {
   type MediaReference,
   type Project,
   type Render3DApis,
-  type Render3DAsset,
   type ReviewWorkflowNode,
   type WorkflowGenerationRole,
   type WorkflowNode,
@@ -36,6 +35,11 @@ import {
   ExportButton,
   type ExportPackageModel,
 } from '@/features/export-package'
+import {
+  GenerationPreviewCard,
+  GenerationProgressCopy,
+  type GenerationProgressKind,
+} from '@/shared/ui'
 import { loadDefaultActionPresets, type WorkflowEditorSession } from './runtime'
 import { useWorkflowEditorSession } from './use-workflow-editor-session'
 import { WorkflowEditorView, type WorkflowCardNode } from './workflow-editor-view'
@@ -88,14 +92,8 @@ const CARD_SUMMARY =
 
 const CARD_TEXT = 'm-0 text-[11px] leading-[1.6] text-[var(--color-app-muted)]'
 
-/**
- * 三渲二判据只有一条:该造型有没有已确认的绑骨 3D 模型(`Outfit.model3dUrl`)。
- * 没有就不提供这个选项——猜一个"反正总能兜底成 i2v"等于让用户在不知情下换了路线。
- * 建模型本身是按次计费、每造型一次性(图生 3D + 绑骨),且生成后要人工确认模型才能继续绑骨。
- */
-const RENDER3D_UNAVAILABLE_HINT =
-  '该造型暂无绑骨 3D 模型，暂不能使用三渲二。到「身份母版」卡片上的「建 3D 资产」建一份：' +
-  '图生 3D + 自动绑骨，按次计费、每造型一次性，中间有一道人工确认；不合格只能重新生成，不能修改。'
+/** 三渲二只对已有绑骨模型的造型开放；页面不再提供创建 3D 资产的入口。 */
+const RENDER3D_UNAVAILABLE_HINT = '该造型暂无绑骨 3D 模型，暂不能使用三渲二。'
 
 /** 加号菜单里的条目：撑满菜单宽度的两行文字，跟卡片主按钮完全不同。 */
 const MENU_ITEM =
@@ -305,7 +303,7 @@ interface ProjectionInput {
   publishReviewedAction(reviewNodeId: ReviewWorkflowNode['id']): Promise<Character>
   project: Project
   character: Character | null
-  /** 母版预检与建 3D 资产；页面不直连适配器，替身注入只有会话这一个入口。 */
+  /** 母版预检与已有 3D 资产判定；页面不直连适配器，替身注入只有会话这一个入口。 */
   render3d: Render3DApis
   generations: Record<string, Generation | null>
   exportModels: ReadonlyMap<string, ExportPackageModel>
@@ -419,7 +417,7 @@ function WorkflowImage({
 
   const frameClass =
     variant === 'master'
-      ? 'aspect-[4/3] rounded-lg border border-app-line bg-app-surface'
+      ? 'aspect-square rounded-lg border border-app-line bg-app-surface'
       : variant === 'thumbnail'
         ? 'aspect-square rounded-md bg-app-surface'
         : 'aspect-square rounded border border-app-line bg-app-surface'
@@ -427,7 +425,10 @@ function WorkflowImage({
     variant === 'master' ? 'object-contain p-2 [image-rendering:pixelated]' : 'object-cover'
 
   return (
-    <span className={`relative block w-full overflow-hidden ${frameClass}`}>
+    <span
+      data-workflow-image-shape="square"
+      className={`relative block w-full overflow-hidden ${frameClass}`}
+    >
       {state === 'loading' ? (
         <span
           role="status"
@@ -650,40 +651,37 @@ function CharacterTemplateContent({
       <div className={CARD_STACK}>
         <WorkflowImage src={node.selectedImageUrl} alt="已确认身份母版" variant="master" />
         <span className="text-center text-[11px] text-[var(--color-app-muted)]">身份已锁定</span>
-        {input.character && outfit ? (
-          <Render3DAssetPanel
-            input={input}
-            characterId={input.character.id}
-            outfitId={outfit.id}
-            hasModel={Boolean(outfit.model3dUrl)}
-          />
-        ) : null}
-        {outfit ? <NodeExportButton model={input.exportModels.get(outfit.id)} /> : null}
-        <div className="grid gap-2">
-          <button
-            type="button"
-            className={CARD_BUTTON}
-            disabled={branchBusy}
-            onClick={() =>
-              input.runCommand(branchKey, () =>
-                input.controller.regenerateCharacterTemplate(node.id, {
-                  spriteWidth: input.project.spriteSize.width,
-                  spriteHeight: input.project.spriteSize.height,
-                  mode: 'regenerate',
-                }),
-              )
-            }
-          >
-            重新生成角色母版
-          </button>
-          <button
-            type="button"
-            className={CARD_BUTTON}
-            disabled={branchBusy}
-            onClick={() => setRefining((active) => !active)}
-          >
-            微调角色母版
-          </button>
+        <div className="grid gap-2" role="group" aria-label="角色母版操作">
+          {outfit ? <NodeExportButton model={input.exportModels.get(outfit.id)} /> : null}
+          <div className="grid grid-cols-2 gap-2" role="group" aria-label="调整角色母版">
+            <button
+              type="button"
+              className={CARD_BUTTON_SECONDARY}
+              aria-label="重新生成角色母版"
+              disabled={branchBusy}
+              onClick={() =>
+                input.runCommand(branchKey, () =>
+                  input.controller.regenerateCharacterTemplate(node.id, {
+                    spriteWidth: input.project.spriteSize.width,
+                    spriteHeight: input.project.spriteSize.height,
+                    mode: 'regenerate',
+                  }),
+                )
+              }
+            >
+              重新生成
+            </button>
+            <button
+              type="button"
+              className={CARD_BUTTON_SECONDARY}
+              aria-label="微调角色母版"
+              aria-expanded={refining}
+              disabled={branchBusy}
+              onClick={() => setRefining((active) => !active)}
+            >
+              微调
+            </button>
+          </div>
           {refining ? (
             <div className="grid gap-2">
               <textarea
@@ -752,9 +750,8 @@ function CharacterTemplateContent({
  * 最终**（拓扑、绑点在生成那一步定死，事后改不动）。母版不合格 → 模型必然不合格 →
  * 只能整个重来。所以要在最便宜的位置纠错，而不是等模型出来再看。
  *
- * 闸上摆的是**零成本就能判的**那几条（后端 master_check）。判不了的（画的是不是这个
- * 角色、朝向对不对、画面里有没有文字）由人自己看放大图 —— 所以放大图是这道闸的主体，
- * 预检只是旁证。
+ * 候选缩略图本身承担人工选择，选中边框就是唯一选择反馈；闸内只保留后端 master_check
+ * 的旁证和确认操作，不再重复放一张大图把节点撑长。
  */
 function MasterGate({
   node,
@@ -775,7 +772,6 @@ function MasterGate({
 
   return (
     <div className={CARD_STACK}>
-      <WorkflowImage src={imageUrl} alt="待确认定妆母版" variant="master" />
       <MasterPrecheckReadout state={precheck} />
       <button
         type="button"
@@ -896,174 +892,6 @@ function MasterPrecheckReadout({ state }: { state: MasterPrecheckState }) {
   )
 }
 
-/**
- * 建 3D 资产：把 `Render3DAssetBuilder` 那条链交到用户手里。
- *
- * 三件事不能省：
- *  - **成本先说**。图生 3D + 绑骨按次计费，每造型一次性；数字由后端从计费实现取，
- *    这里不抄常量。用户不知情就触发按次计费是红线。
- *  - **人工确认闸不能自动放行**。模型出来后停在 `awaiting_review`，等人点头才绑骨。
- *  - **不装进度条**。没有 3D 预览能力，就给状态、给模型下载地址、给怎么看的说明，
- *    而不是转一个和真实进度无关的圈。
- */
-function Render3DAssetPanel({
-  input,
-  characterId,
-  outfitId,
-  hasModel,
-}: {
-  input: ProjectionInput
-  characterId: string
-  outfitId: string
-  hasModel: boolean
-}) {
-  const { render3d } = input
-  const [asset, setAsset] = useState<Render3DAsset | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [busy, setBusy] = useState(false)
-  const [refreshKey, setRefreshKey] = useState(0)
-
-  const inFlight = asset?.state === 'building' || asset?.state === 'rigging'
-
-  useEffect(() => {
-    let cancelled = false
-    const read = () =>
-      render3d
-        .getOutfitAsset(characterId, outfitId)
-        .then((next) => {
-          if (!cancelled) setAsset(next)
-        })
-        .catch((cause: unknown) => {
-          if (!cancelled) setError(errorMessage(cause, '读取 3D 资产状态失败'))
-        })
-    void read()
-    // 两段付费调用各要几十秒到几分钟，跑在后端线程上，只能轮询。停在闸上时不轮询——
-    // 那个状态只会因为人点按钮而改变，轮询它纯属浪费。
-    if (!inFlight)
-      return () => {
-        cancelled = true
-      }
-    const timer = window.setInterval(() => void read(), 3000)
-    return () => {
-      cancelled = true
-      window.clearInterval(timer)
-    }
-  }, [characterId, inFlight, outfitId, refreshKey, render3d])
-
-  // 轮询拿到 ready 时,页面级 Character 还停在旧值,而三渲二能不能选读的正是它
-  // (`outfits[].model3dUrl`)。不回填的话,用户等完两段付费流程仍看到那条路线是灰的,
-  // 得整页刷新才能继续 —— 刚花掉三十积分的人最不该撞上这个。
-  // 守卫只用 hasModel,不另设"同步过了"的一次性开关:那种开关在 Character 被别处
-  // 重新拉取、回到没有 model3dUrl 的旧值时就再也不会补,又退回"必须刷新页面"。
-  useEffect(() => {
-    if (asset?.state !== 'ready' || !asset.model3dUrl || hasModel) return
-    const character = input.character
-    if (!character) return
-    input.setCharacter({
-      ...character,
-      outfits: character.outfits.map((outfit) =>
-        outfit.id === outfitId ? { ...outfit, model3dUrl: asset.model3dUrl } : outfit,
-      ),
-    })
-  }, [asset, hasModel, input, outfitId])
-
-  const act = (operation: () => Promise<Render3DAsset>) => {
-    if (busy) return
-    setBusy(true)
-    setError(null)
-    void operation()
-      .then((next) => setAsset(next))
-      .catch((cause: unknown) => setError(errorMessage(cause, '操作 3D 资产失败')))
-      .finally(() => {
-        setBusy(false)
-        setRefreshKey((key) => key + 1)
-      })
-  }
-
-  if (!asset) {
-    return <p className={CARD_SUMMARY}>{error ?? '正在读取 3D 资产状态…'}</p>
-  }
-
-  const cost = asset.cost
-  const costLine =
-    `图生 3D ${cost.model3dCredits} 积分 + 绑骨 ${cost.autorigCredits} 积分 = ` +
-    `${cost.totalCredits} 积分。每造型一次性，做多少个动作都不再收。`
-
-  return (
-    <section className={CARD_STACK} aria-label="三渲二 3D 资产">
-      {error ? <p className={CARD_SUMMARY}>{error}</p> : null}
-      {asset.state === 'absent' || asset.state === 'failed' ? (
-        <>
-          <p className={CARD_SUMMARY}>{costLine}</p>
-          {asset.state === 'failed' && asset.error ? (
-            <p className={CARD_SUMMARY}>上次没建成：{asset.error}</p>
-          ) : null}
-          <button
-            type="button"
-            className={CARD_BUTTON}
-            disabled={busy}
-            onClick={() => act(() => render3d.buildOutfitAsset(characterId, outfitId))}
-          >
-            建 3D 资产（{cost.totalCredits} 积分）
-          </button>
-        </>
-      ) : null}
-
-      {asset.state === 'building' ? (
-        <p className={CARD_SUMMARY} role="status">
-          正在图生 3D（{cost.model3dCredits} 积分已计费）。这一步几十秒到几分钟，
-          出来后会停下来等你确认，不会自己接着绑骨。
-        </p>
-      ) : null}
-
-      {asset.state === 'awaiting_review' ? (
-        <>
-          <p className={CARD_SUMMARY}>
-            模型已生成，等你确认。<b>混元的模型改不动</b>——不合格只能重新生成，
-            所以这一步别放水：绑骨还要再花 {cost.autorigCredits} 积分。
-          </p>
-          {asset.reviewModelUrl ? (
-            <p className={CARD_TEXT}>
-              <a href={asset.reviewModelUrl} target="_blank" rel="noreferrer">
-                下载待审模型（.glb）
-              </a>
-              ：用 Blender 或任意 glTF 查看器打开，看四肢有没有粘连、有没有多出来的物体。
-            </p>
-          ) : (
-            <p className={CARD_TEXT}>待审模型暂时取不到地址，先别放行。</p>
-          )}
-          <button
-            type="button"
-            className={CARD_BUTTON}
-            disabled={busy}
-            onClick={() => act(() => render3d.approveOutfitAsset(characterId, outfitId))}
-          >
-            通过 · 继续绑骨（{cost.autorigCredits} 积分）
-          </button>
-          <button
-            type="button"
-            className={CARD_BUTTON}
-            disabled={busy}
-            onClick={() => act(() => render3d.discardOutfitAsset(characterId, outfitId))}
-          >
-            不合格 · 重新生成（再花 {cost.model3dCredits} 积分）
-          </button>
-        </>
-      ) : null}
-
-      {asset.state === 'rigging' ? (
-        <p className={CARD_SUMMARY} role="status">
-          正在自动绑骨（{cost.autorigCredits} 积分已计费）。完成后这个造型就能选三渲二了。
-        </p>
-      ) : null}
-
-      {asset.state === 'ready' ? (
-        <p className={CARD_SUMMARY}>3D 资产已就绪，这个造型可以走三渲二了。</p>
-      ) : null}
-    </section>
-  )
-}
-
 function ActionMenu({ input, templateNodeId }: { input: ProjectionInput; templateNodeId: string }) {
   const outfits = input.character?.outfits ?? []
   const selectedOutfit = outfits.find((outfit) => outfit.id === input.selectedOutfitId) ?? null
@@ -1072,7 +900,7 @@ function ActionMenu({ input, templateNodeId }: { input: ProjectionInput; templat
 
   if (input.actionMenuLevel === 'root') {
     return (
-      <div className="contents">
+      <div className="contents" role="menu" aria-label="新增节点">
         <button
           type="button"
           className={`${MENU_ITEM} ${MENU_ITEM_LEAD}`}
@@ -1087,14 +915,6 @@ function ActionMenu({ input, templateNodeId }: { input: ProjectionInput; templat
           }}
         >
           <b className={MENU_ITEM_TITLE}>生成动作 ›</b>
-        </button>
-        <button type="button" className={MENU_ITEM} disabled>
-          <b className={MENU_ITEM_TITLE}>生成静态资产</b>
-          <small className={MENU_ITEM_HINT}>本期不做，需单独提案</small>
-        </button>
-        <button type="button" className={MENU_ITEM} disabled>
-          <b className={MENU_ITEM_TITLE}>导出</b>
-          <small className={MENU_ITEM_HINT}>完成审核后打包动作</small>
         </button>
       </div>
     )
@@ -1615,9 +1435,24 @@ function StatusText({ node, input }: { node: WorkflowNode; input: ProjectionInpu
       </div>
     )
   }
-  const label =
-    node.status === 'locked' ? '等待上游节点' : node.phase === 'generating' ? '生成中…' : '处理中…'
-  if (node.phase === 'generating' || (node.status === 'active' && label === '处理中…')) {
+  if (node.phase === 'generating') {
+    return (
+      <div className={`${CARD_STACK} justify-items-center`}>
+        <GenerationProgressCopy
+          kind={generationProgressKind(node)}
+          label={generationProgressLabel(node)}
+          placement="node"
+        />
+        <GenerationPreviewCard
+          label={generationPreviewLabel(node)}
+          radius="node"
+          size="candidate"
+        />
+      </div>
+    )
+  }
+  const label = node.status === 'locked' ? '等待上游节点' : '处理中…'
+  if (node.status === 'active' && label === '处理中…') {
     return (
       <p role="status" className={`${CARD_SUMMARY} flex items-center gap-2`}>
         <span className="workflow-status-pulse h-1.5 w-1.5 shrink-0 rounded-full bg-app-accent" />
@@ -1626,6 +1461,26 @@ function StatusText({ node, input }: { node: WorkflowNode; input: ProjectionInpu
     )
   }
   return <p className={CARD_SUMMARY}>{label}</p>
+}
+
+function generationPreviewLabel(node: WorkflowNode) {
+  if (node.type === 'character-template') return '身份母版生成预览'
+  if (node.type === 'action-first-frame') return '动作首帧生成预览'
+  if (node.type === 'action-full-frame') return '完整动作生成预览'
+  return '生成任务预览'
+}
+
+function generationProgressLabel(node: WorkflowNode) {
+  if (node.type === 'character-template') return '身份母版生成进度'
+  if (node.type === 'action-first-frame') return '动作首帧生成进度'
+  if (node.type === 'action-full-frame') return '完整动作生成进度'
+  return '生成任务进度'
+}
+
+function generationProgressKind(node: WorkflowNode): GenerationProgressKind {
+  if (node.type === 'action-first-frame') return 'action-first-frame'
+  if (node.type === 'action-full-frame') return 'action-full-frame'
+  return 'character-template'
 }
 
 function EditorBoundary({ message }: { message: string }) {


### PR DESCRIPTION
统一 Workflow Editor 与 Quick Start 的生成反馈，并整理身份母版与加号菜单的操作层级，让生成中、候选选择与完成状态保持一致的视觉语义。

## Why

Workflow Editor 的生成中卡片、循环文案和动效此前与 Quick Start 不一致，生成前后还存在比例与尺寸跳变。身份母版卡片同时混入当前不可用、未实现和重复入口，增加了误操作与理解成本。

## Changes

- 三类生成节点复用共享预览卡片、循环文案和逐字动画。
- 生成预览、候选图与最终母版统一使用正方形媒体语义和节点圆角。
- 候选确认只保留选中边框、预检与确认操作，不再重复展示大图。
- 移除 3D 资产创建 UI、静态资产占位和加号菜单中的重复导出入口。
- 将导出保留为整行操作，重新生成与微调收为并排次级操作。

## Implementation

- Workflow Editor 只消费 `shared/ui` 的生成反馈组件，不复制动画或文案常量。
- 生成反馈 helper 只接受三种真实支持 `generating` 的节点，不保留产品状态上不可达的分支。
- 3D 后端、API、数据结构和已有模型的三渲二判定均未删除。

## Verification

- [x] `npm run format:check`：通过。
- [x] `npm run lint`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npm test -- --run src/pages/workflow-editor/index.test.tsx`：1 个测试文件、62 个测试通过。
- [x] `npm run test:coverage`：64 个测试文件、817 个测试通过，statements 92%、lines 95.12%。
- [x] `npm run build`：通过；仅保留既有 chunk size warning。

## Scope

- 本 PR 不包含：Render3D 后端/API 删除、Generation API、WorkflowController 状态机、开发态 Mock 或生产数据改动。

## Related Issues

Closes #485
