### PR TITLE
fix(quick-start): isolate agent chat storage by draft and run

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -676,6 +676,33 @@ describe('QuickStartPage', () => {
     expect(screen.queryByText('第二条运行的对话')).toBeNull()
   })
 
+  it('migrates only legacy Agent turns bound to the current run', async () => {
+    const run = workflow(setupAndTemplate(), 'run-1')
+    const legacyKey = 'windup.quick-start.agent-chat.v1:7'
+    window.localStorage.setItem(
+      legacyKey,
+      JSON.stringify({ runId: null, turns: [{ role: 'user', content: '旧版未绑定草稿' }] }),
+    )
+
+    const unboundView = renderAt('/quick-start/run-1', serviceFor(run))
+
+    expect(screen.queryByText('旧版未绑定草稿')).toBeNull()
+    expect(window.localStorage.getItem(legacyKey)).toContain('旧版未绑定草稿')
+
+    unboundView.unmount()
+    window.localStorage.setItem(
+      legacyKey,
+      JSON.stringify({ runId: 'run-1', turns: [{ role: 'user', content: '旧版运行对话' }] }),
+    )
+    renderAt('/quick-start/run-1', serviceFor(run))
+
+    expect(await screen.findByText('旧版运行对话')).toBeTruthy()
+    expect(window.localStorage.getItem('windup.quick-start.agent-chat.v2:run:7:run-1')).toContain(
+      '旧版运行对话',
+    )
+    expect(window.localStorage.getItem(legacyKey)).toBeNull()
+  })
+
   it('rewrites the real optimized prompt in the composer and waits for explicit generation send', async () => {
     vi.useFakeTimers()
     const service = serviceFor(null)

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router'
+import { BrowserRouter, MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { QuickStartCandidate, QuickStartEntryService, QuickStartSession } from './service'
@@ -18,6 +18,8 @@ import { QuickStartPage } from './index'
 afterEach(() => {
   cleanup()
   window.localStorage.clear()
+  window.sessionStorage.clear()
+  window.history.replaceState(null, '', '/')
   vi.useRealTimers()
 })
 
@@ -205,6 +207,22 @@ function renderAt(
         <Route path="/playtest/:characterId/:outfitId" element={<PlaytestLocation />} />
       </Routes>
     </MemoryRouter>,
+  )
+}
+
+function renderInBrowserHistory(
+  service: QuickStartEntryService,
+  agent: CreateQuickStartAgentOptions = agentFor(),
+) {
+  return render(
+    <BrowserRouter>
+      <Routes>
+        <Route
+          path="/quick-start"
+          element={<QuickStartPage service={service} activeRunUserId="7" agent={agent} />}
+        />
+      </Routes>
+    </BrowserRouter>,
   )
 }
 
@@ -551,7 +569,7 @@ describe('QuickStartPage', () => {
     expect(standaloneAvatar).toBeUndefined()
   })
 
-  it('persists real Agent turns on the frontend without a demo route or WorkflowRun turns', async () => {
+  it('keeps an unbound Agent draft in its current Quick Start history entry', async () => {
     const service = serviceFor(null)
     const planner = vi.fn(async () => ({
       text: '可以。你最想保留哪个外观特征？',
@@ -559,10 +577,14 @@ describe('QuickStartPage', () => {
       toolCalls: [],
     }))
     const agent = agentFor({ planner })
-    const firstView = renderAt('/quick-start?demo=conversation', service, agent)
+    window.history.replaceState(null, '', '/quick-start')
+    const firstView = renderInBrowserHistory(service, agent)
 
     expect(screen.queryByText('MOCK 演示')).toBeNull()
     expect(screen.getByRole('textbox', { name: '创作指令' })).toBeTruthy()
+    expect(window.sessionStorage.length).toBe(0)
+    expect(window.localStorage.length).toBe(0)
+    expect(window.history.state?.windupQuickStartAgentDraftId).toBeUndefined()
 
     fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
       target: { value: '我想做一个住在云端的机械师。' },
@@ -572,16 +594,86 @@ describe('QuickStartPage', () => {
     expect(await screen.findByText('我想做一个住在云端的机械师。')).toBeTruthy()
     expect(await screen.findByText('可以。你最想保留哪个外观特征？')).toBeTruthy()
     expect(planner).toHaveBeenCalledTimes(1)
-    const persistedAgentChat = window.localStorage.getItem('windup.quick-start.agent-chat.v1:7')
+    const draftId = window.history.state?.windupQuickStartAgentDraftId
+    expect(draftId).toEqual(expect.any(String))
+    const persistedAgentChat = window.sessionStorage.getItem(
+      `windup.quick-start.agent-chat.v2:draft:7:${draftId}`,
+    )
     expect(persistedAgentChat).toContain('我想做一个住在云端的机械师。')
     expect(persistedAgentChat).toContain('可以。你最想保留哪个外观特征？')
     expect(persistedAgentChat).not.toContain('勾勒角色轮廓')
+    expect(window.localStorage.length).toBe(0)
 
     firstView.unmount()
-    renderAt('/quick-start', service, agent)
+    const restoredView = renderInBrowserHistory(service, agent)
 
     expect(screen.getByText('我想做一个住在云端的机械师。')).toBeTruthy()
     expect(screen.getByText('可以。你最想保留哪个外观特征？')).toBeTruthy()
+
+    restoredView.unmount()
+    window.history.pushState(null, '', '/quick-start')
+    renderInBrowserHistory(service, agent)
+
+    expect(screen.queryByText('我想做一个住在云端的机械师。')).toBeNull()
+    expect(screen.queryByText('可以。你最想保留哪个外观特征？')).toBeNull()
+  })
+
+  it('moves the Agent draft into a run-scoped sidecar when generation starts', async () => {
+    vi.useFakeTimers()
+    const createdRun = workflow(setupAndTemplate({ phase: 'generating' }), 'run-created')
+    const service = serviceFor(createdRun, {
+      runId: 'run-created',
+      getWorkflow: vi.fn(() => createdRun),
+      resume: vi.fn(async () => createdRun),
+    })
+    renderAt(
+      '/quick-start',
+      service,
+      agentFor({
+        startCharacterGeneration: vi.fn(async () => ({ runId: 'run-created' })),
+      }),
+    )
+
+    fireEvent.change(screen.getByLabelText('创作指令'), {
+      target: { value: '提着风灯的森林守夜人' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    await act(async () => undefined)
+
+    const draftId = window.history.state?.windupQuickStartAgentDraftId
+    expect(draftId).toEqual(expect.any(String))
+    expect(
+      window.sessionStorage.getItem(`windup.quick-start.agent-chat.v2:draft:7:${draftId}`),
+    ).toContain('提着风灯的森林守夜人')
+
+    await act(async () => vi.advanceTimersByTimeAsync(760))
+    fireEvent.click(screen.getByRole('button', { name: '发送生成' }))
+    await act(async () => undefined)
+    await act(async () => vi.advanceTimersByTime(460))
+
+    expect(
+      window.localStorage.getItem('windup.quick-start.agent-chat.v2:run:7:run-created'),
+    ).toContain('提着风灯的森林守夜人')
+    expect(
+      window.sessionStorage.getItem(`windup.quick-start.agent-chat.v2:draft:7:${draftId}`),
+    ).toBeNull()
+  })
+
+  it('loads Agent turns only from the matching run sidecar', async () => {
+    window.localStorage.setItem(
+      'windup.quick-start.agent-chat.v2:run:7:run-1',
+      JSON.stringify({ turns: [{ role: 'user', content: '第一条运行的对话' }] }),
+    )
+    window.localStorage.setItem(
+      'windup.quick-start.agent-chat.v2:run:7:run-2',
+      JSON.stringify({ turns: [{ role: 'user', content: '第二条运行的对话' }] }),
+    )
+    const run = workflow(setupAndTemplate(), 'run-1')
+
+    renderAt('/quick-start/run-1', serviceFor(run))
+
+    expect(await screen.findByText('第一条运行的对话')).toBeTruthy()
+    expect(screen.queryByText('第二条运行的对话')).toBeNull()
   })
 
   it('rewrites the real optimized prompt in the composer and waits for explicit generation send', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -132,6 +132,7 @@ const ROLE_DEFAULT_MESSAGE: readonly KineticCopyMessage[] = [
 const ENTRY_HANDOFF_MS = 460
 const PROMPT_REWRITE_MS = 760
 const AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v2'
+const LEGACY_AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v1'
 const AGENT_DRAFT_HISTORY_STATE_KEY = 'windupQuickStartAgentDraftId'
 
 type AgentConversationTurn = {
@@ -151,6 +152,10 @@ function agentDraftConversationStorageKey(userId: string | null, draftId: string
 
 function agentRunConversationStorageKey(userId: string | null, runId: string): string {
   return `${AGENT_CONVERSATION_STORAGE_KEY}:run:${userId ?? 'local'}:${runId}`
+}
+
+function legacyAgentConversationStorageKey(userId: string | null): string {
+  return `${LEGACY_AGENT_CONVERSATION_STORAGE_KEY}:${userId ?? 'local'}`
 }
 
 function readAgentDraftId(): string | null {
@@ -223,6 +228,40 @@ function removeAgentConversation(storageName: AgentConversationStorageName, key:
     window[storageName].removeItem(key)
   } catch {
     // 清理失败只会留下当前标签页的孤立草稿，不影响真实生成流程。
+  }
+}
+
+function readAgentRunConversation(
+  userId: string | null,
+  runId: string,
+): readonly AgentConversationTurn[] {
+  const runKey = agentRunConversationStorageKey(userId, runId)
+  const currentTurns = readAgentConversation('localStorage', runKey)
+  if (currentTurns.length > 0) return currentTurns
+
+  const legacyKey = legacyAgentConversationStorageKey(userId)
+  try {
+    const stored = window.localStorage.getItem(legacyKey)
+    if (!stored) return []
+    const parsed: unknown = JSON.parse(stored)
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('runId' in parsed) ||
+      parsed.runId !== runId
+    ) {
+      return []
+    }
+
+    // v1 只有用户级 key；仅迁移已绑定当前运行的记录，避免复活未绑定的全局草稿。
+    const legacyTurns = readAgentConversation('localStorage', legacyKey)
+    if (legacyTurns.length === 0) return []
+    if (writeAgentConversation('localStorage', runKey, { turns: legacyTurns })) {
+      removeAgentConversation('localStorage', legacyKey)
+    }
+    return legacyTurns
+  } catch {
+    return []
   }
 }
 
@@ -1095,8 +1134,7 @@ function QuickStartRun({
   const [confirmingCandidate, setConfirmingCandidate] = useState(false)
   const [confirmingFirstFrame, setConfirmingFirstFrame] = useState(false)
   const agentConversationTurns = useMemo(
-    () =>
-      readAgentConversation('localStorage', agentRunConversationStorageKey(activeRunUserId, runId)),
+    () => readAgentRunConversation(activeRunUserId, runId),
     [activeRunUserId, runId],
   )
   const automaticPublishAttempt = useRef<string | null>(null)

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -131,7 +131,8 @@ const ROLE_DEFAULT_MESSAGE: readonly KineticCopyMessage[] = [
 
 const ENTRY_HANDOFF_MS = 460
 const PROMPT_REWRITE_MS = 760
-const AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v1'
+const AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v2'
+const AGENT_DRAFT_HISTORY_STATE_KEY = 'windupQuickStartAgentDraftId'
 
 type AgentConversationTurn = {
   role: 'user' | 'assistant'
@@ -139,22 +140,54 @@ type AgentConversationTurn = {
 }
 
 type AgentConversationRecord = {
-  runId: string | null
   turns: readonly AgentConversationTurn[]
 }
 
-function agentConversationStorageKey(userId: string | null): string {
-  return `${AGENT_CONVERSATION_STORAGE_KEY}:${userId ?? 'local'}`
+type AgentConversationStorageName = 'localStorage' | 'sessionStorage'
+
+function agentDraftConversationStorageKey(userId: string | null, draftId: string): string {
+  return `${AGENT_CONVERSATION_STORAGE_KEY}:draft:${userId ?? 'local'}:${draftId}`
 }
 
-function readAgentConversation(userId: string | null): AgentConversationRecord | null {
+function agentRunConversationStorageKey(userId: string | null, runId: string): string {
+  return `${AGENT_CONVERSATION_STORAGE_KEY}:run:${userId ?? 'local'}:${runId}`
+}
+
+function readAgentDraftId(): string | null {
   try {
-    const stored = window.localStorage.getItem(agentConversationStorageKey(userId))
-    if (!stored) return null
+    const state: unknown = window.history.state
+    if (typeof state !== 'object' || state === null || !(AGENT_DRAFT_HISTORY_STATE_KEY in state)) {
+      return null
+    }
+    const draftId = (state as Record<string, unknown>)[AGENT_DRAFT_HISTORY_STATE_KEY]
+    return typeof draftId === 'string' && draftId ? draftId : null
+  } catch {
+    return null
+  }
+}
+
+function createAgentDraftId(): string {
+  const draftId = window.crypto.randomUUID()
+  try {
+    const state: unknown = window.history.state
+    const currentState = typeof state === 'object' && state !== null ? state : {}
+    window.history.replaceState({ ...currentState, [AGENT_DRAFT_HISTORY_STATE_KEY]: draftId }, '')
+  } catch {
+    // history state 不可写时仍保留本次内存草稿，不阻断对话和生成。
+  }
+  return draftId
+}
+
+function readAgentConversation(
+  storageName: AgentConversationStorageName,
+  key: string,
+): readonly AgentConversationTurn[] {
+  try {
+    const stored = window[storageName].getItem(key)
+    if (!stored) return []
     const parsed: unknown = JSON.parse(stored)
-    if (typeof parsed !== 'object' || parsed === null || !('turns' in parsed)) return null
-    const runId = 'runId' in parsed && typeof parsed.runId === 'string' ? parsed.runId : null
-    if (!Array.isArray(parsed.turns)) return null
+    if (typeof parsed !== 'object' || parsed === null || !('turns' in parsed)) return []
+    if (!Array.isArray(parsed.turns)) return []
     const turns = parsed.turns.filter(
       (turn): turn is AgentConversationTurn =>
         typeof turn === 'object' &&
@@ -165,17 +198,31 @@ function readAgentConversation(userId: string | null): AgentConversationRecord |
         typeof turn.content === 'string' &&
         Boolean(turn.content.trim()),
     )
-    return turns.length > 0 ? { runId, turns } : null
+    return turns
   } catch {
-    return null
+    return []
   }
 }
 
-function writeAgentConversation(userId: string | null, record: AgentConversationRecord): void {
+function writeAgentConversation(
+  storageName: AgentConversationStorageName,
+  key: string,
+  record: AgentConversationRecord,
+): boolean {
   try {
-    window.localStorage.setItem(agentConversationStorageKey(userId), JSON.stringify(record))
+    window[storageName].setItem(key, JSON.stringify(record))
+    return true
   } catch {
     // 对话持久化只增强刷新体验，存储不可用时不能阻断真实生成流程。
+    return false
+  }
+}
+
+function removeAgentConversation(storageName: AgentConversationStorageName, key: string): void {
+  try {
+    window[storageName].removeItem(key)
+  } catch {
+    // 清理失败只会留下当前标签页的孤立草稿，不影响真实生成流程。
   }
 }
 
@@ -209,6 +256,7 @@ export function QuickStartPage({
   agent,
 }: QuickStartPageProps) {
   const { runId } = useParams()
+  const location = useLocation()
   const [searchParams] = useSearchParams()
   const authSession = useOptionalAuthSession()
   const activeRunUserId =
@@ -241,6 +289,7 @@ export function QuickStartPage({
     />
   ) : (
     <QuickStartInput
+      key={location.key}
       service={activeService}
       agent={agent}
       activeRunUserId={activeRunUserId}
@@ -351,10 +400,16 @@ function QuickStartInput({
     'collecting' | 'rewriting' | 'ready' | 'confirmed'
   >('collecting')
   const [error, setError] = useState<string | null>(null)
+  const draftIdRef = useRef(readAgentDraftId())
   const [conversationTurns, setConversationTurns] = useState<readonly AgentConversationTurn[]>(
     () => {
-      const stored = readAgentConversation(activeRunUserId)
-      return stored?.runId === null ? stored.turns : []
+      const draftId = draftIdRef.current
+      return draftId
+        ? readAgentConversation(
+            'sessionStorage',
+            agentDraftConversationStorageKey(activeRunUserId, draftId),
+          )
+        : []
     },
   )
   const fileInput = useRef<HTMLInputElement>(null)
@@ -389,10 +444,44 @@ function QuickStartInput({
     [prompt],
   )
 
-  const persistConversation = useCallback(
-    (turns: readonly AgentConversationTurn[], runId: string | null = null) => {
+  const ensureDraftId = useCallback(() => {
+    const current = draftIdRef.current
+    if (current) return current
+    const draftId = createAgentDraftId()
+    draftIdRef.current = draftId
+    return draftId
+  }, [])
+
+  const persistDraftConversation = useCallback(
+    (turns: readonly AgentConversationTurn[]) => {
       conversationTurnsRef.current = turns
-      writeAgentConversation(activeRunUserId, { runId, turns })
+      const draftId = ensureDraftId()
+      writeAgentConversation(
+        'sessionStorage',
+        agentDraftConversationStorageKey(activeRunUserId, draftId),
+        { turns },
+      )
+    },
+    [activeRunUserId, ensureDraftId],
+  )
+
+  const persistRunConversation = useCallback(
+    (turns: readonly AgentConversationTurn[], runId: string) => {
+      conversationTurnsRef.current = turns
+      const stored = writeAgentConversation(
+        'localStorage',
+        agentRunConversationStorageKey(activeRunUserId, runId),
+        { turns },
+      )
+      if (stored) {
+        const draftId = draftIdRef.current
+        if (draftId) {
+          removeAgentConversation(
+            'sessionStorage',
+            agentDraftConversationStorageKey(activeRunUserId, draftId),
+          )
+        }
+      }
     },
     [activeRunUserId],
   )
@@ -401,11 +490,11 @@ function QuickStartInput({
     (turn: AgentConversationTurn) => {
       setConversationTurns((current) => {
         const next = [...current, turn]
-        persistConversation(next)
+        persistDraftConversation(next)
         return next
       })
     },
-    [persistConversation],
+    [persistDraftConversation],
   )
 
   useEffect(
@@ -477,7 +566,7 @@ function QuickStartInput({
           appendConversationTurn({ role: 'assistant', content: result.message })
           return
         }
-        persistConversation(conversationTurnsRef.current, result.runId)
+        persistRunConversation(conversationTurnsRef.current, result.runId)
         setEntryTransition('leaving')
         await new Promise<void>((resolve) => {
           handoffTimer.current = setTimeout(() => {
@@ -1005,10 +1094,11 @@ function QuickStartRun({
   const [publishing, setPublishing] = useState(false)
   const [confirmingCandidate, setConfirmingCandidate] = useState(false)
   const [confirmingFirstFrame, setConfirmingFirstFrame] = useState(false)
-  const agentConversationTurns = useMemo(() => {
-    const stored = readAgentConversation(activeRunUserId)
-    return stored?.runId === runId ? stored.turns : []
-  }, [activeRunUserId, runId])
+  const agentConversationTurns = useMemo(
+    () =>
+      readAgentConversation('localStorage', agentRunConversationStorageKey(activeRunUserId, runId)),
+    [activeRunUserId, runId],
+  )
   const automaticPublishAttempt = useRef<string | null>(null)
   const transcriptScrollRegion = useRef<HTMLElement>(null)
   const workflowConflictRef = useRef(false)


### PR DESCRIPTION
本 PR 修复 Quick Start Agent 对话按用户全局复用的问题，让纯对话草稿只属于当前浏览器历史入口，并在生成开始后迁移到对应运行的独立前端 sidecar。

## Why

此前 Agent turns 以用户为粒度写入单一 `localStorage` 记录。新的 Quick Start 入口会恢复上一段未绑定对话，后续运行也可能覆盖历史运行的 Agent transcript，造成跨会话串话。

## Changes

- 第一条用户消息前不创建草稿；首条消息后仅创建一个 history-bound 草稿，后续 turn 覆盖同一记录。
- 当前历史入口刷新或返回时恢复草稿，新入口不继承旧草稿。
- Agent 返回 `runId` 后，将 turns 迁移到 `userId + runId` sidecar；写入成功后清理 session 草稿。
- `/quick-start/:runId` 只读取当前用户、当前运行对应的 Agent turns。
- 升级时仅迁移 `runId` 精确匹配的 v1 transcript；未绑定的旧草稿不会恢复。

## Implementation

- 未绑定草稿保存在 `sessionStorage`，草稿 ID 保存在当前 `history.state`，并保留 React Router 既有 state 字段。
- 已绑定对话保存在独立 `localStorage` sidecar；WorkflowRun 仍是生成状态唯一事实源。
- v1 兼容读取写入 v2 sidecar 成功后才清理旧 key，存储失败时仍可继续显示旧对话。
- 不向 WorkflowRun 节点、metadata 或生成消息写入 Agent turns，也不修改 Controller、Editor 或后端。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx --configLoader runner`：77 项通过。
- [x] `npm run build`：通过；仅有既存 chunk size warning。
- [x] `npx oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `git diff --check`：通过。
- [x] 真实浏览器：当前硬直达草稿刷新后恢复；离开后再次硬直达 `/quick-start` 不继承旧草稿；控制台无 error。

## Scope

- 本 PR 不包含：WorkflowRun、WorkflowController、Workflow Editor、后端或 Agent Tool 改动。
- 本次没有可见 UI 变化，因此不新增截图资源。

## Related Issues

Fixes #526
