### PR TITLE
fix(orchestrator): 母版尺寸适配改为等比 contain

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -113,7 +113,7 @@ def _load_constraints(session: Session, project_id: int | None) -> ProjectConstr
 
 
 def _fit_to(png: bytes, w: int, h: int, *, smooth: bool = False) -> bytes:
-    """把图等比缩放进 w×h(透明补边),落实尺寸约束。
+    """把图等比 contain 进 w×h(透明补边),落实尺寸约束。
 
     ``smooth`` 决定重采样:序列帧是像素画,必须 NEAREST(插值会把硬边糊成灰边、
     并引入调色板外的颜色);全彩角色母版反过来,NEAREST 缩图会明显锯齿,用 LANCZOS。
@@ -125,8 +125,14 @@ def _fit_to(png: bytes, w: int, h: int, *, smooth: bool = False) -> bytes:
     im = Image.open(io.BytesIO(png)).convert("RGBA")
     if im.size == (w, h):
         return png
-    fitted = im.copy()
-    fitted.thumbnail((w, h), Image.LANCZOS if smooth else Image.NEAREST)
+    # 小于画布也要缩放:原尺寸贴入会按画布比例压小主体占幅、把脚线一并上移,而母版是
+    # 交付物,后面没有环节把这两样补回来(#512)。取整兜到 1 像素,免得极端长宽比缩成
+    # 空图 —— 那是一张能通过尺寸断言的全透明母版。
+    scale = min(w / im.width, h / im.height)
+    fitted = im.resize(
+        (max(1, round(im.width * scale)), max(1, round(im.height * scale))),
+        Image.LANCZOS if smooth else Image.NEAREST,
+    )
     canvas = Image.new("RGBA", (w, h), (0, 0, 0, 0))
     canvas.alpha_composite(fitted, ((w - fitted.width) // 2, (h - fitted.height) // 2))
     buf = io.BytesIO()

--- a/backend/tests/test_master_cutout.py
+++ b/backend/tests/test_master_cutout.py
@@ -74,11 +74,11 @@ class _Gen:
         return self._png
 
 
-def _constraints() -> ProjectConstraints:
-    return ProjectConstraints(sprite_w=64, sprite_h=64)
+def _constraints(size: int = 64) -> ProjectConstraints:
+    return ProjectConstraints(sprite_w=size, sprite_h=size)
 
 
-def _run(png: bytes, *, matte=None, num_images: int = 1):
+def _run(png: bytes, *, matte=None, num_images: int = 1, want: int = 64):
     got: list[bytes] = []
     ex = ImageTaskExecutor(
         image=_Gen(png),
@@ -86,14 +86,21 @@ def _run(png: bytes, *, matte=None, num_images: int = 1):
         upload=lambda b: (got.append(b), f"u{len(got)}")[1],
     )
     urls, quality = ex._produce_image(
-        CharacterImageInput(prompt="勇者", width=64, height=64, num_images=num_images),
-        _constraints(),
+        CharacterImageInput(prompt="勇者", width=want, height=want, num_images=num_images),
+        _constraints(want),
     )
     return got, urls, quality
 
 
 def _alpha(png: bytes) -> np.ndarray:
     return np.asarray(Image.open(io.BytesIO(png)).convert("RGBA"))[:, :, 3]
+
+
+def _geometry(png: bytes) -> tuple[float, float]:
+    """主体的高度占幅与脚线位置,都取比例 —— 换画布尺寸不该改变这两个数。"""
+    a = _alpha(png)
+    rows = np.where(a.max(axis=1) > 128)[0]
+    return (rows.max() + 1 - rows.min()) / a.shape[0], (rows.max() + 1) / a.shape[0]
 
 
 def test_delivered_master_has_no_background_left():
@@ -109,6 +116,24 @@ def test_delivered_master_has_no_background_left():
 
     assert _alpha(got[0])[0, 0] == 0
     assert _alpha(got[0])[20:44, 6:24].min() == 255, "主体不能被一起抠掉"
+
+
+def test_master_smaller_than_canvas_is_scaled_up_not_pasted():
+    """#512:源图小于项目画布时,主体占幅与脚线必须原样保住。
+
+    断言几何而不是画布尺寸:把 64 的图原尺寸居中贴进 256 画布,尺寸一样是对的,
+    可主体只剩四分之一大、脚线跟着上移,而母版是交付物,后面没有环节补得回来。
+    """
+    src = _master(size=64)
+    want_span, want_foot = _geometry(_BackgroundMatte().cutout(src))
+    assert want_span == pytest.approx(0.375), "仪器自检:源图主体占满高度的 3/8"
+
+    got, _, _ = _run(src, want=256)
+
+    assert Image.open(io.BytesIO(got[0])).size == (256, 256)
+    span, foot = _geometry(got[0])
+    assert span == pytest.approx(want_span, abs=0.01)
+    assert foot == pytest.approx(want_foot, abs=0.01)
 
 
 def test_multi_subject_master_is_counted_at_the_image_exit():


### PR DESCRIPTION
Closes #512

`_fit_to` 用 `Image.thumbnail()`，而它只缩不放。源图小于项目 sprite 尺寸时主体原尺寸居中贴入，占幅按画布比例被压小、脚线随之上移，母版是交付物，后面没有环节补得回来。

改成等比 contain 而不是照序列帧那条「尺寸不符即报错」：`ImageProvider.gen_image(prompt, refs) -> bytes` 没有尺寸参数，`submit_image` 发出的 body 里也没有宽高，出图尺寸由模型自己定；而序列帧那条能报错是因为画布尺寸经 `generate(..., canvas=...)` 交给了引擎，本就受控。母版这条没有对应通道，报错等于绝大多数母版任务直接 FAILED。

实测几何（64×64 源，主体高占幅 0.375、脚线 0.6875）：

| | 主体高占幅 | 脚线 |
|---|---|---|
| 源图 | 0.375 | 0.6875 |
| 旧实现 64→256 | 0.0938 | 0.5469 |
| 本 PR 64→256 | 0.375 | 0.6875 |
| 本 PR 1024→256（缩小方向） | 0.0234 | 0.0430（与源一致） |

新增用例断言主体占幅与脚线，不断言画布尺寸：换回 `thumbnail` 实现后 `assert Image.open(...).size == (256, 256)` 照样通过，红的是占幅那行（`0.09375 != 0.375 ± 0.01`）。

本分支验证：`ruff check .` 通过、`lint-imports` 2 kept 0 broken、`export_openapi` 后 `openapi.json` 无漂移、`pytest -q` 1330 passed / 14 skipped。

已知未覆盖：非方形画布下 contain 仍会改变占幅（64² 进 128×256，scale 取 min，占幅 0.375→0.1875）。这是 contain 的固有语义；要让占幅跨长宽比恒定需走 `align_bottom_center` 那套主体感知定标，会改动母版构图契约，超出本 issue 的「不改 sprite 尺寸契约」。