### PR TITLE
perf(generation): i2v 轮询改为先短后长

### DIFF
--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -83,17 +83,20 @@ class SufyVideoProvider(VideoProvider):
         mode: str = "std",
         poll_interval: float = 60.0,
         max_min: int = 30,
+        first_poll_after: float = 5.0,
     ) -> None:
-        # 轮询间隔必须 > 0:下面用 `max_min * 60 // poll` 算预算次数,传 0 直接除零
-        # (2026-08-11 补 i2v 主流程测试时逮到)。0 的语义本身也不成立 —— 那是忙等,
-        # 会把网关打满。测试要跑快就把 time.sleep 打桩掉,别把间隔设成 0。
+        # 轮询间隔必须 > 0:0 的语义不成立 —— 那是忙等,会把网关打满。
+        # 测试要跑快就把 time.sleep 打桩掉,别把间隔设成 0。
         if poll_interval <= 0:
             raise ValueError(f"poll_interval 必须为正数,收到 {poll_interval}")
+        if first_poll_after <= 0:
+            raise ValueError(f"first_poll_after 必须为正数,收到 {first_poll_after}")
         self._cfg = config
         self._model = model or config.video_model
         self._mode = mode
         self._poll = poll_interval
         self._max_min = max_min
+        self._first_poll_after = min(first_poll_after, poll_interval)
 
     def _client(self) -> httpx.Client:
         return httpx.Client(
@@ -122,8 +125,20 @@ class SufyVideoProvider(VideoProvider):
             job = client.post("/videos", json=body).raise_for_status().json()
             jid = job.get("id")
             url = None
-            for _ in range(max(1, int(self._max_min * 60 // self._poll))):
-                time.sleep(self._poll)
+            # 先短后长,而不是每次都睡满 ``poll_interval``。此前第一次查询也要等满一个
+            # 间隔:60 秒的间隔下,一段 20 秒就绪的视频要到第 60 秒才被发现,纯白等。
+            # 退避到上限后与原来一致,所以对慢任务不增加网关压力。
+            # 次数与时间双上限。只用时间会让"永不完成"这类用例必须真等满预算
+            # (实测把一条 0.01 秒的用例拖成 60 秒);只用次数则退避变快之后预算被提前
+            # 耗光。两者取先到的那个。
+            budget = max(1, int(self._max_min * 60 // self._poll))
+            deadline = time.monotonic() + self._max_min * 60
+            wait = self._first_poll_after
+            for _ in range(budget):
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(wait)
+                wait = min(wait * 2, self._poll)
                 st = client.get(f"/videos/{jid}").raise_for_status().json()
                 status = st.get("status")
                 if status == "completed":

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -839,3 +839,52 @@ def test_non_positive_poll_interval_is_rejected_at_construction():
     for bad in (0, -1, -0.5):
         with pytest.raises(ValueError, match="poll_interval"):
             SufyVideoProvider(config=cfg, poll_interval=bad)
+
+
+# ── 轮询节奏:先短后长,别每次都睡满一个间隔 ─────────────────────────────────
+
+
+def test_first_poll_happens_long_before_a_full_interval(monkeypatch):
+    """一段 20 秒就绪的视频不该等满 60 秒才被发现。
+
+    线上实测:一次 walk 的轮询段 125.8 秒 / 2 次,第一次就白等了 60 秒。
+    """
+    import windup_framework.providers.sufy as sufy
+
+    slept: list[float] = []
+    monkeypatch.setattr(sufy.time, "sleep", slept.append)
+
+    seen: dict = {}
+    p = _video_provider(_i2v_handler(seen, statuses=("processing", "completed")))
+    p.i2v(_jpeg_first_frame(), "walk")
+
+    assert slept, "至少要睡过一次"
+    assert slept[0] <= 5.0, f"第一次就睡了 {slept[0]} 秒,又是先睡再查"
+    assert sum(slept) < 60.0, f"两次查询共睡 {sum(slept)} 秒,不该超过一个完整间隔"
+
+
+def test_backoff_never_exceeds_the_configured_interval(monkeypatch):
+    """退避有上限:慢任务的网关压力不能比原来大。"""
+    import windup_framework.providers.sufy as sufy
+
+    slept: list[float] = []
+    monkeypatch.setattr(sufy.time, "sleep", slept.append)
+
+    seen: dict = {}
+    # _video_provider 固定 poll_interval=30，退避上限即 30。
+    p = _video_provider(_i2v_handler(seen, statuses=("processing",) * 12 + ("completed",)))
+    p.i2v(_jpeg_first_frame(), "walk")
+
+    assert max(slept) <= 30.0, f"睡了 {max(slept)} 秒,超过了配置的间隔"
+    assert slept[-1] == 30.0, "退避到上限后应保持在上限"
+    assert slept[0] < slept[-1], "应当是先短后长,而不是一上来就睡满"
+
+
+def test_non_positive_first_poll_is_rejected_at_construction():
+    from windup_framework.config.provider import AIProviderSettings
+    from windup_framework.providers.sufy import SufyVideoProvider
+
+    cfg = AIProviderSettings(base_url="https://gw.example.com/v1", api_key="k")
+    for bad in (0, -1.0):
+        with pytest.raises(ValueError, match="first_poll_after"):
+            SufyVideoProvider(config=cfg, first_poll_after=bad)


### PR DESCRIPTION
## 变更内容

i2v 轮询由「每次睡满 `poll_interval` 再查」改为「首次 5 秒、之后指数退避到 `poll_interval` 封顶」，并给循环加上次数与时间双上限。

新增 `first_poll_after` 构造参数（默认 5 秒，取值不超过 `poll_interval`），与既有的 `poll_interval` 一样在构造时校验为正数。

## 关联

Closes #487

## 为什么这么做

线上一次 walk 的分段是 建单 6.8s / 轮询 125.8s / 下载 26.5s，轮询占整单 79%，其中第一次是纯白等——视频若在 20 秒就绪也要到第 60 秒才被发现。退避到上限后与原来一致，所以对慢任务不增加网关压力。

双上限那一条是被测试逼出来的：第一版只用 deadline，结果「永不完成的任务在预算用尽后抛错」那条用例从 0.01 秒变成真等 60 秒——它原本靠 `max_min=1` 把预算压到 2 次来保持快速。次数上限把这个加速手段还了回去。

## 本地验证

跑的是 CI 的原样命令，全树非单文件。

- `uv run ruff check .` → All checks passed
- `uv run lint-imports` → Contracts: 2 kept, 0 broken
- `uv run python -m scripts.export_openapi` → `openapi.json` 无差异
- `uv run pytest -q` → **1183 passed, 14 skipped**

新增三条用例：首次等待远早于一个完整间隔、退避不超过配置值且末次停在上限、`first_poll_after` 非正数在构造时被拒。改动只涉及 `providers/sufy.py` 与其测试两个文件。
