### PR TITLE
fix(worker): 读回任务载荷里的体型

### DIFF
--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -22,6 +22,7 @@ from windup_app.server.orchestrator.model import (
     TaskStatus,
 )
 from windup_common.directions import ActionDirection
+from windup_common.models import CharacterStance
 from windup_app.server.user.service import VERIFY_CODE_KEY
 from windup_framework.db.redis import get_redis
 from windup_framework.db.session import SessionLocal
@@ -79,6 +80,9 @@ def _action_input(payload: dict) -> CharacterActionInput:
     # 帧数缺失时原样传 None,交给入参按动作类型解析:在这里兜一个数就是第二份约定,
     # 它与真正的约定分叉时任务照跑、帧数照出,没有一处会红。
     raw_frames = payload.get("num_frames")
+    # 体型缺失时原样传 None,不在这里兜成双足:兜了以后"没给"与"明确给了双足"就再也
+    # 分不开,而四足/蛇形角色落回双足时帧数、时长、成色全部正常,没有一处会红。
+    raw_stance = payload.get("stance")
     return CharacterActionInput(
         character_id=int(payload["character_id"]),
         action_type=action_type,
@@ -90,6 +94,7 @@ def _action_input(payload: dict) -> CharacterActionInput:
         video_model=payload.get("video_model"),
         outfit_id=payload.get("outfit_id"),
         model_3d_url=payload.get("model_3d_url"),
+        stance=CharacterStance(raw_stance) if raw_stance is not None else None,
         direction=ActionDirection(payload.get("direction") or ActionDirection.EAST.value),
     )
 

--- a/backend/tests/test_mq_worker.py
+++ b/backend/tests/test_mq_worker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import threading
 import uuid
@@ -35,6 +36,7 @@ from windup_app.worker.handlers import (
 )
 from windup_app.worker.pending_timeout import release_stale_pending_tasks
 from windup_common.directions import ActionDirection
+from windup_common.models import CharacterStance
 from windup_framework.db.base import Base
 from windup_framework.mq.config import MAX_CONSUME_ATTEMPTS
 from windup_framework.mq.model import MqMessage
@@ -938,3 +940,71 @@ def test_action_input_keeps_the_stored_frame_count():
     rebuilt = _action_input({"character_id": 1, "action_type": "idle", "num_frames": 20})
 
     assert rebuilt.num_frames == 20
+
+
+def _stored_payload(**overrides) -> dict:
+    """产线落库的那份 input_payload —— ``asdict`` 后经 JSONB 存取,枚举回来是字符串。"""
+    fields: dict = {"character_id": 1, "action_type": ActionType.WALK}
+    fields.update(overrides)
+    return json.loads(json.dumps(dataclasses.asdict(CharacterActionInput(**fields))))
+
+
+def test_action_input_reads_the_stored_stance():
+    """体型丢在 MQ 重建这一步时,四足角色照跑双足动作,帧数、时长、成色全部正常。"""
+    from windup_app.worker.handlers import _action_input
+
+    rebuilt = _action_input(_stored_payload(stance=CharacterStance.QUADRUPED))
+
+    assert rebuilt.stance is CharacterStance.QUADRUPED
+
+
+def test_action_input_keeps_the_stance_unset_when_none_was_declared():
+    """没声明体型就原样传 None:在这层兜成双足,编排层从此分不出"没给"与"给了双足"。"""
+    from windup_app.worker.handlers import _action_input
+
+    rebuilt = _action_input(_stored_payload())
+
+    assert rebuilt.stance is None
+
+
+class _CardCaptured(Exception):
+    """card 一到手就停:后面是出帧、上传、判官,本用例一样都不需要。"""
+
+
+class _CardSpy:
+    """出帧替身,只记下编排层组出来的 card。"""
+
+    def __init__(self) -> None:
+        self.card = None
+
+    def generate(self, card, action, master, progress, canvas=None):
+        self.card = card
+        raise _CardCaptured
+
+
+def test_the_card_still_carries_the_stance_after_the_mq_rebuild():
+    """落库 → MQ 重建 → 编排层走完,card 上的体型仍是四足。
+
+    体型门禁装在 ai_engine 侧,card 是它唯一的入口;链路上任一段丢掉它,四足角色
+    就静默落回 CharacterCard 的双足默认值。
+    """
+    from windup_app.server.orchestrator.executor import (
+        ActionTaskExecutor,
+        ProjectConstraints,
+    )
+    from windup_app.worker.handlers import _action_input
+
+    spy = _CardSpy()
+    executor = ActionTaskExecutor(
+        generator=spy,
+        fetch_master=lambda _input: b"master-bytes",
+        fetch_constraints=lambda *_: ProjectConstraints(sprite_w=64, sprite_h=64),
+    )
+    rebuilt = _action_input(
+        _stored_payload(stance=CharacterStance.QUADRUPED, num_frames=4)
+    )
+
+    with pytest.raises(_CardCaptured):
+        executor._produce_action(rebuilt, ProjectConstraints(sprite_w=64, sprite_h=64))
+
+    assert spy.card.stance is CharacterStance.QUADRUPED


### PR DESCRIPTION
Closes #565

体型从请求层带到落库，却没在 `_action_input` 重建入参时读回来。生产执行走的正是这条 MQ 路径，于是 `input.stance` 恒为 `None`，`executor.py` 里 `CharacterCard(**({"stance": input.stance} if input.stance is not None else {}))` 这个分支从不成立——**四足与蛇形角色到编排层永远落回双足默认值**，而帧数、时长、成色全部正常，没有一处会红。

改动 5 行。缺失时原样传 `None` 不兜成双足：兜了以后「没给」与「明确给了双足」就再也分不开。

## 逐字段审计

不是肉眼比对，是「每个字段赋非默认值 → `asdict` → JSON 往返（模拟 JSONB）→ `_action_input`」实测：`stance` 是唯一漏读的字段，修后丢失字段数为 0。顺带对了 `_image_input` × `CharacterImageInput` 全 7 个字段，没有漏字段。

## 验证

两个变异体各自转红：

| 改法 | 转红用例 |
|---|---|
| 删掉读回那一行 | `test_action_input_reads_the_stored_stance`、`test_the_card_still_carries_the_stance_after_the_mq_rebuild`（后者报 `assert <CharacterStance.BIPED> is <CharacterStance.QUADRUPED>`，直接复现 issue 的验收句） |
| 缺省兜成双足 | `test_action_input_keeps_the_stance_unset_when_none_was_declared` |

用例从**任务载荷**出发跑完 MQ 重建这一段——既有测试全绿正是因为它们直接构造 `CharacterActionInput` 绕过了这一步。

本分支验证：`ruff check .` 通过、`lint-imports` 2 kept 0 broken、`export_openapi` 后 `openapi.json` 无漂移、`pytest -q` 1355 passed / 14 skipped。

## 顺带发现，未修

`_image_input` 的 `num_images` 有第二份默认值：`CharacterImageInput` 默认 `2`，而重建写的是 `int(payload.get("num_images") or 1)` —— 载荷里没这个键时重建成 1 而不是 2，且 `num_images=0` 也被 `or` 吃成 1。字段没漏，是「第二份约定」，与本 PR 是同一类问题但会改出图张数即费用，另开 issue 处理，不夹带。