### PR TITLE
feat(quick-start): connect agent chat to generation flow

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -208,6 +208,12 @@ function renderAt(
   )
 }
 
+async function confirmAgentGeneration() {
+  const send = await screen.findByRole('button', { name: '发送生成' })
+  fireEvent.click(send)
+  await act(async () => undefined)
+}
+
 function renderWithRunSwitcher(
   service: QuickStartEntryService,
   initialRunId: string,
@@ -505,7 +511,7 @@ describe('QuickStartPage', () => {
     expect(readActiveRun('7')).toBeNull()
   })
 
-  it('presents Agent replies as restrained product copy without display typography or avatars', async () => {
+  it('reuses generation-copy typography and blur reveal for Agent replies without avatars', async () => {
     renderStateFixture('action-generating')
 
     const transcript = await screen.findByTestId('quick-start-transcript')
@@ -517,12 +523,83 @@ describe('QuickStartPage', () => {
     expect(agentCopies.length).toBeGreaterThan(0)
     expect(
       agentCopies.every((copy) => {
+        const motion = copy.querySelector<HTMLElement>('[data-copy-motion-mode="characters"]')
         return (
-          copy.className.includes('font-sans') && !copy.querySelector('[data-copy-motion-mode]')
+          copy.className.includes('font-serif') &&
+          copy.className.includes('generation-progress-copy--conversation') &&
+          motion &&
+          !motion.className.includes('generation-progress-copy') &&
+          copy.querySelectorAll('.kinetic-copy-character').length > 0 &&
+          copy.querySelectorAll('[data-agent-character]').length === 0
         )
       }),
     ).toBe(true)
     expect(standaloneAvatar).toBeUndefined()
+  })
+
+  it('persists real Agent turns on the frontend without a demo route or WorkflowRun turns', async () => {
+    const service = serviceFor(null)
+    const planner = vi.fn(async () => ({
+      text: '可以。你最想保留哪个外观特征？',
+      finishReason: 'stop',
+      toolCalls: [],
+    }))
+    const agent = agentFor({ planner })
+    const firstView = renderAt('/quick-start?demo=conversation', service, agent)
+
+    expect(screen.queryByText('MOCK 演示')).toBeNull()
+    expect(screen.getByRole('textbox', { name: '创作指令' })).toBeTruthy()
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '我想做一个住在云端的机械师。' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+
+    expect(await screen.findByText('我想做一个住在云端的机械师。')).toBeTruthy()
+    expect(await screen.findByText('可以。你最想保留哪个外观特征？')).toBeTruthy()
+    expect(planner).toHaveBeenCalledTimes(1)
+    const persistedAgentChat = window.localStorage.getItem('windup.quick-start.agent-chat.v1:7')
+    expect(persistedAgentChat).toContain('我想做一个住在云端的机械师。')
+    expect(persistedAgentChat).toContain('可以。你最想保留哪个外观特征？')
+    expect(persistedAgentChat).not.toContain('勾勒角色轮廓')
+
+    firstView.unmount()
+    renderAt('/quick-start', service, agent)
+
+    expect(screen.getByText('我想做一个住在云端的机械师。')).toBeTruthy()
+    expect(screen.getByText('可以。你最想保留哪个外观特征？')).toBeTruthy()
+  })
+
+  it('rewrites the real optimized prompt in the composer and waits for explicit generation send', async () => {
+    vi.useFakeTimers()
+    const service = serviceFor(null)
+    const startCharacterGeneration = vi.fn(() => new Promise<{ runId: string }>(() => undefined))
+    const agent = agentFor({ startCharacterGeneration })
+    renderAt('/quick-start', service, agent)
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '云端工坊的银发机械师' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    await act(async () => undefined)
+
+    const composer = screen.getByTestId('quick-start-composer')
+    const input = screen.getByRole('textbox', { name: '创作指令' }) as HTMLInputElement
+    expect(composer.dataset.promptState).toBe('rewriting')
+    const promptRewrite = composer.querySelector('[data-prompt-rewrite]')
+    expect(promptRewrite?.querySelector('[data-copy-motion-mode="characters"]')).toBeTruthy()
+    expect(promptRewrite?.querySelectorAll('.kinetic-copy-character').length).toBeGreaterThan(0)
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+
+    await act(async () => vi.advanceTimersByTimeAsync(760))
+    expect(composer.dataset.promptState).toBe('ready')
+    expect(input.value).toBe('云端工坊的银发机械师')
+    expect(screen.getByRole('button', { name: '发送生成' })).toBeTruthy()
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: '发送生成' }))
+    await act(async () => undefined)
+    expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
   })
 
   it('keeps one persistent Agent shell with a floating composer outside the scrolling transcript', async () => {
@@ -542,6 +619,7 @@ describe('QuickStartPage', () => {
     expect(composer.className).toContain('absolute')
     expect(agentTurns.length).toBeGreaterThanOrEqual(2)
     expect(userTurns.length).toBeGreaterThanOrEqual(2)
+    expect(userTurns.every((turn) => turn.className.includes('w-fit'))).toBe(true)
     expect(transcript.querySelector('[data-agent-identity]')).toBeNull()
   })
 
@@ -770,19 +848,28 @@ describe('QuickStartPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
     await act(async () => undefined)
     expect(screen.getByText('提着风灯的森林守夜人')).toBeTruthy()
-    await act(async () => vi.advanceTimersByTimeAsync(32))
+    expect(screen.getByTestId('quick-start-composer').dataset.promptState).toBe('rewriting')
+    expect(screen.queryByTestId('quick-start-run')).toBeNull()
+
+    await act(async () => vi.advanceTimersByTimeAsync(760))
+    expect(screen.getByRole('button', { name: '发送生成' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '发送生成' }))
+    await act(async () => undefined)
 
     const entry = screen.getByLabelText('创作指令').closest('[data-layout="quick-start-entry"]')
     expect(entry?.getAttribute('data-transition')).toBe('leaving')
-    expect(
-      entry?.querySelector('[data-layout="quick-start-starters"]')?.getAttribute('data-presence'),
-    ).toBe('hidden')
-    expect(screen.queryByTestId('quick-start-transcript')).toBeNull()
+    expect(screen.getByTestId('quick-start-transcript').textContent).toContain(
+      '提着风灯的森林守夜人',
+    )
 
     await act(async () => vi.advanceTimersByTime(459))
-    expect(screen.queryByTestId('quick-start-transcript')).toBeNull()
+    expect(screen.queryByTestId('quick-start-run')).toBeNull()
 
     await act(async () => vi.advanceTimersByTime(1))
+    const runTranscript = screen.getByTestId('quick-start-transcript')
+    expect(runTranscript.textContent).toContain('提着风灯的森林守夜人')
+    expect(runTranscript.querySelector('[data-conversation-kind="agent"]')).toBeTruthy()
+    expect(runTranscript.querySelector('[data-conversation-kind="workflow"]')).toBeTruthy()
     expect(screen.getByRole('img', { name: '角色图生成画布' }).getAttribute('data-reveal')).toBe(
       'generation-canvas',
     )
@@ -934,10 +1021,14 @@ describe('QuickStartPage', () => {
       target: { value: '16-bit 像素风，请直接生成' },
     })
     fireEvent.click(screen.getByRole('button', { name: '继续' }))
-    expect(await screen.findByText('优化后描述')).toBeTruthy()
-    expect(await screen.findByText('银发骑士，16-bit 像素风，全身像')).toBeTruthy()
-    expect(screen.getByText('默认单角色')).toBeTruthy()
-    expect(screen.getByText('动作稍后处理')).toBeTruthy()
+    const optimizedPrompt = (await screen.findByRole('textbox', {
+      name: '创作指令',
+    })) as HTMLInputElement
+    await waitFor(() => expect(optimizedPrompt.value).toBe('银发骑士，16-bit 像素风，全身像'))
+    expect(await screen.findByText(/默认处理：默认单角色、动作稍后处理/u)).toBeTruthy()
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+
+    await confirmAgentGeneration()
     await waitFor(() => expect(startCharacterGeneration).toHaveBeenCalledTimes(1))
 
     action.resolve({ runId: 'run-new' })
@@ -978,6 +1069,8 @@ describe('QuickStartPage', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: '重新开始' }))
 
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+    await confirmAgentGeneration()
     await waitFor(() => expect(startCharacterGeneration).toHaveBeenCalledTimes(1))
     expect(planner.mock.calls[2]?.[0].messages).toEqual([
       { role: 'user', content: '16-bit 银发像素骑士，请直接生成' },
@@ -1014,6 +1107,8 @@ describe('QuickStartPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /16-bit 日式 RPG/u }))
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+    await confirmAgentGeneration()
     await waitFor(() =>
       expect(startCharacterGeneration).toHaveBeenCalledWith({
         prompt: '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',
@@ -1061,6 +1156,7 @@ describe('QuickStartPage', () => {
 
     fireEvent.change(screen.getByLabelText('创作指令'), { target: { value: '像素骑士' } })
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    await confirmAgentGeneration()
 
     await waitFor(() => expect(service.resume).toHaveBeenCalled())
     expect(service.open).toHaveBeenCalledWith('run-new')
@@ -1083,6 +1179,7 @@ describe('QuickStartPage', () => {
     expect(screen.queryByText('hero.png')).toBeNull()
     fireEvent.change(screen.getByLabelText('创作指令'), { target: { value: '骑士' } })
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    await confirmAgentGeneration()
     expect((await screen.findByRole('alert')).textContent).toContain('服务繁忙')
   })
 

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -21,7 +21,7 @@ import {
 import { forgetActiveRun, isMissingActiveRunError, syncActiveRun } from '@/features/active-run'
 import { useOptionalAuthSession } from '@/features/auth-session'
 import { ExportButton, type ExportPackageModel } from '@/features/export-package'
-import { useQuickStartAgent, type QuickStartAgentState } from '@/features/quick-start-agent/react'
+import { useQuickStartAgent } from '@/features/quick-start-agent/react'
 import type { CreateQuickStartAgentOptions } from '@/features/quick-start-agent/runtime'
 import {
   GenerationPreviewCard,
@@ -130,6 +130,60 @@ const ROLE_DEFAULT_MESSAGE: readonly KineticCopyMessage[] = [
 ]
 
 const ENTRY_HANDOFF_MS = 460
+const PROMPT_REWRITE_MS = 760
+const AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v1'
+
+type AgentConversationTurn = {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+type AgentConversationRecord = {
+  runId: string | null
+  turns: readonly AgentConversationTurn[]
+}
+
+function agentConversationStorageKey(userId: string | null): string {
+  return `${AGENT_CONVERSATION_STORAGE_KEY}:${userId ?? 'local'}`
+}
+
+function readAgentConversation(userId: string | null): AgentConversationRecord | null {
+  try {
+    const stored = window.localStorage.getItem(agentConversationStorageKey(userId))
+    if (!stored) return null
+    const parsed: unknown = JSON.parse(stored)
+    if (typeof parsed !== 'object' || parsed === null || !('turns' in parsed)) return null
+    const runId = 'runId' in parsed && typeof parsed.runId === 'string' ? parsed.runId : null
+    if (!Array.isArray(parsed.turns)) return null
+    const turns = parsed.turns.filter(
+      (turn): turn is AgentConversationTurn =>
+        typeof turn === 'object' &&
+        turn !== null &&
+        'role' in turn &&
+        (turn.role === 'user' || turn.role === 'assistant') &&
+        'content' in turn &&
+        typeof turn.content === 'string' &&
+        Boolean(turn.content.trim()),
+    )
+    return turns.length > 0 ? { runId, turns } : null
+  } catch {
+    return null
+  }
+}
+
+function writeAgentConversation(userId: string | null, record: AgentConversationRecord): void {
+  try {
+    window.localStorage.setItem(agentConversationStorageKey(userId), JSON.stringify(record))
+  } catch {
+    // 对话持久化只增强刷新体验，存储不可用时不能阻断真实生成流程。
+  }
+}
+
+function planConfirmationCopy(assumptions: readonly string[]): string {
+  return assumptions.length > 0
+    ? `提示词优化已完成。\n默认处理：${assumptions.join('、')}。确认后点击发送。`
+    : '提示词优化已完成。请检查输入框，确认后点击发送。'
+}
 
 function playtestPath(characterId: string, outfitId: string, actionId?: string): string {
   const path = `/playtest/${encodeURIComponent(characterId)}/${encodeURIComponent(outfitId)}`
@@ -186,7 +240,12 @@ export function QuickStartPage({
       onSessionCreated={setCreatedSession}
     />
   ) : (
-    <QuickStartInput service={activeService} agent={agent} onSessionCreated={setCreatedSession} />
+    <QuickStartInput
+      service={activeService}
+      agent={agent}
+      activeRunUserId={activeRunUserId}
+      onSessionCreated={setCreatedSession}
+    />
   )
 }
 
@@ -272,65 +331,15 @@ function QuickStartActionInput({
   )
 }
 
-function QuickStartAgentInlineState({ state }: { state: QuickStartAgentState }) {
-  if (state.status === 'idle') return null
-  if (state.status === 'planning') {
-    return (
-      <p role="status" className="mb-3 px-1 text-sm text-app-muted">
-        正在判断信息是否足够…
-      </p>
-    )
-  }
-  if (state.status === 'awaiting-input' || state.status === 'restart-required') {
-    return (
-      <p
-        role="status"
-        className="mb-3 rounded-xl border border-app-line bg-app-surface/80 px-4 py-3 text-sm text-app-ink-soft"
-      >
-        {state.message}
-      </p>
-    )
-  }
-  if (state.status === 'error') {
-    return (
-      <p
-        role="alert"
-        className="mb-3 rounded-xl bg-app-danger px-4 py-3 text-sm text-app-danger-soft"
-      >
-        {state.message}
-      </p>
-    )
-  }
-  return (
-    <div
-      role="status"
-      className="mb-3 rounded-xl border border-app-line-strong bg-app-surface/90 px-4 py-3"
-    >
-      <p className="font-mono text-[10px] font-bold tracking-[0.12em] text-app-muted">优化后描述</p>
-      <p className="mt-1 text-sm leading-6 text-app-ink">{state.optimizedPrompt}</p>
-      {state.assumptions.length > 0 ? (
-        <ul className="mt-2 flex flex-wrap gap-1.5" aria-label="本次生成采用的默认假设">
-          {state.assumptions.map((assumption) => (
-            <li
-              key={assumption}
-              className="rounded-md bg-app-surface-muted px-2 py-1 text-xs text-app-muted"
-            >
-              {assumption}
-            </li>
-          ))}
-        </ul>
-      ) : null}
-    </div>
-  )
-}
-
 function QuickStartInput({
   service,
   agent,
+  activeRunUserId,
   onSessionCreated,
 }: {
   service: QuickStartEntryService
   agent: CreateQuickStartAgentOptions
+  activeRunUserId: string | null
   onSessionCreated: (session: QuickStartSession) => void
 }) {
   const navigate = useNavigate()
@@ -338,23 +347,98 @@ function QuickStartInput({
   const [templateFile, setTemplateFile] = useState<File | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [entryTransition, setEntryTransition] = useState<'idle' | 'leaving'>('idle')
+  const [promptState, setPromptState] = useState<
+    'collecting' | 'rewriting' | 'ready' | 'confirmed'
+  >('collecting')
   const [error, setError] = useState<string | null>(null)
+  const [conversationTurns, setConversationTurns] = useState<readonly AgentConversationTurn[]>(
+    () => {
+      const stored = readAgentConversation(activeRunUserId)
+      return stored?.runId === null ? stored.turns : []
+    },
+  )
   const fileInput = useRef<HTMLInputElement>(null)
   const submitAbortController = useRef<AbortController | null>(null)
   const handoffTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const agentSession = useQuickStartAgent(agent)
+  const rewriteTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const generationConfirmation = useRef<(() => void) | null>(null)
+  const conversationTurnsRef = useRef(conversationTurns)
+  const initialConversationLength = useRef(conversationTurns.length)
+  const waitForGenerationConfirmation = useCallback(
+    () =>
+      new Promise<void>((resolve) => {
+        generationConfirmation.current = resolve
+      }),
+    [],
+  )
+  const agentSession = useQuickStartAgent({
+    ...agent,
+    waitForPresentation: waitForGenerationConfirmation,
+  })
   const unavailableReason = service.unavailableReason
-  const entryBusy = submitting || agentSession.busy
+  const agentPlanning = agentSession.state.status === 'planning'
+  const generationStarting = promptState === 'confirmed'
+  const entryBusy = submitting || agentPlanning || promptState === 'rewriting' || generationStarting
   const hasPrompt = Boolean(prompt.trim())
-  const showStylePrompts = !hasPrompt && !templateFile && agentSession.state.status === 'idle'
+  const hasConversation = conversationTurns.length > 0
+  const showStylePrompts =
+    !hasPrompt && !templateFile && !hasConversation && agentSession.state.status === 'idle'
+  const showConversation = hasConversation || agentPlanning || agentSession.state.status === 'error'
+  const promptMessage = useMemo<readonly KineticCopyMessage[]>(
+    () => [{ lines: [prompt] }],
+    [prompt],
+  )
+
+  const persistConversation = useCallback(
+    (turns: readonly AgentConversationTurn[], runId: string | null = null) => {
+      conversationTurnsRef.current = turns
+      writeAgentConversation(activeRunUserId, { runId, turns })
+    },
+    [activeRunUserId],
+  )
+
+  const appendConversationTurn = useCallback(
+    (turn: AgentConversationTurn) => {
+      setConversationTurns((current) => {
+        const next = [...current, turn]
+        persistConversation(next)
+        return next
+      })
+    },
+    [persistConversation],
+  )
 
   useEffect(
     () => () => {
       submitAbortController.current?.abort()
       if (handoffTimer.current) clearTimeout(handoffTimer.current)
+      if (rewriteTimer.current) clearTimeout(rewriteTimer.current)
+      generationConfirmation.current?.()
+      generationConfirmation.current = null
     },
     [],
   )
+
+  useEffect(() => {
+    const state = agentSession.state
+    if (state.status !== 'dispatching') return
+
+    setPrompt(state.optimizedPrompt)
+    setPromptState('rewriting')
+    rewriteTimer.current = setTimeout(() => {
+      rewriteTimer.current = null
+      setPromptState('ready')
+      appendConversationTurn({
+        role: 'assistant',
+        content: planConfirmationCopy(state.assumptions),
+      })
+    }, PROMPT_REWRITE_MS)
+
+    return () => {
+      if (rewriteTimer.current) clearTimeout(rewriteTimer.current)
+      rewriteTimer.current = null
+    }
+  }, [agentSession.state, appendConversationTurn])
 
   function selectTemplateFile(event: ChangeEvent<HTMLInputElement>) {
     if (entryBusy) return
@@ -371,16 +455,29 @@ function QuickStartInput({
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const normalizedPrompt = prompt.trim()
+
+    if (agentSession.state.status === 'dispatching' && promptState === 'ready') {
+      const confirm = generationConfirmation.current
+      if (!confirm) return
+      generationConfirmation.current = null
+      setPromptState('confirmed')
+      confirm()
+      return
+    }
+
     if ((!normalizedPrompt && !templateFile) || entryBusy || unavailableReason) return
 
     if (!templateFile) {
       setError(null)
+      appendConversationTurn({ role: 'user', content: normalizedPrompt })
+      setPrompt('')
       try {
         const result = await agentSession.submit(normalizedPrompt)
         if (result.kind === 'message') {
-          setPrompt('')
+          appendConversationTurn({ role: 'assistant', content: result.message })
           return
         }
+        persistConversation(conversationTurnsRef.current, result.runId)
         setEntryTransition('leaving')
         await new Promise<void>((resolve) => {
           handoffTimer.current = setTimeout(() => {
@@ -392,6 +489,7 @@ function QuickStartInput({
       } catch (cause) {
         if (!(cause instanceof Error && cause.name === 'AbortError')) {
           setEntryTransition('idle')
+          setPromptState('collecting')
         }
       }
       return
@@ -432,6 +530,28 @@ function QuickStartInput({
     }
   }
 
+  const inputLocked =
+    submitting || agentPlanning || promptState === 'rewriting' || generationStarting
+  const awaitingGenerationConfirmation =
+    agentSession.state.status === 'dispatching' && promptState === 'ready'
+  const buttonLabel = submitting
+    ? '正在创建…'
+    : agentPlanning
+      ? '正在判断…'
+      : promptState === 'rewriting'
+        ? '优化中'
+        : awaitingGenerationConfirmation
+          ? '发送生成'
+          : generationStarting
+            ? '正在开始生成…'
+            : agentSession.state.status === 'restart-required'
+              ? '重新开始'
+              : agentSession.state.status === 'awaiting-input'
+                ? '继续'
+                : '生成角色'
+  const canSubmit =
+    awaitingGenerationConfirmation || Boolean(prompt.trim()) || Boolean(templateFile)
+
   return (
     <section className="relative min-h-[100dvh] overflow-hidden border border-app-line bg-app-canvas pt-14 text-app-ink shadow-app-page">
       <AmbientGrid />
@@ -443,56 +563,122 @@ function QuickStartInput({
       >
         <div
           data-layout="quick-start-entry-stage"
-          className={`mx-auto grid w-full max-w-3xl content-center gap-5 pb-8 transition-[opacity,transform,filter] duration-[460ms] ease-[cubic-bezier(0.55,0,1,0.45)] motion-reduce:transition-none sm:gap-6 ${
+          className={`mx-auto grid min-h-0 w-full max-w-3xl gap-5 overflow-y-auto pb-8 transition-[opacity,transform,filter] duration-[460ms] ease-[cubic-bezier(0.55,0,1,0.45)] motion-reduce:transition-none sm:gap-6 ${
+            showConversation ? 'content-end' : 'content-center'
+          } ${
             entryTransition === 'leaving'
               ? 'pointer-events-none -translate-y-3 scale-[0.985] opacity-0 blur-[7px]'
               : 'translate-y-0 scale-100 opacity-100 blur-0'
           }`}
         >
-          <KineticCopyCycle
-            active={!templateFile && !entryBusy}
-            as="h1"
-            ariaLabel="想做一个什么角色？"
-            motionMode="characters"
-            firstCycleMs={2_400}
-            loopStartIndex={1}
-            messages={hasPrompt ? ROLE_DEFAULT_MESSAGE : ROLE_IDEA_MESSAGES}
-            className="min-h-12 text-center font-serif text-[clamp(1.75rem,4vw,2.65rem)] leading-none font-medium tracking-[-0.045em]"
-          />
+          {showConversation ? (
+            <div
+              data-testid="quick-start-transcript"
+              className="grid min-h-full w-full content-end gap-5 py-4"
+            >
+              {conversationTurns.map((turn, index) => (
+                <div
+                  key={`${turn.role}:${index}:${turn.content}`}
+                  data-conversation-kind="agent"
+                  className="min-w-0"
+                >
+                  {turn.role === 'user' ? (
+                    <UserTurn>{turn.content}</UserTurn>
+                  ) : (
+                    <AgentCopy
+                      lines={turn.content.split('\n')}
+                      animate={index >= initialConversationLength.current}
+                    />
+                  )}
+                </div>
+              ))}
+              {agentPlanning ? (
+                <div
+                  data-conversation-kind="agent"
+                  data-agent-loading
+                  role="status"
+                  aria-label="Agent 正在思考"
+                  className="quick-start-agent-loading min-w-0"
+                >
+                  <span aria-hidden="true" className="quick-start-agent-loading-dots">
+                    {[0, 1, 2].map((dot) => (
+                      <span
+                        key={dot}
+                        className="quick-start-agent-loading-dot"
+                        style={{ '--agent-loading-index': dot } as CSSProperties}
+                      />
+                    ))}
+                  </span>
+                </div>
+              ) : null}
+              {agentSession.state.status === 'error' ? (
+                <div role="alert" data-conversation-kind="agent" className="min-w-0">
+                  <AgentCopy lines={[agentSession.state.message]} tone="danger" />
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <>
+              <KineticCopyCycle
+                active={!templateFile && !entryBusy}
+                as="h1"
+                ariaLabel="想做一个什么角色？"
+                motionMode="characters"
+                firstCycleMs={2_400}
+                loopStartIndex={1}
+                messages={hasPrompt ? ROLE_DEFAULT_MESSAGE : ROLE_IDEA_MESSAGES}
+                className="min-h-12 text-center font-serif text-[clamp(1.75rem,4vw,2.65rem)] leading-none font-medium tracking-[-0.045em]"
+              />
 
-          <div
-            data-layout="quick-start-starters"
-            data-presence={showStylePrompts ? 'visible' : 'hidden'}
-            aria-hidden={!showStylePrompts}
-            className={`grid gap-2 transition-[opacity,transform,filter] duration-[460ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none sm:grid-cols-3 ${
-              showStylePrompts
-                ? 'translate-y-0 scale-100 opacity-100 blur-0'
-                : 'pointer-events-none -translate-y-2 scale-[0.985] opacity-0 blur-[6px]'
-            }`}
-          >
-            {STYLE_PROMPTS.map((stylePrompt) => (
-              <button
-                key={stylePrompt.title}
-                type="button"
-                disabled={!showStylePrompts}
-                aria-label={`${stylePrompt.title}：${stylePrompt.detail}`}
-                onClick={() => setPrompt(stylePrompt.prompt)}
-                className="group grid min-h-16 content-center gap-1 rounded-xl border border-app-line bg-app-surface/70 px-4 py-3 text-left transition duration-200 hover:-translate-y-0.5 hover:border-app-line-strong hover:bg-app-surface-raised hover:shadow-app-card focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent motion-reduce:transform-none"
+              <div
+                data-layout="quick-start-starters"
+                data-presence={showStylePrompts ? 'visible' : 'hidden'}
+                aria-hidden={!showStylePrompts}
+                className={`grid gap-2 transition-[opacity,transform,filter] duration-[460ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none sm:grid-cols-3 ${
+                  showStylePrompts
+                    ? 'translate-y-0 scale-100 opacity-100 blur-0'
+                    : 'pointer-events-none -translate-y-2 scale-[0.985] opacity-0 blur-[6px]'
+                }`}
               >
-                <strong className="text-sm font-semibold text-app-ink">{stylePrompt.title}</strong>
-                <span className="text-[11px] text-app-muted">{stylePrompt.detail}</span>
-              </button>
-            ))}
-          </div>
+                {STYLE_PROMPTS.map((stylePrompt) => (
+                  <button
+                    key={stylePrompt.title}
+                    type="button"
+                    disabled={!showStylePrompts}
+                    aria-label={`${stylePrompt.title}：${stylePrompt.detail}`}
+                    onClick={() => setPrompt(stylePrompt.prompt)}
+                    className="group grid min-h-16 content-center gap-1 rounded-xl border border-app-line bg-app-surface/70 px-4 py-3 text-left transition duration-200 hover:-translate-y-0.5 hover:border-app-line-strong hover:bg-app-surface-raised hover:shadow-app-card focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent motion-reduce:transform-none"
+                  >
+                    <strong className="text-sm font-semibold text-app-ink">
+                      {stylePrompt.title}
+                    </strong>
+                    <span className="text-[11px] text-app-muted">{stylePrompt.detail}</span>
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
         </div>
 
-        <div data-layout="quick-start-composer" className="mx-auto w-full max-w-3xl self-end">
-          {!templateFile ? <QuickStartAgentInlineState state={agentSession.state} /> : null}
+        <div
+          data-testid="quick-start-composer"
+          data-layout="quick-start-composer"
+          data-position="floating"
+          data-prompt-state={promptState}
+          className={`mx-auto w-full max-w-3xl self-end transition-[opacity,transform,filter] duration-[460ms] ease-[cubic-bezier(0.55,0,1,0.45)] motion-reduce:transition-none ${
+            entryTransition === 'leaving'
+              ? 'pointer-events-none translate-y-2 opacity-0 blur-[5px]'
+              : 'translate-y-0 opacity-100 blur-0'
+          }`}
+        >
           <form
             onSubmit={(event) => void submit(event)}
-            className="grid items-center gap-1.5 rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)] sm:grid-cols-[1fr_auto_auto]"
+            data-prompt-state={promptState}
+            className={`quick-start-agent-composer grid items-center gap-1.5 overflow-hidden rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)] ${
+              hasConversation ? 'sm:grid-cols-[1fr_auto]' : 'sm:grid-cols-[1fr_auto_auto]'
+            }`}
           >
-            <label className="min-w-0" htmlFor="quick-start-prompt">
+            <label className="relative min-w-0" htmlFor="quick-start-prompt">
               <span className="sr-only">创作指令</span>
               <input
                 id="quick-start-prompt"
@@ -500,12 +686,36 @@ function QuickStartInput({
                 aria-label="创作指令"
                 value={prompt}
                 onChange={(event) => setPrompt(event.target.value)}
-                disabled={entryBusy}
+                disabled={inputLocked}
+                readOnly={agentSession.state.status === 'dispatching'}
                 placeholder={
-                  templateFile ? '描述动作，可留空生成待机动作…' : '描述角色的外形、身份和气质…'
+                  agentPlanning
+                    ? 'Agent 正在整理…'
+                    : generationStarting
+                      ? '正在创建素材流程…'
+                      : templateFile
+                        ? '描述动作，可留空生成待机动作…'
+                        : '描述角色的外形、身份和气质…'
                 }
-                className="h-10 w-full min-w-0 border-0 bg-transparent px-3 text-[15px] text-app-ink outline-none placeholder:text-app-faint"
+                className={`h-10 w-full min-w-0 border-0 bg-transparent px-3 text-[15px] text-app-ink outline-none placeholder:text-app-faint ${
+                  promptState === 'rewriting' ? 'text-transparent caret-transparent' : ''
+                }`}
               />
+              {promptState === 'rewriting' ? (
+                <span
+                  data-prompt-rewrite
+                  aria-hidden="true"
+                  className="quick-start-prompt-rewrite absolute inset-0 flex h-10 items-center overflow-hidden px-3 text-[15px] whitespace-nowrap text-app-ink"
+                >
+                  <KineticCopyCycle
+                    active
+                    as="span"
+                    messages={promptMessage}
+                    motionMode="characters"
+                    className="quick-start-prompt-kinetic"
+                  />
+                </span>
+              ) : null}
             </label>
 
             <input
@@ -513,7 +723,7 @@ function QuickStartInput({
               type="file"
               accept="image/*"
               aria-label="上传角色母版"
-              disabled={entryBusy}
+              disabled={entryBusy || hasConversation}
               className="sr-only"
               onChange={selectTemplateFile}
             />
@@ -539,7 +749,7 @@ function QuickStartInput({
                   <X aria-hidden="true" size={14} weight="bold" />
                 </button>
               </span>
-            ) : (
+            ) : !hasConversation ? (
               <button
                 type="button"
                 disabled={entryBusy}
@@ -549,25 +759,13 @@ function QuickStartInput({
                 <ImageSquare aria-hidden="true" size={17} weight="duotone" />
                 添加母版
               </button>
-            )}
+            ) : null}
             <button
               type="submit"
-              disabled={
-                (!prompt.trim() && !templateFile) || entryBusy || Boolean(unavailableReason)
-              }
+              disabled={!canSubmit || entryBusy || Boolean(unavailableReason)}
               className="inline-flex h-10 items-center gap-2 rounded-lg bg-app-accent px-4 text-sm font-bold whitespace-nowrap text-app-on-accent transition hover:bg-app-accent-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-45"
             >
-              {templateFile && submitting
-                ? '正在创建…'
-                : agentSession.state.status === 'planning'
-                  ? '正在判断…'
-                  : agentSession.state.status === 'dispatching'
-                    ? '正在开始生成…'
-                    : agentSession.state.status === 'restart-required'
-                      ? '重新开始'
-                      : agentSession.state.status === 'awaiting-input'
-                        ? '继续'
-                        : '生成角色'}
+              {buttonLabel}
               {!entryBusy ? <ArrowUp aria-hidden="true" size={16} weight="bold" /> : null}
             </button>
           </form>
@@ -594,24 +792,35 @@ function QuickStartInput({
 function AgentCopy({
   lines,
   tone = 'default',
+  animate = true,
 }: {
   lines: readonly string[]
   tone?: 'default' | 'danger'
+  animate?: boolean
 }) {
+  const copy = lines.join('\n')
+  const messages = useMemo<readonly KineticCopyMessage[]>(
+    () => [{ lines: copy.split('\n') }],
+    [copy],
+  )
+
   return (
     <div
       data-agent-copy
       aria-label={lines.join(' ')}
-      className={`quick-start-agent-copy font-sans ${
+      className={`quick-start-agent-copy generation-progress-copy generation-progress-copy--conversation font-serif ${
         tone === 'danger' ? 'text-app-danger' : 'text-app-ink-soft'
       }`}
     >
-      <p className="text-sm leading-6 font-medium">{lines[0]}</p>
-      {lines.slice(1).map((line) => (
-        <p key={line} className="mt-0.5 max-w-2xl text-[13px] leading-5 text-app-muted">
-          {line}
-        </p>
-      ))}
+      <span aria-hidden="true" className="sr-only">
+        {lines.join(' ')}
+      </span>
+      <KineticCopyCycle
+        active={animate}
+        messages={messages}
+        motionMode="characters"
+        className="quick-start-agent-copy font-serif"
+      />
     </div>
   )
 }
@@ -620,7 +829,7 @@ function UserTurn({ children }: { children: ReactNode }) {
   return (
     <div
       data-user-turn
-      className="ml-auto max-w-[78%] rounded-[1.15rem] rounded-br-md bg-app-surface-muted px-4 py-2.5 text-left text-sm leading-6 text-app-ink-soft"
+      className="ml-auto w-fit max-w-[78%] rounded-[1.15rem] rounded-br-md bg-app-surface-muted px-4 py-2.5 text-left text-sm leading-6 text-app-ink-soft"
     >
       <span>{children}</span>
     </div>
@@ -793,6 +1002,10 @@ function QuickStartRun({
   const [publishing, setPublishing] = useState(false)
   const [confirmingCandidate, setConfirmingCandidate] = useState(false)
   const [confirmingFirstFrame, setConfirmingFirstFrame] = useState(false)
+  const agentConversationTurns = useMemo(() => {
+    const stored = readAgentConversation(activeRunUserId)
+    return stored?.runId === runId ? stored.turns : []
+  }, [activeRunUserId, runId])
   const automaticPublishAttempt = useRef<string | null>(null)
   const transcriptScrollRegion = useRef<HTMLElement>(null)
   const workflowConflictRef = useRef(false)
@@ -1249,7 +1462,23 @@ function QuickStartRun({
             data-testid="quick-start-transcript"
             className="mx-auto grid min-h-full w-full max-w-3xl content-end gap-7 pb-8 sm:gap-9"
           >
-            <UserTurn>{workflowPrompt(run) || '未命名角色创作'}</UserTurn>
+            {agentConversationTurns.map((turn, index) => (
+              <div
+                key={`${turn.role}:${index}:${turn.content}`}
+                data-conversation-kind="agent"
+                className="min-w-0"
+              >
+                {turn.role === 'user' ? (
+                  <UserTurn>{turn.content}</UserTurn>
+                ) : (
+                  <AgentCopy lines={turn.content.split('\n')} animate={false} />
+                )}
+              </div>
+            ))}
+
+            <div data-conversation-kind="workflow" className="min-w-0">
+              <UserTurn>{workflowPrompt(run) || '未命名角色创作'}</UserTurn>
+            </div>
 
             <AgentTurn step="character-template" current={characterTurnIsCurrent}>
               {candidates.length ? (

--- a/frontend/src/pages/quick-start/quick-start-motion.css
+++ b/frontend/src/pages/quick-start/quick-start-motion.css
@@ -2,6 +2,57 @@
   width: 100%;
 }
 
+.quick-start-agent-loading {
+  min-height: 1.75rem;
+  display: flex;
+  align-items: center;
+}
+
+.quick-start-agent-loading-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.quick-start-agent-loading-dot {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 999px;
+  background: var(--color-app-muted);
+  opacity: 0.22;
+  filter: blur(1px);
+  animation: quick-start-agent-loading 1.1s ease-in-out infinite;
+  animation-delay: calc(var(--agent-loading-index, 0) * 150ms);
+}
+
+.quick-start-agent-composer {
+  position: relative;
+}
+
+.quick-start-agent-composer[data-prompt-state='rewriting'] {
+  border-color: color-mix(in srgb, var(--color-app-accent) 58%, var(--color-app-line-strong));
+  box-shadow: var(--shadow-app-composer-focus);
+}
+
+.quick-start-agent-composer[data-prompt-state='rewriting']::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    100deg,
+    transparent 15%,
+    color-mix(in srgb, var(--color-app-accent) 8%, transparent) 48%,
+    transparent 82%
+  );
+  transform: translateX(-110%);
+  animation: quick-start-prompt-sweep 1.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.quick-start-prompt-kinetic {
+  place-items: start;
+}
+
 .quick-start-reveal-card {
   opacity: 0;
   filter: blur(7px);
@@ -56,10 +107,36 @@
   }
 }
 
+@keyframes quick-start-agent-loading {
+  50% {
+    opacity: 0.9;
+    filter: blur(0);
+    transform: translateY(-0.16rem);
+  }
+}
+
+@keyframes quick-start-prompt-sweep {
+  to {
+    transform: translateX(110%);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .quick-start-reveal-card,
   .quick-start-generated-image {
     opacity: 1;
+    filter: none;
+    transform: none;
+    animation: none;
+  }
+
+  .quick-start-agent-composer[data-prompt-state='rewriting']::after {
+    display: none;
+    animation: none;
+  }
+
+  .quick-start-agent-loading-dot {
+    opacity: 0.55;
     filter: none;
     transform: none;
     animation: none;


### PR DESCRIPTION
本 PR 将真实 Quick Start Agent 会话与后续素材生成衔接为一条连续时间线，同时保持 Agent 会话和 WorkflowRun 的数据边界独立。

## Why

此前 Agent 在启动生成后退出，页面虽然继续推进 WorkflowRun，但用户会感觉对话突然中断；本地视觉草稿还依赖固定演示数据，不能直接进入正式实现。

## Changes

- 使用真实 Planner 输入与回复构建对话，并按当前用户仅在前端持久化。
- 在输入框内复用公共逐字模糊动画呈现优化提示词，等待用户明确发送后才执行生成 Tool。
- 进入真实 Run 后承接前序对话，并继续用 WorkflowRun 状态呈现角色、动作、失败和完成反馈。
- 统一 Agent 字体、加载态和用户气泡，不保留 demo 路由或固定生成数据。

## Implementation

- 页面通过既有 `waitForPresentation` 暂停 dispatch；确认后仍沿 `Agent → app adapter → WorkflowController → WorkflowRun` 执行。
- `localStorage` 只保存 Agent turn，并以 `runId` 关联展示；WorkflowRun 消息始终由真实 Run 状态恢复。
- 复用 `KineticCopyCycle`，局部 CSS 只补加载、输入框扫光和 reduced-motion 降级。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx --configLoader runner`：72 项通过。
- [x] `npm run build`：通过；仅有既存 chunk size warning。
- [x] `npx oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx src/pages/quick-start/quick-start-motion.css`：通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `git diff --check`：通过。
- [x] 真实本地浏览器：Planner 优化后等待确认，点击后进入 `/quick-start/26`；刷新后 Agent 与 WorkflowRun 仍在同一 transcript，当前时间窗口控制台无错误。

## Screenshots

### Desktop

<img width="1349" height="847" alt="Quick Start Agent conversation flowing into asset generation" src="https://github.com/user-attachments/assets/747ea098-e48c-45cc-9bc2-9cd4f421ed41" />

## Scope

- 本 PR 不包含：后端对话持久化、Agent Core / Tool / Controller / Service / Entity 变更。
- 本 PR 不让 Agent 读取或控制 WorkflowRun，也不增加生成阶段的 LLM 调用。

## Related Issues

Closes #506

Refs #443
