### PR TITLE
fix(frontend): self-host consistent serif font

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.31",
+        "@fontsource-variable/noto-serif-sc": "^5.3.0",
         "@phosphor-icons/react": "^2.1.10",
         "@xyflow/react": "^12.11.2",
         "ai": "^7.0.68",
@@ -438,6 +439,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/noto-serif-sc": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-serif-sc/-/noto-serif-sc-5.3.0.tgz",
+      "integrity": "sha512-7LcN2NEf4HDjoSkGWc79WqDDyMK8JvSPdA/gsHjJpZ8l9A9mcK/GQTazp3klmkBwJooy0eqeNvlmaZFXPupHrA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^3.0.31",
+    "@fontsource-variable/noto-serif-sc": "^5.3.0",
     "@phosphor-icons/react": "^2.1.10",
     "@xyflow/react": "^12.11.2",
     "ai": "^7.0.68",

--- a/frontend/src/features/account-panel/account-panel.css
+++ b/frontend/src/features/account-panel/account-panel.css
@@ -122,7 +122,7 @@
 }
 
 .auth-register-title {
-  font-family: 'Songti SC', 'Noto Serif CJK SC', STSong, Georgia, serif;
+  font-family: var(--font-serif);
   margin: 0;
   overflow: hidden;
   font-size: clamp(2.75rem, 5vw, 3.25rem);

--- a/frontend/src/font-delivery.test.ts
+++ b/frontend/src/font-delivery.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { build } from 'vite'
+
+const buildDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    buildDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+  )
+})
+
+describe('production serif font delivery', () => {
+  it('ships one same-origin WOFF2 family for every serif entry point', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'windup-font-delivery-'))
+    buildDirectories.push(outDir)
+
+    await build({
+      build: { emptyOutDir: true, outDir },
+      configFile: new URL('../vite.config.ts', import.meta.url).pathname,
+      logLevel: 'silent',
+      root: new URL('..', import.meta.url).pathname,
+    })
+
+    const assetNames = await readdir(join(outDir, 'assets'))
+    const cssNames = assetNames.filter((name) => name.endsWith('.css'))
+    const css = (
+      await Promise.all(cssNames.map((name) => readFile(join(outDir, 'assets', name), 'utf8')))
+    ).join('\n')
+
+    expect(assetNames.some((name) => name.endsWith('.woff2'))).toBe(true)
+    expect(css).toContain('@font-face')
+    expect(css).toContain('font-family:Noto Serif SC Variable')
+    expect(css).toContain('font-display:swap')
+    expect(css).toContain('unicode-range:')
+    expect(css).toContain('--font-serif:"Noto Serif SC Variable", serif')
+    expect(css).toContain('.font-serif{font-family:var(--font-serif)}')
+    expect(css).not.toMatch(/Songti SC|Noto Serif CJK SC|STSong|Georgia|Times New Roman/)
+  }, 15_000)
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -180,6 +180,8 @@ body,
  * 中性发丝线的语义名，不再承担锈红装饰，避免与深绿产品界面形成廉价撞色。
  */
 @theme {
+  --font-serif: 'Noto Serif SC Variable', serif;
+
   --color-paper: #f5f5f2;
   --color-paper-raised: #fbfbfa;
   --color-paper-sunken: #e9eae4;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client'
 import { App } from '@/app'
 import { userApis } from '@/entities'
 import { AuthSessionProvider } from '@/features/auth-session'
+import '@fontsource-variable/noto-serif-sc/wght.css'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/pages/landing/index.tsx
+++ b/frontend/src/pages/landing/index.tsx
@@ -547,7 +547,7 @@ export function LandingPage() {
               从角色设定到可玩的 2D 动作资产
             </p>
             <h1
-              className={`${riseClassName} mx-auto mt-5 w-full max-w-[12em] font-['Songti_SC','Noto_Serif_CJK_SC','STSong',Georgia,serif] text-[clamp(3rem,13vw,5.25rem)] leading-[1.08] font-semibold tracking-[-0.055em] text-[#23231f] sm:max-w-[11em] sm:text-[clamp(4rem,5.5vw,5.25rem)] sm:leading-[1.12]`}
+              className={`${riseClassName} mx-auto mt-5 w-full max-w-[12em] font-serif text-[clamp(3rem,13vw,5.25rem)] leading-[1.08] font-semibold tracking-[-0.055em] text-[#23231f] sm:max-w-[11em] sm:text-[clamp(4rem,5.5vw,5.25rem)] sm:leading-[1.12]`}
               style={riseDelay(1)}
             >
               <span className="block">让你的角色，</span>


### PR DESCRIPTION
Windup 现在为所有明确使用衬线字体的内容随站点发布同一套 Noto Serif SC Web Font，消除访问设备本地字体差异，同时保持现有字号、布局与业务行为不变。

## Why

现有 `font-serif`、Landing Hero 和注册标题分别依赖 `ui-serif`、宋体、STSong、Georgia 等本地字体栈。生产页面没有 `@font-face` 或字体请求，因此不同电脑和手机会选中不同字形，并可能改变字宽与换行。

## Changes

- 通过 Fontsource 引入 OFL-1.1 的 Noto Serif SC Variable，由前端构建同源发布 WOFF2。
- 将 Tailwind `--font-serif` 统一指向该字体，并让 Landing Hero、注册标题回到共享 token。
- 新增生产构建回归测试，约束 WOFF2、`@font-face`、`font-display: swap`、Unicode 分片、token 接入与旧设备字体栈回归。

## Implementation

- 入口加载 Fontsource `wght.css`；字体权重覆盖 200–900，CSS 使用 Unicode range 分片，页面按实际字符请求对应 WOFF2。
- 不新增第三方字体 CDN 请求；构建资源 URL 由 Vite 输出到站点同源 `/assets/`。

## Verification

- [x] `npm test -- src/font-delivery.test.ts src/pages/landing/index.test.tsx src/features/account-panel/index.test.tsx`：3 个测试文件、29 个测试通过。
- [x] `npm exec oxlint -- src/font-delivery.test.ts src/main.tsx src/index.css src/features/account-panel/account-panel.css src/pages/landing/index.tsx`：通过。
- [x] `npm exec oxfmt -- --check package.json package-lock.json src/font-delivery.test.ts src/main.tsx src/index.css src/features/account-panel/account-panel.css src/pages/landing/index.tsx`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run build`：通过，构建产物包含 101 个 Unicode 分片 WOFF2。
- [x] Chrome production preview：1440×900、390×844 与注册页目标元素 computed `font-family` 均为 `Noto Serif SC Variable`；手机无横向溢出；页面实际观察到 9 个同源 WOFF2 请求，控制台无错误。

## Screenshots

### Desktop

<img width="1440" height="900" alt="Windup landing page using the self-hosted serif font" src="https://github.com/user-attachments/assets/f9a9f631-e92f-443f-a9cd-38136b937bb3" />

## Scope

- 本 PR 不包含：无衬线字体改造、字号或视觉层级重设计、业务逻辑、后端、部署。
- 未验证边界：Safari、Firefox、真实物理手机、弱网首次加载与部署后缓存行为。

## Related Issues

Closes #581
