### PR TITLE
feat(quick-start): play completed action preview

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -940,6 +940,30 @@ describe('QuickStartPage', () => {
     expect(complete.container.querySelector('[data-generation-progress]')).toBeNull()
   })
 
+  it('animates only the completed action preview with the action fps fallback', async () => {
+    vi.useFakeTimers()
+    const run = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'passed' })
+    const service = serviceFor(run, {
+      getActionFrames: vi.fn(async () => [
+        { index: 0, imageUrl: 'https://example.test/action-1.png', durationMs: null },
+        { index: 1, imageUrl: 'https://example.test/action-2.png', durationMs: null },
+      ]),
+    })
+    renderAt('/quick-start/run-1', service)
+
+    await act(async () => undefined)
+    const preview = screen.getByRole('img', { name: '完整动作预览' })
+    const firstThumbnail = screen.getByRole('img', { name: '动作第 1 帧' })
+    expect(preview.getAttribute('src')).toBe('https://example.test/action-1.png')
+
+    await act(async () => vi.advanceTimersByTime(82))
+    expect(preview.getAttribute('src')).toBe('https://example.test/action-1.png')
+
+    await act(async () => vi.advanceTimersByTime(1))
+    expect(preview.getAttribute('src')).toBe('https://example.test/action-2.png')
+    expect(firstThumbnail.getAttribute('src')).toBe('https://example.test/action-1.png')
+  })
+
   it('reveals generated candidate frames with staggered motion', async () => {
     renderStateFixture('template-selecting')
 

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -24,6 +24,7 @@ import { ExportButton, type ExportPackageModel } from '@/features/export-package
 import { useQuickStartAgent } from '@/features/quick-start-agent/react'
 import type { CreateQuickStartAgentOptions } from '@/features/quick-start-agent/runtime'
 import {
+  FrameAnimationPlayer,
   GenerationPreviewCard,
   GenerationProgressCopy,
   KineticCopyCycle,
@@ -1848,10 +1849,14 @@ function QuickStartRun({
                         data-layout="agent-result-set"
                         className="grid w-full max-w-2xl grid-cols-3 gap-3"
                       >
-                        <AssetVisual
-                          src={actionFrames[0]!.imageUrl}
+                        <FrameAnimationPlayer
+                          frames={actionFrames}
                           alt="完整动作预览"
-                          priority
+                          fps={firstFrameStep?.input.fps}
+                          loop
+                          loading="eager"
+                          decoding="async"
+                          fetchPriority="high"
                           className="quick-start-generated-image aspect-square w-full rounded-2xl border border-app-line bg-app-surface-muted object-contain [image-rendering:pixelated]"
                         />
                       </div>


### PR DESCRIPTION
Quick Start 的动作完成态现可直接循环播放完整逐帧动画，同时保留原有结果布局、静态帧条与后续操作。

## Why

共享 `FrameAnimationPlayer` 已在 #557 提供，但 Quick Start 完成态仍只展示第一帧。用户必须离开当前结果区进入 Play Test，才能确认动作是否连贯。

## Changes

- 将动作完成态的大号静态预览替换为共享逐帧播放器。
- 使用生成结果的逐帧时长，并以当前动作 FPS 作为缺省时序。
- 保留底部静态帧条、保存状态、资产工作台与 Play Test 入口。

## Implementation

- `QuickStartFrame` 与共享播放器帧契约结构一致，页面直接传入现有 `actionFrames`。
- 播放器沿用原预览的方形容器、`object-contain`、像素渲染和优先加载属性。
- 页面仅从最新动作首帧节点读取 FPS，不扩展共享组件的业务语义。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx`：79/79 通过。
- [x] `npm test -- src/shared/ui/frame-animation-player.test.tsx`：9/9 通过。
- [x] `npx oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run typecheck`：通过。
- [x] 本地真实浏览器 UI fixture：主预览帧源发生变化，8 个静态缩略图保留，控制台 0 error；未作为真实后端生成链路证据。

## Scope

- 本 PR 不包含：共享 Player、Workflow Editor、Workflow、Generation、Character、后端、路由、保存或导出流程修改。
- 后续事项：其他消费页面通过各自 Issue / PR 接入共享 Player。

## Related Issues

Closes #573
Refs #557
