### PR TITLE
fix(quick-start): disable prompt autocomplete

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -511,6 +511,14 @@ describe('QuickStartPage', () => {
     )
   })
 
+  it('keeps browser form history out of the creation composer', () => {
+    renderAt('/quick-start', serviceFor(null))
+    const composer = screen.getByRole('textbox', { name: '创作指令' })
+
+    expect(composer.getAttribute('autocomplete')).toBe('off')
+    expect(composer.closest('form')?.getAttribute('autocomplete')).toBe('off')
+  })
+
   it('keeps the entry and run canvases at least viewport height', async () => {
     const entry = renderAt('/quick-start', serviceFor(null))
     expect(entry.getByLabelText('创作指令').closest('section')?.className).toContain(

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -808,6 +808,7 @@ function QuickStartInput({
         >
           <form
             onSubmit={(event) => void submit(event)}
+            autoComplete="off"
             data-prompt-state={promptState}
             className={`quick-start-agent-composer grid items-center gap-1.5 overflow-hidden rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)] ${
               hasConversation ? 'sm:grid-cols-[1fr_auto]' : 'sm:grid-cols-[1fr_auto_auto]'
@@ -822,6 +823,7 @@ function QuickStartInput({
                 ref={promptInput}
                 id="quick-start-prompt"
                 rows={1}
+                autoComplete="off"
                 aria-label="创作指令"
                 value={prompt}
                 onChange={(event) => setPrompt(event.target.value)}


### PR DESCRIPTION
修复 Quick Start 创作指令输入框被浏览器识别为普通历史表单的问题，避免历史角色描述建议遮挡创作界面。

## Why

当前输入框与所属表单未声明自动补全策略，浏览器会在聚焦时弹出历史表单内容；对话式创作输入不应复用这类建议。

## Changes

- 在 Quick Start 创作指令表单与输入框上关闭 `autocomplete`。
- 增加定向回归测试，锁定浏览器自动补全契约。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx --configLoader runner -t 'keeps browser form history'`：1 passed。
- [x] `oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `git diff --check upstream/main...HEAD`：通过。

## Scope

- 本 PR 不包含：输入框多行化、富文本编辑器、生成逻辑或业务流程调整。

## Related Issues

Closes #552
