### PR TITLE
feat(route-motion): add shared page transitions

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -240,7 +240,7 @@ describe('AppHeader', () => {
     expect(screen.getByTestId('location').textContent).toBe('/projects')
   })
 
-  it('点击后先播放方向过渡，再执行返回', () => {
+  it('点击后立即请求返回，同时保留箭头反馈', () => {
     vi.useFakeTimers()
     window.history.replaceState({ idx: 0 }, '')
     renderHeader('/projects')
@@ -249,13 +249,10 @@ describe('AppHeader', () => {
     fireEvent.click(back)
 
     expect(back.classList.contains('app-header-back-in-flight')).toBe(true)
-    expect(screen.getByTestId('location').textContent).toBe('/projects')
-
-    act(() => vi.advanceTimersByTime(190))
-    expect(screen.getByTestId('location').textContent).toBe('/projects')
-
-    act(() => vi.advanceTimersByTime(50))
     expect(screen.getByTestId('location').textContent).toBe('/workspace')
+
+    act(() => vi.advanceTimersByTime(240))
+    expect(back.classList.contains('app-header-back-in-flight')).toBe(false)
   })
 
   it('动画进行中重复点击不会推迟返回', () => {

--- a/frontend/src/app/layout/index.tsx
+++ b/frontend/src/app/layout/index.tsx
@@ -6,6 +6,7 @@ import { SessionExpiredNotice } from '@/features/auth-guard'
 import { useAuthSession } from '@/features/auth-session'
 import { ActiveRunMonitor } from './active-run-monitor'
 import { AppHeader } from './app-header'
+import { RouteMotionSurface } from '../route-motion'
 
 export interface AppShellProps {
   /** 渲染在全局导航下方的当前路由页面。 */
@@ -17,7 +18,7 @@ export function AppShell({ children }: AppShellProps) {
   const { pathname } = useLocation()
   const session = useAuthSession()
   return (
-    <div className="min-h-screen bg-app-canvas text-app-ink">
+    <div className="min-h-screen overflow-x-clip bg-app-canvas text-app-ink">
       {session.state.status === 'authenticated' ? (
         <ActiveRunMonitor userId={session.state.user.id} pathname={pathname} />
       ) : null}
@@ -27,7 +28,9 @@ export function AppShell({ children }: AppShellProps) {
         也不按 pathname 分支给不同页面配不同容器。
         顶栏悬浮不占布局高度，内容页的避让由 PageContainer 统一让出，满幅页面自己让。
       */}
-      <main className="w-full">{children}</main>
+      <RouteMotionSurface as="main" className="w-full">
+        {children}
+      </RouteMotionSurface>
       <AccountPanel />
       <SessionExpiredNotice />
     </div>
@@ -37,8 +40,8 @@ export function AppShell({ children }: AppShellProps) {
 /** 公开页面外壳只提供认证面板与会话提醒，宣传导航由 LandingPage 自己组合。 */
 export function MarketingShell({ children }: AppShellProps) {
   return (
-    <div className="min-h-[100dvh] bg-[#f6f8f3] text-[#1d2920]">
-      {children}
+    <div className="min-h-[100dvh] overflow-x-clip bg-[#f6f8f3] text-[#1d2920]">
+      <RouteMotionSurface>{children}</RouteMotionSurface>
       <AccountPanel />
       <SessionExpiredNotice />
     </div>

--- a/frontend/src/app/layout/page-back-button.tsx
+++ b/frontend/src/app/layout/page-back-button.tsx
@@ -48,7 +48,6 @@ export function PageBackButton() {
     transitioningRef.current = false
     fallbackTimerRef.current = null
     setTransitioning(false)
-    navigateBack()
   }
 
   function requestBack() {
@@ -61,6 +60,7 @@ export function PageBackButton() {
     transitioningRef.current = true
     setTransitioning(true)
     fallbackTimerRef.current = window.setTimeout(finishTransition, backTransitionDurationMs)
+    navigateBack()
   }
 
   return (

--- a/frontend/src/app/route-motion-model.ts
+++ b/frontend/src/app/route-motion-model.ts
@@ -1,0 +1,44 @@
+export type RouteMotionDirection = 'forward' | 'backward' | 'lateral'
+
+function describeRoute(pathname: string): { depth: number; order: number; section: string } {
+  if (pathname === '/') return { section: 'marketing', order: -1, depth: 0 }
+  if (pathname === '/workspace') return { section: 'workspace', order: 0, depth: 0 }
+  if (pathname === '/account') return { section: 'account', order: 4, depth: 0 }
+
+  if (pathname.startsWith('/projects')) {
+    const depth = /^\/projects\/[^/]+\/assets\/[^/]+$/.test(pathname)
+      ? 2
+      : pathname === '/projects'
+        ? 0
+        : 1
+    return { section: 'projects', order: 1, depth }
+  }
+
+  if (pathname.startsWith('/playtest')) {
+    return { section: 'playtest', order: 2, depth: pathname === '/playtest' ? 0 : 1 }
+  }
+
+  if (pathname.startsWith('/workflow-editor')) {
+    return { section: 'create', order: 3, depth: 2 }
+  }
+
+  if (pathname.startsWith('/quick-start')) {
+    return { section: 'create', order: 3, depth: pathname === '/quick-start' ? 0 : 1 }
+  }
+
+  return { section: pathname, order: 5, depth: 0 }
+}
+
+export function getRouteMotionDirection(
+  currentPath: string,
+  nextPath: string,
+): RouteMotionDirection {
+  const current = describeRoute(currentPath)
+  const next = describeRoute(nextPath)
+
+  if (current.section === next.section && current.depth !== next.depth) {
+    return next.depth > current.depth ? 'forward' : 'backward'
+  }
+  if (current.section === next.section || current.order === next.order) return 'lateral'
+  return next.order > current.order ? 'forward' : 'backward'
+}

--- a/frontend/src/app/route-motion.test.tsx
+++ b/frontend/src/app/route-motion.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { StrictMode } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Link, MemoryRouter, Route, Routes } from 'react-router'
+
+import { RouteMotionSurface } from './route-motion'
+
+function MotionFixture() {
+  return (
+    <>
+      <Link to="/workspace">首页</Link>
+      <Link to="/projects">项目资产</Link>
+      <Link to="/projects?view=recent">项目筛选</Link>
+      <Link to="/projects#recent">项目锚点</Link>
+      <RouteMotionSurface>
+        <Routes>
+          <Route path="/workspace" element={<main>工作台</main>} />
+          <Route path="/projects" element={<main>项目资产</main>} />
+        </Routes>
+      </RouteMotionSurface>
+    </>
+  )
+}
+
+afterEach(cleanup)
+
+describe('RouteMotionSurface', () => {
+  it('keeps header-order direction through StrictMode double renders', () => {
+    render(
+      <StrictMode>
+        <MemoryRouter initialEntries={['/workspace']}>
+          <MotionFixture />
+        </MemoryRouter>
+      </StrictMode>,
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: '项目资产' }))
+    expect(screen.getByTestId('route-motion-surface').dataset.motionDirection).toBe('forward')
+
+    fireEvent.click(screen.getByRole('link', { name: '首页' }))
+    expect(screen.getByTestId('route-motion-surface').dataset.motionDirection).toBe('backward')
+  })
+
+  it.each(['项目筛选', '项目锚点'])('does not reactivate motion for %s navigation', (link) => {
+    render(
+      <StrictMode>
+        <MemoryRouter initialEntries={['/workspace']}>
+          <MotionFixture />
+        </MemoryRouter>
+      </StrictMode>,
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: '项目资产' }))
+    expect(screen.getByTestId('route-motion-surface').dataset.motionActive).toBe('true')
+
+    fireEvent.click(screen.getByRole('link', { name: link }))
+    expect(screen.getByTestId('route-motion-surface').dataset.motionActive).toBe('false')
+  })
+})

--- a/frontend/src/app/route-motion.tsx
+++ b/frontend/src/app/route-motion.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+import { useLocation } from 'react-router'
+
+import { getRouteMotionDirection } from './route-motion-model'
+
+function motionPathname(pathname: string): string {
+  return /^\/projects\/[^/]+$/.test(pathname) ? `${pathname}/assets` : pathname
+}
+
+/** 页面只在真实 pathname 变化后进入；search、hash 与索引补全不重复播放。 */
+export function RouteMotionSurface({
+  as: Component = 'div',
+  children,
+  className = '',
+}: {
+  as?: 'div' | 'main'
+  children: ReactNode
+  className?: string
+}) {
+  const { pathname } = useLocation()
+  const routeKey = motionPathname(pathname)
+  const previousPathname = useRef(routeKey)
+  const changed = previousPathname.current !== routeKey
+  const direction = changed
+    ? getRouteMotionDirection(previousPathname.current, routeKey)
+    : 'lateral'
+
+  useEffect(() => {
+    previousPathname.current = routeKey
+  }, [routeKey])
+
+  return (
+    <Component
+      key={routeKey}
+      data-testid="route-motion-surface"
+      data-motion-active={changed ? 'true' : 'false'}
+      data-motion-direction={direction}
+      className={`route-motion-surface ${className}`}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -377,14 +377,41 @@ body,
   }
 }
 
-@keyframes route-transition {
+@keyframes route-page-enter-forward {
   from {
-    opacity: 0;
-    transform: translateY(6px);
+    transform: translate3d(14px, 0, 0);
   }
+
+  68% {
+    transform: translate3d(1px, 0, 0);
+  }
+
   to {
-    opacity: 1;
-    transform: translateY(0);
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes route-page-enter-backward {
+  from {
+    transform: translate3d(-14px, 0, 0);
+  }
+
+  68% {
+    transform: translate3d(-1px, 0, 0);
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes route-page-enter-lateral {
+  from {
+    transform: translate3d(8px, 0, 0);
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
   }
 }
 
@@ -405,8 +432,37 @@ body,
   animation: projects-dialog-panel 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.route-transition {
-  animation: route-transition 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+.route-motion-surface[data-motion-active='true']
+  :where(header, main, aside, footer, section[aria-label], [role='region'], h1:not(header *)) {
+  backface-visibility: hidden;
+  --route-motion-lag: 0ms;
+}
+
+.route-motion-surface[data-motion-active='true']
+  :where(main, section[aria-label], [role='region']) {
+  --route-motion-lag: 18ms;
+}
+
+.route-motion-surface[data-motion-active='true'] :where(aside, footer) {
+  --route-motion-lag: 34ms;
+}
+
+.route-motion-surface[data-motion-active='true'][data-motion-direction='forward']
+  :where(header, main, aside, footer, section[aria-label], [role='region'], h1:not(header *)) {
+  animation: route-page-enter-forward 222ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: var(--route-motion-lag);
+}
+
+.route-motion-surface[data-motion-active='true'][data-motion-direction='backward']
+  :where(header, main, aside, footer, section[aria-label], [role='region'], h1:not(header *)) {
+  animation: route-page-enter-backward 222ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: var(--route-motion-lag);
+}
+
+.route-motion-surface[data-motion-active='true'][data-motion-direction='lateral']
+  :where(header, main, aside, footer, section[aria-label], [role='region'], h1:not(header *)) {
+  animation: route-page-enter-lateral 222ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: var(--route-motion-lag);
 }
 
 .action-reveal {
@@ -418,7 +474,9 @@ body,
   .projects-card-enter,
   .projects-dialog-backdrop,
   .projects-dialog-panel,
-  .route-transition,
+  .route-motion-surface,
+  .route-motion-surface
+    :where(header, main, aside, footer, section[aria-label], [role='region'], h1:not(header *)),
   .action-reveal,
   .project-pixel-mark i {
     animation: none !important;

--- a/frontend/src/pages/project-detail/index.test.tsx
+++ b/frontend/src/pages/project-detail/index.test.tsx
@@ -57,7 +57,8 @@ describe('ProjectDetailPage', () => {
     expect(await screen.findByRole('heading', { name: '轻装信使' })).toBeTruthy()
     expect(screen.getByRole('link', { name: '项目资产' })).toBeTruthy()
     expect(screen.queryByText('穿戴')).toBeNull()
-    expect(container.querySelector('[data-route-transition="/projects/42/assets/51"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="route-motion-surface"]')).toBeTruthy()
+    expect(container.querySelector('[data-route-transition]')).toBeNull()
   })
 
   it('keeps the Project workspace available when the character count request fails', async () => {

--- a/frontend/src/pages/project-detail/index.tsx
+++ b/frontend/src/pages/project-detail/index.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState, type ReactNode } from 'react'
-import { Outlet, useLocation, useParams } from 'react-router'
+import { Outlet, useParams } from 'react-router'
 
 import { projectApis, type Project } from '@/entities'
 
 /** 项目常驻工作区；子路由负责具体资产内容。 */
 export function ProjectDetailPage() {
   const { projectId } = useParams()
-  const location = useLocation()
   const [project, setProject] = useState<Project | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -56,11 +55,7 @@ export function ProjectDetailPage() {
 
   return (
     <div className="min-h-[100dvh] bg-app-canvas px-4 pb-8 pt-[4.25rem] text-app-ink sm:px-6 lg:px-8">
-      <div
-        key={location.pathname}
-        data-route-transition={location.pathname}
-        className="route-transition mx-auto min-h-full w-full max-w-[90rem]"
-      >
+      <div className="mx-auto min-h-full w-full max-w-[90rem]">
         <Outlet context={project} />
       </div>
     </div>

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -338,6 +338,20 @@ describe('QuickStartPage', () => {
     expect(entrySection?.className).toContain('pt-14')
   })
 
+  it('exposes the creation entry as a shared route-motion region', () => {
+    renderAt('/quick-start', serviceFor(null))
+
+    expect(screen.getByRole('region', { name: '创作入口' })).toBeTruthy()
+  })
+
+  it('keeps the creation entry on the app canvas without a second page frame', () => {
+    renderAt('/quick-start', serviceFor(null))
+
+    const entry = screen.getByRole('region', { name: '创作入口' })
+    expect(entry.className).not.toContain('border-app-line')
+    expect(entry.className).not.toContain('shadow-app-page')
+  })
+
   it('uses a centered creation desk with style prompts before the composer', () => {
     const entry = renderAt('/quick-start', serviceFor(null))
     const entrySection = entry.getByLabelText('创作指令').closest('section')

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -553,7 +553,10 @@ function QuickStartInput({
     awaitingGenerationConfirmation || Boolean(prompt.trim()) || Boolean(templateFile)
 
   return (
-    <section className="relative min-h-[100dvh] overflow-hidden border border-app-line bg-app-canvas pt-14 text-app-ink shadow-app-page">
+    <section
+      aria-label="创作入口"
+      className="relative min-h-[100dvh] overflow-hidden bg-app-canvas pt-14 text-app-ink"
+    >
       <AmbientGrid />
 
       <div


### PR DESCRIPTION
本 PR 为所有真实 pathname 页面增加统一的横向进入动画，并保持产品顶栏稳定、业务页面单实例和 Quick Start 单画布。

## Why

现有页面切换缺少连续的方向语义，项目页还保留局部进入动画；分散实现容易造成双重运动、创作页页面框堆叠，以及 search/hash 更新误触发整页动画。

## Changes

- 在产品与公开页共享外壳中接入统一的页面 motion surface。
- 按 Header 顺序与栏目深度计算 forward、backward、lateral 方向。
- 使用纯横向 `translate3d`、非线性 easing 和 0/18/34ms 纵向层级延迟。
- 仅在标准化 pathname 真变化时激活；search/hash 与项目索引补全不重播。
- 移除项目页局部页面动画，让后退立即触发路由，并让 Quick Start 保持同一画布。

## Implementation

- React ref 只在 effect 中提交上一 pathname，避免 StrictMode 双 render 覆盖方向。
- 通过 keyed surface 只挂载当前业务页面，不保留旧页退出层，也不使用 snapshot、mask、blur 或 clone。
- `prefers-reduced-motion` 下关闭共享页面位移动画。

## Verification

- [x] `npm test -- src/app/app.test.tsx src/app/layout/app-header.test.tsx src/app/route-motion.test.tsx src/app/workflow-editor-route.test.tsx src/pages/project-detail/index.test.tsx src/pages/quick-start/index.test.tsx`：6 个文件、131 个测试通过。
- [x] `npm run build`：TypeScript 与 Vite 生产构建通过；仅保留已有的 chunk size 提示。
- [x] `npx oxlint <changed TS/TSX files>`：改动文件检查通过。
- [x] `npx oxfmt --check <changed TS/TSX/CSS files>`：改动文件格式检查通过。
- [x] 本地真实页面：`/workspace → /projects` 为 forward，返回为 backward，进入 `/quick-start` 为 forward；全程只有一个 motion surface，创作页无页面级边框与阴影。

## Scope

- 本 PR 不包含：路由架构迁移、新动画依赖、旧页退出/交叉叠放、页面布局或组件微交互重做。
- 后续事项：无。

## Related Issues

Closes #507
