### PR TITLE
feat(projects): add persistent card actions

### DIFF
--- a/backend/packages/app/src/windup_app/server/project/interface.py
+++ b/backend/packages/app/src/windup_app/server/project/interface.py
@@ -55,5 +55,11 @@ class ProjectService(ABC):
         """一次查询当前页项目的资产预览，结果包含所有传入项目 ID。"""
 
     @abstractmethod
+    def rename_project(
+        self, session: Session, project: Project, *, project_name: str
+    ) -> Project:
+        """修改已完成归属校验的项目名称。"""
+
+    @abstractmethod
     def delete_project(self, session: Session, project_id: int) -> bool:
         """删除项目并返回是否找到。"""

--- a/backend/packages/app/src/windup_app/server/project/service.py
+++ b/backend/packages/app/src/windup_app/server/project/service.py
@@ -126,6 +126,13 @@ class SqlAlchemyProjectService(ProjectService):
                 )
         return previews
 
+    def rename_project(
+        self, session: Session, project: Project, *, project_name: str
+    ) -> Project:
+        project.project_name = project_name
+        session.flush()
+        return project
+
     def delete_project(self, session: Session, project_id: int) -> bool:
         project = session.get(Project, project_id)
         if project is None:

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -34,6 +34,12 @@ class ProjectCreate(BaseModel):
     sprite_sample_url: str | None = None
 
 
+class ProjectRename(BaseModel):
+    """重命名项目请求。"""
+
+    project_name: str = Field(min_length=1, max_length=20)
+
+
 class ProjectOut(BaseModel):
     """项目响应。"""
 
@@ -127,6 +133,35 @@ def get_project(
     if project is None or project.user_id != request.state.current_user.id:
         raise BizException("项目不存在", code=BizCode.NOT_FOUND)
     return Response.success(ProjectOut.model_validate(project))
+
+
+@router.patch("/{project_id}", response_model=Response[ProjectOut])
+def rename_project(
+    project_id: int,
+    body: ProjectRename,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> Response[ProjectOut]:
+    user_id = request.state.current_user.id
+    project = service.get_project(session, project_id, for_update=True)
+    if project is None or project.user_id != user_id:
+        raise BizException("项目不存在", code=BizCode.NOT_FOUND)
+    if project.project_name == body.project_name:
+        return Response.success(
+            ProjectOut.model_validate(project), message="重命名成功"
+        )
+    if service.project_name_exists(
+        session, user_id=user_id, project_name=body.project_name
+    ):
+        raise BizException("项目名称已存在", code=BizCode.BAD_REQUEST)
+    try:
+        project = service.rename_project(
+            session, project, project_name=body.project_name
+        )
+    except IntegrityError:
+        session.rollback()
+        raise BizException("项目名称已存在", code=BizCode.BAD_REQUEST) from None
+    return Response.success(ProjectOut.model_validate(project), message="重命名成功")
 
 
 @router.delete("/{project_id}", response_model=Response[None])

--- a/backend/tests/test_project_api.py
+++ b/backend/tests/test_project_api.py
@@ -227,6 +227,58 @@ def test_list_loads_all_project_previews_with_one_character_query(auth_client, e
     assert len(statements) == 1
 
 
+# -- PATCH /projects/{id} ----------------------------------------------------
+
+
+def test_rename_success_persists_the_new_name(auth_client):
+    created = auth_client.post(
+        "/projects", json=_payload(project_name="重命名前")
+    ).json()["data"]
+
+    resp = auth_client.patch(
+        f"/projects/{created['id']}", json={"project_name": "重命名后"}
+    )
+
+    body = resp.json()
+    assert body["code"] == 200
+    assert body["message"] == "重命名成功"
+    assert body["data"]["project_name"] == "重命名后"
+    persisted = auth_client.get(f"/projects/{created['id']}").json()["data"]
+    assert persisted["project_name"] == "重命名后"
+
+
+def test_rename_duplicate_name_returns_400(auth_client):
+    auth_client.post("/projects", json=_payload(project_name="已存在"))
+    created = auth_client.post(
+        "/projects", json=_payload(project_name="待修改")
+    ).json()["data"]
+
+    resp = auth_client.patch(
+        f"/projects/{created['id']}", json={"project_name": "已存在"}
+    )
+
+    assert resp.json()["code"] == 400
+    assert resp.json()["message"] == "项目名称已存在"
+    persisted = auth_client.get(f"/projects/{created['id']}").json()["data"]
+    assert persisted["project_name"] == "待修改"
+
+
+def test_rename_rejects_another_users_project(auth_client, auth_client_b):
+    created = auth_client.post(
+        "/projects", json=_payload(project_name="我的项目")
+    ).json()["data"]
+
+    resp = auth_client_b.patch(
+        f"/projects/{created['id']}", json={"project_name": "越权改名"}
+    )
+
+    assert resp.json()["code"] == 404
+    assert (
+        auth_client.get(f"/projects/{created['id']}").json()["data"]["project_name"]
+        == "我的项目"
+    )
+
+
 # -- DELETE /projects/{id} ---------------------------------------------------
 
 

--- a/frontend/src/entities/project/index.test.ts
+++ b/frontend/src/entities/project/index.test.ts
@@ -117,6 +117,25 @@ describe('projectApis', () => {
     expect(requestUrl).toBe('https://api.windup.test/projects/42')
   })
 
+  it('renames one Project through the backend resource path', async () => {
+    let request: Request | undefined
+    const renamedDto = { ...projectDto, project_name: '新项目名' }
+    const { projectApis } = await loadProjectApis(async (input, init) => {
+      request = new Request(input, init)
+      return jsonResponse(renamedDto)
+    })
+
+    await expect(projectApis.rename('42', '新项目名')).resolves.toMatchObject({
+      id: '42',
+      name: '新项目名',
+    })
+    expect(request?.url).toBe('https://api.windup.test/projects/42')
+    expect(request?.method).toBe('PATCH')
+    await expect(request?.json()).resolves.toEqual({
+      project_name: '新项目名',
+    })
+  })
+
   it('uses the access-token provider registered at the shared HTTP boundary', async () => {
     let authorization: string | null = null
     const { projectApis } = await loadProjectApis(async (input, init) => {
@@ -160,6 +179,10 @@ describe('projectApis', () => {
         spriteSize: { width: 256, height: 256 },
       }),
     ).rejects.toBeInstanceOf(ProjectNameConflictError)
+
+    await expect(projectApis.rename('42', '点灯人')).rejects.toBeInstanceOf(
+      ProjectNameConflictError,
+    )
   })
 
   it('maps the backend in-use project contract to a stable domain error', async () => {

--- a/frontend/src/entities/project/index.ts
+++ b/frontend/src/entities/project/index.ts
@@ -75,11 +75,12 @@ export const DIRECTIONAL_MOVEMENT: Record<DirectionalMovement, string> = {
   'eight-way': '八向',
 }
 
-/** Project 对应的一组后端接口。PR #75 未提供更新端点，因此这里不声明 update。 */
+/** Project 对应的一组后端接口。 */
 export interface ProjectApis {
   list(query?: ProjectPageQuery): Promise<Paged<Project>>
   get(id: Project['id']): Promise<Project>
   create(input: CreateProjectInput): Promise<Project>
+  rename(id: Project['id'], name: string): Promise<Project>
   remove(id: Project['id']): Promise<void>
 }
 
@@ -206,6 +207,27 @@ export const projectApis: ProjectApis = {
     } catch (error) {
       // 后端目前只返回通用 BAD_REQUEST；中文 message 是项目重名的唯一可辨识契约。
       // 文案映射仅留在 HTTP 适配器，业务用例只依赖稳定的前端错误类型。
+      if (
+        error instanceof ApiError &&
+        error.kind === 'business' &&
+        error.code === 400 &&
+        error.message === '项目名称已存在'
+      ) {
+        throw new ProjectNameConflictError({ cause: error })
+      }
+      throw error
+    }
+  },
+
+  async rename(id, name) {
+    try {
+      return mapProject(
+        await getApiClient().request<ProjectDto>(`/projects/${encodeURIComponent(id)}`, {
+          method: 'PATCH',
+          json: { project_name: name },
+        }),
+      )
+    } catch (error) {
       if (
         error instanceof ApiError &&
         error.kind === 'business' &&

--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -201,6 +201,53 @@ describe('ProjectsPage', () => {
     ).toHaveLength(0)
   })
 
+  it('keeps project actions discoverable and persists a renamed project', async () => {
+    const backend = installBackend()
+    render(
+      <AuthenticatedAuthSession>
+        <MemoryRouter initialEntries={['/projects']}>
+          <AppRoutes />
+        </MemoryRouter>
+      </AuthenticatedAuthSession>,
+    )
+
+    expect(await screen.findAllByRole('link', { name: /打开项目/ })).toHaveLength(2)
+    const actions = screen.getByRole('button', { name: '项目操作 空白海岸' })
+    expect(actions.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(actions)
+
+    expect(actions.getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getByRole('group', { name: '空白海岸的项目操作' })).toBeTruthy()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(actions.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByRole('group', { name: '空白海岸的项目操作' })).toBeNull()
+
+    fireEvent.click(actions)
+    const actionsGroup = screen.getByRole('group', {
+      name: '空白海岸的项目操作',
+    })
+    fireEvent.click(within(actionsGroup).getByRole('button', { name: '重命名项目' }))
+
+    const dialog = screen.getByRole('dialog', { name: '重命名项目' })
+    const nameInput = within(dialog).getByRole('textbox', { name: '项目名称' })
+    expect(nameInput.getAttribute('value')).toBe('空白海岸')
+    fireEvent.change(nameInput, { target: { value: '雾港' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: '保存名称' }))
+
+    expect(await screen.findByRole('link', { name: '打开项目 雾港' })).toBeTruthy()
+    expect(screen.queryByRole('dialog', { name: '重命名项目' })).toBeNull()
+    const renameRequest = backend.requests.find(
+      (request) => request.method === 'PATCH' && request.url.endsWith('/projects/99'),
+    )
+    expect(renameRequest).toBeTruthy()
+    await expect(renameRequest?.json()).resolves.toEqual({
+      project_name: '雾港',
+    })
+  })
+
   it('sends creation to the project create page and deletes through the Project API', async () => {
     const backend = installBackend()
     render(
@@ -217,7 +264,8 @@ describe('ProjectsPage', () => {
     )
     expect(screen.queryByRole('dialog', { name: '新建项目' })).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: '删除项目 空白海岸' }))
+    fireEvent.click(screen.getByRole('button', { name: '项目操作 空白海岸' }))
+    fireEvent.click(screen.getByRole('button', { name: '删除项目' }))
     fireEvent.click(screen.getByRole('button', { name: '确认删除项目' }))
 
     await waitFor(() => {
@@ -243,7 +291,8 @@ describe('ProjectsPage', () => {
     )
 
     expect(await screen.findByRole('link', { name: '打开项目 点灯人 · MVP' })).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: '删除项目 点灯人 · MVP' }))
+    fireEvent.click(screen.getByRole('button', { name: '项目操作 点灯人 · MVP' }))
+    fireEvent.click(screen.getByRole('button', { name: '删除项目' }))
     fireEvent.click(screen.getByRole('button', { name: '确认删除项目' }))
 
     expect(await screen.findByText('项目下仍有角色，无法删除')).toBeTruthy()

--- a/frontend/src/pages/projects/index.tsx
+++ b/frontend/src/pages/projects/index.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, type CSSProperties } from 'react'
+import { DotsThree, PencilSimple, Trash } from '@phosphor-icons/react'
+import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import { Link } from 'react-router'
 
 import assetLibraryArtwork from '@/assets/workspace/asset-library.png'
@@ -7,6 +8,7 @@ import {
   DIRECTIONAL_MOVEMENT,
   projectApis,
   ProjectHasCharactersError,
+  ProjectNameConflictError,
   type Project,
 } from '@/entities'
 import type { Paged } from '@/shared/pagination'
@@ -25,6 +27,9 @@ type ProjectPreviewState = { status: 'ready'; url: string } | { status: 'empty' 
 export function ProjectsPage() {
   const [pageNumber, setPageNumber] = useState(1)
   const [projectsPage, setProjectsPage] = useState<Paged<Project> | null>(null)
+  const [renameTarget, setRenameTarget] = useState<Project | null>(null)
+  const [renaming, setRenaming] = useState(false)
+  const [renameError, setRenameError] = useState<string | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<Project | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -73,6 +78,31 @@ export function ProjectsPage() {
     }
   }
 
+  async function renameProject(project: Project, name: string) {
+    setRenaming(true)
+    setRenameError(null)
+    try {
+      const renamed = await projectApis.rename(project.id, name)
+      setProjectsPage((current) =>
+        current
+          ? {
+              ...current,
+              items: current.items.map((item) =>
+                item.id === project.id ? { ...renamed, previewUrl: item.previewUrl } : item,
+              ),
+            }
+          : current,
+      )
+      setRenameTarget(null)
+    } catch (error) {
+      setRenameError(
+        error instanceof ProjectNameConflictError ? error.message : '项目暂时无法重命名',
+      )
+    } finally {
+      setRenaming(false)
+    }
+  }
+
   return (
     <div className="mx-auto w-full max-w-[1560px] px-4 pb-8 pt-[4.5rem] sm:px-6 xl:px-8">
       <section aria-label="项目资产">
@@ -92,6 +122,10 @@ export function ProjectsPage() {
             <ProjectGallery
               projects={projectsPage.items}
               total={projectsPage.total}
+              onRename={(project) => {
+                setRenameError(null)
+                setRenameTarget(project)
+              }}
               onDelete={setDeleteTarget}
             />
           ) : null}
@@ -105,6 +139,19 @@ export function ProjectsPage() {
           />
         ) : null}
       </section>
+
+      {renameTarget ? (
+        <RenameProjectDialog
+          project={renameTarget}
+          pending={renaming}
+          error={renameError}
+          onClose={() => {
+            setRenameError(null)
+            setRenameTarget(null)
+          }}
+          onConfirm={(name) => renameProject(renameTarget, name)}
+        />
+      ) : null}
 
       {deleteTarget ? (
         <DeleteProjectDialog
@@ -186,10 +233,12 @@ function ProjectGalleryLoading() {
 function ProjectGallery({
   projects,
   total,
+  onRename,
   onDelete,
 }: {
   projects: Project[]
   total: number
+  onRename: (project: Project) => void
   onDelete: (project: Project) => void
 }) {
   return (
@@ -209,6 +258,7 @@ function ProjectGallery({
             project={project}
             preview={projectPreview(project)}
             motionOrder={index}
+            onRename={() => onRename(project)}
             onDelete={() => onDelete(project)}
           />
         ))}
@@ -226,11 +276,13 @@ function ProjectGalleryTile({
   project,
   preview,
   motionOrder,
+  onRename,
   onDelete,
 }: {
   project: Project
   preview: ProjectPreviewState
   motionOrder: number
+  onRename: () => void
   onDelete: () => void
 }) {
   const updatedAt = new Intl.DateTimeFormat('zh-CN', {
@@ -264,15 +316,81 @@ function ProjectGalleryTile({
           {project.gameStyle || '未设置游戏风格'}
         </p>
       </Link>
+      <ProjectActions project={project} onRename={onRename} onDelete={onDelete} />
+    </article>
+  )
+}
+
+function ProjectActions({
+  project,
+  onRename,
+  onDelete,
+}: {
+  project: Project
+  onRename: () => void
+  onDelete: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function closeOnOutsidePress(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', closeOnOutsidePress)
+    document.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsidePress)
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [open])
+
+  return (
+    <div ref={rootRef} className="absolute right-3 top-3 z-10">
       <button
         type="button"
-        aria-label={`删除项目 ${project.name}`}
-        onClick={onDelete}
-        className="absolute right-3 top-3 rounded-full border border-app-line bg-app-surface/90 px-2.5 py-1.5 text-sm leading-none text-app-faint opacity-0 backdrop-blur-sm transition hover:text-app-danger group-hover/tile:opacity-100 focus-visible:opacity-100"
+        aria-label={`项目操作 ${project.name}`}
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        className="grid h-9 w-9 place-items-center rounded-full border border-app-line bg-app-canvas/95 text-app-ink-soft shadow-sm backdrop-blur-sm transition hover:border-app-line-strong hover:text-app-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-ink"
       >
-        ⋯
+        <DotsThree aria-hidden="true" size={20} weight="bold" />
       </button>
-    </article>
+      {open ? (
+        <div
+          role="group"
+          aria-label={`${project.name}的项目操作`}
+          className="absolute right-0 top-11 w-36 overflow-hidden rounded-xl border border-app-line bg-app-surface-raised p-1.5 shadow-lg"
+        >
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false)
+              onRename()
+            }}
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-app-ink-soft transition hover:bg-app-surface-muted hover:text-app-ink focus-visible:outline-2 focus-visible:outline-app-ink"
+          >
+            <PencilSimple aria-hidden="true" size={16} />
+            重命名项目
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false)
+              onDelete()
+            }}
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-app-danger transition hover:bg-app-danger-soft focus-visible:outline-2 focus-visible:outline-app-danger"
+          >
+            <Trash aria-hidden="true" size={16} />
+            删除项目
+          </button>
+        </div>
+      ) : null}
+    </div>
   )
 }
 
@@ -352,6 +470,81 @@ function ProjectPreviewMessage({
     >
       <div aria-hidden="true" className="project-preview-message-grid" />
       <span>{children}</span>
+    </div>
+  )
+}
+
+function RenameProjectDialog({
+  project,
+  pending,
+  error,
+  onClose,
+  onConfirm,
+}: {
+  project: Project
+  pending: boolean
+  error: string | null
+  onClose: () => void
+  onConfirm: (name: string) => Promise<void>
+}) {
+  const [name, setName] = useState(project.name)
+  const normalizedName = name.trim()
+
+  return (
+    <div className="projects-dialog-backdrop fixed inset-0 z-50 grid place-items-center bg-app-ink/20 p-4 backdrop-blur-sm">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label="重命名项目"
+        className="projects-dialog-panel w-full max-w-md rounded-[1.5rem] border border-app-line bg-app-surface-raised p-6"
+      >
+        <h2 className="text-lg font-semibold text-app-ink">重命名项目</h2>
+        <p className="mt-2 text-sm leading-6 text-app-muted">项目名称会同步更新到项目中心。</p>
+        <form
+          className="mt-5"
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (normalizedName) void onConfirm(normalizedName)
+          }}
+        >
+          <label className="block text-sm font-medium text-app-ink" htmlFor="project-rename-name">
+            项目名称
+          </label>
+          <input
+            id="project-rename-name"
+            autoFocus
+            required
+            maxLength={20}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            className="mt-2 w-full rounded-xl border border-app-line bg-app-surface px-3.5 py-2.5 text-sm text-app-ink outline-none transition focus:border-app-ink"
+          />
+          <div className="mt-2 flex items-start justify-between gap-4 text-xs">
+            <span role={error ? 'alert' : undefined} className="text-app-danger">
+              {error}
+            </span>
+            <span className="ml-auto shrink-0 text-app-faint">{name.length}/20</span>
+          </div>
+          <div className="mt-6 flex justify-end gap-2">
+            <button
+              type="button"
+              disabled={pending}
+              onClick={onClose}
+              className="rounded-full border border-app-line px-4 py-2 text-sm disabled:opacity-50"
+            >
+              取消
+            </button>
+            <button
+              type="submit"
+              aria-label="保存名称"
+              disabled={pending || !normalizedName || normalizedName === project.name}
+              className="rounded-full bg-app-accent px-4 py-2 text-sm font-semibold text-app-on-accent disabled:opacity-50"
+            >
+              {pending ? '正在保存…' : '保存名称'}
+            </button>
+          </div>
+        </form>
+      </section>
     </div>
   )
 }

--- a/frontend/src/test/project-assets-backend.ts
+++ b/frontend/src/test/project-assets-backend.ts
@@ -244,6 +244,24 @@ export function createProjectAssetsBackend({
       const projectId = Number(url.pathname.split('/').at(-1))
       const project = projects.find((item) => item.id === projectId)
       if (request.method === 'GET' && project) return response(project)
+      if (request.method === 'PATCH' && project) {
+        const body = (await request.json()) as { project_name: string }
+        if (
+          projects.some((item) => item.id !== projectId && item.project_name === body.project_name)
+        ) {
+          return new Response(
+            JSON.stringify({
+              code: 400,
+              message: '项目名称已存在',
+              data: null,
+            }),
+            { headers: { 'content-type': 'application/json' } },
+          )
+        }
+        project.project_name = body.project_name
+        project.update_at = '2026-08-07T00:00:00Z'
+        return response(project, '重命名成功')
+      }
       if (request.method === 'DELETE' && project) {
         projects = projects.filter((item) => item.id !== projectId)
         return response(null, '删除成功')

--- a/openapi.json
+++ b/openapi.json
@@ -2190,6 +2190,22 @@
         "title": "ProjectOut",
         "type": "object"
       },
+      "ProjectRename": {
+        "description": "重命名项目请求。",
+        "properties": {
+          "project_name": {
+            "maxLength": 20,
+            "minLength": 1,
+            "title": "Project Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "project_name"
+        ],
+        "title": "ProjectRename",
+        "type": "object"
+      },
       "RefreshRequest": {
         "description": "刷新 token 请求。",
         "properties": {
@@ -4399,6 +4415,56 @@
           }
         },
         "summary": "Get Project",
+        "tags": [
+          "projects"
+        ]
+      },
+      "patch": {
+        "operationId": "rename_project_projects__project_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectRename"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_ProjectOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Rename Project",
         "tags": [
           "projects"
         ]


### PR DESCRIPTION
项目卡片现在常驻显示右上角操作入口，并在同一菜单中提供重命名与删除；同时补齐后端重命名接口、唯一性与权限保护。

## Why

原入口只在悬停时出现，用户难以发现，而且只能删除项目，无法修正项目名称。

## Changes

- 将项目卡片操作按钮常驻在右上角，并使用页面暖黄色画布色。
- 在操作菜单中提供“重命名项目”和“删除项目”。
- 新增项目重命名弹窗、重复名称反馈和成功后的列表更新。
- 新增 `PATCH /projects/{project_id}`，保留用户归属和名称唯一性约束。

## Implementation

- 后端在锁定项目后校验归属与重复名称，并以数据库唯一约束兜底并发冲突。
- 前端通过 Project API 更新名称，同时保留已有卡片预览。
- 操作入口采用普通披露控件语义，支持 Escape 关闭，不改变卡片跳转、分页和删除规则。

## Verification

- [x] `uv run ruff check .`：通过
- [x] `uv run lint-imports`：2 个契约通过
- [x] `uv run pytest -q --cov=packages --cov-report=term-missing --cov-report=xml:coverage.xml`：1332 passed，14 skipped
- [x] `npm run format:check`、`npm run lint`、`npm run typecheck`：通过
- [x] `npm test -- src/pages/projects/index.test.tsx`：10 passed
- [x] 真实本地后端验证重命名、刷新持久化并恢复原名
- [ ] `npm run test:coverage`：本机全量运行出现大范围无关页面超时，已停止；以 GitHub CI runner 结果为准

## Scope

- 本 PR 不改变项目卡片跳转、分页、预览和删除业务规则。
- 本 PR 不包含部署。

## Related Issues

Closes #549
