### PR TITLE
fix(quick-start): align textarea composer vertically

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -492,7 +492,7 @@ describe('QuickStartPage', () => {
     )
   })
 
-  it('keeps the entry composer compact before expanding with content', () => {
+  it('keeps the entry composer compact without a textarea baseline gap', () => {
     renderAt('/quick-start', serviceFor(null))
     const composer = screen.getByRole('textbox', { name: '创作指令' })
     const editingSurface = composer.closest('label')
@@ -501,6 +501,7 @@ describe('QuickStartPage', () => {
     expect((composer as HTMLTextAreaElement).rows).toBe(1)
     expect(composer.className).toContain('min-h-10')
     expect(composer.className).toContain('[field-sizing:content]')
+    expect(composer.className).toContain('block')
     expect(composer.className).toContain('px-4')
     expect(editingSurface?.className).toContain('ml-2')
     expect(editingSurface?.className).toContain('rounded-lg')

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -835,7 +835,7 @@ function QuickStartInput({
                         ? '描述动作，可留空生成待机动作…'
                         : '描述角色的外形、身份和气质…'
                 }
-                className={`min-h-10 max-h-40 w-full min-w-0 resize-none overflow-y-auto border-0 bg-transparent px-4 py-2.5 text-[15px] leading-5 text-app-ink outline-none [field-sizing:content] placeholder:text-app-faint ${
+                className={`block min-h-10 max-h-40 w-full min-w-0 resize-none overflow-y-auto border-0 bg-transparent px-4 py-2.5 text-[15px] leading-5 text-app-ink outline-none [field-sizing:content] placeholder:text-app-faint ${
                   promptState === 'rewriting' ? 'text-transparent caret-transparent' : ''
                 }`}
               />


### PR DESCRIPTION
修复 Quick Start 角色创建输入框在切换为 `textarea` 后出现的底部基线空隙，使输入区与文字恢复上下对称，同时保留现有多行增长和提交行为。

## Why

`textarea` 默认以内联级盒参与基线排版，父级行盒会在控件底部保留额外空间，导致外框上下白边和文字位置看起来不一致。

## Changes

- 将 Quick Start 主提示词 `textarea` 显式设为块级控件，移除行内基线空隙。
- 更新已有紧凑布局测试，锁定 `textarea` 的块级布局契约。

## Implementation

- 仅在 `QuickStartInput` 的主创作指令控件增加 `block`，不修改高度、padding、行高、自动增长、上传母版或生成逻辑。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx`：1 个测试文件、78 个测试全部通过。
- [x] `npm exec oxfmt -- --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：2 个文件格式检查通过。
- [x] 真实浏览器桌面检查：`display: block`；上下 padding 均为 `10px`；输入框外框上/下间距分别为 `7.333374px` / `7.333294px`。
- [x] 独立子代理只读验收：通过，无阻塞问题、无范围外改动。

## Scope

- 本 PR 不包含：业务流程、路由、接口、按钮、其他输入框或设计调整。
- 后续事项：无。

## Related Issues

Closes #583
