### PR TITLE
fix(render3d): 删掉宣称多朝向已算好的死分支

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
@@ -321,22 +321,10 @@ class RenderFrameStrategy(DerivationStrategy):
                 f"三渲二未产出任何帧(动作 {action.action.value}、朝向 {chosen.direction})。"
             )
 
-        extra = [d for d in available if d != chosen.direction]
-        if extra:
-            # 如实报:这些朝向已经渲出来了、零额外成本,但出参装不下,只能丢。
-            # 不写成 warning 日志而是进度文案,因为这串字最终会经 server 到用户眼前,
-            # 而"多朝向"正是这条路线的卖点 —— 用户该知道它已经算好了。
-            progress.step(
-                "derive",
-                1,
-                3,
-                f"已渲 {len(available)} 个朝向,本次出参只带 {chosen.direction};"
-                f"其余 {','.join(extra)} 零成本可用但当前契约装不下(#122)",
-            )
-        else:
-            progress.step(
-                "derive", 1, 3, f"朝向 {chosen.direction} 共 {len(frames)} 帧"
-            )
+        # 只报拿到的这一个朝向。这里曾有一条"其余朝向零成本可用但契约装不下"的分支,
+        # 而 ``want`` 恒非 None → ``direction`` 恒传入 → 出帧台恒把方向表裁成单条,
+        # 那条分支在生产里无条件不成立。留着会让人以为多朝向已经算好了只是没带出来。
+        progress.step("derive", 1, 3, f"朝向 {chosen.direction} 共 {len(frames)} 帧")
 
         # 3D 帧本来就是透明底,**不套抠图**:去白边那一步会把浅灰甲当漏白吃掉。
         # 像素化仍按 ActionSpec 走。

--- a/backend/tests/test_render3d_route_and_assets.py
+++ b/backend/tests/test_render3d_route_and_assets.py
@@ -135,6 +135,8 @@ class _FakeRenderer:
         self._directions = directions
         self.last_size: tuple[int, int] | None = None
         self.last_direction: str | None = None
+        # honor_requested=False 只用于注入"出帧台没给请求的朝向"这个故障,
+        # 不代表任何生产路径 —— 策略恒传 direction,真出帧台据此裁成单条。
         self._honor_requested = honor_requested
 
     def render(self, rigged_model, *, clip=None, directions=4, frames=12,
@@ -455,15 +457,18 @@ def test_missing_direction_raises_instead_of_handing_back_another():
         RenderFrameStrategy(renderer).derive(_card(), _spec(), b"RIGGED", _NullProgress())
 
 
-def test_extra_directions_are_reported_not_silently_dropped():
-    """多渲出来的朝向零成本、但出参装不下 —— 这笔浪费要**可见**。"""
+def test_only_the_requested_direction_is_rendered_and_reported():
+    """出帧台只渲请求的那一个朝向,进度文案也只报它。
+
+    这条钉的是生产实际走的路径。原来那条断言的是"多渲出来的朝向零成本但出参装不下",
+    只有给假渲染器传 ``honor_requested=False`` 才跑得到 —— 而策略恒传 ``direction``,
+    出帧台据此把方向表裁成单条,生产里不存在"多渲出来的朝向"。
+    """
     spy = _SpyProgress()
-    RenderFrameStrategy(
-        _FakeRenderer(directions=("e", "n", "w", "s"), honor_requested=False)
-    ).derive(
-        _card(), _spec(), b"RIGGED", spy,
-    )
-    assert any("零成本可用但当前契约装不下" in n for n in spy.notes), spy.notes
+    renderer = _FakeRenderer(directions=("e", "n", "w", "s"))
+    RenderFrameStrategy(renderer).derive(_card(), _spec(), b"RIGGED", spy)
+    assert renderer.last_direction is not None, "策略必须指名朝向,不能让出帧台渲全部"
+    assert not any("装不下" in n for n in spy.notes), spy.notes
 
 
 def test_render_uses_the_measured_portrait_canvas():


### PR DESCRIPTION
Closes #519

## 问题

`want` 恒非 None（`concrete.py:287-290`，`direction is None` 时回落到 facing 映射），所以 `direction=want` 恒传给出帧台；出帧台据此把方向表裁成单条（`sprite.py:180-187`）。`available` 恒为 1 条、`extra` 恒空，那段「其余朝向零成本可用但当前契约装不下」的进度文案永远不会出现。

那串字是会经 server 到用户眼前的。它说的是「多朝向已经算好了，只是没带出来」，而 #449 之后出帧台根本没渲其余朝向 —— 对外承诺了一个不存在的既成事实。

锁住它的测试只有给假渲染器传 `honor_requested=False` 才跑得到，断言的是生产已经到不了的路径。

## 方案

删掉死分支，进度文案只报实际拿到的那一个朝向。测试换成钉生产路径：策略必须指名朝向。假渲染器的 `honor_requested=False` 保留，但注释写明它只用于注入「出帧台没给请求的朝向」这个故障，不代表任何生产路径 —— `test_missing_direction_raises_instead_of_handing_back_another` 用的是它。

## 不包含

出参能不能带多朝向是 #192 子项 8 的设计问题，本 PR 一行不碰出参形状。

## 验收

把策略改成 `direction=None`（让出帧台渲全部）时，新测试失败：

```
FAILED tests/test_render3d_route_and_assets.py::test_only_the_requested_direction_is_rendered_and_reported
```

改动前后 `ruff check .`、`lint-imports`（2 kept, 0 broken）、`pytest -q`（1199 passed, 14 skipped）；render3d 那 27 条用例全过。
