### PR TITLE
feat(workflow-editor): play completed animations

### DIFF
--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -1243,6 +1243,84 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     })
   })
 
+  it('完整动画完成后用共享播放器替代逐帧网格', async () => {
+    vi.useFakeTimers()
+    defaultSessionLoader.mockResolvedValue(
+      createSession(reviewingActionWorkflow(), {
+        generationApis: generationApisFixture({
+          get: vi.fn().mockResolvedValue(completeAnimationGeneration()),
+        }),
+      }),
+    )
+    const view = renderEditor('/workflow-editor/42')
+    try {
+      await act(async () => undefined)
+      await act(async () => undefined)
+
+      const player = screen.getByRole('img', { name: '完整动画预览' })
+      expect(player.getAttribute('src')).toContain('/walk-01.png')
+      expect(screen.queryByRole('img', { name: '动画帧 1' })).toBeNull()
+      expect(screen.queryByRole('img', { name: '动画帧 2' })).toBeNull()
+
+      act(() => vi.advanceTimersByTime(100))
+      expect(player.getAttribute('src')).toContain('/walk-02.png')
+    } finally {
+      view.unmount()
+      vi.useRealTimers()
+    }
+  })
+
+  it('多方向完整动画为每个真实源方向分别播放结果', async () => {
+    const workflow = reviewingActionWorkflow()
+    const fullFrame = workflow.nodes.find((node) => node.type === 'action-full-frame')
+    if (!fullFrame || fullFrame.type !== 'action-full-frame') {
+      throw new Error('missing full frame')
+    }
+    const directions = ['east', 'north', 'south'] as const
+    fullFrame.generations = directions.map((direction) => ({
+      taskId: `generation-${direction}`,
+      role: 'complete_animation' as const,
+      direction,
+    }))
+    defaultSessionLoader.mockResolvedValue(
+      createSession(workflow, {
+        project: { ...projectFixture(), directionalMovement: 'four-way' },
+        generationApis: generationApisFixture({
+          get: vi.fn(async (_projectId: string, taskId: string) => {
+            const direction = taskId.replace('generation-', '') as (typeof directions)[number]
+            return {
+              ...completeAnimationGeneration(),
+              id: taskId,
+              result: {
+                type: 'complete_animation' as const,
+                direction,
+                frames: [
+                  {
+                    index: 0,
+                    url: `https://assets.windup.test/${direction}-01.png`,
+                    durationMs: 100,
+                  },
+                ],
+              },
+            }
+          }) as GenerationApis['get'],
+        }),
+      }),
+    )
+
+    renderEditor('/workflow-editor/42')
+
+    expect(
+      (await screen.findByRole('img', { name: '东完整动画预览' })).getAttribute('src'),
+    ).toContain('/east-01.png')
+    expect(screen.getByRole('img', { name: '北完整动画预览' }).getAttribute('src')).toContain(
+      '/north-01.png',
+    )
+    expect(screen.getByRole('img', { name: '南完整动画预览' }).getAttribute('src')).toContain(
+      '/south-01.png',
+    )
+  })
+
   it('发布与审核命令失败时显示错误并释放分支锁', async () => {
     const publishReviewedAction = vi.fn(() => Promise.reject(new Error('审核保存失败')))
     const session = createSession(reviewingActionWorkflow(), {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -37,7 +37,7 @@ import {
   ExportButton,
   type ExportPackageModel,
 } from '@/features/export-package'
-import { GenerationPreviewCard, GenerationProgressCopy } from '@/shared/ui'
+import { FrameAnimationPlayer, GenerationPreviewCard, GenerationProgressCopy } from '@/shared/ui'
 import { loadDefaultActionPresets, type WorkflowEditorSession } from './runtime'
 import { useWorkflowEditorSession } from './use-workflow-editor-session'
 import { WorkflowEditorView, type WorkflowCardNode } from './workflow-editor-view'
@@ -1474,16 +1474,21 @@ function AnimationContent({
         {groups.map(({ direction, frames: directionFrames }) => (
           <div key={direction} className="grid gap-1.5">
             <p className={CARD_TEXT}>方向：{directionLabel(direction)}</p>
-            <div className="nodrag nopan nowheel grid max-h-40 grid-cols-8 gap-[3px] overflow-auto">
-              {directionFrames.map((frame, index) => (
-                <WorkflowImage
-                  key={`${frame.url}-${index}`}
-                  src={frame.url}
-                  alt={`${groups.length === 1 ? '动画帧' : `${directionLabel(direction)}动画帧`} ${index + 1}`}
-                  variant="frame"
-                />
-              ))}
-            </div>
+            <FrameAnimationPlayer
+              frames={directionFrames.map((frame) => ({
+                index: frame.index,
+                imageUrl: frame.url,
+                durationMs: frame.durationMs,
+              }))}
+              fps={firstFrameNode?.input.fps}
+              alt={
+                groups.length === 1 ? '完整动画预览' : `${directionLabel(direction)}完整动画预览`
+              }
+              loop
+              className="nodrag nopan nowheel aspect-square w-full rounded-[10px] border border-app-line bg-app-surface object-contain p-2 [image-rendering:pixelated]"
+              loading="eager"
+              decoding="async"
+            />
           </div>
         ))}
         {firstFrameNode ? (


### PR DESCRIPTION
Workflow Editor 的完整动画完成态现在直接循环播放动作结果，不再用逐帧缩略图网格代替动态预览，同时保留原有方向分组和导出入口。

## Why

共享 Player 已由 #557 合入，但 Workflow Editor 仍要求用户从静态逐帧图自行判断动作效果。完整动画阶段缺少直接的动态结果反馈，多方向结果也无法逐方向播放检查。

## Changes

- 用共享 `FrameAnimationPlayer` 替换完整动画卡片中的逐帧网格。
- 单向结果显示一个循环预览，多方向结果按真实源方向分别播放。
- 保留方向标签、完整动作导出入口和现有 WorkflowRun 阶段行为。

## Implementation

- 页面层将 Generation Frame 的 `url` 映射为 Player 的 `imageUrl`，不把方向语义下沉到共享组件。
- 逐帧 `durationMs` 继续优先；缺失时向 Player 传入动作首帧节点的 FPS 作为兜底。
- Player 沿用 Workflow Editor 的方形像素资产容器样式，不新增页面状态或 CSS 契约。

## Verification

- [x] `npm test -- src/pages/workflow-editor/index.test.tsx src/shared/ui/frame-animation-player.test.tsx`：2 个文件、78 个测试通过。
- [x] `npx oxfmt --check src/pages/workflow-editor/index.tsx src/pages/workflow-editor/index.test.tsx`：通过。
- [x] `npx oxlint src/pages/workflow-editor/index.tsx src/pages/workflow-editor/index.test.tsx`：通过。
- [x] `npm run typecheck`：通过。
- [x] 本地浏览器自动化：未完成；本机浏览器策略阻止自动访问 `127.0.0.1`，按要求不附截图。

## Scope

- 本 PR 不包含：Quick Start、共享 Player、资产库、Playtest、后端、生成、审核或导出逻辑改动。
- 后续事项：无。

## Related Issues

Closes #574
Refs #556
Refs #557
