### PR TITLE
feat(shared-ui): add frame animation player

### DIFF
--- a/frontend/src/shared/ui/frame-animation-player.test.tsx
+++ b/frontend/src/shared/ui/frame-animation-player.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FrameAnimationPlayer } from './frame-animation-player'
+
+const frames = [
+  { index: 1, imageUrl: '/frame-2.png', durationMs: 120 },
+  { index: 0, imageUrl: '/frame-1.png', durationMs: 80 },
+] as const
+
+function visibleFrame() {
+  return screen.getByRole('img', { name: '角色动作' })
+}
+
+describe('FrameAnimationPlayer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('plays frames by explicit index and per-frame duration', () => {
+    render(<FrameAnimationPlayer frames={frames} alt="角色动作" />)
+
+    expect(visibleFrame().getAttribute('src')).toBe('/frame-1.png')
+
+    act(() => vi.advanceTimersByTime(79))
+    expect(visibleFrame().getAttribute('src')).toBe('/frame-1.png')
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(visibleFrame().getAttribute('src')).toBe('/frame-2.png')
+  })
+
+  it('loops to the first frame after the last frame duration', () => {
+    render(<FrameAnimationPlayer frames={frames} alt="角色动作" />)
+
+    act(() => vi.advanceTimersByTime(200))
+
+    expect(visibleFrame().getAttribute('src')).toBe('/frame-1.png')
+  })
+
+  it('holds the last frame for a non-looping action', () => {
+    render(<FrameAnimationPlayer frames={frames} alt="角色动作" loop={false} />)
+
+    act(() => vi.advanceTimersByTime(2_000))
+
+    expect(visibleFrame().getAttribute('src')).toBe('/frame-2.png')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each([
+    [{ ...frames[0], durationMs: null }, 20, 49, 1],
+    [{ ...frames[0], durationMs: null }, 0, 99, 1],
+  ] as const)(
+    'falls back from a missing frame duration with fps %s',
+    (firstFrame, fps, beforeAdvance, finalAdvance) => {
+      render(
+        <FrameAnimationPlayer
+          frames={[
+            { ...firstFrame, index: 0 },
+            { ...frames[1], index: 1 },
+          ]}
+          fps={fps}
+          alt="角色动作"
+        />,
+      )
+
+      act(() => vi.advanceTimersByTime(beforeAdvance))
+      expect(visibleFrame().getAttribute('src')).toBe('/frame-2.png')
+
+      act(() => vi.advanceTimersByTime(finalAdvance))
+      expect(visibleFrame().getAttribute('src')).toBe('/frame-1.png')
+    },
+  )
+
+  it('restarts from the first frame when the sequence changes', () => {
+    const { rerender } = render(<FrameAnimationPlayer frames={frames} alt="角色动作" />)
+    act(() => vi.advanceTimersByTime(80))
+    expect(visibleFrame().getAttribute('src')).toBe('/frame-2.png')
+
+    rerender(
+      <FrameAnimationPlayer
+        frames={[
+          { index: 5, imageUrl: '/new-2.png', durationMs: 100 },
+          { index: 4, imageUrl: '/new-1.png', durationMs: 100 },
+        ]}
+        alt="角色动作"
+      />,
+    )
+
+    expect(visibleFrame().getAttribute('src')).toBe('/new-1.png')
+  })
+
+  it('keeps playback progress when a parent recreates equivalent frames', () => {
+    const { rerender } = render(<FrameAnimationPlayer frames={frames} alt="角色动作" />)
+    act(() => vi.advanceTimersByTime(50))
+
+    rerender(<FrameAnimationPlayer frames={frames.map((frame) => ({ ...frame }))} alt="角色动作" />)
+    act(() => vi.advanceTimersByTime(30))
+
+    expect(visibleFrame().getAttribute('src')).toBe('/frame-2.png')
+  })
+
+  it('passes image presentation attributes through to the visible frame', () => {
+    render(
+      <FrameAnimationPlayer
+        frames={frames}
+        alt="角色动作"
+        className="pixel-preview"
+        draggable={false}
+      />,
+    )
+
+    expect(visibleFrame().className).toBe('pixel-preview')
+    expect(visibleFrame().getAttribute('draggable')).toBe('false')
+  })
+
+  it('is available from the shared UI entry', async () => {
+    const sharedUi = (await import('.')) as Record<string, unknown>
+
+    expect(sharedUi.FrameAnimationPlayer).toBeTypeOf('function')
+  })
+})

--- a/frontend/src/shared/ui/frame-animation-player.tsx
+++ b/frontend/src/shared/ui/frame-animation-player.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState, type ImgHTMLAttributes } from 'react'
+
+const DEFAULT_FRAME_DURATION_MS = 100
+
+export interface FrameAnimationFrame {
+  readonly index: number
+  readonly imageUrl: string
+  readonly durationMs: number | null
+}
+
+export interface FrameAnimationPlayerProps extends Omit<
+  ImgHTMLAttributes<HTMLImageElement>,
+  'alt' | 'src'
+> {
+  readonly frames: readonly FrameAnimationFrame[]
+  readonly alt: string
+  readonly fps?: number
+  readonly loop?: boolean
+}
+
+interface PlaybackFrame {
+  readonly imageUrl: string
+  readonly durationMs: number
+}
+
+function fallbackDurationMs(fps: number | undefined): number {
+  if (fps !== undefined && Number.isFinite(fps) && fps > 0) {
+    return Math.max(1, Math.round(1000 / fps))
+  }
+  return DEFAULT_FRAME_DURATION_MS
+}
+
+function prepareFrames(
+  frames: readonly FrameAnimationFrame[],
+  fps: number | undefined,
+): readonly PlaybackFrame[] {
+  const fallback = fallbackDurationMs(fps)
+  return [...frames]
+    .sort((left, right) => left.index - right.index)
+    .map((frame) => ({
+      imageUrl: frame.imageUrl,
+      durationMs:
+        frame.durationMs !== null && Number.isFinite(frame.durationMs) && frame.durationMs > 0
+          ? Math.max(1, frame.durationMs)
+          : fallback,
+    }))
+}
+
+export function FrameAnimationPlayer({
+  frames,
+  alt,
+  fps,
+  loop = true,
+  ...imageProps
+}: FrameAnimationPlayerProps) {
+  const playbackFrames = prepareFrames(frames, fps)
+  const sequenceKey = JSON.stringify(playbackFrames)
+  const latestFrames = useRef(playbackFrames)
+  latestFrames.current = playbackFrames
+  const [playback, setPlayback] = useState({ sequenceKey, index: 0 })
+  const sequenceChanged = playback.sequenceKey !== sequenceKey
+  const frameIndex = sequenceChanged ? 0 : Math.min(playback.index, playbackFrames.length - 1)
+  const frame = playbackFrames[frameIndex]
+
+  useEffect(() => {
+    const activeFrames = latestFrames.current
+    setPlayback({ sequenceKey, index: 0 })
+    if (activeFrames.length < 2) return
+
+    let currentIndex = 0
+    let timer: ReturnType<typeof setTimeout>
+    const scheduleNextFrame = () => {
+      timer = setTimeout(() => {
+        const lastFrameIndex = activeFrames.length - 1
+        if (!loop && currentIndex === lastFrameIndex) return
+
+        currentIndex = (currentIndex + 1) % activeFrames.length
+        setPlayback({ sequenceKey, index: currentIndex })
+        scheduleNextFrame()
+      }, activeFrames[currentIndex]!.durationMs)
+    }
+
+    scheduleNextFrame()
+    return () => clearTimeout(timer)
+  }, [loop, sequenceKey])
+
+  if (!frame) return null
+  return <img {...imageProps} src={frame.imageUrl} alt={alt} />
+}

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -16,3 +16,5 @@ export type {
 export { KineticCopyCycle } from './kinetic-copy-cycle'
 export type { KineticCopyCycleProps, KineticCopyMessage } from './kinetic-copy-cycle'
 export { PixelMatrix } from './pixel-matrix'
+export { FrameAnimationPlayer } from './frame-animation-player'
+export type { FrameAnimationFrame, FrameAnimationPlayerProps } from './frame-animation-player'


### PR DESCRIPTION
新增与页面和业务实体解耦的共享逐帧播放器，统一帧排序、时序兜底、循环/单次和序列更新语义，为后续页面接入提供稳定边界。

## Why

Playtest 的播放逻辑当前属于页面内部运行时，其他页面没有可复用的基础播放器。先建立纯共享组件，可以让后续 Quick Start、Workflow Editor 和资产详情分别接入，而不在本 PR 混入页面改造。

## Changes

- 新增 `FrameAnimationPlayer` 及独立帧输入类型。
- 按 `index` 排序，优先使用逐帧时长，缺失时按 FPS 或 100ms 兜底。
- 支持循环播放与单次播放停在末帧。
- 动作内容真实变化时从首帧重启；父组件重建等价数组时保持播放进度。
- 从 `@/shared/ui` 公开导出组件与类型。

## Implementation

- 组件只依赖 React 和原生 `<img>` 属性，不依赖 Character、Generation 或页面模型。
- 使用归一化播放序列生成语义 key，避免把数组引用变化误判成新动作。
- 定时器随语义序列或循环模式变化清理并重建，空序列不渲染、单帧不启动定时器。

## Verification

- [x] `npm test -- src/shared/ui/frame-animation-player.test.tsx`：9/9 通过。
- [x] `npx oxfmt --check src/shared/ui/frame-animation-player.tsx src/shared/ui/frame-animation-player.test.tsx src/shared/ui/index.ts`：通过。
- [x] `npx oxlint src/shared/ui/frame-animation-player.tsx src/shared/ui/frame-animation-player.test.tsx src/shared/ui/index.ts`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npx vite build`：构建成功；仅保留仓库现有的大 chunk 提示。
- [x] 本地真实浏览器临时验收页：观察到 FRAME 1 → FRAME 2 切换，控制台 0 error；临时验收文件未提交。
- [x] 子代理只读验收：首次发现等价数组重启问题，修复后由同一代理复验通过。

## Scope

- 本 PR 不包含：Quick Start、Workflow Editor、资产库或 Playtest 页面接入。
- 本 PR 不修改 Workflow、Generation、Character、后端、路由、审核、保存或导出流程。
- 后续事项：各消费页面分别通过独立 Issue / PR 接入播放器。

## Related Issues

Closes #556
