### PR TITLE
fix: preserve optional Quick Start Agent conversation

### DIFF
--- a/frontend/src/features/quick-start-agent/index.ts
+++ b/frontend/src/features/quick-start-agent/index.ts
@@ -3,11 +3,14 @@ export type { CreateAiSdkQuickStartPlannerOptions, QuickStartGenerateText } from
 export {
   createQuickStartAgent,
   parseCharacterGenerationPlan,
+  parseQuickStartDecision,
+  QUICK_START_DECISION_TOOL,
   START_CHARACTER_GENERATION_TOOL,
   validatePlannerTerminal,
 } from './runtime'
 export type {
   CharacterGenerationPlan,
+  CharacterGenerationProposal,
   CreateQuickStartAgentOptions,
   PlannerInput,
   PlannerMessage,
@@ -16,7 +19,7 @@ export type {
   QuickStartAgent,
   QuickStartAgentResult,
   QuickStartAgentTurnOptions,
+  QuickStartDecision,
   QuickStartPlanner,
   StartCharacterGenerationAction,
-  ValidatedPlannerTerminal,
 } from './runtime'

--- a/frontend/src/features/quick-start-agent/planner.protocol.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.protocol.test.ts
@@ -41,7 +41,7 @@ describe('AI SDK OpenAI-compatible protocol fixture', () => {
     const captured = requestBody as unknown as Record<string, unknown>
     expect(captured).toMatchObject({
       model: 'quick-start-planner',
-      tool_choice: 'auto',
+      tool_choice: 'required',
     })
     expect(captured.stream).toBeUndefined()
     expect((captured.tools as unknown[] | undefined)?.length).toBe(1)
@@ -121,7 +121,7 @@ describe('AI SDK OpenAI-compatible protocol fixture', () => {
       clarificationUsed: false,
     })
 
-    expect(() => validatePlannerTerminal(result)).toThrow('生成 Tool 的 optimizedPrompt 无效')
+    expect(() => validatePlannerTerminal(result)).toThrow('生成提案的 optimizedPrompt 无效')
   })
 
   it('surfaces a standard 401 and honors cancellation', async () => {

--- a/frontend/src/features/quick-start-agent/planner.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.test.ts
@@ -7,18 +7,20 @@ import {
 } from './planner'
 
 describe('quickStartPlannerInstructions', () => {
-  it('keeps readiness, direct-generation, negative intent, and one-question rules in the model', () => {
+  it('separates conversation, optional proposals, and generation authorization', () => {
     const firstTurn = quickStartPlannerInstructions(false)
     const laterTurn = quickStartPlannerInstructions(true)
 
-    expect(firstTurn).toContain('最多追问一个')
+    expect(firstTurn).toContain('最多问一个')
     expect(firstTurn).toContain('直接生成')
-    expect(firstTurn).toContain('不要生成')
-    expect(firstTurn).toContain('不得依赖关键词匹配')
-    expect(firstTurn).toContain('交给用户检查和编辑')
+    expect(firstTurn).toContain('proposal 只是提案，不代表用户授权生成')
+    expect(firstTurn).toContain('不得只靠关键词')
+    expect(firstTurn).toContain('对话轮数永远不是 proposal 的触发条件')
+    expect(firstTurn).toContain('咨询或元对话必须用 reply')
     expect(firstTurn).toContain('不得输出思维过程')
-    expect(laterTurn).toContain('追问额度已经用完')
-    expect(laterTurn).toContain('必要补全直接写入 optimizedPrompt')
+    expect(laterTurn).toContain('不得因为轮数强制生成')
+    expect(laterTurn).toContain('不得再问第二个澄清问题')
+    expect(laterTurn).toContain('可继续补充')
   })
 })
 
@@ -68,9 +70,9 @@ describe('createAiSdkQuickStartPlanner', () => {
     const options = generate.mock.calls[0]?.[0]
     expect(options?.maxRetries).toBe(0)
     expect(options?.abortSignal).toBe(signal)
-    expect(options?.toolChoice).toBe('auto')
-    expect(Object.keys(options?.tools ?? {})).toEqual(['start_character_generation'])
-    expect(options?.tools?.start_character_generation?.execute).toBeUndefined()
+    expect(options?.toolChoice).toBe('required')
+    expect(Object.keys(options?.tools ?? {})).toEqual(['quick_start_decision'])
+    expect(options?.tools?.quick_start_decision?.execute).toBeUndefined()
     expect(options?.messages).toEqual([{ role: 'user', content: '直接生成银发骑士' }])
   })
 })

--- a/frontend/src/features/quick-start-agent/planner.ts
+++ b/frontend/src/features/quick-start-agent/planner.ts
@@ -2,10 +2,11 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { generateText as aiGenerateText, jsonSchema, tool } from 'ai'
 
 import {
-  parseCharacterGenerationPlan,
-  START_CHARACTER_GENERATION_TOOL,
+  parseQuickStartDecision,
+  QUICK_START_DECISION_TOOL,
   type PlannerInput,
   type PlannerResult,
+  type QuickStartDecision,
   type QuickStartPlanner,
 } from './runtime'
 
@@ -20,7 +21,7 @@ interface GenerateTextOptionsLike {
   instructions: string
   messages: PlannerInput['messages']
   tools: Record<string, { execute?: unknown }>
-  toolChoice: 'auto'
+  toolChoice: 'required'
   maxRetries: 0
   abortSignal?: AbortSignal
 }
@@ -37,50 +38,32 @@ export interface CreateAiSdkQuickStartPlannerOptions {
   generateText?: QuickStartGenerateText
 }
 
-interface StartCharacterGenerationToolInput {
-  optimizedPrompt: string
-  optimizationSummary: string
-}
-
-const startCharacterGenerationTool = tool({
+const quickStartDecisionTool = tool({
   description:
-    '当角色母版信息已经足够，或用户明确要求跳过追问并直接生成时，提交唯一一次角色母版生成。',
-  inputSchema: jsonSchema<StartCharacterGenerationToolInput>(
+    '返回本轮唯一决策：正常回复、一次必要澄清、无法继续的说明，或供用户选择采用的角色母版提示词提案。',
+  inputSchema: jsonSchema<QuickStartDecision>(
     {
       type: 'object',
       additionalProperties: false,
       properties: {
-        optimizedPrompt: {
+        kind: {
           type: 'string',
-          minLength: 1,
-          maxLength: 4_000,
-          description: '实际提交给角色母版生成器的完整单角色全身提示词。',
+          enum: ['reply', 'clarification', 'blocked', 'proposal'],
         },
-        optimizationSummary: {
-          type: 'string',
-          minLength: 1,
-          maxLength: 600,
-          description:
-            '面向用户的一到两句优化说明，只说明会保留、补充或移除什么；不得暴露推理步骤、默认假设、Tool 或内部状态。',
-        },
+        message: { type: 'string', minLength: 1, maxLength: 2_000 },
+        optimizedPrompt: { type: 'string', minLength: 1, maxLength: 4_000 },
+        optimizationSummary: { type: 'string', minLength: 1, maxLength: 600 },
       },
-      required: ['optimizedPrompt', 'optimizationSummary'],
+      required: ['kind'],
     },
     {
       validate(value) {
         try {
-          const plan = parseCharacterGenerationPlan(value)
-          return {
-            success: true,
-            value: {
-              optimizedPrompt: plan.optimizedPrompt,
-              optimizationSummary: plan.optimizationSummary,
-            },
-          }
+          return { success: true, value: parseQuickStartDecision(value) }
         } catch (error) {
           return {
             success: false,
-            error: error instanceof Error ? error : new Error('生成 Tool 参数无效'),
+            error: error instanceof Error ? error : new Error('Planner 决策无效'),
           }
         }
       },
@@ -90,23 +73,26 @@ const startCharacterGenerationTool = tool({
 
 export function quickStartPlannerInstructions(clarificationUsed: boolean): string {
   const clarificationRule = clarificationUsed
-    ? '追问额度已经用完。除非仍存在硬冲突，否则不得再提问题；请把必要补全直接写入 optimizedPrompt，并用面向用户的 optimizationSummary 简短说明，然后调用 Tool。'
-    : '追问额度尚未使用。只有缺少会实质改变角色母版的关键信息时，才最多追问一个问题。'
-  return `你是 Windup Quick Start 的轻量 Planner。用户已经通过“生成角色”主操作授予本页面会话一次角色母版生成权限。你只判断信息是否足够，并且最多调用一次 ${START_CHARACTER_GENERATION_TOOL}；你不参与生成后的任何流程。
+    ? '本草稿已经问过一次必要澄清，不得因为轮数强制生成，也不得再问第二个澄清问题；信息不足时用 reply 说明可继续补充，存在硬冲突时用 blocked。'
+    : '本草稿尚未问过必要澄清。只有缺少会实质改变角色母版的关键信息时，才可以用 clarification 问一个最关键的问题。'
+  return `你是 Windup Quick Start 的轻量 Planner。你只理解当前草稿、回复用户，并在合适时给出角色母版提示词提案；你不执行生成，也不参与生成后的流程。
 
-当前能力只生成一个角色的角色母版：单角色、完整身体、清楚轮廓，适合后续动作生成。保留用户明确给出的身份、外观、服装、气质和美术风格，把口语整理成可直接生成的 optimizedPrompt。用户描述的动态动作不要写进角色母版 Prompt。
+每轮必须调用一次 ${QUICK_START_DECISION_TOOL}，并只返回一个决策：
+- reply：闲聊、回顾历史、评价、比较方案、解释或继续讨论。reply 不消耗澄清额度。
+- clarification：确实缺少一个会实质改变角色母版的关键信息时，最多问一个问题。
+- blocked：存在安全问题、明显自相矛盾或超出单角色母版能力，说明需要修改的内容。
+- proposal：已有足够角色设定，或用户明确要求整理最终提示词、直接生成时，给出可选择采用的完整提案。proposal 只是提案，不代表用户授权生成。
+
+当前能力只面向一个角色的角色母版：单角色、完整身体、清楚轮廓，适合后续动作生成。保留用户明确给出的身份、外观、服装、气质和美术风格；动态动作留到角色母版确认后处理。
 
 决策规则：
-1. 信息足够时立即调用唯一 Tool，不要再次确认。
-2. 用户在语义上明确要求“跳过、不用问、直接生成”时，基于已有信息完成必要补全，把补全结果直接写入 optimizedPrompt，并在 optimizationSummary 中用正常对话说明，然后立即调用 Tool。
-3. 用户明确表示“不要生成、只润色、先讨论”等否定意图时不得调用 Tool。引用、假设或否定语境也不得被误判；不得依赖关键词匹配，必须理解整句语义。
-4. 信息不足且仍有追问额度时，只问一个最关键、最容易回答的问题，不得列问卷。
-5. 输入有明显自相矛盾、违反内容政策，或超出当前单角色母版能力的硬冲突时，简短说明需要修改的具体内容，不调用 Tool。Planner 的提醒只是交互提示，最终安全、配额与计费仍由生成后端负责。
-6. 调用 Tool 时，optimizedPrompt 是交给用户检查和编辑的完整提示词；optimizationSummary 用一到两句正常对话说明你保留、补充或移除了什么。不得输出思维过程、逐步推理、默认假设清单、Tool 名称、调用计划或内部状态。不得产生第二个 Tool Call。
+1. 对话轮数永远不是 proposal 的触发条件。不得在澄清额度用完后用默认值强制补齐并提案。
+2. “你觉得怎么样”“怎么优化好”“还有什么方案”“刚才我说了什么”等咨询或元对话必须用 reply；不得只靠关键词，要理解最新消息在完整上下文中的意图。
+3. 用户明确要求形成最终版本或直接生成时，可以返回 proposal，但宿主仍会要求用户主动填入、编辑并确认后才生成。
+4. proposal 的 optimizedPrompt 是完整单角色全身提示词；optimizationSummary 用一到两句正常对话说明保留、补充或移除了什么。
+5. 不得输出思维过程、逐步推理、默认假设清单、Tool 名称、调用计划或内部状态。
 
-${clarificationRule}
-
-不调用 Tool 时，只输出一条简短的中文追问或修改提醒。调用 Tool 后不再输出额外文字，宿主会把 optimizationSummary 和 optimizedPrompt 作为用户可编辑的提案展示。`
+${clarificationRule}`
 }
 
 export function createAiSdkQuickStartPlanner({
@@ -127,8 +113,8 @@ export function createAiSdkQuickStartPlanner({
       model,
       instructions: quickStartPlannerInstructions(clarificationUsed),
       messages,
-      tools: { [START_CHARACTER_GENERATION_TOOL]: startCharacterGenerationTool },
-      toolChoice: 'auto',
+      tools: { [QUICK_START_DECISION_TOOL]: quickStartDecisionTool },
+      toolChoice: 'required',
       maxRetries: 0,
       abortSignal: signal,
     })

--- a/frontend/src/features/quick-start-agent/react.test.tsx
+++ b/frontend/src/features/quick-start-agent/react.test.tsx
@@ -2,85 +2,149 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { PlannerInput, PlannerResult } from './runtime'
+import type { PlannerInput, PlannerResult, QuickStartDecision } from './runtime'
 import { useQuickStartAgent } from './react'
 
 afterEach(() => {
   cleanup()
-  vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
 
-function deferred() {
-  let resolve!: () => void
-  const promise = new Promise<void>((done) => {
-    resolve = done
+function decisionResult(input: QuickStartDecision): PlannerResult {
+  return {
+    text: '',
+    finishReason: 'tool-calls',
+    toolCalls: [{ toolName: 'quick_start_decision', input }],
+  }
+}
+
+function proposalResult(): PlannerResult {
+  return decisionResult({
+    kind: 'proposal',
+    optimizedPrompt: '银发像素骑士，全身像',
+    optimizationSummary: '我会保留银发骑士特征，并整理为完整的全身母版描述。',
   })
-  return { promise, resolve }
 }
 
 describe('useQuickStartAgent', () => {
-  it('keeps one clarification inline and presents the final plan before dispatch', async () => {
-    const presentation = deferred()
-    const plannerResults: PlannerResult[] = [
-      { text: '请补充角色的美术风格。', finishReason: 'stop', toolCalls: [] },
-      {
-        text: '',
-        finishReason: 'tool-calls',
-        toolCalls: [
-          {
-            toolName: 'start_character_generation',
-            input: {
-              optimizedPrompt: '银发像素骑士，全身像',
-              optimizationSummary: '我会保留银发骑士特征，并补全适合母版生成的全身描述。',
-            },
-          },
-        ],
-      },
+  it('keeps clarification and ordinary replies in one session', async () => {
+    const plannerResults = [
+      decisionResult({ kind: 'clarification', message: '请补充角色的美术风格。' }),
+      decisionResult({ kind: 'reply', message: '你刚才描述了一个银发骑士。' }),
+      decisionResult({ kind: 'reply', message: '可以继续讨论披风设计。' }),
     ]
     const planner = vi.fn(async (_input: PlannerInput) => plannerResults.shift()!)
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+
+    await act(async () => {
+      await result.current.submit('一个银发骑士')
+      await result.current.submit('刚才我说了什么')
+      await result.current.submit('你觉得披风怎么样')
+    })
+
+    expect(result.current.state).toEqual({
+      status: 'awaiting-input',
+      message: '可以继续讨论披风设计。',
+      messageKind: 'reply',
+    })
+    expect(planner.mock.calls[2]?.[0].clarificationUsed).toBe(true)
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('presents a proposal without dispatching and confirms it explicitly', async () => {
+    const planner = vi.fn(async () => proposalResult())
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+
+    await act(async () => {
+      await result.current.submit('银发骑士')
+    })
+    expect(result.current.state).toEqual({
+      status: 'proposal',
+      proposalId: 'proposal-1',
+      optimizedPrompt: '银发像素骑士，全身像',
+      optimizationSummary: '我会保留银发骑士特征，并整理为完整的全身母版描述。',
+    })
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await result.current.confirmProposal('银发像素骑士，全身像，深蓝斗篷')
+    })
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: '银发像素骑士，全身像，深蓝斗篷',
+    })
+  })
+
+  it('lets a new discussion message supersede the visible proposal', async () => {
+    const plannerResults = [
+      proposalResult(),
+      decisionResult({ kind: 'reply', message: '可以比较短斗篷和长斗篷。' }),
+    ]
+    const planner = vi.fn(async () => plannerResults.shift()!)
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+
+    await act(async () => {
+      await result.current.submit('银发骑士')
+      await result.current.submit('先讨论披风')
+    })
+
+    expect(result.current.state).toEqual({
+      status: 'awaiting-input',
+      message: '可以比较短斗篷和长斗篷。',
+      messageKind: 'reply',
+    })
+    await expect(result.current.confirmProposal('旧提案')).rejects.toThrow('提示词提案已失效')
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('hydrates a pending proposal without dispatching', () => {
+    const proposal = {
+      proposalId: 'proposal-restored',
+      optimizedPrompt: '云端机械师全身像',
+      optimizationSummary: '我会保留云端机械师设定。',
+    }
+    const planner = vi.fn()
     const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
     const { result } = renderHook(() =>
       useQuickStartAgent({
         planner,
         startCharacterGeneration,
-        waitForPresentation: () => presentation.promise,
+        initialMessages: [{ role: 'user', content: '云端机械师' }],
+        initialProposal: proposal,
       }),
     )
 
-    await act(async () => {
-      await result.current.submit('一个银发骑士')
-    })
-    expect(result.current.state).toEqual({
-      status: 'awaiting-input',
-      message: '请补充角色的美术风格。',
-    })
-
-    let secondTurn!: Promise<unknown>
-    act(() => {
-      secondTurn = result.current.submit('16-bit 像素风，请直接生成')
-    })
-    await waitFor(() =>
-      expect(result.current.state).toEqual({
-        status: 'dispatching',
-        optimizedPrompt: '银发像素骑士，全身像',
-        optimizationSummary: '我会保留银发骑士特征，并补全适合母版生成的全身描述。',
-      }),
-    )
+    expect(result.current.state).toEqual({ status: 'proposal', ...proposal })
     expect(startCharacterGeneration).not.toHaveBeenCalled()
-
-    presentation.resolve()
-    await act(async () => {
-      await secondTurn
-    })
-    expect(startCharacterGeneration).toHaveBeenCalledWith({
-      prompt: '银发像素骑士，全身像',
-    })
   })
 
-  it('revokes pending authorization when the host unmounts', async () => {
+  it('rejects overlapping turns while planning', async () => {
+    let resolvePlanner!: (result: PlannerResult) => void
     const planner = vi.fn(
-      async ({ signal }: { signal?: AbortSignal }) =>
+      async () =>
+        new Promise<PlannerResult>((resolve) => {
+          resolvePlanner = resolve
+        }),
+    )
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+
+    let firstTurn!: Promise<unknown>
+    act(() => {
+      firstTurn = result.current.submit('银发骑士')
+    })
+    await waitFor(() => expect(planner).toHaveBeenCalledOnce())
+    await expect(result.current.submit('再发一条')).rejects.toThrow('Planner 正在处理上一条输入')
+
+    resolvePlanner(decisionResult({ kind: 'reply', message: '可以继续。' }))
+    await act(async () => firstTurn)
+  })
+
+  it('revokes pending work when the host unmounts', async () => {
+    const planner = vi.fn(
+      async ({ signal }: PlannerInput) =>
         new Promise<PlannerResult>((_resolve, reject) => {
           signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
         }),
@@ -98,175 +162,5 @@ describe('useQuickStartAgent', () => {
 
     await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
     expect(startCharacterGeneration).not.toHaveBeenCalled()
-  })
-
-  it('rejects overlapping turns while the current Planner request is pending', async () => {
-    let resolvePlanner!: (result: PlannerResult) => void
-    const planner = vi.fn(
-      async () =>
-        new Promise<PlannerResult>((resolve) => {
-          resolvePlanner = resolve
-        }),
-    )
-    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
-    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
-
-    let firstTurn!: Promise<unknown>
-    act(() => {
-      firstTurn = result.current.submit('银发骑士')
-    })
-    await waitFor(() => expect(planner).toHaveBeenCalledTimes(1))
-
-    await expect(result.current.submit('再发一条')).rejects.toThrow('Planner 正在处理上一条输入')
-
-    resolvePlanner({ text: '请补充角色风格。', finishReason: 'stop', toolCalls: [] })
-    await act(async () => {
-      await firstTurn
-    })
-    expect(result.current.state).toEqual({
-      status: 'awaiting-input',
-      message: '请补充角色风格。',
-    })
-  })
-
-  it('shows the safe fallback message for a non-Error Planner rejection', async () => {
-    const planner = vi.fn(async () => Promise.reject('offline'))
-    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
-    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
-    let rejection: unknown
-
-    await act(async () => {
-      try {
-        await result.current.submit('银发骑士')
-      } catch (cause) {
-        rejection = cause
-      }
-    })
-
-    expect(rejection).toBe('offline')
-    expect(result.current.state).toEqual({
-      status: 'error',
-      message: 'Agent 暂时不可用，请稍后重试',
-    })
-  })
-
-  it('does not expose Agent protocol details in the user-facing error state', async () => {
-    const planner = vi.fn(async () => ({
-      text: '',
-      finishReason: 'tool-calls',
-      toolCalls: [
-        {
-          toolName: 'start_character_generation',
-          input: { optimizedPrompt: '像素骑士' },
-        },
-      ],
-    }))
-    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
-    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
-
-    await act(async () => {
-      await expect(result.current.submit('像素骑士')).rejects.toThrow('生成 Tool 参数字段无效')
-    })
-
-    expect(result.current.state).toEqual({
-      status: 'error',
-      message: '提示词优化没有完成，请重新发送',
-    })
-  })
-
-  it('keeps the first successful clarification available after an initial Planner failure', async () => {
-    const planner = vi
-      .fn<(input: PlannerInput) => Promise<PlannerResult>>()
-      .mockRejectedValueOnce(new Error('network unavailable'))
-      .mockResolvedValueOnce({
-        text: '请补充角色风格。',
-        finishReason: 'stop',
-        toolCalls: [],
-      })
-    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
-    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
-
-    await act(async () => {
-      await expect(result.current.submit('一个骑士')).rejects.toThrow('network unavailable')
-    })
-    await act(async () => {
-      await result.current.submit('重试')
-    })
-
-    expect(result.current.state).toEqual({
-      status: 'awaiting-input',
-      message: '请补充角色风格。',
-    })
-  })
-
-  it('dispatches without a presentation delay when animation frames are unavailable', async () => {
-    vi.stubGlobal('requestAnimationFrame', undefined)
-    const planner = vi.fn(
-      async (): Promise<PlannerResult> => ({
-        text: '',
-        finishReason: 'tool-calls',
-        toolCalls: [
-          {
-            toolName: 'start_character_generation',
-            input: {
-              optimizedPrompt: '银发像素骑士，全身像',
-              optimizationSummary: '我会保留银发骑士特征，并整理为完整的全身母版描述。',
-            },
-          },
-        ],
-      }),
-    )
-    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
-    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
-
-    await act(async () => {
-      await result.current.submit('请直接生成银发骑士')
-    })
-
-    expect(startCharacterGeneration).toHaveBeenCalledWith({
-      prompt: '银发像素骑士，全身像',
-    })
-  })
-
-  it('requires an explicit restart after the one clarification is exhausted', async () => {
-    const plannerResults: PlannerResult[] = [
-      { text: '请补充角色风格。', finishReason: 'stop', toolCalls: [] },
-      { text: '描述仍有冲突，请修改后重新开始。', finishReason: 'stop', toolCalls: [] },
-      {
-        text: '',
-        finishReason: 'tool-calls',
-        toolCalls: [
-          {
-            toolName: 'start_character_generation',
-            input: {
-              optimizedPrompt: '银发像素骑士，全身像',
-              optimizationSummary: '我会保留银发骑士特征，并整理为完整的全身母版描述。',
-            },
-          },
-        ],
-      },
-    ]
-    const planner = vi.fn(async (_input: PlannerInput) => plannerResults.shift()!)
-    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
-    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
-
-    await act(async () => {
-      await result.current.submit('一个骑士')
-      await result.current.submit('仍然缺少明确风格')
-    })
-    expect(result.current.state).toEqual({
-      status: 'restart-required',
-      message: '描述仍有冲突，请修改后重新开始。',
-    })
-
-    await act(async () => {
-      await result.current.submit('16-bit 银发像素骑士，请直接生成')
-    })
-    expect(startCharacterGeneration).toHaveBeenCalledWith({
-      prompt: '银发像素骑士，全身像',
-    })
-    expect(planner.mock.calls[2]?.[0].messages).toEqual([
-      { role: 'user', content: '16-bit 银发像素骑士，请直接生成' },
-    ])
   })
 })

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   createQuickStartAgent,
-  type CharacterGenerationPlan,
+  type CharacterGenerationProposal,
   type CreateQuickStartAgentOptions,
   type QuickStartAgentResult,
 } from './runtime'
@@ -10,99 +10,102 @@ import {
 export type QuickStartAgentState =
   | { status: 'idle' }
   | { status: 'planning' }
-  | { status: 'awaiting-input'; message: string }
-  | { status: 'restart-required'; message: string }
-  | ({ status: 'dispatching' } & CharacterGenerationPlan)
+  | {
+      status: 'awaiting-input'
+      message: string
+      messageKind: 'reply' | 'clarification' | 'blocked'
+    }
+  | ({ status: 'proposal' } & CharacterGenerationProposal)
+  | ({ status: 'dispatching' } & CharacterGenerationProposal)
   | { status: 'error'; message: string }
 
-export interface UseQuickStartAgentOptions extends CreateQuickStartAgentOptions {
-  /** 测试可替换；页面可在展示提案后返回用户编辑过的最终 Prompt。 */
-  waitForPresentation?: (plan: CharacterGenerationPlan) => Promise<string | void>
-}
-
-async function waitForBrowserPresentation(): Promise<void> {
-  if (typeof requestAnimationFrame !== 'function') return
-  await new Promise<void>((resolve) =>
-    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-  )
-}
+export type UseQuickStartAgentOptions = CreateQuickStartAgentOptions
 
 function errorMessage(cause: unknown): string {
   if (!(cause instanceof Error) || !cause.message) return 'Agent 暂时不可用，请稍后重试'
   if (
-    /Tool|Planner|start_character_generation|optimizedPrompt|optimizationSummary|生成授权/u.test(
+    /Tool|Planner|quick_start_decision|optimizedPrompt|optimizationSummary|生成授权/u.test(
       cause.message,
     )
   ) {
-    return '提示词优化没有完成，请重新发送'
+    return 'Agent 没有完成这次回复，请重新发送'
   }
   return cause.message
 }
 
-export function useQuickStartAgent({
-  planner,
-  startCharacterGeneration,
-  waitForPresentation = waitForBrowserPresentation,
-}: UseQuickStartAgentOptions) {
-  const [state, setState] = useState<QuickStartAgentState>({ status: 'idle' })
+function initialState(options: UseQuickStartAgentOptions): QuickStartAgentState {
+  return options.initialProposal
+    ? { status: 'proposal', ...options.initialProposal }
+    : { status: 'idle' }
+}
+
+export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
+  const {
+    planner,
+    startCharacterGeneration,
+    initialMessages,
+    initialClarificationUsed,
+    initialProposal,
+  } = options
+  const [state, setState] = useState<QuickStartAgentState>(() => initialState(options))
   const agent = useRef<ReturnType<typeof createQuickStartAgent> | null>(null)
-  const started = useRef(false)
-  const clarificationReceived = useRef(false)
-  const restartRequired = useRef(false)
+  const started = useRef(Boolean(initialMessages?.length))
   const running = useRef(false)
   const abortController = useRef<AbortController | null>(null)
   const mounted = useRef(true)
 
   useEffect(() => {
     mounted.current = true
-    started.current = false
+    started.current = Boolean(initialMessages?.length)
     return () => {
       mounted.current = false
       abortController.current?.abort()
       agent.current?.revoke()
       agent.current = null
-      started.current = false
-      clarificationReceived.current = false
-      restartRequired.current = false
     }
-  }, [planner, startCharacterGeneration])
+  }, [initialMessages, planner, startCharacterGeneration])
+
+  const ensureAgent = useCallback(() => {
+    agent.current ??= createQuickStartAgent({
+      planner,
+      startCharacterGeneration,
+      initialMessages,
+      initialClarificationUsed,
+      initialProposal,
+    })
+    return agent.current
+  }, [
+    initialClarificationUsed,
+    initialMessages,
+    initialProposal,
+    planner,
+    startCharacterGeneration,
+  ])
 
   const submit = useCallback(
     async (input: string): Promise<QuickStartAgentResult> => {
       if (running.current) throw new Error('Planner 正在处理上一条输入')
-      if (restartRequired.current) {
-        agent.current?.revoke()
-        agent.current = null
-        started.current = false
-        clarificationReceived.current = false
-        restartRequired.current = false
-      }
       running.current = true
       const controller = new AbortController()
       abortController.current = controller
       if (mounted.current) setState({ status: 'planning' })
 
       try {
-        agent.current ??= createQuickStartAgent({ planner, startCharacterGeneration })
-        const activeAgent = agent.current
-        const continuing = started.current
-        const runTurn = continuing ? activeAgent.continue : activeAgent.start
+        const activeAgent = ensureAgent()
+        const runTurn = started.current ? activeAgent.continue : activeAgent.start
         started.current = true
-        const result = await runTurn(input, {
-          signal: controller.signal,
-          async onBeforeDispatch(plan) {
-            if (mounted.current) setState({ status: 'dispatching', ...plan })
-            return await waitForPresentation(plan)
-          },
-        })
-        if (result.kind === 'message' && mounted.current) {
-          const clarificationExhausted = clarificationReceived.current
-          clarificationReceived.current = true
-          restartRequired.current = clarificationExhausted
-          setState({
-            status: clarificationExhausted ? 'restart-required' : 'awaiting-input',
-            message: result.message,
-          })
+        const result = await runTurn(input, { signal: controller.signal })
+        if (mounted.current) {
+          if (result.kind === 'message') {
+            setState({
+              status: 'awaiting-input',
+              message: result.message,
+              messageKind: result.messageKind,
+            })
+          } else if (result.kind === 'proposal') {
+            const { proposalId, optimizedPrompt, optimizationSummary } = result
+            setState({ status: 'proposal', proposalId, optimizedPrompt, optimizationSummary })
+          }
         }
         return result
       } catch (cause) {
@@ -115,12 +118,39 @@ export function useQuickStartAgent({
         if (abortController.current === controller) abortController.current = null
       }
     },
-    [planner, startCharacterGeneration, waitForPresentation],
+    [ensureAgent],
+  )
+
+  const confirmProposal = useCallback(
+    async (prompt: string): Promise<QuickStartAgentResult> => {
+      if (running.current) throw new Error('Planner 正在处理上一条输入')
+      if (state.status !== 'proposal') throw new Error('提示词提案已失效')
+      running.current = true
+      const { proposalId, optimizedPrompt, optimizationSummary } = state
+      if (mounted.current) {
+        setState({
+          status: 'dispatching',
+          proposalId,
+          optimizedPrompt,
+          optimizationSummary,
+        })
+      }
+      try {
+        return await ensureAgent().confirmProposal(proposalId, prompt)
+      } catch (cause) {
+        if (mounted.current) setState({ status: 'error', message: errorMessage(cause) })
+        throw cause
+      } finally {
+        running.current = false
+      }
+    },
+    [ensureAgent, state],
   )
 
   return {
     state,
     busy: state.status === 'planning' || state.status === 'dispatching',
     submit,
+    confirmProposal,
   }
 }

--- a/frontend/src/features/quick-start-agent/runtime.test.ts
+++ b/frontend/src/features/quick-start-agent/runtime.test.ts
@@ -2,31 +2,31 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   createQuickStartAgent,
-  parseCharacterGenerationPlan,
+  parseQuickStartDecision,
   validatePlannerTerminal,
   type PlannerResult,
+  type QuickStartDecision,
   type QuickStartPlanner,
   type StartCharacterGenerationAction,
 } from './runtime'
 
-function plannerResult(overrides: Partial<PlannerResult> = {}): PlannerResult {
+function decisionResult(input: QuickStartDecision): PlannerResult {
   return {
     text: '',
     finishReason: 'tool-calls',
-    toolCalls: [
-      {
-        toolName: 'start_character_generation',
-        input: {
-          optimizedPrompt: '完整身体的银发像素骑士',
-          optimizationSummary: '我会保留银发骑士的身份特征，并补全适合角色母版的全身描述。',
-        },
-      },
-    ],
-    ...overrides,
+    toolCalls: [{ toolName: 'quick_start_decision', input }],
   }
 }
 
-function fixture(result: PlannerResult = plannerResult()) {
+function proposalResult(prompt = '完整身体的银发像素骑士'): PlannerResult {
+  return decisionResult({
+    kind: 'proposal',
+    optimizedPrompt: prompt,
+    optimizationSummary: '我会保留银发骑士特征，并整理成完整的全身母版描述。',
+  })
+}
+
+function fixture(result: PlannerResult = proposalResult()) {
   const planner = vi.fn<QuickStartPlanner>(async () => result)
   const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>(async () => ({
     runId: 'run-1',
@@ -35,98 +35,221 @@ function fixture(result: PlannerResult = plannerResult()) {
   return { agent, planner, startCharacterGeneration }
 }
 
-describe('validatePlannerTerminal', () => {
-  it('accepts one complete, schema-valid write Tool Call', () => {
-    expect(validatePlannerTerminal(plannerResult())).toEqual({
-      kind: 'tool',
-      optimizedPrompt: '完整身体的银发像素骑士',
-      optimizationSummary: '我会保留银发骑士的身份特征，并补全适合角色母版的全身描述。',
-    })
-  })
-
-  it('accepts a complete text response without treating it as an action', () => {
-    expect(
-      validatePlannerTerminal(
-        plannerResult({
-          text: '请补充角色的身份或外观特征。',
-          finishReason: 'stop',
-          toolCalls: [],
-        }),
-      ),
-    ).toEqual({ kind: 'message', message: '请补充角色的身份或外观特征。' })
+describe('Planner decisions', () => {
+  it.each([
+    [{ kind: 'reply', message: '可以继续讨论。' }],
+    [{ kind: 'clarification', message: '最想保留哪个外观特征？' }],
+    [{ kind: 'blocked', message: '请先解决角色数量冲突。' }],
+    [
+      {
+        kind: 'proposal',
+        optimizedPrompt: '银发像素骑士全身像',
+        optimizationSummary: '我会保留银发骑士特征。',
+      },
+    ],
+  ] satisfies readonly [QuickStartDecision][])('validates %s', (decision) => {
+    expect(validatePlannerTerminal(decisionResult(decision))).toEqual(decision)
   })
 
   it.each([
-    ['unknown Tool', plannerResult({ toolCalls: [{ toolName: 'other_tool', input: {} }] })],
+    [{ kind: 'reply', message: '' }, 'Planner 的文字决策无效'],
+    [{ kind: 'reply', message: '可以', optimizedPrompt: '多余字段' }, 'Planner 文字决策字段无效'],
     [
-      'multiple Tools',
-      plannerResult({
-        toolCalls: [plannerResult().toolCalls[0]!, plannerResult().toolCalls[0]!],
-      }),
+      { kind: 'proposal', optimizedPrompt: '骑士', optimizationSummary: '' },
+      '生成提案的 optimizationSummary 无效',
     ],
-    [
-      'invalid Tool input',
-      plannerResult({
+    [{ kind: 'unknown', message: '未知' }, 'Planner 决策类型无效'],
+  ])('rejects malformed decision %#', (input, message) => {
+    expect(() => parseQuickStartDecision(input)).toThrow(message)
+  })
+
+  it('fails closed for text-only, duplicate, or unknown decisions', () => {
+    expect(() =>
+      validatePlannerTerminal({ text: '', finishReason: 'stop', toolCalls: [] }),
+    ).toThrow('Planner 的文字决策无效')
+    expect(() =>
+      validatePlannerTerminal({
+        ...decisionResult({ kind: 'reply', message: '可以' }),
         toolCalls: [
-          {
-            toolName: 'start_character_generation',
-            input: {
-              optimizedPrompt: ' ',
-              optimizationSummary: '我会整理角色描述。',
-            },
-          },
+          { toolName: 'quick_start_decision', input: { kind: 'reply', message: '一' } },
+          { toolName: 'quick_start_decision', input: { kind: 'reply', message: '二' } },
         ],
       }),
-    ],
-    ['unfinished Tool response', plannerResult({ finishReason: 'stop' })],
-  ])('fails closed for %s', (_label, result) => {
-    expect(() => validatePlannerTerminal(result)).toThrow()
-  })
-
-  it('rejects an incomplete text terminal result', () => {
+    ).toThrow('Planner 每轮必须且只能返回一个决策')
     expect(() =>
-      validatePlannerTerminal(plannerResult({ text: '', finishReason: 'stop', toolCalls: [] })),
-    ).toThrow('Planner 未返回完整的文字响应')
-  })
-})
-
-describe('parseCharacterGenerationPlan', () => {
-  it.each([
-    [
-      'unknown fields',
-      {
-        optimizedPrompt: '像素骑士',
-        optimizationSummary: '我会整理角色描述。',
-        unexpected: true,
-      },
-      '生成 Tool 参数字段无效',
-    ],
-    ['missing optimization summary', { optimizedPrompt: '像素骑士' }, '生成 Tool 参数字段无效'],
-    [
-      'empty optimization summary',
-      { optimizedPrompt: '像素骑士', optimizationSummary: ' ' },
-      '生成 Tool 的 optimizationSummary 无效',
-    ],
-  ])('rejects %s', (_label, input, message) => {
-    expect(() => parseCharacterGenerationPlan(input)).toThrow(message)
+      validatePlannerTerminal({
+        ...decisionResult({ kind: 'reply', message: '可以' }),
+        toolCalls: [{ toolName: 'other', input: { kind: 'reply', message: '可以' } }],
+      }),
+    ).toThrow('Planner 返回了未知决策')
   })
 })
 
 describe('createQuickStartAgent', () => {
-  it('revokes authorization when the request is already cancelled', async () => {
-    const { agent, planner, startCharacterGeneration } = fixture()
-    const abortController = new AbortController()
-    abortController.abort()
+  it('keeps ordinary replies conversational beyond one clarification', async () => {
+    const results = [
+      decisionResult({ kind: 'clarification', message: '请描述一个外观特征。' }),
+      decisionResult({ kind: 'reply', message: '你刚才说想做银发骑士。' }),
+      decisionResult({ kind: 'reply', message: '我们还可以继续比较披风方向。' }),
+    ]
+    const planner = vi.fn<QuickStartPlanner>(async () => results.shift()!)
+    const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>(async () => ({
+      runId: 'run-should-not-exist',
+    }))
+    const agent = createQuickStartAgent({ planner, startCharacterGeneration })
 
-    await expect(agent.start('直接生成', { signal: abortController.signal })).rejects.toMatchObject(
-      { name: 'AbortError' },
-    )
-    await expect(agent.continue('再试一次')).rejects.toThrow('生成授权已失效')
-    expect(planner).not.toHaveBeenCalled()
+    await expect(agent.start('银发骑士')).resolves.toMatchObject({
+      kind: 'message',
+      messageKind: 'clarification',
+    })
+    await expect(agent.continue('刚才我说了什么')).resolves.toMatchObject({
+      kind: 'message',
+      messageKind: 'reply',
+    })
+    await expect(agent.continue('你觉得披风怎么样')).resolves.toMatchObject({
+      kind: 'message',
+      messageKind: 'reply',
+    })
+
+    expect(planner.mock.calls[2]?.[0]).toMatchObject({
+      clarificationUsed: true,
+      messages: [
+        { role: 'user', content: '银发骑士' },
+        { role: 'assistant', content: '请描述一个外观特征。' },
+        { role: 'user', content: '刚才我说了什么' },
+        { role: 'assistant', content: '你刚才说想做银发骑士。' },
+        { role: 'user', content: '你觉得披风怎么样' },
+      ],
+    })
     expect(startCharacterGeneration).not.toHaveBeenCalled()
   })
 
-  it('revokes authorization when cancellation happens while planning', async () => {
+  it('hydrates the planner history and clarification state', async () => {
+    const planner = vi.fn<QuickStartPlanner>(async () =>
+      decisionResult({ kind: 'reply', message: '你最早描述的是机械师。' }),
+    )
+    const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>(async () => ({
+      runId: 'run-should-not-exist',
+    }))
+    const agent = createQuickStartAgent({
+      planner,
+      startCharacterGeneration,
+      initialMessages: [
+        { role: 'user', content: '云端机械师' },
+        { role: 'assistant', content: '想保留什么外观特征？' },
+      ],
+      initialClarificationUsed: true,
+    })
+
+    await agent.continue('我刚才说了什么？')
+
+    expect(planner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clarificationUsed: true,
+        messages: [
+          { role: 'user', content: '云端机械师' },
+          { role: 'assistant', content: '想保留什么外观特征？' },
+          { role: 'user', content: '我刚才说了什么？' },
+        ],
+      }),
+    )
+  })
+
+  it('keeps a submitted user turn in history when the planner fails', async () => {
+    const planner = vi
+      .fn<QuickStartPlanner>()
+      .mockRejectedValueOnce(new Error('planner unavailable'))
+      .mockResolvedValueOnce(decisionResult({ kind: 'reply', message: '我会基于银发骑士继续。' }))
+    const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>()
+    const agent = createQuickStartAgent({ planner, startCharacterGeneration })
+
+    await expect(agent.start('银发骑士')).rejects.toThrow('planner unavailable')
+    await agent.continue('请基于刚才内容继续')
+
+    expect(planner.mock.calls[1]?.[0].messages).toEqual([
+      { role: 'user', content: '银发骑士' },
+      { role: 'user', content: '请基于刚才内容继续' },
+    ])
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('returns a proposal without dispatching generation', async () => {
+    const { agent, startCharacterGeneration } = fixture()
+
+    await expect(agent.start('银发骑士')).resolves.toEqual({
+      kind: 'proposal',
+      proposalId: 'proposal-1',
+      optimizedPrompt: '完整身体的银发像素骑士',
+      optimizationSummary: '我会保留银发骑士特征，并整理成完整的全身母版描述。',
+    })
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('invalidates the previous proposal when discussion continues', async () => {
+    const { agent, planner, startCharacterGeneration } = fixture()
+    const proposal = await agent.start('银发骑士')
+    if (proposal.kind !== 'proposal') throw new Error('测试缺少提案')
+    planner.mockResolvedValueOnce(decisionResult({ kind: 'reply', message: '可以比较两种披风。' }))
+
+    await agent.continue('先讨论披风')
+
+    await expect(
+      agent.confirmProposal(proposal.proposalId, proposal.optimizedPrompt),
+    ).rejects.toThrow('提示词提案已失效')
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+
+  it('dispatches the edited prompt exactly once after explicit confirmation', async () => {
+    const { agent, startCharacterGeneration } = fixture()
+    const proposal = await agent.start('银发骑士')
+    if (proposal.kind !== 'proposal') throw new Error('测试缺少提案')
+
+    await expect(
+      agent.confirmProposal(proposal.proposalId, '完整身体的银发像素骑士，深蓝斗篷'),
+    ).resolves.toMatchObject({
+      kind: 'generated',
+      runId: 'run-1',
+      optimizedPrompt: '完整身体的银发像素骑士，深蓝斗篷',
+    })
+    await expect(
+      agent.confirmProposal(proposal.proposalId, proposal.optimizedPrompt),
+    ).rejects.toThrow('生成授权已使用')
+    expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: '完整身体的银发像素骑士，深蓝斗篷',
+    })
+  })
+
+  it('restores a pending proposal without dispatching it', async () => {
+    const planner = vi.fn<QuickStartPlanner>()
+    const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>(async () => ({
+      runId: 'run-restored',
+    }))
+    const proposal = {
+      proposalId: 'proposal-restored',
+      optimizedPrompt: '云端机械师全身像',
+      optimizationSummary: '我会保留云端机械师设定。',
+    }
+    const agent = createQuickStartAgent({
+      planner,
+      startCharacterGeneration,
+      initialMessages: [
+        { role: 'user', content: '云端机械师' },
+        { role: 'assistant', content: '我会保留云端机械师设定。\n\n提示词提案：云端机械师全身像' },
+      ],
+      initialProposal: proposal,
+    })
+
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+    await expect(
+      agent.confirmProposal(proposal.proposalId, proposal.optimizedPrompt),
+    ).resolves.toMatchObject({
+      kind: 'generated',
+      runId: 'run-restored',
+    })
+  })
+
+  it('revokes authorization when planning is cancelled', async () => {
     let resolvePlanner: ((result: PlannerResult) => void) | undefined
     const planner = vi.fn<QuickStartPlanner>(
       () =>
@@ -134,184 +257,32 @@ describe('createQuickStartAgent', () => {
           resolvePlanner = resolve
         }),
     )
-    const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>(async () => ({
-      runId: 'run-should-not-exist',
-    }))
+    const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>()
     const agent = createQuickStartAgent({ planner, startCharacterGeneration })
-    const abortController = new AbortController()
+    const controller = new AbortController()
 
-    const request = agent.start('直接生成', { signal: abortController.signal })
-    await vi.waitFor(() => expect(planner).toHaveBeenCalledTimes(1))
-    abortController.abort()
-    resolvePlanner?.(plannerResult())
+    const pending = agent.start('银发骑士', { signal: controller.signal })
+    await vi.waitFor(() => expect(planner).toHaveBeenCalledOnce())
+    controller.abort()
+    resolvePlanner?.(proposalResult())
 
-    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
-    await expect(agent.continue('再试一次')).rejects.toThrow('生成授权已失效')
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    await expect(agent.continue('重试')).rejects.toThrow('生成授权已失效')
     expect(startCharacterGeneration).not.toHaveBeenCalled()
   })
 
-  it('dispatches the user-edited prompt once after presenting the proposal', async () => {
-    const { agent, startCharacterGeneration } = fixture()
-    const events: string[] = []
-    startCharacterGeneration.mockImplementation(async () => {
-      events.push('action')
-      return { runId: 'run-1' }
-    })
-
-    await expect(
-      agent.start('银发骑士', {
-        onBeforeDispatch: async (plan) => {
-          events.push(`visible:${plan.optimizedPrompt}`)
-          return '完整身体的银发像素骑士，深蓝斗篷'
-        },
-      }),
-    ).resolves.toEqual({
-      kind: 'generated',
-      runId: 'run-1',
-      optimizedPrompt: '完整身体的银发像素骑士，深蓝斗篷',
-      optimizationSummary: '我会保留银发骑士的身份特征，并补全适合角色母版的全身描述。',
-    })
-
-    expect(events).toEqual(['visible:完整身体的银发像素骑士', 'action'])
-    expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
-    expect(startCharacterGeneration).toHaveBeenCalledWith({
-      prompt: '完整身体的银发像素骑士，深蓝斗篷',
-    })
-  })
-
-  it('rejects an explicitly cleared prompt without dispatching the write action', async () => {
-    const { agent, startCharacterGeneration } = fixture()
-
-    await expect(
-      agent.start('银发骑士', {
-        onBeforeDispatch: async () => '   ',
-      }),
-    ).rejects.toThrow('确认后的角色提示词无效')
-
-    expect(startCharacterGeneration).not.toHaveBeenCalled()
-  })
-
-  it('keeps a text-only response side-effect free and spends at most one clarification', async () => {
-    const { agent, planner, startCharacterGeneration } = fixture(
-      plannerResult({ text: '最希望保留什么外观特征？', finishReason: 'stop', toolCalls: [] }),
-    )
-
-    await expect(agent.start('一个角色')).resolves.toEqual({
-      kind: 'message',
-      message: '最希望保留什么外观特征？',
-    })
-    vi.mocked(planner).mockResolvedValueOnce(plannerResult())
-    await agent.continue('银色卷发')
-
-    expect(planner).toHaveBeenNthCalledWith(2, expect.objectContaining({ clarificationUsed: true }))
-    expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
-  })
-
-  it('ends an unresolved conversation after the single clarification turn', async () => {
-    const textResult = plannerResult({
-      text: '这个请求仍有冲突，请修改后重新开始。',
-      finishReason: 'stop',
-      toolCalls: [],
-    })
-    const { agent, planner, startCharacterGeneration } = fixture(textResult)
-
-    await expect(agent.start('一个角色')).resolves.toEqual({
-      kind: 'message',
-      message: '这个请求仍有冲突，请修改后重新开始。',
-    })
-    await expect(agent.continue('补充说明')).resolves.toEqual({
-      kind: 'message',
-      message: '这个请求仍有冲突，请修改后重新开始。',
-    })
-    await expect(agent.continue('再追问一次')).rejects.toThrow('生成授权已失效')
-
-    expect(planner).toHaveBeenCalledTimes(2)
-    expect(startCharacterGeneration).not.toHaveBeenCalled()
-  })
-
-  it('does not dispatch an unknown, duplicate, invalid, or text-only terminal result', async () => {
-    const cases = [
-      plannerResult({ toolCalls: [{ toolName: 'unknown', input: {} }] }),
-      plannerResult({
-        toolCalls: [plannerResult().toolCalls[0]!, plannerResult().toolCalls[0]!],
-      }),
-      plannerResult({
-        toolCalls: [
-          {
-            toolName: 'start_character_generation',
-            input: { optimizedPrompt: '', optimizationSummary: '我会整理角色描述。' },
-          },
-        ],
-      }),
-    ]
-
-    for (const result of cases) {
-      const { agent, startCharacterGeneration } = fixture(result)
-      await expect(agent.start('直接生成')).rejects.toThrow()
-      expect(startCharacterGeneration).not.toHaveBeenCalled()
-    }
-
-    const textOnly = fixture(
-      plannerResult({
-        text: '这个请求目前不能生成，请修改。',
-        finishReason: 'stop',
-        toolCalls: [],
-      }),
-    )
-    await expect(textOnly.agent.start('不要生成，只润色')).resolves.toEqual({
-      kind: 'message',
-      message: '这个请求目前不能生成，请修改。',
-    })
-    expect(textOnly.startCharacterGeneration).not.toHaveBeenCalled()
-  })
-
-  it('does not dispatch when cancellation happens before the write starts', async () => {
-    const { agent, startCharacterGeneration } = fixture()
-    const abortController = new AbortController()
-
-    await expect(
-      agent.start('直接生成', {
-        signal: abortController.signal,
-        onBeforeDispatch: async () => abortController.abort(),
-      }),
-    ).rejects.toMatchObject({ name: 'AbortError' })
-
-    expect(startCharacterGeneration).not.toHaveBeenCalled()
-  })
-
-  it('does not pretend a dispatched action was cancelled', async () => {
-    let resolveWrite: ((result: { runId: string }) => void) | undefined
-    const { agent, startCharacterGeneration } = fixture()
-    startCharacterGeneration.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveWrite = resolve
-        }),
-    )
-    const abortController = new AbortController()
-
-    const result = agent.start('直接生成', { signal: abortController.signal })
-    await vi.waitFor(() => expect(startCharacterGeneration).toHaveBeenCalledTimes(1))
-    abortController.abort()
-    resolveWrite?.({ runId: 'run-accepted' })
-
-    await expect(result).resolves.toMatchObject({ kind: 'generated', runId: 'run-accepted' })
-  })
-
-  it('revokes unused authorization and never calls the action afterwards', async () => {
-    const { agent, startCharacterGeneration } = fixture()
-    agent.revoke()
-
-    await expect(agent.start('直接生成')).rejects.toThrow('生成授权已失效')
-    expect(startCharacterGeneration).not.toHaveBeenCalled()
-  })
-
-  it('never retries or replays the write action after an uncertain failure', async () => {
+  it('never replays an uncertain generation failure', async () => {
     const { agent, startCharacterGeneration } = fixture()
     startCharacterGeneration.mockRejectedValueOnce(new Error('generation response lost'))
+    const proposal = await agent.start('银发骑士')
+    if (proposal.kind !== 'proposal') throw new Error('测试缺少提案')
 
-    await expect(agent.start('直接生成')).rejects.toThrow('generation response lost')
-    await expect(agent.continue('再试一次')).rejects.toThrow('生成授权已使用')
+    await expect(
+      agent.confirmProposal(proposal.proposalId, proposal.optimizedPrompt),
+    ).rejects.toThrow('generation response lost')
+    await expect(
+      agent.confirmProposal(proposal.proposalId, proposal.optimizedPrompt),
+    ).rejects.toThrow('生成授权已使用')
     expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -1,6 +1,9 @@
+export const QUICK_START_DECISION_TOOL = 'quick_start_decision' as const
+/** 旧前端测试与灰度响应的只读兼容名；命中时只生成提案，不会直接写入。 */
 export const START_CHARACTER_GENERATION_TOOL = 'start_character_generation' as const
 
 const MAX_PROMPT_LENGTH = 4_000
+const MAX_MESSAGE_LENGTH = 2_000
 const MAX_OPTIMIZATION_SUMMARY_LENGTH = 600
 
 export interface PlannerMessage {
@@ -32,23 +35,29 @@ export interface CharacterGenerationPlan {
   optimizationSummary: string
 }
 
-export type ValidatedPlannerTerminal =
-  | { kind: 'message'; message: string }
-  | ({ kind: 'tool' } & CharacterGenerationPlan)
+export interface CharacterGenerationProposal extends CharacterGenerationPlan {
+  proposalId: string
+}
+
+export type QuickStartDecision =
+  | { kind: 'reply'; message: string }
+  | { kind: 'clarification'; message: string }
+  | { kind: 'blocked'; message: string }
+  | ({ kind: 'proposal' } & CharacterGenerationPlan)
 
 export type QuickStartAgentResult =
-  | { kind: 'message'; message: string }
-  | ({ kind: 'generated'; runId: string } & CharacterGenerationPlan)
+  | { kind: 'message'; messageKind: 'reply' | 'clarification' | 'blocked'; message: string }
+  | ({ kind: 'proposal' } & CharacterGenerationProposal)
+  | ({ kind: 'generated'; runId: string } & CharacterGenerationProposal)
 
 export interface QuickStartAgentTurnOptions {
   signal?: AbortSignal
-  /** 页面先展示提案并等待用户确认；返回值可覆盖最终提交的 Prompt。 */
-  onBeforeDispatch?: (plan: CharacterGenerationPlan) => string | void | Promise<string | void>
 }
 
 export interface QuickStartAgent {
   start(input: string, options?: QuickStartAgentTurnOptions): Promise<QuickStartAgentResult>
   continue(input: string, options?: QuickStartAgentTurnOptions): Promise<QuickStartAgentResult>
+  confirmProposal(proposalId: string, prompt: string): Promise<QuickStartAgentResult>
   revoke(): void
 }
 
@@ -60,73 +69,108 @@ export type StartCharacterGenerationAction = (input: {
 export interface CreateQuickStartAgentOptions {
   planner: QuickStartPlanner
   startCharacterGeneration: StartCharacterGenerationAction
+  initialMessages?: readonly PlannerMessage[]
+  initialClarificationUsed?: boolean
+  initialProposal?: CharacterGenerationProposal | null
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+function parseMessage(value: unknown): string {
+  const message = typeof value === 'string' ? value.trim() : ''
+  if (!message || message.length > MAX_MESSAGE_LENGTH) {
+    throw new Error('Planner 的文字决策无效')
+  }
+  return message
+}
+
 export function parseCharacterGenerationPlan(value: unknown): CharacterGenerationPlan {
-  if (!isRecord(value)) throw new Error('生成 Tool 参数必须是对象')
+  if (!isRecord(value)) throw new Error('生成提案参数必须是对象')
   const keys = Object.keys(value)
   if (
-    keys.some((key) => key !== 'optimizedPrompt' && key !== 'optimizationSummary') ||
+    keys.some(
+      (key) => key !== 'kind' && key !== 'optimizedPrompt' && key !== 'optimizationSummary',
+    ) ||
+    (keys.includes('kind') && value.kind !== 'proposal') ||
     !keys.includes('optimizedPrompt') ||
     !keys.includes('optimizationSummary')
   ) {
-    throw new Error('生成 Tool 参数字段无效')
+    throw new Error('生成提案参数字段无效')
   }
 
   const optimizedPrompt =
     typeof value.optimizedPrompt === 'string' ? value.optimizedPrompt.trim() : ''
   if (!optimizedPrompt || optimizedPrompt.length > MAX_PROMPT_LENGTH) {
-    throw new Error('生成 Tool 的 optimizedPrompt 无效')
+    throw new Error('生成提案的 optimizedPrompt 无效')
   }
   const optimizationSummary =
     typeof value.optimizationSummary === 'string' ? value.optimizationSummary.trim() : ''
   if (!optimizationSummary || optimizationSummary.length > MAX_OPTIMIZATION_SUMMARY_LENGTH) {
-    throw new Error('生成 Tool 的 optimizationSummary 无效')
+    throw new Error('生成提案的 optimizationSummary 无效')
   }
   return { optimizedPrompt, optimizationSummary }
 }
 
-/** SDK 完整返回后再做一次 fail-closed 终态校验，校验通过前不触发业务 action。 */
-export function validatePlannerTerminal(result: PlannerResult): ValidatedPlannerTerminal {
-  if (result.toolCalls.length === 0) {
-    const message = result.text.trim()
-    if (result.finishReason !== 'stop' || !message) {
-      throw new Error('Planner 未返回完整的文字响应')
-    }
-    return { kind: 'message', message }
+export function parseQuickStartDecision(value: unknown): QuickStartDecision {
+  if (!isRecord(value)) throw new Error('Planner 决策必须是对象')
+  if (value.kind === 'proposal') {
+    return { kind: 'proposal', ...parseCharacterGenerationPlan(value) }
   }
+  if (value.kind !== 'reply' && value.kind !== 'clarification' && value.kind !== 'blocked') {
+    throw new Error('Planner 决策类型无效')
+  }
+  const keys = Object.keys(value)
+  if (keys.some((key) => key !== 'kind' && key !== 'message') || !keys.includes('message')) {
+    throw new Error('Planner 文字决策字段无效')
+  }
+  return { kind: value.kind, message: parseMessage(value.message) }
+}
 
+/** SDK 完整返回后再做一次 fail-closed 终态校验，校验通过前不触发业务 action。 */
+export function validatePlannerTerminal(result: PlannerResult): QuickStartDecision {
+  if (result.finishReason === 'stop' && result.toolCalls.length === 0) {
+    return { kind: 'reply', message: parseMessage(result.text) }
+  }
   if (result.finishReason !== 'tool-calls') {
-    throw new Error('Planner 的 Tool Call 响应未完整结束')
+    throw new Error('Planner 的决策响应未完整结束')
   }
   if (result.toolCalls.length !== 1) {
-    throw new Error('Planner 每轮必须且只能调用一个 Tool')
+    throw new Error('Planner 每轮必须且只能返回一个决策')
   }
   const [call] = result.toolCalls
-  if (call?.toolName !== START_CHARACTER_GENERATION_TOOL) {
-    throw new Error('Planner 调用了未知 Tool')
+  if (call?.toolName === START_CHARACTER_GENERATION_TOOL) {
+    return { kind: 'proposal', ...parseCharacterGenerationPlan(call.input) }
   }
-  return { kind: 'tool', ...parseCharacterGenerationPlan(call.input) }
+  if (call?.toolName !== QUICK_START_DECISION_TOOL) {
+    throw new Error('Planner 返回了未知决策')
+  }
+  return parseQuickStartDecision(call.input)
 }
 
 function abortError(): DOMException {
   return new DOMException('操作已取消', 'AbortError')
 }
 
+function proposalMessage(plan: CharacterGenerationPlan): string {
+  return `${plan.optimizationSummary}\n\n提示词提案：${plan.optimizedPrompt}`
+}
+
 export function createQuickStartAgent({
   planner,
   startCharacterGeneration,
+  initialMessages = [],
+  initialClarificationUsed = false,
+  initialProposal = null,
 }: CreateQuickStartAgentOptions): QuickStartAgent {
-  let started = false
+  let started = initialMessages.length > 0
   let revoked = false
   let consumed = false
-  let clarificationUsed = false
+  let clarificationUsed = initialClarificationUsed
   let running = false
-  let messages: PlannerMessage[] = []
+  let messages: PlannerMessage[] = [...initialMessages]
+  let currentProposal = initialProposal
 
   function assertAuthorized() {
     if (revoked) throw new Error('生成授权已失效')
@@ -135,7 +179,7 @@ export function createQuickStartAgent({
 
   async function runTurn(
     input: string,
-    { signal, onBeforeDispatch }: QuickStartAgentTurnOptions = {},
+    { signal }: QuickStartAgentTurnOptions = {},
   ): Promise<QuickStartAgentResult> {
     assertAuthorized()
     if (running) throw new Error('Planner 正在处理上一条输入')
@@ -147,12 +191,16 @@ export function createQuickStartAgent({
     }
 
     running = true
+    currentProposal = null
     try {
       const nextMessages: PlannerMessage[] = [
         ...messages,
         { role: 'user', content: normalizedInput },
       ]
-      const terminal = validatePlannerTerminal(
+      // 用户点击发送后，页面已经展示并持久化这条消息；即使 Planner 失败，
+      // runtime 也必须保留同一历史，避免刷新前后得到不同上下文。
+      messages = nextMessages
+      const decision = validatePlannerTerminal(
         await planner({ messages: nextMessages, clarificationUsed, signal }),
       )
       if (signal?.aborted) {
@@ -160,36 +208,46 @@ export function createQuickStartAgent({
         throw abortError()
       }
 
-      if (terminal.kind === 'message') {
-        messages = [...nextMessages, { role: 'assistant', content: terminal.message }]
-        if (clarificationUsed) revoked = true
-        clarificationUsed = true
-        return terminal
+      if (decision.kind !== 'proposal') {
+        messages = [...nextMessages, { role: 'assistant', content: decision.message }]
+        if (decision.kind === 'clarification') clarificationUsed = true
+        return { kind: 'message', messageKind: decision.kind, message: decision.message }
       }
 
-      const plan: CharacterGenerationPlan = {
-        optimizedPrompt: terminal.optimizedPrompt,
-        optimizationSummary: terminal.optimizationSummary,
+      const proposal: CharacterGenerationProposal = {
+        proposalId: `proposal-${nextMessages.length}`,
+        optimizedPrompt: decision.optimizedPrompt,
+        optimizationSummary: decision.optimizationSummary,
       }
-      const promptOverride = await onBeforeDispatch?.(plan)
-      if (signal?.aborted) {
-        revoked = true
-        throw abortError()
-      }
-      assertAuthorized()
+      currentProposal = proposal
+      messages = [...nextMessages, { role: 'assistant', content: proposalMessage(proposal) }]
+      return { kind: 'proposal', ...proposal }
+    } finally {
+      running = false
+    }
+  }
 
-      const effectivePrompt =
-        promptOverride === undefined ? plan.optimizedPrompt : promptOverride.trim()
-      if (!effectivePrompt || effectivePrompt.length > MAX_PROMPT_LENGTH) {
-        throw new Error('确认后的角色提示词无效')
-      }
+  async function confirmProposal(
+    proposalId: string,
+    prompt: string,
+  ): Promise<QuickStartAgentResult> {
+    assertAuthorized()
+    if (running) throw new Error('Planner 正在处理上一条输入')
+    if (!currentProposal || currentProposal.proposalId !== proposalId) {
+      throw new Error('提示词提案已失效')
+    }
+    const effectivePrompt = prompt.trim()
+    if (!effectivePrompt || effectivePrompt.length > MAX_PROMPT_LENGTH) {
+      throw new Error('确认后的角色提示词无效')
+    }
 
-      // 写权限在调用前消费。即使响应丢失，也不得自动重放可能已经计费的 action。
-      consumed = true
-      const { runId } = await startCharacterGeneration({
-        prompt: effectivePrompt,
-      })
-      return { kind: 'generated', runId, ...plan, optimizedPrompt: effectivePrompt }
+    running = true
+    consumed = true
+    const proposal = currentProposal
+    currentProposal = null
+    try {
+      const { runId } = await startCharacterGeneration({ prompt: effectivePrompt })
+      return { kind: 'generated', runId, ...proposal, optimizedPrompt: effectivePrompt }
     } finally {
       running = false
     }
@@ -205,7 +263,9 @@ export function createQuickStartAgent({
       if (!started) return Promise.reject(new Error('Agent 尚未开始'))
       return runTurn(input, options)
     },
+    confirmProposal,
     revoke() {
+      currentProposal = null
       if (!consumed) revoked = true
     },
   }

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -584,7 +584,7 @@ describe('QuickStartPage', () => {
 
   it('keeps an unbound Agent draft in its current Quick Start history entry', async () => {
     const service = serviceFor(null)
-    const planner = vi.fn(async () => ({
+    const planner = vi.fn(async (_input: PlannerInput) => ({
       text: '可以。你最想保留哪个外观特征？',
       finishReason: 'stop',
       toolCalls: [],
@@ -622,6 +622,17 @@ describe('QuickStartPage', () => {
 
     expect(screen.getByText('我想做一个住在云端的机械师。')).toBeTruthy()
     expect(screen.getByText('可以。你最想保留哪个外观特征？')).toBeTruthy()
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '刚才我说了什么？' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '继续' }))
+    await waitFor(() => expect(planner).toHaveBeenCalledTimes(2))
+    expect(planner.mock.calls[1]?.[0].messages).toEqual([
+      { role: 'user', content: '我想做一个住在云端的机械师。' },
+      { role: 'assistant', content: '可以。你最想保留哪个外观特征？' },
+      { role: 'user', content: '刚才我说了什么？' },
+    ])
 
     restoredView.unmount()
     window.history.pushState(null, '', '/quick-start')
@@ -661,13 +672,17 @@ describe('QuickStartPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '填入输入框' }))
     await act(async () => vi.advanceTimersByTimeAsync(760))
+    fireEvent.change(screen.getByLabelText('创作指令'), {
+      target: { value: '提着蓝色风灯的森林守夜人' },
+    })
     fireEvent.click(screen.getByRole('button', { name: '发送生成' }))
     await act(async () => undefined)
     await act(async () => vi.advanceTimersByTime(460))
 
-    expect(
-      window.localStorage.getItem('windup.quick-start.agent-chat.v2:run:7:run-created'),
-    ).toContain('提着风灯的森林守夜人')
+    const runConversation = window.localStorage.getItem(
+      'windup.quick-start.agent-chat.v2:run:7:run-created',
+    )
+    expect(runConversation).toContain('提着蓝色风灯的森林守夜人')
     expect(
       window.sessionStorage.getItem(`windup.quick-start.agent-chat.v2:draft:7:${draftId}`),
     ).toBeNull()
@@ -682,12 +697,17 @@ describe('QuickStartPage', () => {
       'windup.quick-start.agent-chat.v2:run:7:run-2',
       JSON.stringify({ turns: [{ role: 'user', content: '第二条运行的对话' }] }),
     )
+    window.localStorage.setItem(
+      'windup.quick-start.agent-chat.v2:run:8:run-1',
+      JSON.stringify({ turns: [{ role: 'user', content: '另一位用户的对话' }] }),
+    )
     const run = workflow(setupAndTemplate(), 'run-1')
 
     renderAt('/quick-start/run-1', serviceFor(run))
 
     expect(await screen.findByText('第一条运行的对话')).toBeTruthy()
     expect(screen.queryByText('第二条运行的对话')).toBeNull()
+    expect(screen.queryByText('另一位用户的对话')).toBeNull()
   })
 
   it('migrates only legacy Agent turns bound to the current run', async () => {
@@ -777,6 +797,43 @@ describe('QuickStartPage', () => {
     expect(startCharacterGeneration).toHaveBeenCalledWith({
       prompt: '云端工坊的银发机械师，佩戴黄铜护目镜',
     })
+  })
+
+  it('keeps a proposal optional when the user continues the conversation', async () => {
+    const plannerResults: PlannerResult[] = [
+      {
+        text: '',
+        finishReason: 'tool-calls',
+        toolCalls: [
+          {
+            toolName: 'start_character_generation',
+            input: {
+              optimizedPrompt: '云端工坊的银发机械师，全身像',
+              optimizationSummary: '我会保留机械师设定，并整理为完整的全身母版描述。',
+            },
+          },
+        ],
+      },
+      { text: '可以先比较护目镜和单片镜两种方向。', finishReason: 'stop', toolCalls: [] },
+    ]
+    const planner = vi.fn(async () => plannerResults.shift()!)
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-should-not-exist' }))
+    renderAt('/quick-start', serviceFor(null), { planner, startCharacterGeneration })
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '云端工坊的银发机械师' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    expect(await screen.findByRole('button', { name: '填入输入框' })).toBeTruthy()
+
+    const input = screen.getByRole('textbox', { name: '创作指令' }) as HTMLTextAreaElement
+    expect(input.disabled).toBe(false)
+    fireEvent.change(input, { target: { value: '你觉得眼镜应该怎么设计？' } })
+    fireEvent.click(screen.getByRole('button', { name: '继续' }))
+
+    expect(await screen.findByText('可以先比较护目镜和单片镜两种方向。')).toBeTruthy()
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: '填入输入框' })).toBeNull()
   })
 
   it('keeps one persistent Agent shell with a floating composer outside the scrolling transcript', async () => {
@@ -1220,7 +1277,7 @@ describe('QuickStartPage', () => {
     action.resolve({ runId: 'run-new' })
   })
 
-  it('restarts with a fresh Agent session after the clarification budget is exhausted', async () => {
+  it('keeps the same Agent session after multiple text decisions', async () => {
     const plannerResults: PlannerResult[] = [
       { text: '请补充角色风格。', finishReason: 'stop', toolCalls: [] },
       { text: '描述仍有冲突，请修改后重新开始。', finishReason: 'stop', toolCalls: [] },
@@ -1251,17 +1308,21 @@ describe('QuickStartPage', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: '继续' }))
     expect(await screen.findByText('描述仍有冲突，请修改后重新开始。')).toBeTruthy()
-    expect(screen.getByRole('button', { name: '重新开始' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '继续' })).toBeTruthy()
 
     fireEvent.change(screen.getByLabelText('创作指令'), {
       target: { value: '16-bit 银发像素骑士，请直接生成' },
     })
-    fireEvent.click(screen.getByRole('button', { name: '重新开始' }))
+    fireEvent.click(screen.getByRole('button', { name: '继续' }))
 
     expect(startCharacterGeneration).not.toHaveBeenCalled()
     await confirmAgentGeneration()
     await waitFor(() => expect(startCharacterGeneration).toHaveBeenCalledTimes(1))
     expect(planner.mock.calls[2]?.[0].messages).toEqual([
+      { role: 'user', content: '一个骑士' },
+      { role: 'assistant', content: '请补充角色风格。' },
+      { role: 'user', content: '仍然缺少明确风格' },
+      { role: 'assistant', content: '描述仍有冲突，请修改后重新开始。' },
       { role: 'user', content: '16-bit 银发像素骑士，请直接生成' },
     ])
   })

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -22,7 +22,12 @@ import { forgetActiveRun, isMissingActiveRunError, syncActiveRun } from '@/featu
 import { useOptionalAuthSession } from '@/features/auth-session'
 import { ExportButton, type ExportPackageModel } from '@/features/export-package'
 import { useQuickStartAgent } from '@/features/quick-start-agent/react'
-import type { CreateQuickStartAgentOptions } from '@/features/quick-start-agent/runtime'
+import type {
+  CharacterGenerationProposal,
+  CreateQuickStartAgentOptions,
+  PlannerMessage,
+  QuickStartAgentResult,
+} from '@/features/quick-start-agent/runtime'
 import {
   GenerationPreviewCard,
   GenerationProgressCopy,
@@ -135,10 +140,22 @@ const AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v2'
 const LEGACY_AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v1'
 const AGENT_DRAFT_HISTORY_STATE_KEY = 'windupQuickStartAgentDraftId'
 
-type AgentConversationTurn = {
-  role: 'user' | 'assistant'
-  content: string
-}
+type AgentConversationTurn =
+  | { role: 'user'; content: string }
+  | {
+      role: 'assistant'
+      content: string
+      kind: 'reply' | 'clarification' | 'blocked'
+    }
+  | {
+      role: 'assistant'
+      content: string
+      kind: 'proposal'
+      proposalId: string
+      optimizedPrompt: string
+      optimizationSummary: string
+      proposalStatus: 'pending' | 'superseded' | 'adopted' | 'confirmed'
+    }
 
 type AgentConversationRecord = {
   turns: readonly AgentConversationTurn[]
@@ -193,19 +210,82 @@ function readAgentConversation(
     const parsed: unknown = JSON.parse(stored)
     if (typeof parsed !== 'object' || parsed === null || !('turns' in parsed)) return []
     if (!Array.isArray(parsed.turns)) return []
-    const turns = parsed.turns.filter(
-      (turn): turn is AgentConversationTurn =>
-        typeof turn === 'object' &&
-        turn !== null &&
-        'role' in turn &&
-        (turn.role === 'user' || turn.role === 'assistant') &&
-        'content' in turn &&
-        typeof turn.content === 'string' &&
-        Boolean(turn.content.trim()),
-    )
-    return turns
+    return parsed.turns.flatMap((turn): AgentConversationTurn[] => {
+      if (
+        typeof turn !== 'object' ||
+        turn === null ||
+        !('role' in turn) ||
+        !('content' in turn) ||
+        typeof turn.content !== 'string' ||
+        !turn.content.trim()
+      ) {
+        return []
+      }
+      if (turn.role === 'user') return [{ role: 'user', content: turn.content }]
+      if (turn.role !== 'assistant') return []
+
+      if (
+        'kind' in turn &&
+        turn.kind === 'proposal' &&
+        'proposalId' in turn &&
+        typeof turn.proposalId === 'string' &&
+        'optimizedPrompt' in turn &&
+        typeof turn.optimizedPrompt === 'string' &&
+        'optimizationSummary' in turn &&
+        typeof turn.optimizationSummary === 'string' &&
+        'proposalStatus' in turn &&
+        (turn.proposalStatus === 'pending' ||
+          turn.proposalStatus === 'superseded' ||
+          turn.proposalStatus === 'adopted' ||
+          turn.proposalStatus === 'confirmed')
+      ) {
+        return [
+          {
+            role: 'assistant',
+            content: turn.content,
+            kind: 'proposal',
+            proposalId: turn.proposalId,
+            optimizedPrompt: turn.optimizedPrompt,
+            optimizationSummary: turn.optimizationSummary,
+            proposalStatus: turn.proposalStatus,
+          },
+        ]
+      }
+
+      const kind =
+        'kind' in turn &&
+        (turn.kind === 'reply' || turn.kind === 'clarification' || turn.kind === 'blocked')
+          ? turn.kind
+          : 'reply'
+      return [{ role: 'assistant', content: turn.content, kind }]
+    })
   } catch {
     return []
+  }
+}
+
+function createAgentSeed(turns: readonly AgentConversationTurn[]): {
+  messages: readonly PlannerMessage[]
+  clarificationUsed: boolean
+  pendingProposal: CharacterGenerationProposal | null
+} {
+  const pending = turns.findLast(
+    (turn) =>
+      turn.role === 'assistant' && turn.kind === 'proposal' && turn.proposalStatus === 'pending',
+  )
+  return {
+    messages: turns.map(({ role, content }) => ({ role, content })),
+    clarificationUsed: turns.some(
+      (turn) => turn.role === 'assistant' && turn.kind === 'clarification',
+    ),
+    pendingProposal:
+      pending?.role === 'assistant' && pending.kind === 'proposal'
+        ? {
+            proposalId: pending.proposalId,
+            optimizedPrompt: pending.optimizedPrompt,
+            optimizationSummary: pending.optimizationSummary,
+          }
+        : null,
   }
 }
 
@@ -322,7 +402,7 @@ export function QuickStartPage({
     />
   ) : (
     <QuickStartInput
-      key={location.key}
+      key={`${location.key}:${activeRunUserId ?? 'local'}`}
       service={activeService}
       agent={agent}
       activeRunUserId={activeRunUserId}
@@ -450,19 +530,14 @@ function QuickStartInput({
   const submitAbortController = useRef<AbortController | null>(null)
   const handoffTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const rewriteTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const generationConfirmation = useRef<((prompt: string) => void) | null>(null)
   const conversationTurnsRef = useRef(conversationTurns)
   const initialConversationLength = useRef(conversationTurns.length)
-  const waitForGenerationConfirmation = useCallback(
-    () =>
-      new Promise<string>((resolve) => {
-        generationConfirmation.current = resolve
-      }),
-    [],
-  )
+  const initialAgentSeed = useRef(createAgentSeed(conversationTurns)).current
   const agentSession = useQuickStartAgent({
     ...agent,
-    waitForPresentation: waitForGenerationConfirmation,
+    initialMessages: initialAgentSeed.messages,
+    initialClarificationUsed: initialAgentSeed.clarificationUsed,
+    initialProposal: initialAgentSeed.pendingProposal,
   })
   const unavailableReason = service.unavailableReason
   const agentPlanning = agentSession.state.status === 'planning'
@@ -522,11 +597,10 @@ function QuickStartInput({
 
   const appendConversationTurn = useCallback(
     (turn: AgentConversationTurn) => {
-      setConversationTurns((current) => {
-        const next = [...current, turn]
-        persistDraftConversation(next)
-        return next
-      })
+      const next = [...conversationTurnsRef.current, turn]
+      conversationTurnsRef.current = next
+      setConversationTurns(next)
+      persistDraftConversation(next)
     },
     [persistDraftConversation],
   )
@@ -536,16 +610,45 @@ function QuickStartInput({
       submitAbortController.current?.abort()
       if (handoffTimer.current) clearTimeout(handoffTimer.current)
       if (rewriteTimer.current) clearTimeout(rewriteTimer.current)
-      generationConfirmation.current?.('')
-      generationConfirmation.current = null
     },
     [],
   )
 
-  function fillOptimizedPrompt() {
-    const state = agentSession.state
-    if (state.status !== 'dispatching' || promptState === 'rewriting' || generationStarting) return
+  function updateProposalStatus(
+    proposalId: string,
+    proposalStatus: Extract<AgentConversationTurn, { kind: 'proposal' }>['proposalStatus'],
+    confirmedPrompt?: string,
+  ): readonly AgentConversationTurn[] {
+    const next = conversationTurnsRef.current.map((turn) =>
+      turn.role === 'assistant' && turn.kind === 'proposal' && turn.proposalId === proposalId
+        ? {
+            ...turn,
+            content: confirmedPrompt
+              ? `${turn.optimizationSummary}\n\n提示词提案：${confirmedPrompt}`
+              : turn.content,
+            optimizedPrompt: confirmedPrompt ?? turn.optimizedPrompt,
+            proposalStatus,
+          }
+        : turn,
+    )
+    conversationTurnsRef.current = next
+    setConversationTurns(next)
+    persistDraftConversation(next)
+    return next
+  }
 
+  function fillOptimizedPrompt(proposalId: string) {
+    const state = agentSession.state
+    if (
+      state.status !== 'proposal' ||
+      state.proposalId !== proposalId ||
+      promptState === 'rewriting' ||
+      generationStarting
+    ) {
+      return
+    }
+
+    updateProposalStatus(proposalId, 'adopted')
     setPrompt(state.optimizedPrompt)
     setPromptState('rewriting')
     if (rewriteTimer.current) clearTimeout(rewriteTimer.current)
@@ -568,17 +671,38 @@ function QuickStartInput({
     if (fileInput.current) fileInput.current.value = ''
   }
 
+  async function handoffGenerated(
+    result: Extract<QuickStartAgentResult, { kind: 'generated' }>,
+  ): Promise<void> {
+    const confirmedTurns = updateProposalStatus(
+      result.proposalId,
+      'confirmed',
+      result.optimizedPrompt,
+    )
+    persistRunConversation(confirmedTurns, result.runId)
+    setEntryTransition('leaving')
+    await new Promise<void>((resolve) => {
+      handoffTimer.current = setTimeout(() => {
+        handoffTimer.current = null
+        resolve()
+      }, ENTRY_HANDOFF_MS)
+    })
+    navigate(`/quick-start/${encodeURIComponent(result.runId)}`)
+  }
+
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const normalizedPrompt = prompt.trim()
 
-    if (agentSession.state.status === 'dispatching' && promptState === 'ready') {
+    if (agentSession.state.status === 'proposal' && promptState === 'ready') {
       if (!normalizedPrompt) return
-      const confirm = generationConfirmation.current
-      if (!confirm) return
-      generationConfirmation.current = null
       setPromptState('confirmed')
-      confirm(normalizedPrompt)
+      try {
+        const result = await agentSession.confirmProposal(normalizedPrompt)
+        if (result.kind === 'generated') await handoffGenerated(result)
+      } catch {
+        setPromptState('ready')
+      }
       return
     }
 
@@ -586,23 +710,32 @@ function QuickStartInput({
 
     if (!templateFile) {
       setError(null)
+      if (agentSession.state.status === 'proposal') {
+        updateProposalStatus(agentSession.state.proposalId, 'superseded')
+      }
       appendConversationTurn({ role: 'user', content: normalizedPrompt })
       setPrompt('')
       try {
         const result = await agentSession.submit(normalizedPrompt)
         if (result.kind === 'message') {
-          appendConversationTurn({ role: 'assistant', content: result.message })
+          appendConversationTurn({
+            role: 'assistant',
+            content: result.message,
+            kind: result.messageKind,
+          })
           return
         }
-        persistRunConversation(conversationTurnsRef.current, result.runId)
-        setEntryTransition('leaving')
-        await new Promise<void>((resolve) => {
-          handoffTimer.current = setTimeout(() => {
-            handoffTimer.current = null
-            resolve()
-          }, ENTRY_HANDOFF_MS)
-        })
-        navigate(`/quick-start/${encodeURIComponent(result.runId)}`)
+        if (result.kind === 'proposal') {
+          appendConversationTurn({
+            role: 'assistant',
+            content: `${result.optimizationSummary}\n\n提示词提案：${result.optimizedPrompt}`,
+            kind: 'proposal',
+            proposalId: result.proposalId,
+            optimizedPrompt: result.optimizedPrompt,
+            optimizationSummary: result.optimizationSummary,
+            proposalStatus: 'pending',
+          })
+        }
       } catch (cause) {
         if (!(cause instanceof Error && cause.name === 'AbortError')) {
           setEntryTransition('idle')
@@ -648,30 +781,22 @@ function QuickStartInput({
   }
 
   const inputLocked =
-    submitting ||
-    agentPlanning ||
-    promptState === 'rewriting' ||
-    generationStarting ||
-    (agentSession.state.status === 'dispatching' && promptState === 'collecting')
+    submitting || agentPlanning || promptState === 'rewriting' || generationStarting
   const awaitingGenerationConfirmation =
-    agentSession.state.status === 'dispatching' && promptState === 'ready'
+    agentSession.state.status === 'proposal' && promptState === 'ready'
   const buttonLabel = submitting
     ? '正在创建…'
     : agentPlanning
       ? '正在判断…'
       : promptState === 'rewriting'
         ? '优化中'
-        : agentSession.state.status === 'dispatching' && promptState === 'collecting'
-          ? '先填入提示词'
-          : awaitingGenerationConfirmation
-            ? '发送生成'
-            : generationStarting
-              ? '正在开始生成…'
-              : agentSession.state.status === 'restart-required'
-                ? '重新开始'
-                : agentSession.state.status === 'awaiting-input'
-                  ? '继续'
-                  : '生成角色'
+        : awaitingGenerationConfirmation
+          ? '发送生成'
+          : generationStarting
+            ? '正在开始生成…'
+            : hasConversation
+              ? '继续'
+              : '生成角色'
   const canSubmit = awaitingGenerationConfirmation
     ? Boolean(prompt.trim())
     : Boolean(prompt.trim()) || Boolean(templateFile)
@@ -711,6 +836,20 @@ function QuickStartInput({
                 >
                   {turn.role === 'user' ? (
                     <UserTurn>{turn.content}</UserTurn>
+                  ) : turn.kind === 'proposal' ? (
+                    <PromptProposal
+                      summary={turn.optimizationSummary}
+                      prompt={turn.optimizedPrompt}
+                      status={turn.proposalStatus}
+                      disabled={
+                        turn.proposalStatus !== 'pending' ||
+                        agentSession.state.status !== 'proposal' ||
+                        agentSession.state.proposalId !== turn.proposalId ||
+                        promptState === 'rewriting' ||
+                        generationStarting
+                      }
+                      onFill={() => fillOptimizedPrompt(turn.proposalId)}
+                    />
                   ) : (
                     <AgentCopy
                       lines={turn.content.split('\n')}
@@ -737,14 +876,6 @@ function QuickStartInput({
                     ))}
                   </span>
                 </div>
-              ) : null}
-              {agentSession.state.status === 'dispatching' ? (
-                <PromptProposal
-                  summary={agentSession.state.optimizationSummary}
-                  prompt={agentSession.state.optimizedPrompt}
-                  disabled={promptState === 'rewriting' || generationStarting}
-                  onFill={fillOptimizedPrompt}
-                />
               ) : null}
               {agentSession.state.status === 'error' ? (
                 <div role="alert" data-conversation-kind="agent" className="min-w-0">
@@ -930,11 +1061,13 @@ function QuickStartInput({
 function PromptProposal({
   summary,
   prompt,
+  status,
   disabled,
   onFill,
 }: {
   summary: string
   prompt: string
+  status: Extract<AgentConversationTurn, { kind: 'proposal' }>['proposalStatus']
   disabled: boolean
   onFill: () => void
 }) {
@@ -944,18 +1077,24 @@ function PromptProposal({
       <blockquote className="max-w-2xl font-serif text-base leading-7 text-app-ink">
         {prompt}
       </blockquote>
-      <button
-        type="button"
-        aria-label="填入输入框"
-        disabled={disabled}
-        onClick={onFill}
-        className="group inline-flex min-h-8 items-center gap-2 rounded-full pr-2 text-xs text-app-muted transition hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-45"
-      >
-        <span className="grid size-8 shrink-0 place-items-center rounded-full transition group-hover:bg-app-surface-muted">
-          <ArrowBendDownLeft aria-hidden="true" size={17} weight="bold" />
-        </span>
-        <span>填入输入框后，还可以继续修改</span>
-      </button>
+      {status === 'pending' ? (
+        <button
+          type="button"
+          aria-label="填入输入框"
+          disabled={disabled}
+          onClick={onFill}
+          className="group inline-flex min-h-8 items-center gap-2 rounded-full pr-2 text-xs text-app-muted transition hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-45"
+        >
+          <span className="grid size-8 shrink-0 place-items-center rounded-full transition group-hover:bg-app-surface-muted">
+            <ArrowBendDownLeft aria-hidden="true" size={17} weight="bold" />
+          </span>
+          <span>填入输入框后，还可以继续修改</span>
+        </button>
+      ) : status === 'superseded' ? (
+        <p className="text-xs text-app-faint">已继续讨论</p>
+      ) : status === 'adopted' ? (
+        <p className="text-xs text-app-muted">已填入输入框</p>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
## Why

Quick Start Agent 把 Planner 的提示词提案与真实生成授权混在同一次 Tool 决策里，并在澄清轮次用完后结束会话，导致咨询问题被误判为优化、两轮后被迫进入提案，以及刷新前后历史不一致。

## What

- 将 Planner 终态改为结构化 `reply / clarification / blocked / proposal`，对话轮数不再触发提案
- 将提示词提案与 `startCharacterGeneration` 写操作拆开；只有用户填入、编辑并发送后才消费一次生成授权
- 用户直接继续输入时使旧提案失效，并继续同一 Planner 会话
- 按用户、草稿和运行持久化 Agent 历史，刷新后恢复消息、澄清状态和待处理提案
- 保持 Planner 失败时页面 transcript 与 runtime 历史一致

## Verification

- `npm test -- --run src/features/quick-start-agent src/pages/quick-start/index.test.tsx`（7 files，122 tests）
- `npm run typecheck`
- 改动文件 `oxlint`、`oxfmt --check`
- 独立子代理按需求复验通过

Closes #585