### PR TITLE
feat(landing): add immersive fixed marketing header

### DIFF
--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -38,7 +38,10 @@ describe('AppRoutes authentication boundary', () => {
     )
 
     expect(await screen.findByRole('heading', { name: /让你的角色/ })).toBeTruthy()
-    expect(screen.getByRole('navigation', { name: '宣传页导航' })).toBeTruthy()
+    const loginEntry = screen.getByRole('link', { name: '登录' })
+    expect(loginEntry.closest('header')?.getAttribute('data-surface')).toBe('borderless-glass')
+    expect(screen.getByRole('link', { name: '注册' })).toBeTruthy()
+    expect(screen.queryByRole('navigation', { name: '宣传页导航' })).toBeNull()
     expect(screen.queryByRole('navigation', { name: '产品导航' })).toBeNull()
   })
 
@@ -51,8 +54,10 @@ describe('AppRoutes authentication boundary', () => {
       </AuthenticatedAuthSession>,
     )
 
-    expect(await screen.findByRole('navigation', { name: '宣传页导航' })).toBeTruthy()
-    expect(screen.getByRole('link', { name: '进入工作台' }).getAttribute('href')).toBe('/workspace')
+    const workspaceEntry = await screen.findByRole('link', { name: '进入工作台' })
+    expect(workspaceEntry.closest('header')?.getAttribute('data-surface')).toBe('borderless-glass')
+    expect(screen.queryByRole('navigation', { name: '宣传页导航' })).toBeNull()
+    expect(workspaceEntry.getAttribute('href')).toBe('/workspace')
   })
 
   it('protects the workspace home and preserves it as the login return path', async () => {

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -150,7 +150,7 @@ describe('AppHeader 进行中任务入口', () => {
 
     act(() => rememberActiveRun('7', '77'))
 
-    expect(screen.getByRole('button', { name: '创作，有任务进行中' })).toBeTruthy()
+    expect(await screen.findByRole('button', { name: '创作，有任务进行中' })).toBeTruthy()
   })
 
   it('任务进行期间文字旁跟一个张望的小机器人，红点自己不动', async () => {

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -506,7 +506,7 @@ function MarketingHeaderView({ session, wave, onWave }: MarketingHeaderViewProps
     <header
       data-layout="unified"
       data-surface="borderless-glass"
-      className="fixed inset-x-0 top-0 z-50 bg-[#f7f6f0]/28 text-ink backdrop-blur-[18px] backdrop-saturate-[0.82]"
+      className="fixed inset-x-0 top-0 z-50 bg-paper/28 text-ink backdrop-blur-[18px] backdrop-saturate-[0.82]"
     >
       <div className="relative mx-auto flex min-h-18 w-full max-w-[82rem] items-center justify-between px-5 sm:min-h-21 sm:px-8 lg:px-12">
         <Link

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -65,12 +65,6 @@ function navItemClassName(active: boolean, waving: boolean): string {
   } ${waving ? 'app-header-text-wave' : ''}`
 }
 
-function marketingNavItemClassName(waving: boolean): string {
-  return `relative inline-flex min-h-11 items-center px-1.5 text-body font-medium whitespace-nowrap text-app-muted transition-colors after:absolute after:inset-x-1.5 after:bottom-0 after:h-[2px] after:origin-center after:scale-x-0 after:bg-app-accent after:transition-transform hover:text-app-accent hover:after:scale-x-100 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent sm:px-3 sm:after:inset-x-3 ${
-    waving ? 'app-header-text-wave' : ''
-  }`
-}
-
 /**
  * 有任务在跑时跟在"创作"右边的小机器人：圆脸加两只眼，眼睛左右张望。
  * 顶掉文字试过一版：这一项会在图标和文字之间来回换形态，读起来像换了个入口。
@@ -493,12 +487,6 @@ interface MarketingHeaderViewProps {
   onWave: (entry: string) => void
 }
 
-const marketingNavigation = [
-  { href: '#capabilities', label: '产品能力', compactLabel: '能力', motionKey: 'capabilities' },
-  { href: '#workflow', label: '制作流程', compactLabel: '流程', motionKey: 'workflow' },
-  { href: '#workspace', label: '资产工作台', compactLabel: '资产', motionKey: 'workspace' },
-] as const
-
 const marketingLoginEntry = `/?${new URLSearchParams({
   account: 'login',
   returnTo: '/workspace',
@@ -510,28 +498,28 @@ const marketingRegisterEntry = `/?${new URLSearchParams({
 })}`
 
 /**
- * 公开主页只换导航内容，沿用产品顶栏的布局、触控尺寸和视觉表面。
- * 这样两套入口在手机上不会因为各自维护断点而逐渐错位。
+ * 公开主页的顶栏悬在首屏画布上，只保留品牌与账号入口。
+ * 半透明底色负责托住文字，边界交给背景模糊表达，避免把首屏切成上下两块。
  */
 function MarketingHeaderView({ session, wave, onWave }: MarketingHeaderViewProps) {
   return (
     <header
       data-layout="unified"
-      data-surface="frosted-bar"
-      className="sticky top-0 z-50 border-b border-rule bg-app-canvas/92 text-ink backdrop-blur-xl"
+      data-surface="borderless-glass"
+      className="fixed inset-x-0 top-0 z-50 bg-[#f7f6f0]/28 text-ink backdrop-blur-[18px] backdrop-saturate-[0.82]"
     >
-      <div className="relative mx-auto flex min-h-18 w-full max-w-[82rem] items-center justify-between px-4 sm:px-8 lg:px-12">
+      <div className="relative mx-auto flex min-h-18 w-full max-w-[82rem] items-center justify-between px-5 sm:min-h-21 sm:px-8 lg:px-12">
         <Link
           to="/"
           aria-label="返回 Windup 宣传页"
           data-motion="text-wave"
           onClick={() => onWave('brand')}
-          className={`flex min-h-11 shrink-0 items-center gap-2.5 pr-1 text-app-ink focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent max-[360px]:hidden ${
+          className={`flex min-h-11 shrink-0 items-center gap-2.5 pr-1 text-app-ink focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ${
             wave.entry === 'brand' ? 'app-header-text-wave' : ''
           }`}
         >
           <img src="/windup-mark.svg" alt="" className="h-7 w-7" />
-          <strong className="hidden font-serif text-lg leading-none sm:inline">
+          <strong className="font-serif text-lg leading-none">
             <WaveText playId={wave.entry === 'brand' ? wave.playId : 0} text="Windup" />
           </strong>
           <span aria-hidden="true" className="hidden h-4 w-px bg-rule lg:block" />
@@ -539,32 +527,6 @@ function MarketingHeaderView({ session, wave, onWave }: MarketingHeaderViewProps
             2D 角色资产工作台
           </span>
         </Link>
-
-        <nav
-          aria-label="宣传页导航"
-          className="absolute left-1/2 flex -translate-x-1/2 items-stretch gap-0 sm:gap-1 max-[360px]:left-4 max-[360px]:translate-x-0"
-        >
-          {marketingNavigation.map((item) => {
-            const playId = wave.entry === item.motionKey ? wave.playId : 0
-            return (
-              <a
-                key={item.href}
-                aria-label={item.label}
-                href={item.href}
-                data-motion="text-wave"
-                onClick={() => onWave(item.motionKey)}
-                className={marketingNavItemClassName(wave.entry === item.motionKey)}
-              >
-                <span className="hidden sm:inline">
-                  <WaveText playId={playId} text={item.label} />
-                </span>
-                <span className="sm:hidden">
-                  <WaveText playId={playId} text={item.compactLabel} />
-                </span>
-              </a>
-            )
-          })}
-        </nav>
 
         <div
           aria-label="账号"

--- a/frontend/src/pages/landing/index.test.tsx
+++ b/frontend/src/pages/landing/index.test.tsx
@@ -48,12 +48,17 @@ describe('LandingPage', () => {
     )
 
     expect(await screen.findByRole('heading', { name: '让你的角色，真正登场。' })).toBeTruthy()
-    expect(screen.getByRole('navigation', { name: '宣传页导航' })).toBeTruthy()
+    expect(screen.queryByRole('navigation', { name: '宣传页导航' })).toBeNull()
+    expect(screen.queryByText('产品能力')).toBeNull()
+    expect(screen.queryByText('制作流程')).toBeNull()
     const globalHeader = document.querySelector('header[data-layout="unified"]')
     expect(globalHeader?.getAttribute('data-layout')).toBe('unified')
-    expect(globalHeader?.getAttribute('data-surface')).toBe('frosted-bar')
+    expect(globalHeader?.getAttribute('data-surface')).toBe('borderless-glass')
     expect(globalHeader?.firstElementChild?.className).toContain('min-h-18')
-    expect(globalHeader?.className).toContain('sticky')
+    expect(globalHeader?.className).toContain('fixed')
+    expect(globalHeader?.className).toContain('backdrop-blur-[18px]')
+    expect(globalHeader?.className).toContain('backdrop-saturate-[0.82]')
+    expect(globalHeader?.className).not.toContain('border')
     expect(screen.getByRole('link', { name: '登录' }).getAttribute('href')).toBe(
       '/?account=login&returnTo=%2Fworkspace',
     )
@@ -68,15 +73,7 @@ describe('LandingPage', () => {
     for (const link of creationLinks) {
       expect(link.getAttribute('href')).toBe('/?account=login&returnTo=%2Fworkspace')
     }
-    const sectionLinks = [
-      ['产品能力', '#capabilities'],
-      ['制作流程', '#workflow'],
-      ['资产工作台', '#workspace'],
-    ] as const
-    for (const [name, href] of sectionLinks) {
-      expect(screen.getByRole('link', { name }).getAttribute('href')).toBe(href)
-      expect(document.querySelector(href)).not.toBeNull()
-    }
+    expect(screen.getByText('从角色设定到可玩的 2D 动作资产')).toBeTruthy()
     expect(screen.getByRole('heading', { name: '角色做出来，还要留下来、跑起来。' })).toBeTruthy()
     expect(screen.getByRole('heading', { name: '同一份创作，两种进入方式。' })).toBeTruthy()
     expect(screen.getByRole('heading', { name: '资产会留下来，继续生长。' })).toBeTruthy()

--- a/frontend/src/pages/landing/index.tsx
+++ b/frontend/src/pages/landing/index.tsx
@@ -512,7 +512,7 @@ export function LandingPage() {
       <main>
         <section
           aria-label="Windup 首屏"
-          className="relative isolate min-h-0 overflow-hidden border-b border-[#d8d6ce] text-[#252520] [background:linear-gradient(180deg,rgb(247_246_240/0.82),rgb(237_239_231/0.92)),#f2f1ea] sm:min-h-[calc(80dvh_-_4.5rem_+_min(40vw,_36rem))]"
+          className="relative isolate min-h-[100svh] overflow-hidden text-[#252520] [background:linear-gradient(180deg,rgb(247_246_240/0.82),rgb(237_239_231/0.92)),#f2f1ea] sm:min-h-[calc(80dvh_+_min(40vw,_36rem))]"
         >
           <div
             aria-hidden="true"
@@ -526,7 +526,7 @@ export function LandingPage() {
             loading="eager"
             decoding="async"
             fetchPriority="high"
-            className="pointer-events-none absolute top-72 -left-16 z-[1] block h-auto w-[min(52vw,31rem)] rotate-[2deg] select-none sm:top-[18.75rem] sm:-left-24 sm:w-[min(34vw,31rem)]"
+            className="pointer-events-none absolute top-96 -left-16 z-[1] block h-auto w-[min(52vw,31rem)] rotate-[2deg] select-none sm:top-[23.25rem] sm:-left-24 sm:w-[min(34vw,31rem)]"
           />
           <img
             src={gongbiBirdRight}
@@ -536,10 +536,10 @@ export function LandingPage() {
             loading="eager"
             decoding="async"
             fetchPriority="high"
-            className="pointer-events-none absolute top-20 -right-16 z-[1] block h-auto w-[min(48vw,29rem)] -rotate-[4deg] select-none sm:top-21 sm:-right-[9.5rem] sm:w-[min(32vw,29rem)]"
+            className="pointer-events-none absolute top-32 -right-12 z-[1] block h-auto w-[min(48vw,26rem)] -rotate-[4deg] select-none sm:top-[9.75rem] sm:-right-[9.5rem] sm:w-[min(32vw,29rem)]"
           />
 
-          <div className="relative z-10 mx-auto flex w-full max-w-[82rem] flex-col items-center px-4 pt-16 text-center sm:px-12 sm:pt-20">
+          <div className="relative z-10 mx-auto flex w-full max-w-[82rem] flex-col items-center px-4 pt-40 text-center sm:px-12 sm:pt-40">
             <p
               className={`${riseClassName} mx-auto w-full text-[0.875rem] leading-6 font-medium tracking-[0.04em] text-[#696861]`}
               style={riseDelay(0)}
@@ -568,7 +568,7 @@ export function LandingPage() {
             </Link>
           </div>
 
-          <figure className="relative z-20 mx-auto mt-16 w-[calc(100%_-_2rem)] max-w-[72rem] transform-gpu sm:absolute sm:top-[calc(80dvh_-_4.5rem)] sm:left-1/2 sm:mx-0 sm:mt-0 sm:w-[80%] sm:-translate-x-1/2">
+          <figure className="relative z-20 mx-auto mt-16 w-[calc(100%_-_2rem)] max-w-[72rem] transform-gpu sm:absolute sm:top-[80dvh] sm:left-1/2 sm:mx-0 sm:mt-0 sm:w-[80%] sm:-translate-x-1/2">
             <div
               data-testid="workflow-editor-placeholder"
               className="aspect-[2/1] overflow-hidden rounded-2xl border border-[#c9c8c0] bg-[#f9f8f3] shadow-[0_30px_80px_rgba(53,58,49,0.18)]"

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -317,7 +317,7 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     const image = await screen.findByRole('img', { name: '已确认身份母版' })
     fireEvent.error(image)
 
-    expect(screen.getByText('图片加载失败')).toBeTruthy()
+    expect(await screen.findByText('图片加载失败')).toBeTruthy()
     expect(screen.queryByRole('status', { name: '正在加载已确认身份母版' })).toBeNull()
     expect(image.className).toContain('opacity-0')
   })


### PR DESCRIPTION
本 PR 将 Windup 宣传页顶栏改为常驻的无边框毛玻璃层，并收束页内定位入口，让品牌、双鸟、主标题与角色内容区形成连续首屏。

## Why

原宣传页 Header 以高不透明度、底部分隔线和三项定位导航切开首屏；移动端信息密度偏高，滚动后的视觉表面也与期望的连续画布不一致。

## Changes

- 将宣传页 Header 改为固定在视口顶部的无边框毛玻璃层。
- 删除“产品能力 / 制作流程 / 资产工作台”三个页内定位入口。
- 保留品牌、登录、注册、工作台入口、Hero 眉题、双鸟与角色内容占位。
- 调整首屏高度、顶部留白、双鸟与角色内容区的位置关系。

## Implementation

- 改动仅作用于 `AppHeader` 的 marketing variant，不影响产品内 Header。
- 顶栏使用 28% 暖白背景、18px 模糊与 0.82 饱和度，不添加边框或阴影。
- 登录、注册、开始创作和已登录工作台入口的路由语义保持不变。

## Verification

- [x] `./node_modules/.bin/oxfmt --check src/app/layout/app-header.tsx src/pages/landing/index.tsx src/pages/landing/index.test.tsx`：3 个文件格式检查通过。
- [x] `./node_modules/.bin/oxlint src/app/layout/app-header.tsx src/pages/landing/index.tsx src/pages/landing/index.test.tsx`：通过。
- [x] `npm test -- --run src/pages/landing/index.test.tsx`：1 个测试文件、4 个测试通过。
- [x] `npm run build`：前端构建通过。
- [x] 真实浏览器：桌面端与 391×844 移动视口无横向溢出；滚动后 Header 保持 `top: 0`。

## Scope

- 本 PR 不包含：登录注册流程、路由、权限、数据接口、角色占位素材和首屏以外业务交互的调整。
- 后续事项：最终桌面截图由用户在 PR 创建后补充。

## Related Issues

Closes #558
