### PR TITLE
fix(workflow): preserve IME prompt input in editor

### DIFF
--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -978,10 +978,7 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     fireEvent.click(screen.getByRole('button', { name: /自定义动作/ }))
 
     const promptInput = screen.getByRole('textbox', { name: '动作描述' }) as HTMLTextAreaElement
-    const setValue = Object.getOwnPropertyDescriptor(
-      HTMLTextAreaElement.prototype,
-      'value',
-    )?.set
+    const setValue = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set
     if (!setValue) throw new Error('textarea value setter is unavailable')
 
     promptInput.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -1,5 +1,6 @@
 /** @vitest-environment jsdom */
 import { createElement, type ComponentType, type ReactNode } from 'react'
+import { flushSync } from 'react-dom'
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Link, MemoryRouter, Route, Routes } from 'react-router'
@@ -962,6 +963,41 @@ describe('WorkflowEditorPage real runtime boundary', () => {
         ]),
       ),
     )
+  })
+
+  it('画布投影尚未同步时也能保留完整的 IME 动作描述', async () => {
+    const session = createSession(completedTemplateWorkflow('42'), {
+      character: characterFixture(),
+    })
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    fireEvent.click(await screen.findByRole('button', { name: '添加动作分支' }))
+    fireEvent.click(screen.getByRole('button', { name: '生成动作 ›' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择造型 夜行装' }))
+    fireEvent.click(screen.getByRole('button', { name: /自定义动作/ }))
+
+    const promptInput = screen.getByRole('textbox', { name: '动作描述' }) as HTMLTextAreaElement
+    const setValue = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value',
+    )?.set
+    if (!setValue) throw new Error('textarea value setter is unavailable')
+
+    promptInput.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+    for (const character of '快速挥手打招呼') {
+      flushSync(() => {
+        setValue.call(promptInput, promptInput.value + character)
+        promptInput.dispatchEvent(
+          new InputEvent('input', { bubbles: true, data: character, isComposing: true }),
+        )
+      })
+    }
+    promptInput.dispatchEvent(
+      new CompositionEvent('compositionend', { bubbles: true, data: '快速挥手打招呼' }),
+    )
+
+    expect(promptInput.value).toBe('快速挥手打招呼')
   })
 
   it('自定义动作要求非空描述，并可返回重新选择造型', async () => {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -138,7 +138,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
   const [actionMenuOpen, setActionMenuOpen] = useState(false)
   const [actionMenuLevel, setActionMenuLevel] = useState<ActionMenuLevel>('root')
   const [selectedOutfitId, setSelectedOutfitId] = useState<string | null>(null)
-  const [canvasNodes, setCanvasNodes] = useState<WorkflowCardNode[]>([])
+  const [canvasNodeState, setCanvasNodeState] = useState<WorkflowCardNode[]>([])
   const [actionPresets, setActionPresets] = useState<ActionPreset[] | null>(null)
   const [actionPresetError, setActionPresetError] = useState<string | null>(null)
 
@@ -162,7 +162,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
     setActionMenuOpen(false)
     setActionMenuLevel('root')
     setSelectedOutfitId(null)
-    setCanvasNodes([])
+    setCanvasNodeState([])
   }, [runId])
 
   const exportModels = useMemo(() => {
@@ -245,18 +245,19 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
     ],
   )
 
-  useEffect(() => {
-    setCanvasNodes((previous) =>
-      projected.nodes.map((node) => ({
-        ...node,
-        position: previous.find((candidate) => candidate.id === node.id)?.position ?? node.position,
-      })),
-    )
-  }, [projected.nodes])
+  // React Flow gesture state (position, selection and measurements) is local, while node content
+  // must come from the current render. Keeping content in an effect-synchronized copy leaves
+  // controlled textareas one render behind and can reset an in-progress IME composition.
+  const canvasNodes = useMemo(
+    () => mergeCanvasNodes(projected.nodes, canvasNodeState),
+    [canvasNodeState, projected.nodes],
+  )
 
   function onNodesChange(changes: NodeChange<WorkflowCardNode>[]) {
     const safeChanges = changes.filter((change) => change.type !== 'remove')
-    setCanvasNodes((nodes) => applyNodeChanges(safeChanges, nodes))
+    setCanvasNodeState((nodes) =>
+      applyNodeChanges(safeChanges, mergeCanvasNodes(projected.nodes, nodes)),
+    )
   }
 
   if (!runId) {
@@ -288,6 +289,17 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
       onNodesChange={onNodesChange}
     />
   )
+}
+
+function mergeCanvasNodes(
+  projectedNodes: WorkflowCardNode[],
+  canvasNodeState: WorkflowCardNode[],
+): WorkflowCardNode[] {
+  const stateById = new Map(canvasNodeState.map((node) => [node.id, node]))
+  return projectedNodes.map((node) => {
+    const state = stateById.get(node.id)
+    return state ? { ...state, ...node, position: state.position } : node
+  })
 }
 
 interface ProjectionInput {


### PR DESCRIPTION
## Summary

- keep React Flow interaction state separate from projected workflow node content
- derive prompt content synchronously so stale controlled values cannot interrupt IME composition
- add a regression test covering rapid composing input in WorkflowEditor textareas

## Verification

- `npm test -- --run src/pages/workflow-editor/index.test.tsx src/pages/workflow-editor/runtime.test.ts src/app/workflow-editor-route.test.tsx` (90/90 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- full test suite: 957 passed; the existing quick-start-agent boundary test remains the sole unrelated failure

Closes #468