### PR TITLE
fix(gateway): 将 OpenAI 连接错误分类为 UNREACHED

### DIFF
--- a/backend/packages/framework/src/windup_framework/gateway/classify.py
+++ b/backend/packages/framework/src/windup_framework/gateway/classify.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 
 import httpx
+from openai import APIConnectionError, APITimeoutError
 
 from windup_common.enums.model import ModelErrorType
 
@@ -125,30 +126,47 @@ def retry_after_seconds(value: str) -> float | None:
     return min(max(delay, 0.0), _MAX_RETRY_WAIT)
 
 
+def _exception_chain(exc: BaseException):
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        yield current
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+
+
 def classify_exception(exc: BaseException) -> tuple[ModelErrorType, int | None, str]:
     """把没有 HTTP 状态行的传输失败收成策略输入。
 
     对端拆连接、连不上、写出失败:都还没拿到响应,按 UNREACHED(可同路重试)。
+    OpenAI SDK 会把 httpx 连接失败包成 APIConnectionError,要沿异常链识别。
     读超时另算 TIMEOUT:请求可能已经离开本机,不能当成 52x。
+    APITimeoutError 是 APIConnectionError 的子类,必须先按超时处理。
     """
-    status = getattr(exc, "status_code", None)
-    response = getattr(exc, "response", None)
-    if status is None and response is not None:
-        status = getattr(response, "status_code", None)
-    if isinstance(status, int):
-        body = response.text if response is not None else None
-        return classify_http_response(status, body), status, str(exc)[:200]
-    if isinstance(
-        exc,
-        (
-            httpx.RemoteProtocolError,
-            httpx.LocalProtocolError,
-            httpx.ConnectError,
-            httpx.WriteError,
-            httpx.NetworkError,
-        ),
-    ):
-        return ModelErrorType.UNREACHED, None, str(exc)[:200]
-    if isinstance(exc, (httpx.ReadTimeout, httpx.TimeoutException, TimeoutError)):
-        return ModelErrorType.TIMEOUT, None, str(exc)[:200]
-    return ModelErrorType.UNKNOWN, None, str(exc)[:200]
+    edge = str(exc)[:200]
+    for item in _exception_chain(exc):
+        status = getattr(item, "status_code", None)
+        response = getattr(item, "response", None)
+        if status is None and response is not None:
+            status = getattr(response, "status_code", None)
+        if isinstance(status, int):
+            body = response.text if response is not None else None
+            return classify_http_response(status, body), status, edge
+        if isinstance(
+            item,
+            (APITimeoutError, httpx.ReadTimeout, httpx.TimeoutException, TimeoutError),
+        ):
+            return ModelErrorType.TIMEOUT, None, edge
+        if isinstance(
+            item,
+            (
+                APIConnectionError,
+                httpx.RemoteProtocolError,
+                httpx.LocalProtocolError,
+                httpx.ConnectError,
+                httpx.WriteError,
+                httpx.NetworkError,
+            ),
+        ):
+            return ModelErrorType.UNREACHED, None, edge
+    return ModelErrorType.UNKNOWN, None, edge

--- a/backend/packages/framework/src/windup_framework/gateway/classify.py
+++ b/backend/packages/framework/src/windup_framework/gateway/classify.py
@@ -132,35 +132,47 @@ def _exception_chain(exc: BaseException):
     while current is not None and id(current) not in seen:
         yield current
         seen.add(id(current))
-        current = current.__cause__ or current.__context__
+        nxt = current.__cause__
+        if nxt is None and not current.__suppress_context__:
+            nxt = current.__context__
+        current = nxt
+
+
+def _http_status(item: BaseException) -> tuple[int | None, object]:
+    status = getattr(item, "status_code", None)
+    response = getattr(item, "response", None)
+    if status is None and response is not None:
+        status = getattr(response, "status_code", None)
+    if isinstance(status, int):
+        return status, response
+    return None, None
 
 
 def classify_exception(exc: BaseException) -> tuple[ModelErrorType, int | None, str]:
     """把没有 HTTP 状态行的传输失败收成策略输入。
 
     对端拆连接、连不上、写出失败:都还没拿到响应,按 UNREACHED(可同路重试)。
-    OpenAI SDK 会把 httpx 连接失败包成 APIConnectionError,要沿异常链识别。
+    OpenAI SDK 会把 send() 里所有非超时 Exception 包成 APIConnectionError,
+    所以要先看 cause/context 里的具体类型,不能让外层包装短路。
     读超时另算 TIMEOUT:请求可能已经离开本机,不能当成 52x。
-    APITimeoutError 是 APIConnectionError 的子类,必须先按超时处理。
     """
     edge = str(exc)[:200]
-    for item in _exception_chain(exc):
-        status = getattr(item, "status_code", None)
-        response = getattr(item, "response", None)
-        if status is None and response is not None:
-            status = getattr(response, "status_code", None)
-        if isinstance(status, int):
+    chain = tuple(_exception_chain(exc))
+    for item in chain:
+        status, response = _http_status(item)
+        if status is not None:
             body = response.text if response is not None else None
             return classify_http_response(status, body), status, edge
+    for item in chain:
         if isinstance(
             item,
             (APITimeoutError, httpx.ReadTimeout, httpx.TimeoutException, TimeoutError),
         ):
             return ModelErrorType.TIMEOUT, None, edge
+    for item in chain:
         if isinstance(
             item,
             (
-                APIConnectionError,
                 httpx.RemoteProtocolError,
                 httpx.LocalProtocolError,
                 httpx.ConnectError,
@@ -169,4 +181,8 @@ def classify_exception(exc: BaseException) -> tuple[ModelErrorType, int | None, 
             ),
         ):
             return ModelErrorType.UNREACHED, None, edge
+    for item in chain:
+        if isinstance(item, APIConnectionError) and item.__cause__ is None:
+            if item.__suppress_context__ or item.__context__ is None:
+                return ModelErrorType.UNREACHED, None, edge
     return ModelErrorType.UNKNOWN, None, edge

--- a/backend/tests/test_gateway_chat.py
+++ b/backend/tests/test_gateway_chat.py
@@ -5,6 +5,8 @@ import logging
 import httpx
 import pytest
 
+from openai import APIConnectionError
+
 from windup_common.enums.model import ModelErrorType
 from windup_framework.config.provider import AIProviderSettings
 from windup_framework.gateway.chat import (
@@ -283,6 +285,75 @@ def test_langchain_adapter_maps_response_status(monkeypatch):
     assert r.http_status == 401
 
 
+def test_chat_gateway_retries_same_route_on_unreached(caplog):
+    caplog.set_level(logging.INFO, logger="windup.gateway")
+    adapter = FakeChatAdapter({"gpt-4o-mini": [UNREACHED, OK]})
+    gw = ChatGateway(
+        adapter=adapter,
+        circuit=CircuitBreaker(),
+        settings=_primary_cfg(),
+        route_adapters={"primary": adapter},
+    )
+    assert gw.invoke([{"role": "user", "content": "ping"}]) == "pong"
+    assert adapter.calls == ["gpt-4o-mini", "gpt-4o-mini"]
+    records = [json.loads(r.message) for r in caplog.records if r.name == "windup.gateway"]
+    failed = [r for r in records if r.get("outcome") == "failed"]
+    success = [r for r in records if r.get("outcome") == "success"]
+    assert failed[0]["error_type"] == "unreached"
+    assert failed[0]["retry_count"] == 0
+    assert failed[0]["attempt_index"] == 0
+    assert success[-1]["retry_count"] == 1
+    assert success[-1]["attempt_index"] == 1
+
+
+def test_chat_gateway_unknown_fails_without_retry():
+    unknown = ChatAdapterResult(ok=False, error_type=ModelErrorType.UNKNOWN)
+    adapter = FakeChatAdapter({"gpt-4o-mini": [unknown, OK]})
+    gw = ChatGateway(
+        adapter=adapter,
+        circuit=CircuitBreaker(),
+        settings=_primary_cfg(),
+        route_adapters={"primary": adapter},
+    )
+    with pytest.raises(RuntimeError, match="chat gateway failed"):
+        gw.invoke([{"role": "user", "content": "ping"}])
+    assert adapter.calls == ["gpt-4o-mini"]
+
+
+def test_chat_gateway_retries_openai_connection_error(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="windup.gateway")
+    req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
+    calls = {"n": 0}
+
+    class _Flaky:
+        def __init__(self, **kwargs):
+            pass
+
+        async def ainvoke(self, messages, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                cause = httpx.ConnectError("Connection error", request=req)
+                raise APIConnectionError(request=req) from cause
+            return "pong"
+
+    monkeypatch.setattr("windup_framework.gateway.chat.ChatOpenAI", _Flaky)
+    adapter = LangChainChatAdapter(_primary_cfg())
+    gw = ChatGateway(
+        adapter=adapter,
+        circuit=CircuitBreaker(),
+        settings=_primary_cfg(),
+        route_adapters={"primary": adapter},
+    )
+    assert asyncio.run(gw.ainvoke([{"role": "user", "content": "ping"}])) == "pong"
+    assert calls["n"] == 2
+    records = [json.loads(r.message) for r in caplog.records if r.name == "windup.gateway"]
+    failed = [r for r in records if r.get("outcome") == "failed"]
+    success = [r for r in records if r.get("outcome") == "success"]
+    assert failed[0]["error_type"] == "unreached"
+    assert failed[0]["retry_count"] == 0
+    assert success[-1]["retry_count"] == 1
+
+
 def test_langchain_adapter_maps_connect_and_timeout(monkeypatch):
     req = httpx.Request("POST", "https://x")
 
@@ -296,6 +367,18 @@ def test_langchain_adapter_maps_connect_and_timeout(monkeypatch):
     monkeypatch.setattr("windup_framework.gateway.chat.ChatOpenAI", _Connect)
     r = LangChainChatAdapter(_primary_cfg()).invoke([], model="gpt-4o-mini")
     assert r.error_type is ModelErrorType.UNREACHED
+
+    class _OpenAIConnect:
+        def __init__(self, **kwargs):
+            pass
+
+        def invoke(self, messages, **kwargs):
+            raise APIConnectionError(request=req)
+
+    monkeypatch.setattr("windup_framework.gateway.chat.ChatOpenAI", _OpenAIConnect)
+    r = LangChainChatAdapter(_primary_cfg()).invoke([], model="gpt-4o-mini")
+    assert r.error_type is ModelErrorType.UNREACHED
+    assert r.http_status is None
 
     class _Disconnect:
         def __init__(self, **kwargs):

--- a/backend/tests/test_gateway_classify.py
+++ b/backend/tests/test_gateway_classify.py
@@ -1,5 +1,9 @@
+import httpx
+from openai import APIConnectionError, APIStatusError, APITimeoutError
+
 from windup_common.enums.model import ModelErrorType
 from windup_framework.gateway.classify import (
+    classify_exception,
     classify_http,
     classify_http_response,
     retry_after_seconds,
@@ -15,10 +19,6 @@ def test_522_is_unreached():
 
 def test_remote_protocol_error_is_unreached():
     """对端未回任何 HTTP 状态行:与 52x 一样按未达源站,不当已计费。"""
-    import httpx
-
-    from windup_framework.gateway.classify import classify_exception
-
     err = httpx.RemoteProtocolError("Server disconnected without sending a response")
     error_type, status, edge = classify_exception(err)
     assert error_type is ModelErrorType.UNREACHED
@@ -76,3 +76,46 @@ def test_404_follow_is_job_not_found():
 def test_404_config_error_when_endpoint_wrong():
     body = '{"error":"invalid url: no route matched"}'
     assert classify_http_response(404, body) is ModelErrorType.CONFIG_ERROR
+
+
+def test_openai_api_connection_error_is_unreached():
+    req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
+    err = APIConnectionError(request=req)
+    error_type, status, edge = classify_exception(err)
+    assert error_type is ModelErrorType.UNREACHED
+    assert status is None
+    assert "Connection error" in edge
+
+
+def test_wrapped_connect_error_is_unreached():
+    req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
+    cause = httpx.ConnectError("Connection error", request=req)
+    wrapped = Exception("Connection error")
+    wrapped.__cause__ = cause
+    error_type, status, _ = classify_exception(wrapped)
+    assert error_type is ModelErrorType.UNREACHED
+    assert status is None
+
+
+def test_openai_timeout_stays_timeout():
+    req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
+    err = APITimeoutError(request=req)
+    error_type, status, _ = classify_exception(err)
+    assert error_type is ModelErrorType.TIMEOUT
+    assert status is None
+
+
+def test_http_status_error_classification_unchanged():
+    req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
+    resp = httpx.Response(429, request=req)
+    err = APIStatusError("quota", response=resp, body=None)
+    error_type, status, _ = classify_exception(err)
+    assert error_type is ModelErrorType.RATE_LIMIT
+    assert status == 429
+
+
+def test_unknown_exception_stays_unknown():
+    error_type, status, edge = classify_exception(ValueError("weird"))
+    assert error_type is ModelErrorType.UNKNOWN
+    assert status is None
+    assert edge == "weird"

--- a/backend/tests/test_gateway_classify.py
+++ b/backend/tests/test_gateway_classify.py
@@ -87,6 +87,24 @@ def test_openai_api_connection_error_is_unreached():
     assert "Connection error" in edge
 
 
+def test_openai_connection_error_uses_connect_cause():
+    req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
+    err = APIConnectionError(request=req)
+    err.__cause__ = httpx.ConnectError("Connection error", request=req)
+    error_type, status, _ = classify_exception(err)
+    assert error_type is ModelErrorType.UNREACHED
+    assert status is None
+
+
+def test_openai_connection_error_does_not_mask_unknown_cause():
+    req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
+    err = APIConnectionError(request=req)
+    err.__cause__ = ValueError("hook failed")
+    error_type, status, _ = classify_exception(err)
+    assert error_type is ModelErrorType.UNKNOWN
+    assert status is None
+
+
 def test_wrapped_connect_error_is_unreached():
     req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
     cause = httpx.ConnectError("Connection error", request=req)


### PR DESCRIPTION
## Summary
- 修复 AI Gateway 将 OpenAI SDK 的 `APIConnectionError` 误判为 `UNKNOWN`、从而跳过同路重试和备用路由的问题。
- 分类器沿异常链识别包装后的连接失败，归为 `UNREACHED`；`APITimeoutError`、HTTP 状态错误和其他未知异常的既有语义不变。
- 补充分类器与 Chat Gateway 回归测试，确认瞬时连接失败会重试，并在审计日志中记录 `error_type` 与每次 attempt。

Fixes #572

## Test plan
- [x] `cd backend && uv run pytest tests/test_gateway_classify.py tests/test_gateway_chat.py tests/test_gateway_policy.py -q --no-cov`
- [x] 确认 `APIConnectionError` / 包装后的 `ConnectError` 分类为 `unreached`
- [x] 确认超时仍为 `timeout`，429 仍为 `rate_limit`，普通 `ValueError` 仍为 `unknown`
- [x] 确认 Chat Gateway 对 `UNREACHED` 会同路重试一次，并在日志中看到两次 attempt