### PR TITLE
feat(landing): add open-source footer

### DIFF
--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -497,6 +497,8 @@ const marketingRegisterEntry = `/?${new URLSearchParams({
   returnTo: '/workspace',
 })}`
 
+const githubRepository = 'https://github.com/1024XEngineer/Windup'
+
 /**
  * 公开主页的顶栏悬在首屏画布上，只保留品牌与账号入口。
  * 半透明底色负责托住文字，边界交给背景模糊表达，避免把首屏切成上下两块。
@@ -532,6 +534,14 @@ function MarketingHeaderView({ session, wave, onWave }: MarketingHeaderViewProps
           aria-label="账号"
           className="relative ml-auto flex shrink-0 items-center gap-1 sm:gap-6"
         >
+          <a
+            href={githubRepository}
+            target="_blank"
+            rel="noreferrer"
+            className="hidden min-h-11 items-center text-body font-medium text-app-muted transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent xl:inline-flex"
+          >
+            GitHub
+          </a>
           {session.state.status === 'booting' ? (
             <span
               aria-label="正在恢复登录状态"

--- a/frontend/src/pages/landing/index.test.tsx
+++ b/frontend/src/pages/landing/index.test.tsx
@@ -112,4 +112,33 @@ describe('LandingPage', () => {
     expect(document.querySelector('img[src*="workflow-editor"]')).toBeNull()
     expect(document.querySelector('source[srcset*="workflow-editor"]')).toBeNull()
   })
+
+  it('在收尾插画之后提供真实的开源项目入口', async () => {
+    render(
+      <GuestAuthSession>
+        <MemoryRouter>
+          <LandingPage />
+        </MemoryRouter>
+      </GuestAuthSession>,
+    )
+
+    const footer = await screen.findByRole('contentinfo')
+    const header = document.querySelector<HTMLElement>('header[data-layout="unified"]')
+
+    expect(header).not.toBeNull()
+    expect(within(header!).getByRole('link', { name: 'GitHub' }).getAttribute('href')).toBe(
+      'https://github.com/1024XEngineer/Windup',
+    )
+    expect(within(footer).getByText('Windup 是一个开源的 2D 角色资产工作台。')).toBeTruthy()
+    expect(within(footer).getByRole('link', { name: 'GitHub 仓库' }).getAttribute('href')).toBe(
+      'https://github.com/1024XEngineer/Windup',
+    )
+    expect(within(footer).getByRole('link', { name: 'Issues' }).getAttribute('href')).toBe(
+      'https://github.com/1024XEngineer/Windup/issues',
+    )
+    expect(within(footer).getByRole('link', { name: 'Contributors' }).getAttribute('href')).toBe(
+      'https://github.com/1024XEngineer/Windup/graphs/contributors',
+    )
+    expect(within(footer).queryByText(/隐私政策|服务条款|备案/)).toBeNull()
+  })
 })

--- a/frontend/src/pages/landing/index.tsx
+++ b/frontend/src/pages/landing/index.tsx
@@ -16,6 +16,8 @@ const creationEntry = `/?${new URLSearchParams({
   returnTo: '/workspace',
 })}`
 
+const githubRepository = 'https://github.com/1024XEngineer/Windup'
+
 const productCapabilities = [
   {
     outcome:
@@ -686,6 +688,56 @@ export function LandingPage() {
           </div>
         </div>
       </main>
+
+      <footer className="border-t border-rule bg-paper-sunken px-4 py-12 sm:px-8 lg:px-12">
+        <div className="mx-auto grid max-w-[82rem] gap-12 md:grid-cols-[minmax(18rem,1fr)_auto] md:gap-20">
+          <div className="max-w-sm">
+            <Link
+              to="/"
+              aria-label="返回 Windup 宣传页"
+              className="inline-flex items-center gap-3 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-app-accent"
+            >
+              <img src="/windup-mark.svg" alt="" className="h-7 w-7" />
+              <strong className="font-serif text-xl tracking-[-0.02em] text-ink">Windup</strong>
+            </Link>
+            <p className="mt-5 text-body leading-7 text-ink-muted">
+              Windup 是一个开源的 2D 角色资产工作台。
+            </p>
+            <p className="mt-2 text-body leading-7 text-ink-faint">
+              查看源码、报告问题，或参与 Windup 的下一步。
+            </p>
+          </div>
+
+          <nav aria-label="页尾项目导航">
+            <h2 className="text-meta font-semibold tracking-[0.08em] text-ink-faint uppercase">
+              项目
+            </h2>
+            <ul className="mt-4 grid gap-1 text-body text-ink-muted">
+              {[
+                ['GitHub 仓库', githubRepository],
+                ['Issues', `${githubRepository}/issues`],
+                ['Contributors', `${githubRepository}/graphs/contributors`],
+              ].map(([label, href]) => (
+                <li key={href}>
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex min-h-10 items-center transition-colors hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+                  >
+                    {label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+
+        <div className="mx-auto mt-10 flex max-w-[82rem] flex-wrap items-center justify-between gap-3 border-t border-rule pt-5 text-meta text-ink-faint">
+          <p>© {new Date().getFullYear()} Windup</p>
+          <p>2D 角色资产工作台</p>
+        </div>
+      </footer>
     </div>
   )
 }


### PR DESCRIPTION
为 Windup 公开 Landing 页恢复开源项目页脚，并在桌面端宣传页顶栏补充 GitHub 入口，让访客能直接找到源码、问题反馈和贡献记录。

## Why

Landing 页此前以收尾插画结束，没有项目来源与参与入口。这让开源属性和维护路径在公开页面上不可见，也使此前完成但未提交的页脚设计被遗漏。

## Changes

- 在收尾插画后增加与现有纸张视觉一致的轻量页脚。
- 提供产品锚点、GitHub 仓库、Issues 与 Contributors 真实链接。
- 在宽屏宣传页顶栏增加 GitHub 入口，保持产品内 Header 不变。

## Implementation

- 页脚使用语义化 `contentinfo` 与独立导航区，移动端单列、桌面端分栏。
- 外链统一使用 `target="_blank"` 与 `rel="noreferrer"`，并保留键盘焦点样式。
- 测试按导航区域限定同名链接断言，覆盖真实链接与未提供的法律信息边界。

## Verification

- [x] `npm run format:check`：通过。
- [x] `npm test -- src/pages/landing/index.test.tsx`：5/5 通过。
- [x] `npm run typecheck`：通过。
- [x] `git diff --check upstream/main...HEAD`：通过。
- [x] 本地真实浏览器检查 `http://127.0.0.1:5194/`：页脚位于收尾插画之后，桌面布局正常。

## Screenshots

### Desktop

<img width="863" height="823" alt="Windup Landing open-source footer" src="https://github.com/user-attachments/assets/4f915454-d378-41d9-9ee6-a47dfe38c5b9" />

## Scope

- 本 PR 不包含：隐私政策、服务条款、备案、社交账号或 Landing 业务流程调整。
- 后续事项：无。

## Related Issues

Closes #554
