### PR TITLE
feat(workflow-editor): separate animation prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ venv/
 # IDE
 .idea/
 .vscode/
+.repo_memory/
 
 # 系统文件
 .DS_Store

--- a/frontend/src/entities/workflow-run/api.test.ts
+++ b/frontend/src/entities/workflow-run/api.test.ts
@@ -145,6 +145,7 @@ describe('workflowRunApis', () => {
           dependsOnNodeIds: ['generation-method-1'],
           generations: [{ taskId: 'task-animation', role: 'complete_animation' }],
           error: null,
+          input: { prompt: '向前行走并自然摆臂' },
         },
         {
           id: 'review-1',
@@ -165,7 +166,11 @@ describe('workflowRunApis', () => {
         { type: 'character-template', dependsOnNodeIds: ['setup-1'] },
         { type: 'action-first-frame', dependsOnNodeIds: ['template-1'] },
         { type: 'action-generation-method', dependsOnNodeIds: ['first-frame-1'] },
-        { type: 'action-full-frame', dependsOnNodeIds: ['generation-method-1'] },
+        {
+          type: 'action-full-frame',
+          dependsOnNodeIds: ['generation-method-1'],
+          input: { prompt: '向前行走并自然摆臂' },
+        },
         { type: 'review', dependsOnNodeIds: ['full-frame-1'] },
       ],
     })
@@ -306,6 +311,22 @@ describe('workflowRunApis', () => {
         ...workflowRunDto,
         nodes: nodes.map((node) =>
           node.id === 'walk-full-frame' ? { ...node, deletedAt: '' } : node,
+        ),
+      }),
+    )
+
+    await expect(apis.get('17')).rejects.toMatchObject({
+      name: 'ApiError',
+      kind: 'invalid-response',
+    })
+  })
+
+  it('拒绝完整动画节点中非文本类型的独立动作描述', async () => {
+    const apis = await loadWorkflowRunApis(async () =>
+      jsonResponse({
+        ...workflowRunDto,
+        nodes: nodes.map((node) =>
+          node.id === 'walk-full-frame' ? { ...node, input: { prompt: 42 } } : node,
         ),
       }),
     )

--- a/frontend/src/entities/workflow-run/api.ts
+++ b/frontend/src/entities/workflow-run/api.ts
@@ -186,6 +186,8 @@ function isActionFullFrameNode(value: unknown): value is ActionFullFrameWorkflow
     value.type === 'action-full-frame' &&
     hasValidCommonNodeFields(value) &&
     ['ready', 'generating', 'completed'].includes(String(value.phase)) &&
+    (value.input === undefined ||
+      (isRecord(value.input) && isNullableString(value.input.prompt))) &&
     hasOnlyGenerationRole(value, 'complete_animation')
   )
 }

--- a/frontend/src/entities/workflow-run/index.ts
+++ b/frontend/src/entities/workflow-run/index.ts
@@ -106,6 +106,8 @@ export interface ActionGenerationMethodWorkflowNode extends WorkflowNodeBase {
 export interface ActionFullFrameWorkflowNode extends WorkflowNodeBase {
   type: 'action-full-frame'
   phase: 'ready' | 'generating' | 'completed'
+  /** 完整动画自己的动作过程描述；旧 Run 没有该字段。 */
+  input?: { prompt: string | null }
 }
 
 /** 只负责核验完整动画；审核通过不等于下载或导出。 */

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -702,6 +702,7 @@ describe('WorkflowController', () => {
         type: 'action-full-frame',
         status: 'locked',
         dependsOnNodeIds: ['action-walk:action-generation-method'],
+        input: { prompt: null },
       },
       {
         id: 'action-walk:review',
@@ -809,6 +810,43 @@ describe('WorkflowController', () => {
     expect(generation.apis.create).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'complete_animation', outfitId: 'outfit-1' }),
     )
+  })
+
+  it('完整动画保存并使用自己的提示词，不复用动作首帧提示词', async () => {
+    const run = createRun([
+      ...completedCharacterNodes(),
+      firstFrameNode({
+        status: 'passed',
+        phase: 'completed',
+        input: actionInput({ prompt: '挥拳前保持蓄势姿势' }),
+        selectedFirstFrameUrl: 'https://img/first.png',
+      }),
+      generationMethodNode({ status: 'passed', phase: 'completed', method: 'video-cropping' }),
+      fullFrameNode({ status: 'active' }),
+      reviewNode(),
+    ])
+    const { controller, generation } = createController(run)
+
+    await controller.generateCompleteAnimation('action-walk:action-full-frame', {
+      characterId: 'character-backend-1',
+      referenceMedia: [],
+      prompt: '向前挥拳、击中后自然收势，保持身体重心连续',
+    })
+
+    expect(generation.apis.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'complete_animation',
+        prompt: '向前挥拳、击中后自然收势，保持身体重心连续',
+      }),
+    )
+    expect(
+      controller.getWorkflow().nodes.find((node) => node.id === 'action-walk:action-full-frame'),
+    ).toMatchObject({
+      input: { prompt: '向前挥拳、击中后自然收势，保持身体重心连续' },
+    })
+    expect(controller.getWorkflow().nodes.find((node) => node.id === 'action-walk')).toMatchObject({
+      input: { prompt: '挥拳前保持蓄势姿势' },
+    })
   })
 
   it('角色母版通过后按显式边同时解锁多个 Action 首帧节点', async () => {
@@ -1519,7 +1557,7 @@ describe('WorkflowController', () => {
     ])
   })
 
-  it('完整动画只重试失败方向并沿用同方向首帧', async () => {
+  it('完整动画只重试失败方向并沿用同方向首帧和独立动作描述', async () => {
     const run = createRun([
       setupNode({
         status: 'passed',
@@ -1534,6 +1572,7 @@ describe('WorkflowController', () => {
       firstFrameNode({
         status: 'passed',
         phase: 'completed',
+        input: actionInput({ prompt: '挥拳前保持蓄势姿势' }),
         selectedFirstFrameUrl: 'east-frame.png',
         selectedFirstFrameUrls: {
           east: 'east-frame.png',
@@ -1545,6 +1584,7 @@ describe('WorkflowController', () => {
       fullFrameNode({
         status: 'failed',
         phase: 'generating',
+        input: { prompt: '向前挥拳、击中后自然收势' },
         generations: [
           { taskId: 'task-east', role: 'complete_animation' },
           { taskId: 'task-north', role: 'complete_animation', direction: 'north' },
@@ -1585,7 +1625,7 @@ describe('WorkflowController', () => {
       method: 'video-cropping',
       actionType: 'walk',
       firstFrameUrl: 'north-frame.png',
-      prompt: null,
+      prompt: '向前挥拳、击中后自然收势',
       referenceMedia: ['north-reference.png'],
       direction: 'north',
     })

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -64,6 +64,8 @@ export interface GenerateActionOptions {
   characterId: string
   /** 由上传/媒体边界提供，Controller 不把展示 URL 冒充 MediaReference。 */
   referenceMedia: readonly MediaReference[]
+  /** 完整动画自己的动作过程描述，不读取动作首帧描述。 */
+  prompt?: string
 }
 
 export interface GenerateFirstFrameOptions {
@@ -484,6 +486,7 @@ export function createWorkflowController({
         dependsOnNodeIds: [methodId],
         generations: [],
         error: null,
+        input: { prompt: null },
       }
       const methodNode: ActionGenerationMethodWorkflowNode = {
         id: methodId,
@@ -1094,7 +1097,10 @@ export function createWorkflowController({
               method: methodNode.method,
               actionType: firstFrameNode.input.type,
               firstFrameUrl,
-              prompt: firstFrameNode.input.prompt,
+              prompt:
+                node.input === undefined
+                  ? firstFrameNode.input.prompt
+                  : nonEmpty(node.input.prompt ?? '', '完整动作描述'),
               referenceMedia: options.referenceMedia ?? [],
               direction: retryDirection,
             }
@@ -1140,7 +1146,7 @@ export function createWorkflowController({
     )
   }
 
-  function generateCompleteAnimation(
+  async function generateCompleteAnimation(
     nodeId: ActionFullFrameWorkflowNode['id'],
     options: GenerateActionOptions,
   ) {
@@ -1161,6 +1167,13 @@ export function createWorkflowController({
         throw new Error(`动作首帧尚未确认方向 ${direction}`)
       }
     }
+    const prompt = completeAnimationPrompt(targetNode, targetFirstFrame, options.prompt)
+    await persist((run) =>
+      updateNode(run, nodeId, (node) => {
+        if (node.type !== 'action-full-frame') throw new Error('目标节点不是完整动画')
+        return replaceNode(run, { ...node, input: { prompt } })
+      }),
+    )
     return submitDirectionalGenerations(
       nodeId,
       'complete_animation',
@@ -1184,7 +1197,7 @@ export function createWorkflowController({
           method: methodNode.method,
           actionType: firstFrameNode.input.type,
           firstFrameUrl,
-          prompt: firstFrameNode.input.prompt,
+          prompt: nonEmpty(node.input?.prompt ?? '', '完整动作描述'),
           referenceMedia: options.referenceMedia,
           direction,
         }
@@ -2064,6 +2077,18 @@ function nonEmpty(value: string, field: string) {
   const normalized = value.trim()
   if (!normalized) throw new Error(`${field} 不能为空`)
   return normalized
+}
+
+function completeAnimationPrompt(
+  fullFrameNode: ActionFullFrameWorkflowNode,
+  firstFrameNode: ActionFirstFrameWorkflowNode,
+  override: string | undefined,
+) {
+  if (override !== undefined) return nonEmpty(override, '完整动作描述')
+  if (fullFrameNode.input !== undefined) {
+    return nonEmpty(fullFrameNode.input.prompt ?? '', '完整动作描述')
+  }
+  return firstFrameNode.input.prompt?.trim() || firstFrameNode.input.name
 }
 
 function generatedImageReference(value: GeneratedImage['url'] | undefined) {

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -1758,6 +1758,10 @@ describe('createQuickStartService', () => {
       'north-first_frame-2.png',
       'south-first_frame-2.png',
     ])
+    expect(animationCalls.map((input) => input.prompt)).toEqual(['挥手', '挥手', '挥手'])
+    expect(
+      session.getWorkflow().nodes.find((node) => node.type === 'action-full-frame'),
+    ).toMatchObject({ input: { prompt: '挥手' } })
   })
 
   it('Run 已落库但响应丢失时不删除已绑定的 Character', async () => {

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -600,6 +600,7 @@ export function createQuickStartService({
         await controller.generateCompleteAnimation(fullFrame.id, {
           characterId,
           referenceMedia: [],
+          prompt: firstFrame.input.prompt?.trim() || firstFrame.input.name,
         })
       })().then(
         () => {

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -1189,6 +1189,60 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     )
   })
 
+  it('完整动画节点要求填写自己的动作描述并提交该提示词', async () => {
+    const workflow = selectingGenerationMethodWorkflow()
+    const firstFrame = workflow.nodes.find((node) => node.type === 'action-first-frame')
+    if (!firstFrame || firstFrame.type !== 'action-first-frame') throw new Error('missing frame')
+    firstFrame.input.prompt = '挥拳前保持蓄势姿势'
+    for (const node of workflow.nodes) {
+      if (node.type === 'action-full-frame') {
+        node.status = 'locked'
+        node.phase = 'ready'
+        node.generations = []
+      } else if (node.type === 'review') {
+        node.status = 'locked'
+      }
+    }
+    const createGeneration = vi.fn(async () => ({
+      id: 'animation-task',
+      projectId: '1',
+      type: 'complete_animation' as const,
+      status: 'pending' as const,
+      result: null,
+      error: null,
+    })) as GenerationApis['create']
+    const session = createSession(workflow, {
+      character: characterFixture(),
+      generationApis: generationApisFixture({ create: createGeneration }),
+    })
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    fireEvent.click(await screen.findByRole('button', { name: '视频裁剪' }))
+    const generateButton = await screen.findByRole('button', { name: '生成完整动画' })
+    const promptInput = screen.getByRole('textbox', { name: '完整动作描述' })
+    expect((generateButton as HTMLButtonElement).disabled).toBe(true)
+
+    fireEvent.change(promptInput, {
+      target: { value: '向前挥拳、击中后自然收势，保持身体重心连续' },
+    })
+    expect((generateButton as HTMLButtonElement).disabled).toBe(false)
+    fireEvent.click(generateButton)
+
+    await waitFor(() =>
+      expect(createGeneration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: '向前挥拳、击中后自然收势，保持身体重心连续',
+        }),
+      ),
+    )
+    expect(
+      session.controller.getWorkflow().nodes.find((node) => node.type === 'action-full-frame'),
+    ).toMatchObject({
+      input: { prompt: '向前挥拳、击中后自然收势，保持身体重心连续' },
+    })
+  })
+
   it('发布与审核命令失败时显示错误并释放分支锁', async () => {
     const publishReviewedAction = vi.fn(() => Promise.reject(new Error('审核保存失败')))
     const session = createSession(reviewingActionWorkflow(), {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -406,7 +406,9 @@ function contentFor(node: WorkflowNode, input: ProjectionInput): ReactNode {
   }
   if (node.type === 'action-first-frame') return <FirstFrameContent node={node} input={input} />
   if (node.type === 'action-generation-method') return <MethodContent node={node} input={input} />
-  if (node.type === 'action-full-frame') return <AnimationContent node={node} input={input} />
+  if (node.type === 'action-full-frame') {
+    return <AnimationContent key={`${input.run.id}:${node.id}`} node={node} input={input} />
+  }
   return <ReviewContent node={node} input={input} />
 }
 
@@ -1405,6 +1407,7 @@ function AnimationContent({
 }) {
   const branchKey = branchKeyOf(node, input)
   const branchBusy = input.busyBranches.has(branchKey)
+  const [promptDraft, setPromptDraft] = useState(node.input?.prompt ?? '')
   const directions = getDirectionProfile(input.project.directionalMovement).sourceDirections
   const groups = directions.map((direction) => {
     const result =
@@ -1425,22 +1428,37 @@ function AnimationContent({
       ? characterOwningOutfit(input.character, firstFrameNode.input.outfitId)
       : null
     return (
-      <button
-        type="button"
-        className={`${CARD_BUTTON} nodrag nopan nowheel`}
-        disabled={!character || branchBusy}
-        onClick={() => {
-          if (!character) return
-          input.runCommand(branchKey, () =>
-            input.controller.generateCompleteAnimation(node.id, {
-              characterId: character.id,
-              referenceMedia: [],
-            }),
-          )
-        }}
-      >
-        生成完整动画
-      </button>
+      <div className={CARD_STACK}>
+        <textarea
+          aria-label="完整动作描述"
+          rows={4}
+          className="min-h-[76px] w-full resize-y rounded-lg border border-[var(--color-app-line)] bg-app-surface-raised px-3 py-2.5 font-[inherit] text-[11px] leading-[1.55] text-[var(--color-app-ink)] focus:border-app-accent focus:outline focus:outline-2 focus:outline-offset-1 focus:outline-app-accent-soft"
+          placeholder="描述动作过程、节奏、幅度与收势，例如：向前挥拳，击中后自然收势"
+          value={promptDraft}
+          disabled={branchBusy}
+          onChange={(event) => setPromptDraft(event.target.value)}
+        />
+        <p className={CARD_TEXT}>该描述仅用于完整动画，不会覆盖动作首帧描述。</p>
+        <button
+          type="button"
+          className={`${CARD_BUTTON} nodrag nopan nowheel`}
+          disabled={!character || branchBusy || !promptDraft.trim()}
+          onClick={() => {
+            if (!character) return
+            const prompt = promptDraft.trim()
+            if (!prompt) return
+            input.runCommand(branchKey, () =>
+              input.controller.generateCompleteAnimation(node.id, {
+                characterId: character.id,
+                referenceMedia: [],
+                prompt,
+              }),
+            )
+          }}
+        >
+          生成完整动画
+        </button>
+      </div>
     )
   }
   if (


### PR DESCRIPTION
Closes #503

## Summary
- add a dedicated prompt field and required editor input to complete-animation nodes
- persist and reuse the full-animation prompt for generation and directional retries without overwriting first-frame prompts
- preserve legacy WorkflowRun recovery and Quick Start automation

## Verification
- `npm test -- --run src/entities/workflow-run/api.test.ts src/features/workflow-controller/controller.test.ts src/pages/workflow-editor/index.test.tsx src/pages/quick-start/service.test.ts` (229/229 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- full suite: 960 passed; the existing quick-start-agent boundary test remains the sole unrelated failure