### PR TITLE
fix(projects): render project loading shell immediately

### DIFF
--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -22,6 +22,44 @@ function installBackend() {
 }
 
 describe('ProjectsPage', () => {
+  it('renders the project shell while the project list is pending', async () => {
+    const backend = createProjectAssetsBackend()
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')
+    let releaseProjects: (() => void) | undefined
+    const projectsGate = new Promise<void>((resolve) => {
+      releaseProjects = resolve
+    })
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init)
+      if (new URL(request.url).pathname === '/projects') await projectsGate
+      return backend.fetch(input, init)
+    })
+
+    render(
+      <AuthenticatedAuthSession>
+        <MemoryRouter initialEntries={['/projects']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </AuthenticatedAuthSession>,
+    )
+
+    try {
+      expect(await screen.findByRole('link', { name: '新建项目' })).toBeTruthy()
+      const loadingShell = screen.getByRole('status', { name: '正在读取项目' })
+      expect(loadingShell.getAttribute('aria-busy')).toBe('true')
+      expect(loadingShell.querySelectorAll('[data-project-loading-placeholder]')).toHaveLength(3)
+      expect(loadingShell.querySelectorAll('[data-pixel-matrix-dot]')).toHaveLength(3 * 432)
+      expect(screen.queryByText('正在读取项目…')).toBeNull()
+      expect(screen.queryByRole('link', { name: /打开项目/ })).toBeNull()
+    } finally {
+      releaseProjects?.()
+    }
+
+    expect(await screen.findAllByRole('link', { name: /打开项目/ })).toHaveLength(2)
+    expect(screen.queryByRole('status', { name: '正在读取项目' })).toBeNull()
+    expect(document.querySelector('[data-project-loading-placeholder]')).toBeNull()
+  })
+
   it('loads a project card thumbnail and falls back to its original preview', async () => {
     const backend = createProjectAssetsBackend()
     vi.stubEnv('VITE_API_BASE_URL', 'https://api.windup.test')

--- a/frontend/src/pages/projects/index.tsx
+++ b/frontend/src/pages/projects/index.tsx
@@ -85,21 +85,17 @@ export function ProjectsPage() {
             {error}
           </p>
         ) : null}
-        {projectsPage === null && !error ? (
-          <p className="mt-6 text-sm text-app-muted">正在读取项目…</p>
-        ) : null}
-        {projectsPage ? (
-          <div>
-            <ProjectCreateCard />
-            {projectsPage.items.length > 0 ? (
-              <ProjectGallery
-                projects={projectsPage.items}
-                total={projectsPage.total}
-                onDelete={setDeleteTarget}
-              />
-            ) : null}
-          </div>
-        ) : null}
+        <div>
+          <ProjectCreateCard />
+          {projectsPage === null && !error ? <ProjectGalleryLoading /> : null}
+          {projectsPage && projectsPage.items.length > 0 ? (
+            <ProjectGallery
+              projects={projectsPage.items}
+              total={projectsPage.total}
+              onDelete={setDeleteTarget}
+            />
+          ) : null}
+        </div>
         {projectsPage ? (
           <Pagination
             page={projectsPage.page}
@@ -156,6 +152,34 @@ function ProjectCreateCard() {
         />
       </div>
     </Link>
+  )
+}
+
+function ProjectGalleryLoading() {
+  return (
+    <section role="status" aria-label="正在读取项目" aria-busy="true" className="mt-7">
+      <h2 aria-hidden="true" className="mb-4 text-sm font-medium tracking-[0.04em] text-app-ink">
+        最近项目
+      </h2>
+      <div
+        aria-hidden="true"
+        className="grid gap-x-4 gap-y-7 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
+      >
+        {Array.from({ length: 3 }, (_, index) => (
+          <article key={index} data-project-loading-placeholder className="min-w-0">
+            <div className="relative aspect-[16/10] overflow-hidden rounded-[1.25rem] border border-app-line bg-app-surface-muted">
+              <PixelMatrix coverage="compact" />
+            </div>
+            <div className="mt-3 flex items-center justify-between gap-4 px-0.5">
+              <span className="h-3.5 w-2/5 rounded-sm bg-app-line" />
+              <span className="h-3 w-10 rounded-sm bg-app-line" />
+            </div>
+            <span className="mt-2 block h-3 w-3/5 rounded-sm bg-app-line" />
+            <span className="mt-2 block h-2.5 w-2/5 rounded-sm bg-app-line" />
+          </article>
+        ))}
+      </div>
+    </section>
   )
 }
 


### PR DESCRIPTION
项目中心现在会在 `/projects` 请求返回前立即呈现新建项目入口和三张项目卡片骨架，避免聚合请求期间页面近乎空白，同时保留单请求性能优化。

## Why

PR #431 将项目预览聚合进项目列表请求后，页面速度明显提升，但请求返回前只剩一行“正在读取项目…”；创建入口和项目布局会整块延后出现，形成突兀的空白等待。

## Changes

- 请求期间立即显示可点击的“新建项目”入口。
- 在“最近项目”区域显示三张与真实卡片等比例的加载骨架。
- 数据返回后原位替换为真实项目卡片，并保留现有空态、错误态、分页和删除行为。
- 增加回归测试，覆盖加载态可访问性、占位数量及真实数据到达后的清理。

## Implementation

- 复用现有 `PixelMatrix` 作为预览区加载反馈，元数据使用低对比静态占位。
- 保留单次 `/projects` 请求，不恢复逐项目 `/characters` 请求，也不新增动画依赖或样式文件。
- 使用 `role="status"`、`aria-busy="true"` 暴露加载状态，并将装饰骨架从辅助技术中隐藏。

## Verification

- [x] `npm test -- src/pages/projects/index.test.tsx`：1 个测试文件、9 个测试通过。
- [x] `npx oxfmt --check src/pages/projects/index.tsx src/pages/projects/index.test.tsx`：2 个文件通过。
- [x] `npx oxlint src/pages/projects/index.tsx src/pages/projects/index.test.tsx`：通过，无错误。
- [x] `VITE_API_BASE_URL=/api npm run build`：类型检查与生产构建通过；仅保留既有 chunk-size 警告。
- [x] `git diff --check`：通过。
- [x] 受控延迟 `/projects` 的真实浏览器检查：加载骨架稳定显示，视觉验收通过。

## Screenshots

### Desktop

<img width="1206" height="704" alt="项目中心加载骨架" src="https://github.com/user-attachments/assets/1d970b3f-1cc1-4bd4-8415-c30beed0d087" />

## Scope

- 本 PR 不包含：后端或 OpenAPI 改动、逐项目预览请求、通用页面加载组件、Workflow Editor 加载反馈。
- 后续事项：资产预览加载状态继续由 #435 跟踪。

## Related Issues

Closes #510

Refs #431
