### PR TITLE
fix(gateway): video 台账对齐与 404 分层 (#527)

### DIFF
--- a/backend/packages/common/src/windup_common/enums/model.py
+++ b/backend/packages/common/src/windup_common/enums/model.py
@@ -18,6 +18,9 @@ class ModelErrorType(str, Enum):
     UNREACHED = "unreached"                 # 521/522/523/525,请求大概率未到上游
     MAYBE_BILLED = "maybe_billed"           # 520/524/其它可能已计费 5xx
     UPSTREAM_FAILED = "upstream_failed"     # 视频 job failed/cancelled
+    MODEL_NOT_FOUND = "model_not_found"     # 404 模型不存在 → fallback model
+    CONFIG_ERROR = "config_error"             # 404/400 路径或 endpoint 配错 → fail fast
+    JOB_NOT_FOUND = "job_not_found"           # 异步 poll job 404 → 任务失败
     UNKNOWN = "unknown"                     # 未知错误
 
     @property

--- a/backend/packages/framework/src/windup_framework/gateway/billing.py
+++ b/backend/packages/framework/src/windup_framework/gateway/billing.py
@@ -16,6 +16,9 @@ def upstream_reached_label(
     if error_type in {
         ModelErrorType.UNREACHED,
         ModelErrorType.NETWORK,
+        ModelErrorType.MODEL_NOT_FOUND,
+        ModelErrorType.CONFIG_ERROR,
+        ModelErrorType.JOB_NOT_FOUND,
     }:
         return "false"
     if error_type is ModelErrorType.TIMEOUT and http_status is None:
@@ -52,6 +55,9 @@ def billing_flags(
         ModelErrorType.AUTH,
         ModelErrorType.RATE_LIMIT,
         ModelErrorType.UNKNOWN,
+        ModelErrorType.MODEL_NOT_FOUND,
+        ModelErrorType.CONFIG_ERROR,
+        ModelErrorType.JOB_NOT_FOUND,
     }:
         return False
     if error_type in {

--- a/backend/packages/framework/src/windup_framework/gateway/chat.py
+++ b/backend/packages/framework/src/windup_framework/gateway/chat.py
@@ -268,7 +268,7 @@ class ChatGateway:
                         http_status=result.http_status,
                         ok=result.ok,
                     )
-                    if not budget.can_record(maybe_billed):
+                    if not result.ok and not budget.can_record(maybe_billed):
                         self._emit(
                             AttemptTrace(
                                 request_id=request_id,

--- a/backend/packages/framework/src/windup_framework/gateway/classify.py
+++ b/backend/packages/framework/src/windup_framework/gateway/classify.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
+import math
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-import math
 
 import httpx
 
@@ -10,9 +11,102 @@ from windup_common.enums.model import ModelErrorType
 
 _MAX_RETRY_WAIT = 30.0
 
+_MODEL_HINTS = (
+    "model_not_found",
+    "model not found",
+    "invalid model",
+    "unknown model",
+    "does not exist",
+    "model_not_exist",
+)
+_CONFIG_HINTS = (
+    "invalid url",
+    "unknown url",
+    "no route",
+    "endpoint",
+    "not found",
+)
+
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _body_lower(body: str | None) -> str:
+    if not body:
+        return ""
+    return body.lower()
+
+
+def _json_error_code(body: str | None) -> str:
+    if not body:
+        return ""
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    err = payload.get("error")
+    if isinstance(err, dict):
+        code = err.get("code") or err.get("type")
+        return str(code or "").lower()
+    return str(err or "").lower()
+
+
+def _looks_like_model_not_found(status: int, body: str | None) -> bool:
+    if status not in (400, 404):
+        return False
+    text = _body_lower(body)
+    code = _json_error_code(body)
+    if any(h in text or h in code for h in _MODEL_HINTS):
+        return True
+    if status == 404 and "model" in text:
+        return True
+    return status == 404
+
+
+def _looks_like_config_error(status: int, body: str | None) -> bool:
+    if status not in (400, 404):
+        return False
+    text = _body_lower(body)
+    code = _json_error_code(body)
+    if any(h in text or h in code for h in _CONFIG_HINTS):
+        if "model" in text and status in (400, 404):
+            return False
+        return True
+    return False
+
+
+def classify_http_response(
+    status: int,
+    body: str | None = None,
+    *,
+    phase: str = "submit",
+) -> ModelErrorType:
+    if status == 429:
+        return ModelErrorType.RATE_LIMIT
+    if status in (401, 403):
+        return ModelErrorType.AUTH
+    if status in (502, 503):
+        return ModelErrorType.UNREACHED
+    if status in (521, 522, 523, 525):
+        return ModelErrorType.UNREACHED
+    if status == 404 and phase in {"follow", "poll", "download"}:
+        return ModelErrorType.JOB_NOT_FOUND
+    if _looks_like_config_error(status, body):
+        return ModelErrorType.CONFIG_ERROR
+    if _looks_like_model_not_found(status, body):
+        return ModelErrorType.MODEL_NOT_FOUND
+    if status in (400, 404):
+        return ModelErrorType.UNKNOWN
+    if status >= 500:
+        return ModelErrorType.MAYBE_BILLED
+    return ModelErrorType.UNKNOWN
+
+
+def classify_http(status: int) -> ModelErrorType:
+    return classify_http_response(status)
 
 
 def retry_after_seconds(value: str) -> float | None:
@@ -31,22 +125,6 @@ def retry_after_seconds(value: str) -> float | None:
     return min(max(delay, 0.0), _MAX_RETRY_WAIT)
 
 
-def classify_http(status: int) -> ModelErrorType:
-    if status == 429:
-        return ModelErrorType.RATE_LIMIT
-    if status in (401, 403):
-        return ModelErrorType.AUTH
-    if status in (502, 503):
-        return ModelErrorType.UNREACHED
-    if status in (521, 522, 523, 525):
-        return ModelErrorType.UNREACHED
-    if status in (400, 404):
-        return ModelErrorType.UNKNOWN
-    if status >= 500:
-        return ModelErrorType.MAYBE_BILLED
-    return ModelErrorType.UNKNOWN
-
-
 def classify_exception(exc: BaseException) -> tuple[ModelErrorType, int | None, str]:
     """把没有 HTTP 状态行的传输失败收成策略输入。
 
@@ -58,7 +136,8 @@ def classify_exception(exc: BaseException) -> tuple[ModelErrorType, int | None, 
     if status is None and response is not None:
         status = getattr(response, "status_code", None)
     if isinstance(status, int):
-        return classify_http(status), status, str(exc)[:200]
+        body = response.text if response is not None else None
+        return classify_http_response(status, body), status, str(exc)[:200]
     if isinstance(
         exc,
         (

--- a/backend/packages/framework/src/windup_framework/gateway/image.py
+++ b/backend/packages/framework/src/windup_framework/gateway/image.py
@@ -180,7 +180,7 @@ class ImageGateway:
                         http_status=result.http_status,
                         ok=result.ok,
                     )
-                    if not budget.can_record(maybe_billed):
+                    if not result.ok and not budget.can_record(maybe_billed):
                         self._emit(
                             AttemptTrace(
                                 request_id=request_id,

--- a/backend/packages/framework/src/windup_framework/gateway/policy.py
+++ b/backend/packages/framework/src/windup_framework/gateway/policy.py
@@ -12,6 +12,12 @@ def decide(
 ) -> NextStep:
     if error_type in (ModelErrorType.MAYBE_BILLED, ModelErrorType.AUTH):
         return NextStep.FAIL
+    if error_type is ModelErrorType.CONFIG_ERROR:
+        return NextStep.FAIL
+    if error_type is ModelErrorType.JOB_NOT_FOUND:
+        return NextStep.FAIL
+    if error_type is ModelErrorType.MODEL_NOT_FOUND:
+        return NextStep.FALLBACK
     if has_job_id and error_type is ModelErrorType.TIMEOUT:
         return NextStep.FAIL
     if has_job_id and error_type is ModelErrorType.UPSTREAM_FAILED:

--- a/backend/packages/framework/src/windup_framework/gateway/video.py
+++ b/backend/packages/framework/src/windup_framework/gateway/video.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 
 from windup_common.enums.model import ModelErrorType
 from windup_framework.config.provider import AIProviderSettings, settings as default_settings
+from windup_framework.gateway.billing import billing_flags, upstream_reached_label
+from windup_framework.gateway.budget import AttemptBudget
 from windup_framework.gateway.context import current_call_context
 from windup_framework.gateway.image import _CIRCUIT
 from windup_framework.gateway.policy import decide
@@ -18,6 +20,7 @@ from windup_framework.gateway.routes import (
     lookup_adapter,
     routes_from_settings,
 )
+from windup_framework.gateway.sequencer import AttemptSequencer
 from windup_framework.gateway.trace import (
     AttemptDetail,
     AttemptTrace,
@@ -65,6 +68,8 @@ class VideoGateway:
         fallback_reason: str | None = None
         route_reason_override: str | None = None
         routes = self._routes
+        seq = AttemptSequencer()
+        budget = AttemptBudget()
 
         chain = list(self._registry.chain(Scene.CHARACTER_ACTION))
         if ctx.start_from_model and ctx.start_from_model in chain:
@@ -93,13 +98,18 @@ class VideoGateway:
                     scene=Scene.CHARACTER_ACTION,
                     model=model,
                     route=route,
-                    attempt_index=start_i,
+                    attempt_index=seq.next_index(),
                     retry_count=0,
                     route_reason="skip_circuit_open",
                     outcome="failed",
                     circuit_scope="aggregator",
                     total_latency_ms=total_ms(),
-                    detail=AttemptDetail(input_hash=input_hash),
+                    maybe_billed=False,
+                    detail=AttemptDetail(
+                        input_hash=input_hash,
+                        policy_next_step="fail",
+                        upstream_reached="false",
+                    ),
                 )
             )
             fail(None)
@@ -121,7 +131,7 @@ class VideoGateway:
             adapter = self._adapter_for(route)
             switch_to_next_route = False
             for i, model in enumerate(models):
-                attempt_index = start_i + i
+                model_index = start_i + i
                 if self._circuit.is_open("model:" + model):
                     fallback_used = True
                     fallback_reason = "skip"
@@ -131,14 +141,20 @@ class VideoGateway:
                             scene=Scene.CHARACTER_ACTION,
                             model=model,
                             route=route,
-                            attempt_index=attempt_index,
+                            attempt_index=seq.next_index(),
                             retry_count=0,
                             route_reason="skip_circuit_open",
                             outcome="failed",
                             circuit_scope="model",
                             fallback_used=fallback_used,
                             total_latency_ms=total_ms(),
-                            detail=AttemptDetail(input_hash=input_hash),
+                            maybe_billed=False,
+                            detail=AttemptDetail(
+                                input_hash=input_hash,
+                                policy_next_step="fallback",
+                                upstream_reached="false",
+                                model_index=model_index,
+                            ),
                         )
                     )
                     continue
@@ -185,12 +201,46 @@ class VideoGateway:
                     ended_at = _utc_now()
                     attempt_latency_ms = int((time.monotonic() - attempt_t0) * 1000)
                     last_http_status = result.http_status
+                    error_type = (
+                        None if result.ok else (result.error_type or ModelErrorType.UNKNOWN)
+                    )
+                    maybe_billed = billing_flags(
+                        error_type=error_type,
+                        http_status=result.http_status,
+                        ok=result.ok,
+                    )
+                    if not budget.can_record(maybe_billed):
+                        self._emit_result(
+                            request_id=request_id,
+                            model=model,
+                            route=route,
+                            attempt_index=seq.next_index(),
+                            retry_count=retry_count,
+                            route_reason="attempt_budget_exhausted",
+                            result=result,
+                            input_hash=input_hash,
+                            total_latency_ms=total_ms(),
+                            fallback_used=fallback_used,
+                            started_at=started_at,
+                            ended_at=ended_at,
+                            attempt_latency_ms=attempt_latency_ms,
+                            resend_spent=resend_spent,
+                            seconds=seconds,
+                            outcome="failed",
+                            error_type=error_type,
+                            submit_ms=submit_ms,
+                            policy_next_step="fail",
+                            model_index=model_index,
+                            maybe_billed=maybe_billed,
+                        )
+                        fail(last_http_status)
+
                     if result.ok:
                         self._emit_result(
                             request_id=request_id,
                             model=model,
                             route=route,
-                            attempt_index=attempt_index,
+                            attempt_index=seq.next_index(),
                             retry_count=retry_count,
                             route_reason=route_reason,
                             result=result,
@@ -204,6 +254,9 @@ class VideoGateway:
                             seconds=seconds,
                             outcome="fallback_success" if fallback_used else "success",
                             submit_ms=submit_ms,
+                            policy_next_step="success",
+                            model_index=model_index,
+                            maybe_billed=maybe_billed,
                         )
                         return result.body
 
@@ -215,8 +268,19 @@ class VideoGateway:
                         retry_count=retry_count,
                         has_job_id=has_job_id,
                     )
-                    circuit_scope = None
                     has_next_route = route_index + 1 < len(routes)
+                    if step is NextStep.FAIL and bound_job_id is None:
+                        tier_step = budget.tier_b_escalation(
+                            error_type,
+                            has_next_route=has_next_route,
+                            has_job_id=has_job_id,
+                        )
+                        if tier_step is not None:
+                            step = tier_step
+                            if tier_step is NextStep.OPEN_AGGREGATOR:
+                                route_reason_override = "fallback_after_maybe_billed"
+                    policy_next_step = step.value
+                    circuit_scope = None
                     if step is NextStep.OPEN_AGGREGATOR:
                         if has_next_route:
                             self._circuit.open("base_url:" + route.base_url_id)
@@ -231,11 +295,12 @@ class VideoGateway:
                         self._circuit.open("model:" + model)
                         circuit_scope = "model"
 
+                    budget.record(maybe_billed)
                     self._emit_result(
                         request_id=request_id,
                         model=model,
                         route=route,
-                        attempt_index=attempt_index,
+                        attempt_index=seq.next_index(),
                         retry_count=retry_count,
                         route_reason=route_reason,
                         result=result,
@@ -251,6 +316,9 @@ class VideoGateway:
                         circuit_scope=circuit_scope,
                         error_type=error_type,
                         submit_ms=submit_ms,
+                        policy_next_step=policy_next_step,
+                        model_index=model_index,
+                        maybe_billed=maybe_billed,
                     )
                     if (
                         step is NextStep.OPEN_AGGREGATOR
@@ -330,11 +398,19 @@ class VideoGateway:
         circuit_scope: str | None = None,
         error_type: ModelErrorType | None = None,
         submit_ms: int | None = None,
+        policy_next_step: str | None = None,
+        model_index: int | None = None,
+        maybe_billed: bool | None = None,
     ) -> None:
-        billed = result.ok or result.maybe_billed
+        if maybe_billed is None:
+            maybe_billed = billing_flags(
+                error_type=error_type,
+                http_status=result.http_status,
+                ok=result.ok,
+            )
         cost = estimate_cost(
             Scene.CHARACTER_ACTION,
-            billed=billed,
+            billed=result.ok or maybe_billed,
             seconds=seconds,
             image_unit_cost=self._settings.image_unit_cost,
             video_unit_cost_per_second=self._settings.video_unit_cost_per_second,
@@ -363,7 +439,7 @@ class VideoGateway:
                 ended_at=ended_at,
                 attempt_latency_ms=attempt_latency_ms,
                 total_latency_ms=total_latency_ms,
-                maybe_billed=True if result.ok else result.maybe_billed,
+                maybe_billed=maybe_billed,
                 cost=cost,
                 detail=AttemptDetail(
                     input_hash=input_hash,
@@ -379,6 +455,11 @@ class VideoGateway:
                     job_status=result.job_status,
                     edge_fingerprint=result.edge_fingerprint or None,
                     provider_usage=result.provider_usage,
+                    policy_next_step=policy_next_step,
+                    upstream_reached=upstream_reached_label(
+                        error_type, http_status=result.http_status, ok=result.ok
+                    ),
+                    model_index=model_index,
                 ),
             )
         )

--- a/backend/packages/framework/src/windup_framework/gateway/video.py
+++ b/backend/packages/framework/src/windup_framework/gateway/video.py
@@ -209,7 +209,7 @@ class VideoGateway:
                         http_status=result.http_status,
                         ok=result.ok,
                     )
-                    if not budget.can_record(maybe_billed):
+                    if not result.ok and not budget.can_record(maybe_billed):
                         self._emit_result(
                             request_id=request_id,
                             model=model,
@@ -236,6 +236,7 @@ class VideoGateway:
                         fail(last_http_status)
 
                     if result.ok:
+                        budget.record(maybe_billed)
                         self._emit_result(
                             request_id=request_id,
                             model=model,
@@ -358,7 +359,11 @@ class VideoGateway:
                             fail(last_http_status)
                         if (
                             bound_job_id is None
-                            and error_type is not ModelErrorType.RATE_LIMIT
+                            and error_type
+                            not in (
+                                ModelErrorType.RATE_LIMIT,
+                                ModelErrorType.MODEL_NOT_FOUND,
+                            )
                         ):
                             fail(last_http_status)
                         fallback_used = True

--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -34,9 +34,10 @@ import httpx
 
 from windup_common.enums.model import ModelErrorType
 from windup_framework.config.provider import AIProviderSettings, settings
+from windup_framework.gateway.billing import billing_flags
 from windup_framework.gateway.classify import (
     classify_exception,
-    classify_http,
+    classify_http_response,
     retry_after_seconds as _retry_after_seconds,
 )
 from windup_framework.gateway.types import AdapterResult
@@ -95,17 +96,28 @@ def _first_frame_datauri(frame: bytes, size: str) -> str:
     return "data:image/jpeg;base64," + base64.b64encode(_fit_first_frame(frame, size)).decode()
 
 
-def _video_http_error(resp: httpx.Response, *, job_id: str | None = None) -> AdapterResult:
-    error_type = classify_http(resp.status_code)
+def _video_http_error(
+    resp: httpx.Response,
+    *,
+    job_id: str | None = None,
+    phase: str = "submit",
+) -> AdapterResult:
+    error_type = classify_http_response(resp.status_code, resp.text, phase=phase)
     retry_after_header = resp.headers.get("Retry-After")
     retry_after_s = (
         _retry_after_seconds(retry_after_header) if retry_after_header else None
     )
+    maybe_billed = billing_flags(error_type=error_type, http_status=resp.status_code)
+    if job_id is not None and error_type not in {
+        ModelErrorType.UNREACHED,
+        ModelErrorType.NETWORK,
+    }:
+        maybe_billed = True
     return AdapterResult(
         ok=False,
         error_type=error_type,
         http_status=resp.status_code,
-        maybe_billed=job_id is not None or error_type is ModelErrorType.MAYBE_BILLED,
+        maybe_billed=maybe_billed,
         edge_fingerprint=_edge_fingerprint(resp),
         retry_after_s=retry_after_s,
         job_id=job_id,
@@ -254,7 +266,7 @@ class SufyVideoProvider(VideoProvider):
                 resp = _poll_get(client, job_id)
                 poll_count += 1
                 if not (200 <= resp.status_code < 300):
-                    return with_poll(_video_http_error(resp, job_id=job_id))
+                    return with_poll(_video_http_error(resp, job_id=job_id, phase="follow"))
                 try:
                     st = resp.json()
                 except ValueError:
@@ -657,7 +669,7 @@ class ChatCompletionsFace:
         if 200 <= resp.status_code < 300:
             return _image_result_from_2xx(resp)
 
-        error_type = classify_http(resp.status_code)
+        error_type = classify_http_response(resp.status_code, resp.text)
         if resp.status_code in (400, 404):
             edge = (
                 f"网关 {self._cfg.normalized_base_url} 拒绝了模型 {model!r}"

--- a/backend/tests/test_gateway_classify.py
+++ b/backend/tests/test_gateway_classify.py
@@ -1,5 +1,9 @@
 from windup_common.enums.model import ModelErrorType
-from windup_framework.gateway.classify import classify_http, retry_after_seconds
+from windup_framework.gateway.classify import (
+    classify_http,
+    classify_http_response,
+    retry_after_seconds,
+)
 
 
 def test_522_is_unreached():
@@ -54,3 +58,21 @@ def test_retry_after_seconds_number_and_cap():
     assert retry_after_seconds("300") == 30.0
     assert retry_after_seconds("invalid") is None
     assert retry_after_seconds("NaN") is None
+
+
+def test_404_submit_model_not_found():
+    body = '{"error":{"code":"model_not_found","message":"model x not found"}}'
+    assert classify_http_response(404, body) is ModelErrorType.MODEL_NOT_FOUND
+
+
+def test_404_submit_default_is_model_not_found():
+    assert classify_http_response(404) is ModelErrorType.MODEL_NOT_FOUND
+
+
+def test_404_follow_is_job_not_found():
+    assert classify_http_response(404, phase="follow") is ModelErrorType.JOB_NOT_FOUND
+
+
+def test_404_config_error_when_endpoint_wrong():
+    body = '{"error":"invalid url: no route matched"}'
+    assert classify_http_response(404, body) is ModelErrorType.CONFIG_ERROR

--- a/backend/tests/test_gateway_policy.py
+++ b/backend/tests/test_gateway_policy.py
@@ -40,6 +40,18 @@ def test_poll_timeout_fails_without_new_job():
     assert decide(error_type=ModelErrorType.TIMEOUT, retry_count=0, has_job_id=True) is NextStep.FAIL
 
 
+def test_model_not_found_fallbacks():
+    assert decide(error_type=ModelErrorType.MODEL_NOT_FOUND, retry_count=0, has_job_id=False) is NextStep.FALLBACK
+
+
+def test_config_error_fails_fast():
+    assert decide(error_type=ModelErrorType.CONFIG_ERROR, retry_count=0, has_job_id=False) is NextStep.FAIL
+
+
+def test_job_not_found_fails():
+    assert decide(error_type=ModelErrorType.JOB_NOT_FOUND, retry_count=0, has_job_id=True) is NextStep.FAIL
+
+
 def test_circuit_opens_and_cools_down(monkeypatch):
     clock = {"t": 0.0}
     br = CircuitBreaker(cooldown_s=60, monotonic=lambda: clock["t"])

--- a/backend/tests/test_gateway_video.py
+++ b/backend/tests/test_gateway_video.py
@@ -7,6 +7,7 @@ from windup_framework.config.provider import AIProviderSettings
 from windup_framework.gateway.circuit import CircuitBreaker
 from windup_framework.gateway.registry import ModelRegistry
 from windup_framework.gateway.types import AdapterResult
+from windup_framework.gateway.budget import AttemptBudget
 from windup_framework.gateway.video import VideoGateway
 
 UNREACHED = AdapterResult(ok=False, error_type=ModelErrorType.UNREACHED, http_status=522)
@@ -257,6 +258,35 @@ def test_submit_invalid_response_does_not_open_fallback_job():
         _video_gw(ad).i2v(b"frame", "walk")
     assert "kling-v2-6" not in ad.submit_models
     assert ad.submit_models == ["kling-v2-5-turbo"] * 3
+
+
+def test_submit_model_not_found_fallbacks_to_next_model():
+    missing = AdapterResult(
+        ok=False, error_type=ModelErrorType.MODEL_NOT_FOUND, http_status=404
+    )
+    ad = FakeVideoAdapter(
+        submits={
+            "kling-v2-5-turbo": [missing],
+            "kling-v2-6": [AdapterResult(ok=True, job_id="j-alt", maybe_billed=True)],
+        },
+        follows={"j-alt": MP4},
+    )
+    body = _video_gw(ad).i2v(b"frame", "walk")
+    assert body.startswith(b"\x00\x00\x00\x18ftyp")
+    assert ad.submit_models == ["kling-v2-5-turbo", "kling-v2-6"]
+
+
+def test_success_is_not_rejected_when_maybe_billed_budget_full(monkeypatch):
+    monkeypatch.setattr(AttemptBudget, "max_maybe_billed", 0)
+    ad = FakeVideoAdapter(
+        submits={
+            "kling-v2-5-turbo": [AdapterResult(ok=True, job_id="j1", maybe_billed=True)],
+            "kling-v2-6": [],
+        },
+        follows={"j1": MP4},
+    )
+    body = _video_gw(ad).i2v(b"frame", "walk")
+    assert body.startswith(b"\x00\x00\x00\x18ftyp")
 
 
 def test_submit_ok_without_job_id_is_invalid_response():

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -598,7 +598,7 @@ def test_model_missing_from_the_gateway_catalogue_says_so(code):
         return httpx.Response(code, text='{"error":{"message":"model not found"}}')
 
     r = _image_provider(h).submit_image("x", [], "gemini-2.5-flash-image")
-    assert r.error_type is ModelErrorType.UNKNOWN
+    assert r.error_type is ModelErrorType.MODEL_NOT_FOUND
     assert "/models" in r.edge_fingerprint
     assert r.http_status == code
     assert not r.ok


### PR DESCRIPTION
## Summary

- 将 `VideoGateway` 与 chat/image 对齐：接入 `AttemptBudget`、`AttemptSequencer`、`billing_flags` 与台账审计字段（`policy_next_step` / `upstream_reached` / `model_index`）。
- 新增 404 分层：`MODEL_NOT_FOUND` → fallback model；`CONFIG_ERROR` → fail fast；`JOB_NOT_FOUND` → poll 阶段任务失败。
- `classify_http_response(status, body, phase)` 接入 sufy image submit 与 video poll；保留 video submit 阶段 `INVALID_RESPONSE` 不重开 fallback job 的既有语义。

Refs #527

## Test plan

- [x] `uv run pytest tests/test_gateway_*.py tests/test_gateway_executor.py`
- [x] `uv run pytest tests/test_sufy_video_download.py::test_model_missing_from_the_gateway_catalogue_says_so`
- [ ] staging 部署后抽查 video 任务台账：`attempt_index` 单调、`maybe_billed` 与 tier-B 切换符合 #527 策略

Close #527 