### PR TITLE
fix(ci): Codecov patch 不再用自动目标抬高门槛

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
+# 覆盖率只做展示，不当门禁。#167 要的是 PR 评论和 README 徽章。
+# patch 默认 target: auto 会跟着总覆盖率上移：仓库从 90% 涨到 93%，
+# 下一笔新代码也必须达到差不多的 diff 覆盖率，codecov/patch 才会绿。
+# 覆盖率越高门槛越高，会逼出只为百分比而写的测试。见 #498。
 coverage:
   status:
     project:
@@ -6,13 +10,16 @@ coverage:
     patch:
       default:
         informational: true
+        # 即使 GitHub Check 忽略 informational，0% 也不会因 91.30 vs 91.36 失败。
+        target: 0%
+
+flags:
+  backend:
+    paths:
+      - backend/
+  frontend:
+    paths:
+      - frontend/
 
 comment:
   layout: "reach,diff,flags,files"
-  flags:
-    backend:
-      paths:
-        - backend/
-    frontend:
-      paths:
-        - frontend/


### PR DESCRIPTION
Closes #498

## Summary
- Codecov `patch` 默认 `target: auto` 会跟着总覆盖率上移，#331 已被卡在 `91.30% of diff hit (target 91.36%)`。
- 把 `flags` 从 `comment` 挪回顶层，并给 patch 固定 `target: 0%`，覆盖率继续展示、不再当失败门禁（对齐 #167）。

## Test plan
- [ ] PR 上 Codecov 评论和徽章仍在
- [ ] `codecov/patch` 不再因差零点几个百分点失败
- [ ] 后端 `lint-and-test` / 前端 CI 行为不变（本 PR 只改 `codecov.yml`）