### PR TITLE
fix(quick-start): align candidate previews with confirmed assets

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -786,14 +786,14 @@ describe('QuickStartPage', () => {
     expect(cards.every((card) => card.textContent === '')).toBe(true)
   })
 
-  it('presents two equal candidate frames without inventing a preferred result', async () => {
+  it('keeps equal candidate frames at the same size as confirmed assets', async () => {
     renderStateFixture('template-selecting')
 
     const choices = await screen.findAllByRole('button', { name: /选择角色方案/u })
     const resultLayout = choices[0]?.parentElement
 
     expect(resultLayout?.getAttribute('data-layout')).toBe('agent-result-set')
-    expect(resultLayout?.className).toContain('grid-cols-2')
+    expect(resultLayout?.className).toContain('grid-cols-3')
     expect(choices.every((choice) => choice.getAttribute('data-result-priority') === null)).toBe(
       true,
     )
@@ -802,7 +802,7 @@ describe('QuickStartPage', () => {
 
   it.each([
     ['template-generating', '角色图生成画布', 'grid-cols-3'],
-    ['first-selecting', '动作首帧候选 1', 'grid-cols-2'],
+    ['first-selecting', '动作首帧候选 1', 'grid-cols-3'],
     ['complete', '完整动作预览', 'grid-cols-3'],
   ] as const)('keeps %s on the first-round asset frame grid', async (state, label, columns) => {
     const view = renderStateFixture(state)
@@ -1645,6 +1645,35 @@ describe('QuickStartPage', () => {
       }),
     )
     expect((await screen.findByRole('alert')).textContent).toContain('首帧确认失败')
+  })
+
+  it('collapses first-frame candidates to the confirmed frame after confirmation', async () => {
+    const selectingRun = actionWorkflow({ firstStatus: 'active', firstPhase: 'selecting' })
+    const confirmedRun = actionWorkflow({ fullStatus: 'active' })
+    const confirmedFirstFrame = confirmedRun.nodes.find(
+      (node) => node.type === 'action-first-frame',
+    )
+    if (!confirmedFirstFrame || confirmedFirstFrame.type !== 'action-first-frame') {
+      throw new Error('测试工作流缺少动作首帧节点')
+    }
+    confirmedFirstFrame.selectedFirstFrameUrl = 'first-2.png'
+    const pendingRefresh = deferred<ExportPackageModel | null>()
+    const service = serviceFor(selectingRun, {
+      getFirstFrameCandidates: vi.fn(async () =>
+        eastCandidates('first-1.png', 'first-2.png', 'first-3.png'),
+      ),
+      confirmFirstFrame: vi.fn(async () => confirmedRun),
+      getExportModel: vi.fn().mockResolvedValueOnce(null).mockReturnValue(pendingRefresh.promise),
+    })
+    renderAt('/quick-start/run-1', service)
+
+    fireEvent.click(await screen.findByRole('button', { name: '选择动作首帧 2' }))
+    fireEvent.click(screen.getByRole('button', { name: '确认首帧，生成完整动作' }))
+
+    expect((await screen.findByRole('img', { name: '已选择的动作首帧' })).getAttribute('src')).toBe(
+      'first-2.png',
+    )
+    expect(screen.queryByRole('img', { name: /动作首帧候选/u })).toBeNull()
   })
 
   it('四向动作首帧全部选定后才确认并生成完整动作', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -914,7 +914,7 @@ function DirectionCandidatePicker({
               {DIRECTION_LABELS[group.direction]}方向
             </p>
           ) : null}
-          <div data-layout="agent-result-set" className="grid w-full max-w-2xl grid-cols-2 gap-3">
+          <div data-layout="agent-result-set" className="grid w-full max-w-2xl grid-cols-3 gap-3">
             {group.items.map((candidate, displayIndex) => {
               const chosen = selections[group.direction] === candidate.imageUrl
               const directionLabel = multipleDirections
@@ -1130,6 +1130,20 @@ function QuickStartRun({
       setExportModel(null)
       return
     }
+    const templateIsSelecting = run.nodes.some(
+      (node) =>
+        node.type === 'character-template' &&
+        node.status === 'active' &&
+        node.phase === 'selecting',
+    )
+    const firstFrameIsSelecting = run.nodes.some(
+      (node) =>
+        node.type === 'action-first-frame' &&
+        node.status === 'active' &&
+        node.phase === 'selecting',
+    )
+    if (!templateIsSelecting) setCandidates([])
+    if (!firstFrameIsSelecting) setFirstFrameCandidates([])
     let active = true
     void Promise.all([
       session.getTemplateCandidates(),
@@ -1141,18 +1155,6 @@ function QuickStartRun({
       .then(
         ([nextCandidates, nextFirstFrameCandidates, nextFrames, nextExportModel, nextFailed]) => {
           if (!active) return
-          const templateIsSelecting = run.nodes.some(
-            (node) =>
-              node.type === 'character-template' &&
-              node.status === 'active' &&
-              node.phase === 'selecting',
-          )
-          const firstFrameIsSelecting = run.nodes.some(
-            (node) =>
-              node.type === 'action-first-frame' &&
-              node.status === 'active' &&
-              node.phase === 'selecting',
-          )
           if (templateIsSelecting && nextCandidates.length > 0) setCandidates(nextCandidates)
           if (firstFrameIsSelecting && nextFirstFrameCandidates.length > 0) {
             setFirstFrameCandidates(nextFirstFrameCandidates)
@@ -1481,7 +1483,7 @@ function QuickStartRun({
             </div>
 
             <AgentTurn step="character-template" current={characterTurnIsCurrent}>
-              {candidates.length ? (
+              {isTemplateSelecting && candidates.length ? (
                 <>
                   <AgentCopy
                     lines={[
@@ -1555,7 +1557,7 @@ function QuickStartRun({
               <>
                 <UserTurn>{requestedAction || '待机'}</UserTurn>
                 <AgentTurn step="action-first-frame" current={firstFrameTurnIsCurrent}>
-                  {firstFrameCandidates.length ? (
+                  {isFirstFrameSelecting && firstFrameCandidates.length ? (
                     <>
                       <AgentCopy
                         lines={[


### PR DESCRIPTION
修复 Quick Start 候选图尺寸回归，并让动作首帧确认后立即从三张候选收束为一张确认图。

## Why

多方向候选组件在 PR #467 中把原有三列网格改成了两列，导致候选图比确认图更大；同时候选状态依赖一组异步资源读取完成后才清理，确认首帧后可能继续显示旧候选。

## Changes

- 恢复角色母版与动作首帧候选的三列尺寸基准，与确认图保持一致。
- 候选展示与节点 `selecting` 状态绑定，离开选择态后立即清理旧候选。
- 增加尺寸回归和异步刷新阻塞场景下的首帧收束测试。

## Implementation

- 仅调整 Quick Start 页面候选网格与候选状态投影，不修改生成、选择、确认或后端契约。
- 首帧确认展示以最新工作流节点状态为准，不等待无关资源读取完成。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx`：73/73 通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run format:check -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- 浏览器验证未运行：托管本地 UI worktree 存在他人未提交改动，按环境规范停止且未触碰；按需求未提供截图。

## Scope

- 本 PR 不包含：Workflow Editor、图片生成数量、生成流程、后端或其他视觉调整。
- 后续事项：无。

## Related Issues

Closes #523
