### PR TITLE
refactor(render3d): 报价只留积分，去除换算

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_assets.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_assets.py
@@ -44,7 +44,6 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from windup_ai_engine.ports import ProgressPort
 from windup_framework.providers.render3d.tencent import (
-    CREDIT_PRICE_CNY,
     CREDITS,
     RIG_CREDITS,
 )
@@ -69,7 +68,6 @@ RAW_KEY_PREFIX = "raw:"
 MODEL3D_CREDITS = CREDITS["Normal"]
 AUTORIG_CREDITS = RIG_CREDITS
 BUILD_CREDITS = MODEL3D_CREDITS + AUTORIG_CREDITS
-BUILD_CNY = round(BUILD_CREDITS * CREDIT_PRICE_CNY, 2)
 
 
 class Render3DAssetState(str, Enum):
@@ -303,7 +301,7 @@ class Render3DAssetBuilder:
         if not self._may_build_assets:
             raise SpendNotAuthorized(
                 f"造型 {outfit_key!r} 的 3D 资产未就绪,而本实例未获准建(建一次 "
-                f"{BUILD_CREDITS} 积分,约 ¥{BUILD_CNY}:图生 3D {MODEL3D_CREDITS} + "
+                f"{BUILD_CREDITS} 积分:图生 3D {MODEL3D_CREDITS} + "
                 f"绑骨 {AUTORIG_CREDITS})。要现建请显式授权花钱,"
                 "或先把资产备好,或改走 video_i2v。"
             )

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -31,7 +31,6 @@ from windup_ai_engine.ports import MasterRejected
 from windup_app.server.orchestrator._fetch import FetchNotAllowed, fetch_own_media
 from windup_app.server.orchestrator.render3d_assets import (
     AUTORIG_CREDITS,
-    BUILD_CNY,
     BUILD_CREDITS,
     MODEL3D_CREDITS,
     RAW_KEY_PREFIX,
@@ -183,7 +182,7 @@ class Render3DAssetOperations:
         if not self._builder.may_build_assets:
             raise SpendNotAuthorized(
                 f"本部署未开启建 3D 资产(需 WINDUP_RENDER3D_ALLOW_SPEND)。建一次 "
-                f"{BUILD_CREDITS} 积分,约 ¥{BUILD_CNY}。"
+                f"{BUILD_CREDITS} 积分。"
             )
         state = self._builder.state(outfit_key)
         if state is not Render3DAssetState.ABSENT:

--- a/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
+++ b/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
@@ -43,7 +43,7 @@ from .interfaces import (
 
 __all__ = [
     "TencentModel3DProvider", "TencentAutoRigProvider", "TencentCosModelUploader",
-    "SpendNotAuthorizedError", "CREDITS", "CREDIT_PRICE_CNY", "PRESET_MOTIONS",
+    "SpendNotAuthorizedError", "CREDITS", "PRESET_MOTIONS",
     "RIG_CREDITS", "MAX_IMAGE_BYTES", "VIEW_TYPES",
 ]
 
@@ -54,7 +54,6 @@ VERSION = "2025-05-13"
 
 CREDITS = {"Normal": 20, "LowPoly": 25, "Geometry": 15, "Sketch": 25}
 RIG_CREDITS = 10
-CREDIT_PRICE_CNY = 0.12          # 后付费单价;预付费 0.09–0.1
 MAX_IMAGE_BYTES = 6 * 10**6      # ImageBase64 上限
 VIEW_TYPES = ("back", "left", "right")   # 正面走主参数,不在这里
 
@@ -266,10 +265,10 @@ class TencentModel3DProvider:
         self._poll = poll_interval
         self._max_min = max_min
 
-    def quote(self, n_views: int = 1) -> tuple[int, float]:
+    def quote(self, n_views: int = 1) -> int:
         """返回 (积分, 预估元)。PBR、多视图各 +10 积分。纯计算,可在提交前随便调。"""
         credits = CREDITS[self._type] + (10 if self._pbr else 0) + (10 if n_views > 1 else 0)
-        return credits, round(credits * CREDIT_PRICE_CNY, 2)
+        return credits
 
     def build_params(self, master: bytes,
                      extra_views: Mapping[str, bytes] | None = None) -> dict:
@@ -305,10 +304,10 @@ class TencentModel3DProvider:
         if want not in MODEL_FORMATS:
             raise ArtifactFormatError(f"want 只能是 {MODEL_FORMATS},收到 {want!r}")
         params = self.build_params(master, extra_views)
-        credits, cny = self.quote(1 + len(extra_views or {}))
+        credits = self.quote(1 + len(extra_views or {}))
         if not self._allow_spend:
             raise SpendNotAuthorizedError(
-                f"图生 3D 会消耗 {credits} 积分(后付费约 ¥{cny})。"
+                f"图生 3D 会消耗 {credits} 积分。"
                 "确认要花这笔钱后,用 TencentModel3DProvider(..., allow_spend=True) 构造。")
 
         if self._ask_format:
@@ -392,8 +391,8 @@ class TencentAutoRigProvider:
     def preset_motions(self) -> Mapping[str, PresetMotion]:
         return PRESET_MOTIONS
 
-    def quote(self) -> tuple[int, float]:
-        return RIG_CREDITS, round(RIG_CREDITS * CREDIT_PRICE_CNY, 2)
+    def quote(self) -> int:
+        return RIG_CREDITS
 
     def resolve_motion(self, motion: str | int | None) -> PresetMotion | None:
         """动作名 / 编号 → :class:`PresetMotion`。名字不认识就抛,不猜编号。"""
@@ -424,10 +423,10 @@ class TencentAutoRigProvider:
             # 入口预检在**上传与提交之前**:三条硬约束违反了接口不报错,只默默出错结果。
             check_model(model)
 
-        credits, cny = self.quote()
+        credits = self.quote()
         if not self._allow_spend:
             raise SpendNotAuthorizedError(
-                f"绑骨会消耗 {credits} 积分(后付费约 ¥{cny})。"
+                f"绑骨会消耗 {credits} 积分。"
                 "确认要花这笔钱后,用 TencentAutoRigProvider(..., allow_spend=True) 构造。")
 
         url = self._upload(model, src_fmt)

--- a/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
+++ b/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
@@ -266,7 +266,7 @@ class TencentModel3DProvider:
         self._max_min = max_min
 
     def quote(self, n_views: int = 1) -> int:
-        """返回 (积分, 预估元)。PBR、多视图各 +10 积分。纯计算,可在提交前随便调。"""
+        """返回本次要花的积分。PBR、多视图各 +10。纯计算,花钱之前就该问得出花多少。"""
         credits = CREDITS[self._type] + (10 if self._pbr else 0) + (10 if n_views > 1 else 0)
         return credits
 

--- a/backend/tests/test_render3d_tencent.py
+++ b/backend/tests/test_render3d_tencent.py
@@ -111,7 +111,10 @@ def test_model3d_refuses_to_spend_by_default(cloud):
     p = TencentModel3DProvider(CREDS)
     with pytest.raises(SpendNotAuthorizedError) as e:
         p.image_to_3d(b"\x89PNG fake")
-    assert "20 积分" in str(e.value) and "¥2.4" in str(e.value)   # 报价必须写在异常里
+    # 报价写在异常里,但只给积分 —— 人民币是我们付给供应商的成本,不是用户的价钱,
+    # 而本仓是公开仓。同一条判据见 test_render3d_asset_endpoints 里的出参断言。
+    assert "20 积分" in str(e.value)
+    assert "¥" not in str(e.value), "人民币成本不出现在任何对外文案里"
     assert fake.calls == []                                       # 一个请求都没发出去
 
 
@@ -142,11 +145,12 @@ def test_unknown_motion_name_dies_before_the_spend_gate(cloud):
 
 
 def test_quotes_are_pure_computation():
-    assert TencentModel3DProvider(CREDS).quote() == (20, 2.4)
-    assert TencentModel3DProvider(CREDS, generate_type="Geometry").quote() == (15, 1.8)
-    assert TencentModel3DProvider(CREDS, enable_pbr=True).quote() == (30, 3.6)
-    assert TencentModel3DProvider(CREDS).quote(n_views=3) == (30, 3.6)
-    assert TencentAutoRigProvider(Uploader(), CREDS).quote() == (10, 1.2)
+    """报价只出积分。换算人民币要用供应商单价,那个数不该留在公开仓里。"""
+    assert TencentModel3DProvider(CREDS).quote() == 20
+    assert TencentModel3DProvider(CREDS, generate_type="Geometry").quote() == 15
+    assert TencentModel3DProvider(CREDS, enable_pbr=True).quote() == 30
+    assert TencentModel3DProvider(CREDS).quote(n_views=3) == 30
+    assert TencentAutoRigProvider(Uploader(), CREDS).quote() == 10
 
 
 def test_unknown_generate_type_dies_at_construction():


### PR DESCRIPTION
Closes #546

## 问题

#482 把人民币金额从出参里删掉了，还加了反向断言「人民币金额不出参 —— 那是我们的成本，不是用户的价钱」。但它只覆盖了 `render3d_service.py` 一侧，供应商单价与换算留在别处：

- `tencent.py`：`CREDIT_PRICE_CNY = 0.12  # 后付费单价;预付费 0.09–0.1`，两个 `quote()` 返回 `(积分, 人民币)`
- `render3d_assets.py`：`BUILD_CNY`，以及一句带 `约 ¥{BUILD_CNY}` 的文案
- `render3d_service.py`：另一句同样带 `约 ¥{BUILD_CNY}`

**本仓是公开仓**，`0.12` 是付给供应商的后付费单价，注释里还写了预付费区间。

**不把问题说重**：这几处目前不会到用户眼前。它们抛 `SpendNotAuthorized`（`ValueError` 子类），而 `_failure.user_message` 没有对应分支、会落到通用文案。所以不是外泄事故，是两件事——公开仓里留着采购成本，以及一段没有消费方的换算（`quote()` 的第二个返回值全仓无人读取，grep 确认）。

## 方案

删掉 `CREDIT_PRICE_CNY` 与派生的 `BUILD_CNY`；`quote()` 只返回积分（`tuple[int, float]` → `int`）；三处文案只报积分。积分定价（`CREDITS` / `RIG_CREDITS` / `BUILD_CREDITS`）是产品价，一律不动。

## 不包含

- 不改积分定价
- 不改 `_failure.user_message` 的兜底行为
- 不动前端。线上那句「后付费约 ¥3.6」来自 08-20 06:20 构建的旧产物，而 #482 于当日 09:50 合入 —— 前端两侧其实都已删净，重新构建即消失，不需要代码改动

## 验收

`packages/` 下 `grep "¥\|CNY"` 无命中。两条既有用例改成锁新契约，其中一条加了反向断言 `assert "¥" not in str(e.value)`；把 `¥` 加回文案时它失败：

```
FAILED tests/test_render3d_tencent.py::test_model3d_refuses_to_spend_by_default
```

`ruff check .`、`lint-imports`（2 kept, 0 broken）、`export_openapi` 后 `openapi.json` 无漂移、`pytest -q`（1317 passed, 14 skipped）。
