### PR TITLE
fix(generation): 恢复默认三张图片候选

### DIFF
--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -15,6 +15,14 @@ import type { MediaReference } from '../media'
 
 const reference = (url: string) => url as MediaReference
 
+function candidateUrls(prefix = 'https://cdn.test/candidate') {
+  return [1, 2, 3].map((index) => `${prefix}-${index}.png`)
+}
+
+function candidates(prefix?: string) {
+  return candidateUrls(prefix).map((url) => ({ url }))
+}
+
 function success(data: unknown): Response {
   return new Response(JSON.stringify({ code: 200, message: 'success', data }), {
     status: 200,
@@ -28,11 +36,11 @@ function taskData(overrides: Record<string, unknown> = {}) {
     project_id: 42,
     task_type: 'character_image',
     status: 'completed',
-    input_payload: { num_images: 2, direction: 'east' },
+    input_payload: { num_images: 3, direction: 'east' },
     result: {
       type: 'character_image',
       direction: 'east',
-      image_urls: ['https://cdn.test/candidate-1.png', 'https://cdn.test/candidate-2.png'],
+      image_urls: candidateUrls(),
     },
     error_message: null,
     ...overrides,
@@ -78,15 +86,15 @@ describe('createGenerationApis', () => {
     }
   })
 
-  it('固定请求并映射两张角色母版候选', async () => {
+  it('固定请求并映射三张角色母版候选', async () => {
     const request = vi.fn(async (_url: string, _init?: RequestInit) =>
       success(
         taskData({
-          input_payload: { num_images: 2, direction: 'north_east' },
+          input_payload: { num_images: 3, direction: 'north_east' },
           result: {
             type: 'character_image',
             direction: 'north_east',
-            image_urls: ['https://cdn.test/candidate-1.png', 'https://cdn.test/candidate-2.png'],
+            image_urls: candidateUrls(),
           },
         }),
       ),
@@ -119,7 +127,7 @@ describe('createGenerationApis', () => {
           negative_prompt: '',
           width: 64,
           height: 96,
-          num_images: 2,
+          num_images: 3,
           direction: 'north_east',
         }),
       }),
@@ -127,10 +135,7 @@ describe('createGenerationApis', () => {
     expect(generation.result).toEqual({
       type: 'character_template',
       direction: 'north_east',
-      images: [
-        { url: 'https://cdn.test/candidate-1.png' },
-        { url: 'https://cdn.test/candidate-2.png' },
-      ],
+      images: candidates(),
     })
   })
 
@@ -138,11 +143,11 @@ describe('createGenerationApis', () => {
     const request = vi.fn(async (_url: string, _init?: RequestInit) =>
       success(
         taskData({
-          input_payload: { num_images: 2, direction: 'east' },
+          input_payload: { num_images: 3, direction: 'east' },
           result: {
             type: 'character_image',
             direction: 'east',
-            image_urls: ['east-1.png', 'east-2.png'],
+            image_urls: candidateUrls('east'),
           },
         }),
       ),
@@ -165,19 +170,19 @@ describe('createGenerationApis', () => {
     })
     expect(generation.result).toEqual({
       type: 'character_template',
-      images: [{ url: 'east-1.png' }, { url: 'east-2.png' }],
+      images: candidates('east'),
     })
   })
 
-  it('根据角色母版和动作提示词生成两张动作首帧候选', async () => {
+  it('根据角色母版和动作提示词生成三张动作首帧候选', async () => {
     const request = vi.fn(async (_url: string, _init?: RequestInit) =>
       success(
         taskData({
-          input_payload: { num_images: 2, direction: 'south' },
+          input_payload: { num_images: 3, direction: 'south' },
           result: {
             type: 'character_image',
             direction: 'south',
-            image_urls: ['https://cdn.test/candidate-1.png', 'https://cdn.test/candidate-2.png'],
+            image_urls: candidateUrls(),
           },
         }),
       ),
@@ -206,16 +211,13 @@ describe('createGenerationApis', () => {
       negative_prompt: '',
       width: 64,
       height: 96,
-      num_images: 2,
+      num_images: 3,
       direction: 'south',
     })
     expect(generation.result).toEqual({
       type: 'first_frame',
       direction: 'south',
-      images: [
-        { url: 'https://cdn.test/candidate-1.png' },
-        { url: 'https://cdn.test/candidate-2.png' },
-      ],
+      images: candidates(),
     })
   })
 
@@ -415,7 +417,7 @@ describe('createGenerationApis', () => {
       result: {
         type: 'character_image',
         direction: 'north',
-        image_urls: ['north-1.png', 'north-2.png'],
+        image_urls: candidateUrls('north'),
       },
     })
     const actionResultMismatch = taskData({
@@ -429,11 +431,11 @@ describe('createGenerationApis', () => {
       },
     })
     const imageInputMismatch = taskData({
-      input_payload: { num_images: 2, direction: 'north' },
+      input_payload: { num_images: 3, direction: 'north' },
       result: {
         type: 'character_image',
         direction: 'north',
-        image_urls: ['north-1.png', 'north-2.png'],
+        image_urls: candidateUrls('north'),
       },
     })
     const actionInputMismatch = taskData({
@@ -455,10 +457,10 @@ describe('createGenerationApis', () => {
       .mockResolvedValueOnce(
         success(
           taskData({
-            input_payload: { num_images: 2 },
+            input_payload: { num_images: 3 },
             result: {
               type: 'character_image',
-              image_urls: ['legacy-1.png', 'legacy-2.png'],
+              image_urls: candidateUrls('legacy'),
             },
           }),
         ),
@@ -491,11 +493,11 @@ describe('createGenerationApis', () => {
       .mockResolvedValueOnce(
         success(
           taskData({
-            input_payload: { num_images: 2, direction: 'north' },
+            input_payload: { num_images: 3, direction: 'north' },
             result: {
               type: 'character_image',
               direction: 'north',
-              image_urls: ['north-1.png', 'north-2.png'],
+              image_urls: candidateUrls('north'),
             },
           }),
         ),
@@ -529,7 +531,7 @@ describe('createGenerationApis', () => {
       )
       .mockResolvedValueOnce(success(taskData({ input_payload: null })))
       .mockResolvedValueOnce(
-        success(taskData({ input_payload: { num_images: 2, direction: 'up' } })),
+        success(taskData({ input_payload: { num_images: 3, direction: 'up' } })),
       )
     const apis = createGenerationApis({
       transport: { request, stream: vi.fn(() => vi.fn()) },
@@ -1010,13 +1012,13 @@ describe('createGenerationApis', () => {
     ['输入对象', { input_payload: [] }, '生成任务 input_payload 无效'],
     ['结果对象', { result: [] }, '生成任务 result 无效'],
     ['错误字段', { error_message: 1 }, '生成任务 error_message 无效'],
-    ['任务输入', { input_payload: { num_images: 4 } }, 'num_images 必须为 2'],
+    ['任务输入', { input_payload: { num_images: 4 } }, 'num_images 必须为 3'],
     [
       '图片结果类型',
       { result: { type: 'video', image_urls: ['a', 'b', 'c'] } },
       '角色图片结果 type 无效',
     ],
-    ['图片数量', { result: { type: 'character_image', image_urls: ['a'] } }, '必须包含 2 个候选'],
+    ['图片数量', { result: { type: 'character_image', image_urls: ['a'] } }, '必须包含 3 个候选'],
     ['完成结果', { result: null }, '完成任务缺少 result'],
   ])('校验%s', async (_label, overrides, message) => {
     const apis = createGenerationApis({
@@ -1187,7 +1189,7 @@ describe('createGenerationApis', () => {
     )
   })
 
-  it('按显式阶段恢复图片任务为两张动作首帧候选', async () => {
+  it('按显式阶段恢复图片任务为三张动作首帧候选', async () => {
     const request = vi.fn().mockResolvedValueOnce(success(taskData()))
     const apis = createGenerationApis({
       transport: { request, stream: vi.fn(() => vi.fn()) },
@@ -1199,15 +1201,12 @@ describe('createGenerationApis', () => {
       type: 'first_frame',
       result: {
         type: 'first_frame',
-        images: [
-          { url: 'https://cdn.test/candidate-1.png' },
-          { url: 'https://cdn.test/candidate-2.png' },
-        ],
+        images: candidates(),
       },
     })
   })
 
-  it('订阅图片任务时按首帧阶段映射两张候选', () => {
+  it('订阅图片任务时按首帧阶段映射三张候选', () => {
     let streamOptions: EventStreamOptions | undefined
     const onEvent = vi.fn()
     const apis = createGenerationApis({
@@ -1229,10 +1228,7 @@ describe('createGenerationApis', () => {
       status: 'completed',
       result: {
         type: 'first_frame',
-        images: [
-          { url: 'https://cdn.test/candidate-1.png' },
-          { url: 'https://cdn.test/candidate-2.png' },
-        ],
+        images: candidates(),
       },
       error: null,
     })

--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -19,6 +19,10 @@ function candidateUrls(prefix = 'https://cdn.test/candidate') {
   return [1, 2, 3].map((index) => `${prefix}-${index}.png`)
 }
 
+function candidateUrlsForCount(count: number, prefix = 'https://cdn.test/candidate') {
+  return Array.from({ length: count }, (_, index) => `${prefix}-${index + 1}.png`)
+}
+
 function candidates(prefix?: string) {
   return candidateUrls(prefix).map((url) => ({ url }))
 }
@@ -137,6 +141,61 @@ describe('createGenerationApis', () => {
       direction: 'north_east',
       images: candidates(),
     })
+  })
+
+  it.each([1, 2, 3, 4] as const)('允许调用方显式请求 %i 张图片候选', async (candidateCount) => {
+    const request = vi.fn(async (_url: string, _init?: RequestInit) =>
+      success(
+        taskData({
+          input_payload: { num_images: candidateCount, direction: 'east' },
+          result: {
+            type: 'character_image',
+            direction: 'east',
+            image_urls: candidateUrlsForCount(candidateCount),
+          },
+        }),
+      ),
+    )
+    const apis = createGenerationApis({
+      transport: { request, stream: vi.fn(() => vi.fn()) },
+    })
+
+    const generation = await apis.create({
+      type: 'character_template',
+      projectId: '42',
+      referenceMedia: [],
+      prompt: 'pixel hero',
+      spriteWidth: 64,
+      spriteHeight: 64,
+      candidateCount,
+    })
+
+    expect(JSON.parse(String(request.mock.calls[0]?.[1]?.body))).toMatchObject({
+      num_images: candidateCount,
+    })
+    expect(
+      generation.result?.type === 'character_template' && generation.result.images,
+    ).toHaveLength(candidateCount)
+  })
+
+  it.each([0, 5, 1.5])('创建图片任务时拒绝候选数量 %s', async (candidateCount) => {
+    const request = vi.fn()
+    const apis = createGenerationApis({
+      transport: { request, stream: vi.fn(() => vi.fn()) },
+    })
+
+    await expect(
+      apis.create({
+        type: 'character_template',
+        projectId: '42',
+        referenceMedia: [],
+        prompt: 'pixel hero',
+        spriteWidth: 64,
+        spriteHeight: 64,
+        candidateCount: candidateCount as 1,
+      }),
+    ).rejects.toThrow('candidateCount 必须是 1 到 4 之间的整数')
+    expect(request).not.toHaveBeenCalled()
   })
 
   it('未指定方向时用 east 创建兼容的角色母版任务', async () => {
@@ -580,6 +639,92 @@ describe('createGenerationApis', () => {
     )
   })
 
+  it.each([1, 2, 3, 4] as const)('恢复声明生成 %i 张候选的历史图片任务', async (count) => {
+    const request = vi.fn(async () =>
+      success(
+        taskData({
+          input_payload: { num_images: count, direction: 'east' },
+          result: {
+            type: 'character_image',
+            direction: 'east',
+            image_urls: candidateUrlsForCount(count),
+          },
+        }),
+      ),
+    )
+    const apis = createGenerationApis({
+      transport: { request, stream: vi.fn(() => vi.fn()) },
+    })
+
+    const generation = await apis.get('42', '91', { type: 'character_template' })
+
+    expect(
+      generation.result?.type === 'character_template' && generation.result.images,
+    ).toHaveLength(count)
+  })
+
+  it('拒绝图片结果数量与任务声明不一致', async () => {
+    const request = vi.fn(async () =>
+      success(
+        taskData({
+          input_payload: { num_images: 2, direction: 'east' },
+          result: {
+            type: 'character_image',
+            direction: 'east',
+            image_urls: candidateUrlsForCount(3),
+          },
+        }),
+      ),
+    )
+    const apis = createGenerationApis({
+      transport: { request, stream: vi.fn(() => vi.fn()) },
+    })
+
+    await expect(apis.get('42', '91', { type: 'character_template' })).rejects.toThrow(
+      '角色母版结果数量必须与 input_payload.num_images 2 一致',
+    )
+  })
+
+  it('查询后按缓存数量恢复未携带 input_payload 的 SSE 结果', async () => {
+    let streamOptions: EventStreamOptions | undefined
+    const request = vi.fn(async () =>
+      success(
+        taskData({
+          status: 'running',
+          input_payload: { num_images: 2, direction: 'east' },
+          result: null,
+        }),
+      ),
+    )
+    const apis = createGenerationApis({
+      transport: {
+        request,
+        stream: vi.fn((_url: string, options: NonNullable<typeof streamOptions>) => {
+          streamOptions = options
+          return vi.fn()
+        }),
+      },
+    })
+    await apis.get('42', '91', { type: 'character_template' })
+    const onEvent = vi.fn()
+    apis.subscribe('42', '91', onEvent)
+    const event = taskData({
+      input_payload: undefined,
+      result: {
+        type: 'character_image',
+        direction: 'east',
+        image_urls: candidateUrlsForCount(2),
+      },
+    })
+
+    expect(() => streamOptions?.onEvent(JSON.stringify(event), 'completed')).not.toThrow()
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: expect.objectContaining({ images: candidates().slice(0, 2) }),
+      }),
+    )
+  })
+
   it('订阅 task_update，映射终态并把终态关闭信号交给流传输层', () => {
     let subscribedUrl = ''
     let streamOptions: EventStreamOptions | undefined
@@ -1012,13 +1157,17 @@ describe('createGenerationApis', () => {
     ['输入对象', { input_payload: [] }, '生成任务 input_payload 无效'],
     ['结果对象', { result: [] }, '生成任务 result 无效'],
     ['错误字段', { error_message: 1 }, '生成任务 error_message 无效'],
-    ['任务输入', { input_payload: { num_images: 4 } }, 'num_images 必须为 3'],
+    ['任务输入', { input_payload: { num_images: 5 } }, 'num_images 必须是 1 到 4 之间的整数'],
     [
       '图片结果类型',
       { result: { type: 'video', image_urls: ['a', 'b', 'c'] } },
       '角色图片结果 type 无效',
     ],
-    ['图片数量', { result: { type: 'character_image', image_urls: ['a'] } }, '必须包含 3 个候选'],
+    [
+      '图片数量',
+      { result: { type: 'character_image', image_urls: ['a'] } },
+      '结果数量必须与 input_payload.num_images 3 一致',
+    ],
     ['完成结果', { result: null }, '完成任务缺少 result'],
   ])('校验%s', async (_label, overrides, message) => {
     const apis = createGenerationApis({

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -173,7 +173,7 @@ function expectedBackendType(type: GenerationType): BackendGenerationType {
   return type === 'complete_animation' ? 'character_action' : 'character_image'
 }
 
-export const IMAGE_CANDIDATE_COUNT = 2
+export const IMAGE_CANDIDATE_COUNT = 3
 
 const DEFAULT_DIRECTION: ActionDirection = 'east'
 
@@ -600,7 +600,7 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
         negative_prompt: '',
         width: inputPositiveInteger(input.spriteWidth, 'spriteWidth'),
         height: inputPositiveInteger(input.spriteHeight, 'spriteHeight'),
-        // 角色母版和动作首帧都由一次图片任务生成两张候选。
+        // 角色母版和动作首帧都由一次图片任务生成三张候选。
         num_images: IMAGE_CANDIDATE_COUNT,
         direction: input.direction ?? DEFAULT_DIRECTION,
       })

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -20,6 +20,7 @@ import type {
   GenerationInput,
   GenerationResult,
   GenerationType,
+  ImageCandidateCount,
   TaskStatus,
 } from '.'
 import { isActionDirection, type ActionDirection } from '@/entities/character/directions'
@@ -174,6 +175,23 @@ function expectedBackendType(type: GenerationType): BackendGenerationType {
 }
 
 export const IMAGE_CANDIDATE_COUNT = 3
+const MIN_IMAGE_CANDIDATE_COUNT = 1
+const MAX_IMAGE_CANDIDATE_COUNT = 4
+
+export function isImageCandidateCount(value: unknown): value is ImageCandidateCount {
+  return (
+    Number.isSafeInteger(value) &&
+    (value as number) >= MIN_IMAGE_CANDIDATE_COUNT &&
+    (value as number) <= MAX_IMAGE_CANDIDATE_COUNT
+  )
+}
+
+function imageCandidateCount(value: unknown, field: string, code = 0): ImageCandidateCount {
+  if (!isImageCandidateCount(value)) {
+    throw new GenerationApiError(`${field} 必须是 1 到 4 之间的整数`, code)
+  }
+  return value
+}
 
 const DEFAULT_DIRECTION: ActionDirection = 'east'
 
@@ -193,6 +211,7 @@ function nonEmptyString(value: unknown, field: string): string {
 function mapImageResult(
   result: Record<string, unknown>,
   expectation: Extract<GenerationExpectation, { type: 'character_template' | 'first_frame' }>,
+  expectedCandidateCount?: ImageCandidateCount,
 ): GenerationResult {
   if (result.type !== 'character_image') {
     throw new GenerationApiError('角色图片结果 type 无效', 200)
@@ -210,9 +229,15 @@ function mapImageResult(
   }
   const images = result.image_urls.map((url): GeneratedImage => ({ url: url as string }))
 
-  if (images.length !== IMAGE_CANDIDATE_COUNT) {
+  if (!isImageCandidateCount(images.length)) {
     throw new GenerationApiError(
-      `${expectation.type === 'first_frame' ? '动作首帧' : '角色母版'}结果必须包含 ${IMAGE_CANDIDATE_COUNT} 个候选`,
+      `${expectation.type === 'first_frame' ? '动作首帧' : '角色母版'}结果必须包含 1 到 4 个候选`,
+      200,
+    )
+  }
+  if (expectedCandidateCount !== undefined && images.length !== expectedCandidateCount) {
+    throw new GenerationApiError(
+      `${expectation.type === 'first_frame' ? '动作首帧' : '角色母版'}结果数量必须与 input_payload.num_images ${expectedCandidateCount} 一致`,
       200,
     )
   }
@@ -290,6 +315,7 @@ function mapResult(
   result: Record<string, unknown> | null,
   status: TaskStatus,
   expectation: GenerationExpectation,
+  expectedCandidateCount?: ImageCandidateCount,
 ): GenerationResult | null {
   if (status !== 'completed') {
     if (result !== null) {
@@ -300,7 +326,7 @@ function mapResult(
   if (result === null) throw new GenerationApiError('完成任务缺少 result', 200)
   return expectation.type === 'complete_animation'
     ? mapActionResult(result, expectation)
-    : mapImageResult(result, expectation)
+    : mapImageResult(result, expectation, expectedCandidateCount)
 }
 
 function validateStatusError(status: TaskStatus, error: string | null): void {
@@ -318,14 +344,16 @@ function validateStatusError(status: TaskStatus, error: string | null): void {
 function validateInputPayload(
   inputPayload: Record<string, unknown> | null,
   expectation: GenerationExpectation,
-): void {
+  expectedCandidateCount?: ImageCandidateCount,
+): ImageCandidateCount | undefined {
   if (inputPayload === null) {
     throw new GenerationApiError('生成任务缺少 input_payload', 200)
   }
   if (expectation.type !== 'complete_animation') {
-    if (inputPayload.num_images !== IMAGE_CANDIDATE_COUNT) {
+    const candidateCount = imageCandidateCount(inputPayload.num_images, '生成任务 num_images', 200)
+    if (expectedCandidateCount !== undefined && candidateCount !== expectedCandidateCount) {
       throw new GenerationApiError(
-        `${expectation.type === 'first_frame' ? '动作首帧' : '角色母版'}任务 input_payload.num_images 必须为 ${IMAGE_CANDIDATE_COUNT}`,
+        `${expectation.type === 'first_frame' ? '动作首帧' : '角色母版'}任务 input_payload.num_images 与请求的 ${expectedCandidateCount} 不一致`,
         200,
       )
     }
@@ -335,7 +363,7 @@ function validateInputPayload(
         throw new GenerationApiError('生成任务 direction 与请求不一致', 200)
       }
     }
-    return
+    return candidateCount
   }
   const expectedFrameCount = 32
   if (inputPayload.num_frames !== expectedFrameCount) {
@@ -353,6 +381,7 @@ function validateInputPayload(
       throw new GenerationApiError('生成任务 direction 与请求不一致', 200)
     }
   }
+  return undefined
 }
 
 function inferExpectation(dto: GenerationTaskDto): GenerationExpectation {
@@ -384,7 +413,8 @@ function validateTaskIdentity(
   expectedProjectId: number,
   expectation: GenerationExpectation,
   expectedTaskId?: number,
-): void {
+  expectedCandidateCount?: ImageCandidateCount,
+): ImageCandidateCount | undefined {
   if (dto.projectId !== expectedProjectId) {
     throw new GenerationApiError(`生成任务未归属请求中的项目 ${expectedProjectId}`, 200)
   }
@@ -395,7 +425,7 @@ function validateTaskIdentity(
     throw new GenerationApiError(`生成任务类型与 ${expectation.type} 不匹配`, 200)
   }
   validateStatusError(dto.status, dto.errorMessage)
-  validateInputPayload(dto.inputPayload, expectation)
+  return validateInputPayload(dto.inputPayload, expectation, expectedCandidateCount)
 }
 
 function mapTask(
@@ -403,17 +433,27 @@ function mapTask(
   expectedProjectId: number,
   expectation?: GenerationExpectation,
   expectedTaskId?: number,
-): Generation {
+  expectedCandidateCount?: ImageCandidateCount,
+): { generation: Generation; candidateCount?: ImageCandidateCount } {
   const dto = parseTaskDto(value)
   const resolvedExpectation = expectation ?? inferExpectation(dto)
-  validateTaskIdentity(dto, expectedProjectId, resolvedExpectation, expectedTaskId)
+  const candidateCount = validateTaskIdentity(
+    dto,
+    expectedProjectId,
+    resolvedExpectation,
+    expectedTaskId,
+    expectedCandidateCount,
+  )
   return {
-    id: String(dto.id),
-    projectId: String(dto.projectId),
-    type: resolvedExpectation.type,
-    status: dto.status,
-    result: mapResult(dto.result, dto.status, resolvedExpectation),
-    error: dto.errorMessage,
+    generation: {
+      id: String(dto.id),
+      projectId: String(dto.projectId),
+      type: resolvedExpectation.type,
+      status: dto.status,
+      result: mapResult(dto.result, dto.status, resolvedExpectation, candidateCount),
+      error: dto.errorMessage,
+    },
+    ...(candidateCount === undefined ? {} : { candidateCount }),
   }
 }
 
@@ -474,6 +514,7 @@ function mapEvent<TType extends GenerationType>(
   expectedTaskId: number,
   expectation: Extract<GenerationExpectation, { type: TType }>,
   eventName: string,
+  expectedCandidateCount?: ImageCandidateCount,
 ): GenerationEvent<TType> {
   if (!isRecord(value)) throw new GenerationApiError('task_update 不是对象', 200)
   const taskId = eventTaskId(value)
@@ -489,9 +530,14 @@ function mapEvent<TType extends GenerationType>(
   ) {
     throw new GenerationApiError('task_update 不属于当前项目', 200)
   }
-  if (value.input_payload !== undefined) {
-    validateInputPayload(dtoNullableRecord(value.input_payload, 'input_payload'), expectation)
-  }
+  const candidateCount =
+    value.input_payload === undefined
+      ? expectedCandidateCount
+      : validateInputPayload(
+          dtoNullableRecord(value.input_payload, 'input_payload'),
+          expectation,
+          expectedCandidateCount,
+        )
   const status = eventStatus(value, eventName)
   const result = value.result === undefined ? null : dtoNullableRecord(value.result, 'result')
   const error =
@@ -503,7 +549,7 @@ function mapEvent<TType extends GenerationType>(
     taskId: String(taskId),
     type: expectation.type,
     status,
-    result: mapResult(result, status, expectation),
+    result: mapResult(result, status, expectation, candidateCount),
     error,
   }
 }
@@ -521,19 +567,27 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
     throw new GenerationApiError('pollIntervalMs 必须是非负数')
   }
   const expectations = new Map<string, GenerationExpectation>()
+  const candidateCounts = new Map<string, ImageCandidateCount>()
 
   async function post<TType extends GenerationType>(
     path: '/generation/image' | '/generation/action',
     projectId: number,
     expectation: Extract<GenerationExpectation, { type: TType }>,
     body: Record<string, unknown>,
+    expectedCandidateCount?: ImageCandidateCount,
   ): Promise<Generation<TType>> {
     const response = await request(endpoint(config.baseUrl, path), {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
     })
-    return mapTask(await readData(response), projectId, expectation) as Generation<TType>
+    return mapTask(
+      await readData(response),
+      projectId,
+      expectation,
+      undefined,
+      expectedCandidateCount,
+    ).generation as Generation<TType>
   }
 
   const apis: GenerationApis = {
@@ -593,18 +647,29 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
       if (input.type === 'first_frame' && !referenceImageUrl) {
         throw new GenerationApiError('动作首帧生成必须提供已确认的角色母版')
       }
-      const generation = await post('/generation/image', projectId, expectation, {
-        project_id: projectId,
-        reference_image_url: referenceImageUrl,
-        prompt: input.prompt ?? '',
-        negative_prompt: '',
-        width: inputPositiveInteger(input.spriteWidth, 'spriteWidth'),
-        height: inputPositiveInteger(input.spriteHeight, 'spriteHeight'),
-        // 角色母版和动作首帧都由一次图片任务生成三张候选。
-        num_images: IMAGE_CANDIDATE_COUNT,
-        direction: input.direction ?? DEFAULT_DIRECTION,
-      })
+      const candidateCount = imageCandidateCount(
+        input.candidateCount ?? IMAGE_CANDIDATE_COUNT,
+        'candidateCount',
+      )
+      const generation = await post(
+        '/generation/image',
+        projectId,
+        expectation,
+        {
+          project_id: projectId,
+          reference_image_url: referenceImageUrl,
+          prompt: input.prompt ?? '',
+          negative_prompt: '',
+          width: inputPositiveInteger(input.spriteWidth, 'spriteWidth'),
+          height: inputPositiveInteger(input.spriteHeight, 'spriteHeight'),
+          // 缺省生成三张；调用方可按后端契约在 1–4 张之间选择。
+          num_images: candidateCount,
+          direction: input.direction ?? DEFAULT_DIRECTION,
+        },
+        candidateCount,
+      )
       expectations.set(generation.id, expectation)
+      candidateCounts.set(generation.id, candidateCount)
       return generation as Generation<T['type']>
     },
 
@@ -624,8 +689,14 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
       )
       const raw = await readData(response)
       const resolvedExpectation = expectation ?? inferExpectation(parseTaskDto(raw))
-      const generation = mapTask(raw, numericProjectId, resolvedExpectation, numericTaskId)
+      const { generation, candidateCount } = mapTask(
+        raw,
+        numericProjectId,
+        resolvedExpectation,
+        numericTaskId,
+      )
       expectations.set(generation.id, resolvedExpectation)
+      if (candidateCount !== undefined) candidateCounts.set(generation.id, candidateCount)
       return generation
     },
 
@@ -651,6 +722,7 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
         typeof expectationOrOnEvent === 'function'
           ? () => undefined
           : (maybeOnError ?? (() => undefined))
+      const expectedCandidateCount = candidateCounts.get(id)
       const pollingController = new AbortController()
       let polling = false
       let stopStream: () => void = () => undefined
@@ -713,6 +785,7 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
               numericTaskId,
               expectation,
               eventName,
+              expectedCandidateCount,
             )
             onEvent(event as GenerationEvent)
             return event.status === 'completed' || event.status === 'failed'

--- a/frontend/src/entities/generation/index.ts
+++ b/frontend/src/entities/generation/index.ts
@@ -26,6 +26,8 @@ export type TaskStatus = 'pending' | 'running' | 'completed' | 'failed'
  */
 export type GenerationType = 'character_template' | 'first_frame' | 'complete_animation'
 
+export type ImageCandidateCount = 1 | 2 | 3 | 4
+
 export type GenerationExpectation =
   | { type: 'character_template'; direction?: ActionDirection }
   | { type: 'first_frame'; actionType: ActionType; direction?: ActionDirection }
@@ -47,6 +49,8 @@ export interface CharacterTemplateGenerationInput extends GenerationInputBase {
   spriteHeight: number
   /** 当前任务生成的真实源方向；旧调用缺省时按 east 兼容。 */
   direction?: ActionDirection
+  /** 每个方向生成的候选数；缺省为 3，后端允许 1–4。 */
+  candidateCount?: ImageCandidateCount
 }
 
 /** 基于已确认角色母版生成动作首帧候选图。 */
@@ -60,6 +64,8 @@ export interface FirstFrameGenerationInput extends GenerationInputBase {
   spriteHeight: number
   /** 首帧必须与角色母版使用同一个真实源方向。 */
   direction?: ActionDirection
+  /** 每个方向生成的候选数；缺省为 3，后端允许 1–4。 */
+  candidateCount?: ImageCandidateCount
 }
 
 /** 以已确认首帧为起点生成完整动画。 */
@@ -113,7 +119,7 @@ export interface CharacterTemplateGenerationResult {
 
 export interface FirstFrameGenerationResult {
   type: 'first_frame'
-  /** 同一图片任务生成的两张动作首帧候选。 */
+  /** 同一图片任务生成的 1–4 张动作首帧候选。 */
   direction?: ActionDirection
   images: readonly GeneratedImage[]
 }

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -80,6 +80,7 @@ export {
   createGenerationApis,
   GenerationApiError,
   IMAGE_CANDIDATE_COUNT,
+  isImageCandidateCount,
 } from './generation/api'
 export type {
   CharacterTemplateGenerationInput,
@@ -97,6 +98,7 @@ export type {
   GenerationResult,
   GenerationResultFor,
   GenerationType,
+  ImageCandidateCount,
   TaskStatus,
 } from './generation'
 export type { GenerationApiConfig, GenerationTransport } from './generation/api'

--- a/frontend/src/features/workflow-controller/README.md
+++ b/frontend/src/features/workflow-controller/README.md
@@ -34,7 +34,7 @@ async function generateCharacter() {
 - `entities/workflow-run` 定义纯数据和异步 CRUD，不包含推进方法。
 - Controller 根据 `dependsOnNodeIds` 解锁节点，允许同一依赖下的多个 Action 并行。
 - 新增 Action 一次创建动作首帧、动作生成方式、完整动画和审核四个 node，不会遗漏路线选择或用数组位置猜关系。
-- 动作首帧按项目的真实源方向分别调用图片 Generation，每个方向生成两张候选；用户为全部真实方向各确认一张后，完整动画节点才使用对应首帧调用 32 帧动作 Generation。可水平镜像的方向只保存关系，不创建重复任务。
+- 动作首帧按项目的真实源方向分别调用图片 Generation，每个方向生成三张候选；用户为全部真实方向各确认一张后，完整动画节点才使用对应首帧调用 32 帧动作 Generation。可水平镜像的方向只保存关系，不创建重复任务。
 - Controller 方法与后端 Generation、WorkflowRun node 使用同一概念名：`characterTemplate`、`firstFrame`、`completeAnimation` 和 `review`，不再为同一概念保留另一套叫法。
 - 当前视频裁剪路线继续调用既有 Generation；3D 转 2D 选择会随 WorkflowRun 落库，但接口提供前明确阻止生成。
 - Generation 通过 `nodeId + taskId` 写回；节点重做后，旧任务的迟到结果会被丢弃。

--- a/frontend/src/features/workflow-controller/README.md
+++ b/frontend/src/features/workflow-controller/README.md
@@ -34,7 +34,7 @@ async function generateCharacter() {
 - `entities/workflow-run` 定义纯数据和异步 CRUD，不包含推进方法。
 - Controller 根据 `dependsOnNodeIds` 解锁节点，允许同一依赖下的多个 Action 并行。
 - 新增 Action 一次创建动作首帧、动作生成方式、完整动画和审核四个 node，不会遗漏路线选择或用数组位置猜关系。
-- 动作首帧按项目的真实源方向分别调用图片 Generation，每个方向生成三张候选；用户为全部真实方向各确认一张后，完整动画节点才使用对应首帧调用 32 帧动作 Generation。可水平镜像的方向只保存关系，不创建重复任务。
+- 动作首帧按项目的真实源方向分别调用图片 Generation，每个方向默认生成三张候选，也可按调用场景在 1–4 张间调整；用户为全部真实方向各确认一张后，完整动画节点才使用对应首帧调用 32 帧动作 Generation。可水平镜像的方向只保存关系，不创建重复任务。
 - Controller 方法与后端 Generation、WorkflowRun node 使用同一概念名：`characterTemplate`、`firstFrame`、`completeAnimation` 和 `review`，不再为同一概念保留另一套叫法。
 - 当前视频裁剪路线继续调用既有 Generation；3D 转 2D 选择会随 WorkflowRun 落库，但接口提供前明确阻止生成。
 - Generation 通过 `nodeId + taskId` 写回；节点重做后，旧任务的迟到结果会被丢弃。

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -2471,6 +2471,31 @@ describe('WorkflowController', () => {
     expect(controller.getWorkflow().nodes[1].phase).toBe('selecting')
   })
 
+  it('刷新后恢复历史双候选角色母版任务', async () => {
+    const { controller, generation } = createController()
+    await controller.generateCharacterTemplate('setup-1', { spriteWidth: 64, spriteHeight: 64 })
+    await controller.interrupt()
+    generation.snapshots.set('task-1', {
+      id: 'task-1',
+      projectId: '1',
+      type: 'character_template',
+      status: 'completed',
+      result: {
+        type: 'character_template',
+        images: [{ url: 'https://img/legacy-1.png' }, { url: 'https://img/legacy-2.png' }],
+      },
+      error: null,
+    })
+
+    await controller.resume()
+
+    expect(controller.getWorkflow().nodes[1]).toMatchObject({
+      status: 'active',
+      phase: 'selecting',
+      error: null,
+    })
+  })
+
   it('首帧订阅后的补偿查询沿用节点的图片结果预期', async () => {
     const run = createRun([...completedCharacterNodes(), ...actionNodes()])
     const workflow = createWorkflowApis(run)
@@ -3082,7 +3107,7 @@ describe('WorkflowController', () => {
     })
   })
 
-  it('角色母版节点拒绝候选数量不足的结果', async () => {
+  it('角色母版节点拒绝没有候选的结果', async () => {
     const run = createRun([
       setupNode({ status: 'passed', phase: 'completed' }),
       templateNode({
@@ -3101,7 +3126,7 @@ describe('WorkflowController', () => {
         projectId: '1',
         type: 'character_template',
         status: 'completed',
-        result: { type: 'character_template', images: [{ url: 'only-one.png' }] },
+        result: { type: 'character_template', images: [] },
         error: null,
       },
     })

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -253,6 +253,10 @@ function completedAnimationEvent(taskId = 'task-2'): GenerationEvent {
   }
 }
 
+function imageCandidates(prefix: string) {
+  return [1, 2, 3].map((index) => ({ url: `${prefix}-${index}.png` }))
+}
+
 async function flushAsyncWork() {
   await new Promise((resolve) => setTimeout(resolve, 0))
 }
@@ -430,7 +434,7 @@ describe('WorkflowController', () => {
       status: 'completed',
       result: {
         type: 'character_template',
-        images: [{ url: 'https://img/knight-1.png' }, { url: 'https://img/knight-2.png' }],
+        images: imageCandidates('https://img/knight'),
       },
       error: null,
     })
@@ -874,7 +878,7 @@ describe('WorkflowController', () => {
       status: 'completed',
       result: {
         type: 'character_template',
-        images: [{ url: 'https://img/knight-1.png' }, { url: 'https://img/knight-2.png' }],
+        images: imageCandidates('https://img/knight'),
       },
       error: null,
     })
@@ -936,7 +940,7 @@ describe('WorkflowController', () => {
   it.each([
     ['four-way', ['east', 'north', 'south']],
     ['eight-way', ['east', 'north', 'south', 'north_east', 'south_east']],
-  ] as const)('按项目方向为 %s 创建独立的两张候选任务', async (movement, directions) => {
+  ] as const)('按项目方向为 %s 创建独立的三张候选任务', async (movement, directions) => {
     const { controller, generation } = createController(createRun(), movement)
 
     await controller.generateCharacterTemplate('setup-1', {
@@ -953,7 +957,7 @@ describe('WorkflowController', () => {
         result: {
           type: 'character_template',
           direction,
-          images: [{ url: `${direction}-1.png` }, { url: `${direction}-2.png` }],
+          images: imageCandidates(direction),
         },
         error: null,
       })
@@ -1000,7 +1004,7 @@ describe('WorkflowController', () => {
         result: {
           type: 'first_frame',
           direction: direction as 'east' | 'north' | 'south',
-          images: [{ url: `${direction}-1.png` }, { url: `${direction}-2.png` }],
+          images: imageCandidates(direction),
         },
         error: null,
       })
@@ -2406,7 +2410,7 @@ describe('WorkflowController', () => {
       status: 'completed',
       result: {
         type: 'character_template',
-        images: [{ url: 'https://img/knight-1.png' }, { url: 'https://img/knight-2.png' }],
+        images: imageCandidates('https://img/knight'),
       },
       error: null,
     }
@@ -2456,7 +2460,7 @@ describe('WorkflowController', () => {
       status: 'completed',
       result: {
         type: 'character_template',
-        images: [{ url: 'https://img/knight-1.png' }, { url: 'https://img/knight-2.png' }],
+        images: imageCandidates('https://img/knight'),
       },
       error: null,
     })
@@ -2477,7 +2481,7 @@ describe('WorkflowController', () => {
       status: 'completed',
       result: {
         type: 'first_frame',
-        images: [{ url: 'https://img/walk-1.png' }, { url: 'https://img/walk-2.png' }],
+        images: imageCandidates('https://img/walk'),
       },
       error: null,
     }
@@ -3214,7 +3218,7 @@ describe('WorkflowController', () => {
         status: 'completed',
         result: {
           type: 'first_frame',
-          images: [{ url: 'jump-1.png' }, { url: 'jump-2.png' }],
+          images: imageCandidates('jump'),
         },
         error: null,
       },
@@ -3242,7 +3246,11 @@ describe('WorkflowController', () => {
       status: 'completed',
       result: {
         type: 'first_frame',
-        images: [{ url: 'https://img/first.png' }, { url: 'https://img/first-2.png' }],
+        images: [
+          { url: 'https://img/first.png' },
+          { url: 'https://img/first-2.png' },
+          { url: 'https://img/first-3.png' },
+        ],
       },
       error: null,
     })

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -30,7 +30,7 @@ import type {
 } from '@/entities'
 import {
   getDirectionProfile,
-  IMAGE_CANDIDATE_COUNT,
+  isImageCandidateCount,
   ProjectNameConflictError,
   WorkflowRunConflictError,
 } from '@/entities'
@@ -1860,7 +1860,7 @@ function generationResultError(node: WorkflowNode, generation: Generation): stri
   if (node.type === 'character-template') {
     return generation.type === 'character_template' &&
       generation.result?.type === 'character_template' &&
-      generation.result.images.length === IMAGE_CANDIDATE_COUNT
+      isImageCandidateCount(generation.result.images.length)
       ? null
       : '角色候选图结果格式无效'
   }
@@ -1868,7 +1868,7 @@ function generationResultError(node: WorkflowNode, generation: Generation): stri
   if (node.type === 'action-first-frame') {
     return generation.type === 'first_frame' &&
       generation.result?.type === 'first_frame' &&
-      generation.result.images.length === IMAGE_CANDIDATE_COUNT &&
+      isImageCandidateCount(generation.result.images.length) &&
       generation.result.images.every((image) => Boolean(image.url))
       ? null
       : '动作首帧结果格式无效'

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -1507,7 +1507,11 @@ describe('createQuickStartService', () => {
                 status: 'completed' as const,
                 result: {
                   type: 'character_template' as const,
-                  images: [{ url: 'candidate.png' }, { url: 'candidate-2.png' }],
+                  images: [
+                    { url: 'candidate.png' },
+                    { url: 'candidate-2.png' },
+                    { url: 'candidate-3.png' },
+                  ],
                 },
                 error: null,
               }
@@ -1562,6 +1566,7 @@ describe('createQuickStartService', () => {
       await expect(started.getTemplateCandidates()).resolves.toEqual([
         { direction: 'east', index: 0, imageUrl: 'candidate.png' },
         { direction: 'east', index: 1, imageUrl: 'candidate-2.png' },
+        { direction: 'east', index: 2, imageUrl: 'candidate-3.png' },
       ])
     })
 
@@ -1616,6 +1621,7 @@ describe('createQuickStartService', () => {
                   images: [
                     { url: `${direction}-${input.type}-1.png` },
                     { url: `${direction}-${input.type}-2.png` },
+                    { url: `${direction}-${input.type}-3.png` },
                   ],
                 },
                 error: null,
@@ -1652,10 +1658,13 @@ describe('createQuickStartService', () => {
       await expect(session.getTemplateCandidates()).resolves.toEqual([
         { direction: 'east', index: 0, imageUrl: 'east-character_template-1.png' },
         { direction: 'east', index: 1, imageUrl: 'east-character_template-2.png' },
+        { direction: 'east', index: 2, imageUrl: 'east-character_template-3.png' },
         { direction: 'north', index: 0, imageUrl: 'north-character_template-1.png' },
         { direction: 'north', index: 1, imageUrl: 'north-character_template-2.png' },
+        { direction: 'north', index: 2, imageUrl: 'north-character_template-3.png' },
         { direction: 'south', index: 0, imageUrl: 'south-character_template-1.png' },
         { direction: 'south', index: 1, imageUrl: 'south-character_template-2.png' },
+        { direction: 'south', index: 2, imageUrl: 'south-character_template-3.png' },
       ])
     })
     const selectedTemplates = {
@@ -1685,10 +1694,13 @@ describe('createQuickStartService', () => {
       await expect(session.getFirstFrameCandidates()).resolves.toEqual([
         { direction: 'east', index: 0, imageUrl: 'east-first_frame-1.png' },
         { direction: 'east', index: 1, imageUrl: 'east-first_frame-2.png' },
+        { direction: 'east', index: 2, imageUrl: 'east-first_frame-3.png' },
         { direction: 'north', index: 0, imageUrl: 'north-first_frame-1.png' },
         { direction: 'north', index: 1, imageUrl: 'north-first_frame-2.png' },
+        { direction: 'north', index: 2, imageUrl: 'north-first_frame-3.png' },
         { direction: 'south', index: 0, imageUrl: 'south-first_frame-1.png' },
         { direction: 'south', index: 1, imageUrl: 'south-first_frame-2.png' },
+        { direction: 'south', index: 2, imageUrl: 'south-first_frame-3.png' },
       ])
     })
     expect(

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -981,7 +981,7 @@ describe('createDefaultRealWorkflowEditorSession', () => {
           project_id: 1,
           task_type: 'character_image',
           status: 'failed',
-          input_payload: { num_images: 2 },
+          input_payload: { num_images: 3 },
           result: null,
           error_message: 'provider unavailable',
         })


### PR DESCRIPTION
## 问题

#467 合并后把前端图片候选默认值从 3 改成了 2，导致角色母版和动作首帧再次偏离 #471。与此同时，历史任务及其他调用场景仍可能按后端契约生成 1–4 张候选，读取与恢复不能把数量写死为 3。

## 改动

- 将前端角色母版和动作首帧的默认候选数恢复为 3。
- 对调用方开放 `candidateCount`，可显式指定 1–4 张。
- GET、SSE、轮询及工作流恢复接受 1–4 张历史结果，并严格校验结果数量与 `input_payload.num_images` 一致。
- 对齐单向、四向、八向及历史双候选恢复测试。
- 后端保持 `num_images` 默认 3、允许 1–4，本 PR 不改后端。
- 未包含压缩包、构建产物、内部方案文档或其他 PR 的改动。

## 验证

- Generation API 与 WorkflowController：174 项测试通过。
- 全量覆盖率验证：排除一个 `main` 上已有的 Windows 路径分隔符边界测试后，970 项全部通过；语句覆盖率 93.30%。
- `npm run lint`、`npm run typecheck`、`npm run build` 通过。
- 修改文件格式检查通过。

Closes #471