### PR TITLE
fix(quick-start): keep conversation visible during run restore

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -840,11 +840,13 @@ describe('QuickStartPage', () => {
     expect(turns.at(-1)?.dataset.currentTurn).toBe('true')
   })
 
-  it('hands the creation entry off to the generating canvas instead of hard-cutting routes', async () => {
+  it('keeps the Agent conversation visible while the run restore is pending', async () => {
     vi.useFakeTimers()
     const createdRun = workflow(setupAndTemplate({ phase: 'generating' }), 'run-created')
+    const restoredSession = deferred<QuickStartSession>()
     const service = serviceFor(createdRun, {
       runId: 'run-created',
+      open: vi.fn(() => restoredSession.promise),
       getWorkflow: vi.fn(() => createdRun),
       resume: vi.fn(async () => createdRun),
     })
@@ -880,13 +882,13 @@ describe('QuickStartPage', () => {
     expect(screen.queryByTestId('quick-start-run')).toBeNull()
 
     await act(async () => vi.advanceTimersByTime(1))
-    const runTranscript = screen.getByTestId('quick-start-transcript')
-    expect(runTranscript.textContent).toContain('提着风灯的森林守夜人')
-    expect(runTranscript.querySelector('[data-conversation-kind="agent"]')).toBeTruthy()
-    expect(runTranscript.querySelector('[data-conversation-kind="workflow"]')).toBeTruthy()
-    expect(screen.getByRole('img', { name: '角色图生成画布' }).getAttribute('data-reveal')).toBe(
-      'generation-canvas',
-    )
+    const restoringTranscript = screen.getByTestId('quick-start-restoring-transcript')
+    expect(restoringTranscript.textContent).toContain('提着风灯的森林守夜人')
+    expect(screen.queryByText('正在恢复这次创作')).toBeNull()
+    expect(screen.queryByText('正在读取工作流状态…')).toBeNull()
+
+    expect(restoringTranscript.querySelector('[data-conversation-kind="agent"]')).toBeTruthy()
+    expect(screen.getByTestId('quick-start-run').getAttribute('aria-busy')).toBe('true')
   })
 
   it('keeps earlier turns visible while the agent conversation moves downward', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -969,6 +969,44 @@ function GenerationCanvas({ label }: { label: string }) {
   return <GenerationPreviewCard label={label} />
 }
 
+function RestoringConversation({ turns }: { turns: readonly AgentConversationTurn[] }) {
+  return (
+    <section className="relative min-h-screen overflow-hidden bg-app-canvas pt-14 text-app-ink">
+      <div
+        aria-busy="true"
+        data-testid="quick-start-run"
+        data-layout="agent-shell"
+        className="relative h-[calc(100dvh-3.5rem)] overflow-hidden"
+      >
+        <main
+          data-layout="quick-start-scroll-region"
+          className="absolute inset-0 overflow-y-auto px-5 pt-14 pb-32 sm:px-8 sm:pt-10 sm:pb-36"
+        >
+          <div
+            data-testid="quick-start-restoring-transcript"
+            className="mx-auto grid min-h-full w-full max-w-3xl content-end gap-7 pb-8 sm:gap-9"
+          >
+            {turns.map((turn, index) => (
+              <div
+                key={`${turn.role}:${index}:${turn.content}`}
+                data-conversation-kind="agent"
+                className="min-w-0"
+              >
+                {turn.role === 'user' ? (
+                  <UserTurn>{turn.content}</UserTurn>
+                ) : (
+                  <AgentCopy lines={turn.content.split('\n')} animate={false} />
+                )}
+              </div>
+            ))}
+            <div data-testid="quick-start-transcript-end" />
+          </div>
+        </main>
+      </div>
+    </section>
+  )
+}
+
 function QuickStartRun({
   service,
   runId,
@@ -1210,30 +1248,24 @@ function QuickStartRun({
   }, [actionFrames, candidates, firstFrameCandidates, run])
 
   if (!run) {
+    if (restoring) return <RestoringConversation turns={agentConversationTurns} />
+
     return (
       <section className="min-h-[520px] rounded-[2rem] border border-app-line bg-app-canvas p-8 text-app-ink">
         <p className="font-mono text-[10px] font-bold tracking-[0.16em] text-app-muted">
           QUICK START / RECOVERY
         </p>
-        <h1 className="mt-4 font-serif text-4xl">
-          {restoring ? '正在恢复这次创作' : '无法恢复这次创作'}
-        </h1>
-        {restoring ? (
-          <p className="mt-4 max-w-xl text-sm leading-7 text-app-muted">正在读取工作流状态…</p>
-        ) : (
-          <>
-            <p role="alert" className="mt-4 max-w-xl text-sm leading-7 text-app-muted">
-              {error || `没有找到运行记录 ${runId}`}
-            </p>
-            <button
-              type="button"
-              onClick={() => navigate('/quick-start')}
-              className="mt-8 rounded-xl bg-app-accent px-5 py-3 text-sm font-semibold text-app-on-accent"
-            >
-              返回快速开始
-            </button>
-          </>
-        )}
+        <h1 className="mt-4 font-serif text-4xl">无法恢复这次创作</h1>
+        <p role="alert" className="mt-4 max-w-xl text-sm leading-7 text-app-muted">
+          {error || `没有找到运行记录 ${runId}`}
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate('/quick-start')}
+          className="mt-8 rounded-xl bg-app-accent px-5 py-3 text-sm font-semibold text-app-on-accent"
+        >
+          返回快速开始
+        </button>
       </section>
     )
   }


### PR DESCRIPTION
移除 Quick Start Agent 进入图片生成时的可见恢复中断，让已产生的对话在工作流读取期间保持在原对话画布中。

## Why

Agent 触发生成后先导航到 `/quick-start/:runId`，`service.open` 完成前 `run` 暂为空。原页面把这个内部恢复窗口渲染成独立的“正在恢复这次创作”页面，破坏了从对话到生成的连续性。

## Changes

- 恢复期间继续显示当前 run 已绑定的 Agent 对话。
- 删除可见的“正在恢复这次创作”和“正在读取工作流状态”占位页面。
- 保留真实恢复失败时的错误说明与返回入口。
- 增加 `service.open` 持续 pending 时的回归测试。

## Implementation

- 复用正式 Quick Start 对话页的 shell、宽度、滚动区与 Agent turn 样式。
- 仅通过 `aria-busy` 暴露内部忙碌状态，不提前渲染 WorkflowRun、生成画布或操作控件。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx`：74/74 通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run format:check -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- 浏览器验证未运行：托管本地 UI worktree 存在他人未提交改动，按环境规范停止且未触碰；本组 Quick Start 快速修复不提供截图。

## Scope

- 本 PR 不包含：Agent、WorkflowController、生成接口、路由动画或其他页面加载态调整。
- 合并顺序：本 PR 可独立合入；同页 PR #529 随后 rebase 到最新 `main`。

## Related Issues

Closes #531
