### PR TITLE
feat(orchestrator): 生成任务记录代码版本与实际用到的型号

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,6 +42,11 @@ COPY --from=builder /app/packages /app/packages
 # 把 venv/bin 加入 PATH
 ENV PATH="/app/.venv/bin:$PATH"
 
+# 这次构建对应的 commit。镜像里没有 .git,不在构建期烘进来的话,任务落库时的
+# 版本恒为 unknown,线上数据就没法按版本归因(#501)。
+ARG WINDUP_BUILD_COMMIT=""
+ENV WINDUP_BUILD_COMMIT=${WINDUP_BUILD_COMMIT}
+
 # 默认环境变量（可被 docker-compose / .env 覆盖）
 ENV WINDUP_HOST=0.0.0.0
 ENV WINDUP_PORT=8000

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -269,6 +269,11 @@ class ActionTaskExecutor:
                 session.commit()
 
             cons = (self._fetch_constraints or _load_constraints)(session, project_id)
+            # 记的是这次真正用到的型号与路线,不是配置里的默认值。
+            task_repo.merge_runtime(session, task_id, {
+                "video_model": _resolve_video_model(input.video_model),
+                "route": "render_3d" if (input.model_3d_url or "").strip() else "video_i2v",
+            })
             result = self._produce_action(input, cons)
             task_repo.update_result(session, task_id, _ACTION_RESULT, result)
             _settle_credit(session, task_id, success=True)
@@ -602,6 +607,9 @@ class ImageTaskExecutor:
             if own:
                 session.commit()
             cons = _load_constraints(session, project_id)  # 角色图也受项目约束
+            task_repo.merge_runtime(session, task_id, {
+                "image_model": getattr(self._get_image(), "_model", None),
+            })
             urls, quality = self._produce_image(input, cons)
             task_repo.update_result(
                 session,

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -170,6 +170,7 @@ class GenerationTask:
     input_payload: dict | None = None
     result: CharacterImageOutput | CharacterActionOutput | None = None
     error_message: str | None = None
+    runtime: dict | None = None
     create_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     update_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -197,6 +198,12 @@ class GenerationTaskRecord(Base):
     )
     user_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     project_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # 这次生成跑在哪个版本上。写在任务行而不是 result 里:失败的任务同样要能归因,
+    # 而失败时没有 result。见 windup_framework.runtime_version。
+    runtime: Mapped[dict | None] = mapped_column(
+        JSON().with_variant(JSONB, "postgresql"),
+        nullable=True,
+    )
     task_type: Mapped[str] = mapped_column(
         Text,
         nullable=False,

--- a/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
@@ -26,6 +26,7 @@ from windup_app.server.orchestrator.model import (
     TaskStatus,
 )
 from windup_common.directions import ActionDirection
+from windup_framework.runtime_version import runtime_snapshot
 
 logger = logging.getLogger("windup.task_repo")
 
@@ -137,6 +138,7 @@ def create_task(
     project_id: int | None,
     task_type: GenerationType,
     input_payload: dict,
+    runtime: dict | None = None,
 ) -> GenerationTask:
     """创建生成任务记录，返回领域对象。"""
     record = GenerationTaskRecord(
@@ -145,10 +147,26 @@ def create_task(
         task_type=task_type.value,
         status=TaskStatus.PENDING.value,
         input_payload=input_payload,
+        # 建任务时就写死版本,而不是等结果回来 —— 失败的任务同样要能归因,
+        # 而失败时没有 result 可挂。
+        runtime=runtime_snapshot(**(runtime or {})),
     )
     session.add(record)
     session.flush()
     return _record_to_domain(record)
+
+
+def merge_runtime(session: Session, task_id: int, extra: dict) -> None:
+    """把生成侧真正用到的东西并进 ``runtime``。
+
+    合并而不是覆盖:建任务时写的 commit 必须留住。这里只在**真的解析出型号之后**
+    才调用 —— 记配置里的默认值等于记了一件没发生过的事。
+    """
+    record = session.get(GenerationTaskRecord, task_id)
+    if record is None or not extra:
+        return
+    record.runtime = {**(record.runtime or {}), **{k: v for k, v in extra.items() if v}}
+    session.flush()
 
 
 def update_status(
@@ -241,6 +259,7 @@ def _record_to_domain(record: GenerationTaskRecord) -> GenerationTask:
         input_payload=record.input_payload,
         result=result,
         error_message=record.error_message,
+        runtime=record.runtime,
         create_at=record.create_at,
         update_at=record.update_at,
     )

--- a/backend/packages/framework/src/windup_framework/runtime_version.py
+++ b/backend/packages/framework/src/windup_framework/runtime_version.py
@@ -1,0 +1,55 @@
+"""这次生成跑在哪个版本上 —— 供任务落库时记账。
+
+**为什么不复用 ``PROMPT_VERSION``**:那是个手工维护的常量,注释写明"改提示词必须
+连带加一",但它自引入起从未变过,期间 #320 改过攻击提示词、#416 改过动作预设文案,
+两次都没加。靠人记得改的版本号必然漂移,记录不了真实版本。
+
+所以这里只取**不需要人维护**的来源:构建期烘进镜像的 commit,取不到时退回运行期
+探测 git,再取不到才是 unknown。三层都记明来源,让读账的人知道这个值可不可信。
+"""
+from __future__ import annotations
+
+import functools
+import os
+import subprocess
+from pathlib import Path
+
+
+def _from_env() -> tuple[str, str] | None:
+    """构建期注入。生产走这条 —— 镜像里没有 .git。"""
+    sha = (os.getenv("WINDUP_BUILD_COMMIT") or "").strip()
+    return (sha[:12], "build") if sha else None
+
+
+def _from_git() -> tuple[str, str] | None:
+    """开发机走这条。子进程只在首次调用时起一次(见 lru_cache)。"""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parent, capture_output=True, text=True, timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    sha = out.stdout.strip()
+    return (sha[:12], "git") if out.returncode == 0 and sha else None
+
+
+@functools.lru_cache(maxsize=1)
+def code_version() -> dict[str, str]:
+    """``{"commit": ..., "source": build|git|unknown}``。进程内只算一次。"""
+    for probe in (_from_env, _from_git):
+        got = probe()
+        if got:
+            return {"commit": got[0], "source": got[1]}
+    return {"commit": "unknown", "source": "unknown"}
+
+
+def runtime_snapshot(**extra: str | None) -> dict:
+    """任务落库时记的那一份。``extra`` 收生成侧真正用到的型号等。
+
+    只收调用方**实际用到**的值,不收配置里的默认值 —— 配置改了而任务跑在旧进程上时,
+    记下配置等于记了一个没发生过的事实。
+    """
+    snap = dict(code_version())
+    snap.update({k: v for k, v in extra.items() if v})
+    return snap

--- a/backend/tests/test_task_runtime_version.py
+++ b/backend/tests/test_task_runtime_version.py
@@ -1,0 +1,79 @@
+"""任务要能被归因到具体版本 —— 否则线上数据说不了话。
+
+背景：2026-08-21 排查产物质量退化，只能按时间戳分组，而同一天里 08:48 的 walk 正常、
+10:25 的 walk 孔洞峰值 19%、15:54 的又正常，时间戳分不开版本。
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from windup_app.server.orchestrator import task_repo
+from windup_app.server.orchestrator.model import GenerationType, TaskStatus
+from windup_framework.db.base import Base
+from windup_framework.mq.model import MqMessage  # noqa: F401 — register metadata
+from windup_framework.runtime_version import code_version, runtime_snapshot
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def _mk(session, **kw):
+    return task_repo.create_task(
+        session, user_id=1, project_id=None,
+        task_type=GenerationType.CHARACTER_ACTION, input_payload={"action_type": "walk"}, **kw,
+    )
+
+
+def test_version_is_written_at_creation_not_on_success(session_factory):
+    """写在建任务那一步 —— 失败的任务同样要能归因，而失败时没有 result 可挂。"""
+    with session_factory() as s:
+        task = _mk(s)
+        task_repo.update_status(s, task.id, TaskStatus.FAILED, error_message="上游挂了")
+        s.commit()
+        got = task_repo.get_task(s, task.id)
+    assert got.status is TaskStatus.FAILED
+    assert got.runtime and got.runtime.get("commit"), "失败任务没有版本 = 归因链断在最需要它的地方"
+
+
+def test_version_does_not_depend_on_a_hand_maintained_constant():
+    """`PROMPT_VERSION` 恒为 v1、期间提示词改过两次都没人加 —— 靠人记得改的版本号必然漂移。"""
+    v = code_version()
+    assert set(v) == {"commit", "source"}
+    assert v["source"] in ("build", "git", "unknown")
+    if v["source"] != "unknown":
+        assert len(v["commit"]) == 12, "commit 应为 12 位短哈希"
+
+
+def test_merge_keeps_the_commit_written_at_creation(session_factory):
+    """executor 后来并进型号时不能把建任务时写的 commit 冲掉。"""
+    with session_factory() as s:
+        task = _mk(s)
+        before = task_repo.get_task(s, task.id).runtime["commit"]
+        task_repo.merge_runtime(s, task.id, {"video_model": "kling-v2-5-turbo", "route": "video_i2v"})
+        s.commit()
+        got = task_repo.get_task(s, task.id).runtime
+    assert got["commit"] == before
+    assert got["video_model"] == "kling-v2-5-turbo"
+    assert got["route"] == "video_i2v"
+
+
+def test_empty_values_are_not_recorded(session_factory):
+    """空值不写：`{"video_model": None}` 会让读账的人以为量过了。"""
+    with session_factory() as s:
+        task = _mk(s)
+        task_repo.merge_runtime(s, task.id, {"video_model": None, "route": ""})
+        s.commit()
+        got = task_repo.get_task(s, task.id).runtime
+    assert "video_model" not in got and "route" not in got
+
+
+def test_snapshot_carries_extra_only_when_present():
+    snap = runtime_snapshot(image_model="gemini-2.5-flash-image", video_model=None)
+    assert snap["image_model"] == "gemini-2.5-flash-image"
+    assert "video_model" not in snap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,9 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+      args:
+        # 由部署脚本传入:`WINDUP_BUILD_COMMIT=$(git rev-parse HEAD) docker compose build`
+        WINDUP_BUILD_COMMIT: ${WINDUP_BUILD_COMMIT:-}
     container_name: windup-backend
     restart: unless-stopped
     depends_on:
@@ -72,6 +75,9 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+      args:
+        # 由部署脚本传入:`WINDUP_BUILD_COMMIT=$(git rev-parse HEAD) docker compose build`
+        WINDUP_BUILD_COMMIT: ${WINDUP_BUILD_COMMIT:-}
     container_name: windup-worker
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## ⚠️ 合入前必须先给线上表加列

本 PR 给 `windup_generation_task` 加了一列。项目用 `Base.metadata.create_all` 建表，**它不会给已存在的表补列**（本地实测确认：造一张缺该列的旧表再跑 `create_all`，列仍然不存在）。

因此合入后若线上未先执行 DDL，所有生成任务会在建任务那一步失败。上线顺序：

```sql
ALTER TABLE windup_generation_task ADD COLUMN IF NOT EXISTS runtime JSONB;
```

先加列，再部署。列可空，旧数据保持 NULL。

## 变更内容

任务落库时记下这次生成跑在哪个版本上：

- 新增 `windup_framework/runtime_version.py`，按 构建期注入 → 运行期探测 git → unknown 三级取 commit，并记明来源
- `GenerationTaskRecord` 加 `runtime` 列，`create_task` 时写入
- executor 在真正解析出型号后用 `merge_runtime` 并入实际用到的 `video_model` / `image_model` / `route`
- `Dockerfile` 加 `ARG WINDUP_BUILD_COMMIT`，`docker-compose.yml` 两处 build 段透传

## 关联

Closes #501

## 为什么这么做

线上每条已完成任务都是一个真实样本，每次合入都是一次变量改动。把任务与版本关联起来，存量数据就是天然的对照实验：按版本分组比较产物读数即可归因，不用重跑也不产生生成成本。

此前只能按时间戳分组，而时间戳分不开版本——同一天里 08:48 的 walk 正常、10:25 的 walk 孔洞峰值 19%、15:54 的又正常。

**没有复用 `PROMPT_VERSION`**：该常量的注释写明「改动本包任何一个 `build_*_prompt` 的输出都必须连带把这个常量加一」，但它自引入起从未变过，期间 #320 改过攻击提示词、#416 改过动作预设文案，两次都没加。靠人记得改的版本号必然漂移。所以版本只取不需要人维护的来源。

**写在建任务那一步而不是结果里**：失败的任务同样需要归因，而失败时没有 `result` 可挂。

**型号在 executor 里才并入**：那时才是真正用到的值。建任务时读配置等于记了一件可能没发生的事——配置改了而任务跑在旧进程上时两者不一致。

## 本地验证

跑的是 CI 的原样命令，全树非单文件。

- `uv run ruff check .` → All checks passed
- `uv run lint-imports` → Contracts: 2 kept, 0 broken
- `uv run python -m scripts.export_openapi` → `openapi.json` 无差异
- `uv run pytest -q` → **1204 passed, 14 skipped**

新增五条用例，其中三条锁的是容易退化的地方：失败任务也必须有版本、`merge_runtime` 不能冲掉建任务时写的 commit、空值不写入（`{"video_model": null}` 会让读账的人以为量过了）。

构建期注入的优先级也验过：设了 `WINDUP_BUILD_COMMIT` 时 `source` 为 `build`，未设时回退到 `git`。

## 待对齐

`ALTER TABLE` 由谁执行、在哪一步执行。当前没有迁移工具，这类改动每次都要人工介入；是否引入迁移工具是另一个话题，本 PR 不处理。
