### PR TITLE
feat(quick-start): add Agent workflow regeneration tools

### DIFF
--- a/frontend/src/features/quick-start-agent/boundaries.test.ts
+++ b/frontend/src/features/quick-start-agent/boundaries.test.ts
@@ -41,4 +41,12 @@ describe('quick-start-agent architecture boundary', () => {
     expect(pageSource).not.toContain('generateText(')
     expect(pageSource).not.toContain('quickStartPlannerInstructions')
   })
+
+  it('keeps the lazily loaded Planner out of page-level static imports', () => {
+    const pageDependencies = productionFiles(quickStartPageDirectory).flatMap((file) =>
+      moduleSpecifiers(readFileSync(file, 'utf8')),
+    )
+
+    expect(pageDependencies).not.toContain('@/features/quick-start-agent')
+  })
 })

--- a/frontend/src/features/quick-start-agent/index.ts
+++ b/frontend/src/features/quick-start-agent/index.ts
@@ -1,10 +1,15 @@
 export { createAiSdkQuickStartPlanner, quickStartPlannerInstructions } from './planner'
 export type { CreateAiSdkQuickStartPlannerOptions, QuickStartGenerateText } from './planner'
 export {
+  createQuickStartWorkflowAgent,
   createQuickStartAgent,
   parseCharacterGenerationPlan,
   parseQuickStartDecision,
   QUICK_START_DECISION_TOOL,
+  REFINE_CHARACTER_TEMPLATE_TOOL,
+  REFINE_FIRST_FRAME_TOOL,
+  REGENERATE_CHARACTER_TEMPLATE_TOOL,
+  REGENERATE_FIRST_FRAME_TOOL,
   START_CHARACTER_GENERATION_TOOL,
   validatePlannerTerminal,
 } from './runtime'
@@ -12,6 +17,7 @@ export type {
   CharacterGenerationPlan,
   CharacterGenerationProposal,
   CreateQuickStartAgentOptions,
+  CreateQuickStartWorkflowAgentOptions,
   PlannerInput,
   PlannerMessage,
   PlannerResult,
@@ -21,5 +27,10 @@ export type {
   QuickStartAgentTurnOptions,
   QuickStartDecision,
   QuickStartPlanner,
+  QuickStartWorkflowAgent,
+  QuickStartWorkflowAgentResult,
   StartCharacterGenerationAction,
+  WorkflowAgentActions,
+  WorkflowAgentContext,
+  WorkflowAgentToolName,
 } from './runtime'

--- a/frontend/src/features/quick-start-agent/planner.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.test.ts
@@ -75,4 +75,38 @@ describe('createAiSdkQuickStartPlanner', () => {
     expect(options?.tools?.quick_start_decision?.execute).toBeUndefined()
     expect(options?.messages).toEqual([{ role: 'user', content: '直接生成银发骑士' }])
   })
+
+  it('exposes only Controller actions allowed by the current workflow snapshot', async () => {
+    const generate = vi.fn<QuickStartGenerateText>(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'refine_character_template',
+          input: { adjustmentPrompt: '把披风改成深蓝色' },
+        },
+      ],
+    }))
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      generateText: generate,
+    })
+
+    await planner({
+      messages: [{ role: 'user', content: '把披风改成深蓝色' }],
+      clarificationUsed: false,
+      workflow: {
+        availableTools: ['regenerate_character_template', 'refine_character_template'],
+      },
+    })
+
+    const options = generate.mock.calls[0]?.[0]
+    expect(options?.toolChoice).toBe('auto')
+    expect(Object.keys(options?.tools ?? {})).toEqual([
+      'regenerate_character_template',
+      'refine_character_template',
+    ])
+    expect(options?.tools?.refine_character_template?.execute).toBeUndefined()
+    expect(options?.tools?.regenerate_first_frame).toBeUndefined()
+  })
 })

--- a/frontend/src/features/quick-start-agent/planner.ts
+++ b/frontend/src/features/quick-start-agent/planner.ts
@@ -2,12 +2,18 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { generateText as aiGenerateText, jsonSchema, tool } from 'ai'
 
 import {
+  REFINE_CHARACTER_TEMPLATE_TOOL,
+  REFINE_FIRST_FRAME_TOOL,
+  REGENERATE_CHARACTER_TEMPLATE_TOOL,
+  REGENERATE_FIRST_FRAME_TOOL,
   parseQuickStartDecision,
   QUICK_START_DECISION_TOOL,
   type PlannerInput,
   type PlannerResult,
   type QuickStartDecision,
   type QuickStartPlanner,
+  type WorkflowAgentContext,
+  type WorkflowAgentToolName,
 } from './runtime'
 
 interface GenerateTextResultLike {
@@ -21,7 +27,7 @@ interface GenerateTextOptionsLike {
   instructions: string
   messages: PlannerInput['messages']
   tools: Record<string, { execute?: unknown }>
-  toolChoice: 'required'
+  toolChoice: 'auto' | 'required'
   maxRetries: 0
   abortSignal?: AbortSignal
 }
@@ -71,6 +77,45 @@ const quickStartDecisionTool = tool({
   ),
 })
 
+const regenerateToolSchema = jsonSchema<Record<string, never>>({
+  type: 'object',
+  additionalProperties: false,
+  properties: {},
+})
+
+const refinementToolSchema = jsonSchema<{ adjustmentPrompt: string }>({
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    adjustmentPrompt: {
+      type: 'string',
+      minLength: 1,
+      maxLength: 4_000,
+      description: '只描述相对上一版需要改变的内容，不重复角色或动作的完整原始描述。',
+    },
+  },
+  required: ['adjustmentPrompt'],
+})
+
+const workflowTools = {
+  [REGENERATE_CHARACTER_TEMPLATE_TOOL]: tool({
+    description: '用户明确要求放弃当前角色母版结果并按原始描述重新生成时使用。',
+    inputSchema: regenerateToolSchema,
+  }),
+  [REFINE_CHARACTER_TEMPLATE_TOOL]: tool({
+    description: '用户要求基于已确认的角色母版修改外观、服装、颜色或角色细节时使用。',
+    inputSchema: refinementToolSchema,
+  }),
+  [REGENERATE_FIRST_FRAME_TOOL]: tool({
+    description: '用户明确要求放弃当前动作首帧并按原始动作描述重新生成时使用。',
+    inputSchema: regenerateToolSchema,
+  }),
+  [REFINE_FIRST_FRAME_TOOL]: tool({
+    description: '用户要求基于已确认的动作首帧修改姿态、朝向或动作起始细节时使用。',
+    inputSchema: refinementToolSchema,
+  }),
+}
+
 export function quickStartPlannerInstructions(clarificationUsed: boolean): string {
   const clarificationRule = clarificationUsed
     ? '本草稿已经问过一次必要澄清，不得因为轮数强制生成，也不得再问第二个澄清问题；信息不足时用 reply 说明可继续补充，存在硬冲突时用 blocked。'
@@ -95,6 +140,19 @@ export function quickStartPlannerInstructions(clarificationUsed: boolean): strin
 ${clarificationRule}`
 }
 
+function quickStartWorkflowInstructions(context: WorkflowAgentContext): string {
+  const targets = context.availableTools.some((name) => name.includes('character_template'))
+    ? context.availableTools.some((name) => name.includes('first_frame'))
+      ? '已确认的角色母版和动作首帧'
+      : '已确认的角色母版'
+    : '已确认的动作首帧'
+  return `你是 Windup 生成流程中的轻量 Agent。当前可修改：${targets}。宿主只会在生成任务停止、结果允许修改时调用你。
+
+用户明确要求重新生成时，选择与目标对应的 regenerate Tool；重新生成不携带修改描述。用户给出相对上一版的具体修改时，选择对应的 refine Tool，并把具体变化写入 adjustmentPrompt。用户意图含糊、没有说明修改对象或只是在讨论时，直接用简短中文回复澄清，不调用 Tool。否定、引用或假设语境不得触发 Tool。
+
+每轮最多调用一个 Tool。不得输出思维过程、Tool 名称、内部状态或调用计划。所有实际修改由宿主绑定的 WorkflowController 完成。`
+}
+
 export function createAiSdkQuickStartPlanner({
   baseURL,
   modelId = 'quick-start-planner',
@@ -108,13 +166,20 @@ export function createAiSdkQuickStartPlanner({
   })
   const model = provider.chatModel(modelId)
 
-  return async ({ messages, clarificationUsed, signal }): Promise<PlannerResult> => {
+  return async ({ messages, clarificationUsed, workflow, signal }): Promise<PlannerResult> => {
+    const tools = workflow
+      ? Object.fromEntries(
+          workflow.availableTools.map((name: WorkflowAgentToolName) => [name, workflowTools[name]]),
+        )
+      : { [QUICK_START_DECISION_TOOL]: quickStartDecisionTool }
     const result = await generateText({
       model,
-      instructions: quickStartPlannerInstructions(clarificationUsed),
+      instructions: workflow
+        ? quickStartWorkflowInstructions(workflow)
+        : quickStartPlannerInstructions(clarificationUsed),
       messages,
-      tools: { [QUICK_START_DECISION_TOOL]: quickStartDecisionTool },
-      toolChoice: 'required',
+      tools,
+      toolChoice: workflow ? 'auto' : 'required',
       maxRetries: 0,
       abortSignal: signal,
     })

--- a/frontend/src/features/quick-start-agent/react.test.tsx
+++ b/frontend/src/features/quick-start-agent/react.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { PlannerInput, PlannerResult, QuickStartDecision } from './runtime'
-import { useQuickStartAgent } from './react'
+import { useQuickStartAgent, useQuickStartWorkflowAgent } from './react'
 
 afterEach(() => {
   cleanup()
@@ -162,5 +162,44 @@ describe('useQuickStartAgent', () => {
 
     await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
     expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
+})
+
+describe('useQuickStartWorkflowAgent', () => {
+  it('reports the submitted Controller action after planning', async () => {
+    const planner = vi.fn(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'regenerate_character_template',
+          input: {},
+        },
+      ],
+    }))
+    const regenerateCharacterTemplate = vi.fn(async () => undefined)
+    const { result } = renderHook(() =>
+      useQuickStartWorkflowAgent({
+        planner,
+        actions: {
+          getContext: () => ({ availableTools: ['regenerate_character_template'] }),
+          regenerateCharacterTemplate,
+          refineCharacterTemplate: vi.fn(async () => undefined),
+          regenerateFirstFrame: vi.fn(async () => undefined),
+          refineFirstFrame: vi.fn(async () => undefined),
+        },
+      }),
+    )
+
+    await act(async () => {
+      await result.current.submit('重新生成角色')
+    })
+
+    expect(result.current.state).toEqual({
+      status: 'action',
+      action: 'regenerate_character_template',
+      message: '已提交角色母版重新生成。',
+    })
+    expect(regenerateCharacterTemplate).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -2,9 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   createQuickStartAgent,
+  createQuickStartWorkflowAgent,
   type CharacterGenerationProposal,
   type CreateQuickStartAgentOptions,
   type QuickStartAgentResult,
+  type CreateQuickStartWorkflowAgentOptions,
+  type WorkflowAgentToolName,
 } from './runtime'
 
 export type QuickStartAgentState =
@@ -152,5 +155,71 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
     busy: state.status === 'planning' || state.status === 'dispatching',
     submit,
     confirmProposal,
+  }
+}
+
+export type QuickStartWorkflowAgentState =
+  | { status: 'idle' }
+  | { status: 'planning' }
+  | { status: 'awaiting-input'; message: string }
+  | { status: 'action'; action: WorkflowAgentToolName; message: string }
+  | { status: 'error'; message: string }
+
+export function useQuickStartWorkflowAgent({
+  planner,
+  actions,
+  initialMessages,
+}: CreateQuickStartWorkflowAgentOptions) {
+  const [state, setState] = useState<QuickStartWorkflowAgentState>({ status: 'idle' })
+  const agent = useRef<ReturnType<typeof createQuickStartWorkflowAgent> | null>(null)
+  const running = useRef(false)
+  const abortController = useRef<AbortController | null>(null)
+  const mounted = useRef(true)
+
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      abortController.current?.abort()
+      agent.current?.revoke()
+      agent.current = null
+    }
+  }, [actions, initialMessages, planner])
+
+  const submit = useCallback(
+    async (input: string) => {
+      if (running.current) throw new Error('Planner 正在处理上一条输入')
+      running.current = true
+      const controller = new AbortController()
+      abortController.current = controller
+      if (mounted.current) setState({ status: 'planning' })
+      try {
+        agent.current ??= createQuickStartWorkflowAgent({ planner, actions, initialMessages })
+        const result = await agent.current.submit(input, { signal: controller.signal })
+        if (mounted.current) {
+          setState(
+            result.kind === 'action'
+              ? { status: 'action', action: result.action, message: result.message }
+              : { status: 'awaiting-input', message: result.message },
+          )
+        }
+        return result
+      } catch (cause) {
+        if (mounted.current && !(cause instanceof Error && cause.name === 'AbortError')) {
+          setState({ status: 'error', message: errorMessage(cause) })
+        }
+        throw cause
+      } finally {
+        running.current = false
+        if (abortController.current === controller) abortController.current = null
+      }
+    },
+    [actions, initialMessages, planner],
+  )
+
+  return {
+    state,
+    busy: state.status === 'planning',
+    submit,
   }
 }

--- a/frontend/src/features/quick-start-agent/runtime.test.ts
+++ b/frontend/src/features/quick-start-agent/runtime.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   createQuickStartAgent,
+  createQuickStartWorkflowAgent,
   parseQuickStartDecision,
   validatePlannerTerminal,
   type PlannerResult,
   type QuickStartDecision,
   type QuickStartPlanner,
   type StartCharacterGenerationAction,
+  type WorkflowAgentActions,
 } from './runtime'
 
 function decisionResult(input: QuickStartDecision): PlannerResult {
@@ -284,5 +286,93 @@ describe('createQuickStartAgent', () => {
       agent.confirmProposal(proposal.proposalId, proposal.optimizedPrompt),
     ).rejects.toThrow('生成授权已使用')
     expect(startCharacterGeneration).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('createQuickStartWorkflowAgent', () => {
+  function workflowActions(): WorkflowAgentActions {
+    return {
+      getContext: () => ({
+        availableTools: [
+          'regenerate_character_template',
+          'refine_character_template',
+          'regenerate_first_frame',
+          'refine_first_frame',
+        ],
+      }),
+      regenerateCharacterTemplate: vi.fn(async () => undefined),
+      refineCharacterTemplate: vi.fn(async () => undefined),
+      regenerateFirstFrame: vi.fn(async () => undefined),
+      refineFirstFrame: vi.fn(async () => undefined),
+    }
+  }
+
+  it('executes one eligible refinement through the injected Controller action', async () => {
+    const planner = vi.fn<QuickStartPlanner>(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'refine_character_template',
+          input: { adjustmentPrompt: '  把披风改成深蓝色  ' },
+        },
+      ],
+    }))
+    const actions = workflowActions()
+    const agent = createQuickStartWorkflowAgent({
+      planner,
+      actions,
+      initialMessages: [{ role: 'user', content: '银发骑士' }],
+    })
+
+    await expect(agent.submit('把披风改成深蓝色')).resolves.toEqual({
+      kind: 'action',
+      action: 'refine_character_template',
+      message: '已提交角色母版微调。',
+    })
+    expect(actions.refineCharacterTemplate).toHaveBeenCalledWith('把披风改成深蓝色')
+    expect(actions.regenerateCharacterTemplate).not.toHaveBeenCalled()
+    expect(planner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflow: actions.getContext(),
+        messages: [
+          { role: 'user', content: '银发骑士' },
+          { role: 'user', content: '把披风改成深蓝色' },
+        ],
+      }),
+    )
+  })
+
+  it('rejects an action that the current Controller snapshot does not allow', async () => {
+    const planner = vi.fn<QuickStartPlanner>(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [{ toolName: 'regenerate_first_frame', input: {} }],
+    }))
+    const actions = workflowActions()
+    actions.getContext = () => ({
+      availableTools: ['regenerate_character_template', 'refine_character_template'],
+    })
+    const agent = createQuickStartWorkflowAgent({ planner, actions })
+
+    await expect(agent.submit('重新生成动作首帧')).rejects.toThrow('当前流程不能执行该操作')
+    expect(actions.regenerateFirstFrame).not.toHaveBeenCalled()
+  })
+
+  it('keeps ordinary replies in the same workflow conversation without an action', async () => {
+    const planner = vi.fn<QuickStartPlanner>(async () => ({
+      text: '可以。你想调整角色母版，还是动作首帧？',
+      finishReason: 'stop',
+      toolCalls: [],
+    }))
+    const actions = workflowActions()
+    const agent = createQuickStartWorkflowAgent({ planner, actions })
+
+    await expect(agent.submit('我想改一下')).resolves.toEqual({
+      kind: 'message',
+      message: '可以。你想调整角色母版，还是动作首帧？',
+    })
+    expect(actions.regenerateCharacterTemplate).not.toHaveBeenCalled()
+    expect(actions.refineFirstFrame).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -1,6 +1,10 @@
 export const QUICK_START_DECISION_TOOL = 'quick_start_decision' as const
 /** 旧前端测试与灰度响应的只读兼容名；命中时只生成提案，不会直接写入。 */
 export const START_CHARACTER_GENERATION_TOOL = 'start_character_generation' as const
+export const REGENERATE_CHARACTER_TEMPLATE_TOOL = 'regenerate_character_template' as const
+export const REFINE_CHARACTER_TEMPLATE_TOOL = 'refine_character_template' as const
+export const REGENERATE_FIRST_FRAME_TOOL = 'regenerate_first_frame' as const
+export const REFINE_FIRST_FRAME_TOOL = 'refine_first_frame' as const
 
 const MAX_PROMPT_LENGTH = 4_000
 const MAX_MESSAGE_LENGTH = 2_000
@@ -25,6 +29,7 @@ export interface PlannerResult {
 export interface PlannerInput {
   messages: readonly PlannerMessage[]
   clarificationUsed: boolean
+  workflow?: WorkflowAgentContext
   signal?: AbortSignal
 }
 
@@ -72,6 +77,42 @@ export interface CreateQuickStartAgentOptions {
   initialMessages?: readonly PlannerMessage[]
   initialClarificationUsed?: boolean
   initialProposal?: CharacterGenerationProposal | null
+}
+
+export type WorkflowAgentToolName =
+  | typeof REGENERATE_CHARACTER_TEMPLATE_TOOL
+  | typeof REFINE_CHARACTER_TEMPLATE_TOOL
+  | typeof REGENERATE_FIRST_FRAME_TOOL
+  | typeof REFINE_FIRST_FRAME_TOOL
+
+export interface WorkflowAgentContext {
+  availableTools: readonly WorkflowAgentToolName[]
+}
+
+export interface WorkflowAgentActions {
+  getContext(): WorkflowAgentContext
+  regenerateCharacterTemplate(): Promise<void>
+  refineCharacterTemplate(adjustmentPrompt: string): Promise<void>
+  regenerateFirstFrame(): Promise<void>
+  refineFirstFrame(adjustmentPrompt: string): Promise<void>
+}
+
+export interface CreateQuickStartWorkflowAgentOptions {
+  planner: QuickStartPlanner
+  actions: WorkflowAgentActions
+  initialMessages?: readonly PlannerMessage[]
+}
+
+export type QuickStartWorkflowAgentResult =
+  | { kind: 'message'; message: string }
+  | { kind: 'action'; action: WorkflowAgentToolName; message: string }
+
+export interface QuickStartWorkflowAgent {
+  submit(
+    input: string,
+    options?: QuickStartAgentTurnOptions,
+  ): Promise<QuickStartWorkflowAgentResult>
+  revoke(): void
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -267,6 +308,142 @@ export function createQuickStartAgent({
     revoke() {
       currentProposal = null
       if (!consumed) revoked = true
+    },
+  }
+}
+
+interface WorkflowActionTerminal {
+  kind: 'action'
+  action: WorkflowAgentToolName
+  adjustmentPrompt?: string
+}
+
+function parseWorkflowActionInput(
+  action: WorkflowAgentToolName,
+  value: unknown,
+): WorkflowActionTerminal {
+  if (!isRecord(value)) throw new Error('工作流 Tool 参数必须是对象')
+  if (action === REFINE_CHARACTER_TEMPLATE_TOOL || action === REFINE_FIRST_FRAME_TOOL) {
+    if (
+      Object.keys(value).some((key) => key !== 'adjustmentPrompt') ||
+      !Object.hasOwn(value, 'adjustmentPrompt')
+    ) {
+      throw new Error('微调 Tool 参数字段无效')
+    }
+    const adjustmentPrompt =
+      typeof value.adjustmentPrompt === 'string' ? value.adjustmentPrompt.trim() : ''
+    if (!adjustmentPrompt || adjustmentPrompt.length > MAX_PROMPT_LENGTH) {
+      throw new Error('微调描述无效')
+    }
+    return { kind: 'action', action, adjustmentPrompt }
+  }
+  if (Object.keys(value).length > 0) throw new Error('重新生成 Tool 不接受参数')
+  return { kind: 'action', action }
+}
+
+function validateWorkflowPlannerTerminal(
+  result: PlannerResult,
+  context: WorkflowAgentContext,
+): { kind: 'message'; message: string } | WorkflowActionTerminal {
+  if (result.toolCalls.length === 0) {
+    if (result.finishReason !== 'stop') throw new Error('Planner 的工作流回复未完整结束')
+    return { kind: 'message', message: parseMessage(result.text) }
+  }
+  if (result.finishReason !== 'tool-calls' || result.toolCalls.length !== 1) {
+    throw new Error('Planner 每轮必须且只能调用一个工作流 Tool')
+  }
+  const [call] = result.toolCalls
+  const action = call?.toolName as WorkflowAgentToolName | undefined
+  if (!action || !context.availableTools.includes(action)) {
+    throw new Error('当前流程不能执行该操作')
+  }
+  return parseWorkflowActionInput(action, call.input)
+}
+
+function workflowActionMessage(action: WorkflowAgentToolName): string {
+  switch (action) {
+    case REGENERATE_CHARACTER_TEMPLATE_TOOL:
+      return '已提交角色母版重新生成。'
+    case REFINE_CHARACTER_TEMPLATE_TOOL:
+      return '已提交角色母版微调。'
+    case REGENERATE_FIRST_FRAME_TOOL:
+      return '已提交动作首帧重新生成。'
+    case REFINE_FIRST_FRAME_TOOL:
+      return '已提交动作首帧微调。'
+  }
+}
+
+export function createQuickStartWorkflowAgent({
+  planner,
+  actions,
+  initialMessages = [],
+}: CreateQuickStartWorkflowAgentOptions): QuickStartWorkflowAgent {
+  let messages = [...initialMessages]
+  let running = false
+  let revoked = false
+
+  async function submit(
+    input: string,
+    { signal }: QuickStartAgentTurnOptions = {},
+  ): Promise<QuickStartWorkflowAgentResult> {
+    if (revoked) throw new Error('工作流 Agent 已失效')
+    if (running) throw new Error('Planner 正在处理上一条输入')
+    const normalizedInput = input.trim()
+    if (!normalizedInput) throw new Error('请输入想要调整的内容')
+    if (signal?.aborted) {
+      revoked = true
+      throw abortError()
+    }
+
+    running = true
+    try {
+      const context = actions.getContext()
+      const nextMessages = [...messages, { role: 'user' as const, content: normalizedInput }]
+      messages = nextMessages
+      const terminal = validateWorkflowPlannerTerminal(
+        await planner({
+          messages: nextMessages,
+          clarificationUsed: false,
+          workflow: context,
+          signal,
+        }),
+        context,
+      )
+      if (signal?.aborted) {
+        revoked = true
+        throw abortError()
+      }
+      if (terminal.kind === 'message') {
+        messages = [...nextMessages, { role: 'assistant', content: terminal.message }]
+        return terminal
+      }
+
+      switch (terminal.action) {
+        case REGENERATE_CHARACTER_TEMPLATE_TOOL:
+          await actions.regenerateCharacterTemplate()
+          break
+        case REFINE_CHARACTER_TEMPLATE_TOOL:
+          await actions.refineCharacterTemplate(terminal.adjustmentPrompt!)
+          break
+        case REGENERATE_FIRST_FRAME_TOOL:
+          await actions.regenerateFirstFrame()
+          break
+        case REFINE_FIRST_FRAME_TOOL:
+          await actions.refineFirstFrame(terminal.adjustmentPrompt!)
+          break
+      }
+      const message = workflowActionMessage(terminal.action)
+      messages = [...nextMessages, { role: 'assistant', content: message }]
+      return { kind: 'action', action: terminal.action, message }
+    } finally {
+      running = false
+    }
+  }
+
+  return {
+    submit,
+    revoke() {
+      revoked = true
     },
   }
 }

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -137,6 +137,23 @@ function serviceFor(run: WorkflowRun | null, overrides: Partial<QuickStartMock> 
     getFirstFrameCandidates: vi.fn(async () => []),
     getFailedGenerationDirections: vi.fn(async () => []),
     retryGenerationDirection: vi.fn(async () => fallbackRun),
+    getWorkflowAgentContext: vi.fn(() => ({
+      availableTools: fallbackRun.nodes.some(
+        (node) =>
+          node.type === 'character-template' &&
+          node.status === 'passed' &&
+          node.phase === 'completed',
+      )
+        ? ([
+            'regenerate_character_template',
+            'refine_character_template',
+            'regenerate_first_frame',
+            'refine_first_frame',
+          ] as const)
+        : [],
+    })),
+    regenerateCharacterTemplate: vi.fn(async () => fallbackRun),
+    regenerateFirstFrame: vi.fn(async () => fallbackRun),
     confirmFirstFrame: vi.fn(async () => fallbackRun),
     approveReview: vi.fn(async () => fallbackRun),
     getCharacterInfo: vi.fn(() => ({ characterId: 'character-1', outfitId: 'outfit-1' })),
@@ -149,6 +166,84 @@ function serviceFor(run: WorkflowRun | null, overrides: Partial<QuickStartMock> 
   Object.assign(service, overrides)
   return service
 }
+
+describe('Quick Start workflow Agent', () => {
+  it('routes a completed-run refinement through the current Controller session', async () => {
+    const run = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'passed' })
+    const planner = vi.fn(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'refine_character_template',
+          input: { adjustmentPrompt: '把披风改成深蓝色' },
+        },
+      ],
+    }))
+    const service = serviceFor(run)
+    renderAt(`/quick-start/${run.id}`, service, agentFor({ planner }))
+
+    const composer = await screen.findByRole('textbox', { name: '继续描述你的想法' })
+    fireEvent.change(composer, { target: { value: '把披风改成深蓝色' } })
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+
+    await waitFor(() =>
+      expect(service.regenerateCharacterTemplate).toHaveBeenCalledWith(
+        'refine',
+        '把披风改成深蓝色',
+      ),
+    )
+    const workflowPrompt = screen.getByText('像素骑士')
+    const refinementTurn = screen.getByText('把披风改成深蓝色')
+    expect(
+      workflowPrompt.compareDocumentPosition(refinementTurn) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(await screen.findByText('已提交角色母版微调。')).toBeTruthy()
+  })
+
+  it('keeps the conversation input disabled while a generation node is active', async () => {
+    const run = actionWorkflow({
+      firstStatus: 'passed',
+      fullStatus: 'active',
+      reviewStatus: 'locked',
+    })
+    const planner = vi.fn()
+    const service = serviceFor(run)
+    renderAt(`/quick-start/${run.id}`, service, agentFor({ planner }))
+
+    const composer = await screen.findByRole('textbox', { name: '继续描述你的想法' })
+    expect((composer as HTMLInputElement).disabled).toBe(true)
+    expect(planner).not.toHaveBeenCalled()
+  })
+
+  it('keeps persisted workflow Agent turns after the generated results on refresh', async () => {
+    const run = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'passed' })
+    window.localStorage.setItem(
+      `windup.quick-start.agent-chat.v2:run:7:${run.id}`,
+      JSON.stringify({
+        turns: [
+          { role: 'user', content: '银发骑士' },
+          { role: 'user', content: '把披风改成深蓝色', scope: 'workflow' },
+          {
+            role: 'assistant',
+            content: '已提交角色母版微调。',
+            kind: 'reply',
+            scope: 'workflow',
+          },
+        ],
+      }),
+    )
+
+    renderAt(`/quick-start/${run.id}`, serviceFor(run))
+
+    const workflowPrompt = await screen.findByText('像素骑士')
+    const refinementTurn = screen.getByText('把披风改成深蓝色')
+    expect(
+      workflowPrompt.compareDocumentPosition(refinementTurn) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(screen.getByText('已提交角色母版微调。')).toBeTruthy()
+  })
+})
 
 function eastCandidates(...imageUrls: string[]): readonly QuickStartCandidate[] {
   return imageUrls.map((imageUrl, index) => ({ direction: 'east', index, imageUrl }))

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -21,12 +21,13 @@ import {
 import { forgetActiveRun, isMissingActiveRunError, syncActiveRun } from '@/features/active-run'
 import { useOptionalAuthSession } from '@/features/auth-session'
 import { ExportButton, type ExportPackageModel } from '@/features/export-package'
-import { useQuickStartAgent } from '@/features/quick-start-agent/react'
+import { useQuickStartAgent, useQuickStartWorkflowAgent } from '@/features/quick-start-agent/react'
 import type {
   CharacterGenerationProposal,
   CreateQuickStartAgentOptions,
   PlannerMessage,
   QuickStartAgentResult,
+  WorkflowAgentActions,
 } from '@/features/quick-start-agent/runtime'
 import {
   FrameAnimationPlayer,
@@ -142,11 +143,12 @@ const LEGACY_AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v1'
 const AGENT_DRAFT_HISTORY_STATE_KEY = 'windupQuickStartAgentDraftId'
 
 type AgentConversationTurn =
-  | { role: 'user'; content: string }
+  | { role: 'user'; content: string; scope?: 'workflow' }
   | {
       role: 'assistant'
       content: string
       kind: 'reply' | 'clarification' | 'blocked'
+      scope?: 'workflow'
     }
   | {
       role: 'assistant'
@@ -156,6 +158,7 @@ type AgentConversationTurn =
       optimizedPrompt: string
       optimizationSummary: string
       proposalStatus: 'pending' | 'superseded' | 'adopted' | 'confirmed'
+      scope?: 'workflow'
     }
 
 type AgentConversationRecord = {
@@ -222,7 +225,10 @@ function readAgentConversation(
       ) {
         return []
       }
-      if (turn.role === 'user') return [{ role: 'user', content: turn.content }]
+      const scope = 'scope' in turn && turn.scope === 'workflow' ? 'workflow' : undefined
+      if (turn.role === 'user') {
+        return [{ role: 'user', content: turn.content, ...(scope ? { scope } : {}) }]
+      }
       if (turn.role !== 'assistant') return []
 
       if (
@@ -249,6 +255,7 @@ function readAgentConversation(
             optimizedPrompt: turn.optimizedPrompt,
             optimizationSummary: turn.optimizationSummary,
             proposalStatus: turn.proposalStatus,
+            ...(scope ? { scope } : {}),
           },
         ]
       }
@@ -258,7 +265,7 @@ function readAgentConversation(
         (turn.kind === 'reply' || turn.kind === 'clarification' || turn.kind === 'blocked')
           ? turn.kind
           : 'reply'
-      return [{ role: 'assistant', content: turn.content, kind }]
+      return [{ role: 'assistant', content: turn.content, kind, ...(scope ? { scope } : {}) }]
     })
   } catch {
     return []
@@ -391,6 +398,7 @@ export function QuickStartPage({
       onSessionCreated={setCreatedSession}
       onInitialSessionConsumed={consumeCreatedSession}
       activeRunUserId={activeRunUserId}
+      agent={agent}
     />
   ) : (
     <QuickStartInput
@@ -1233,6 +1241,7 @@ function QuickStartRun({
   onSessionCreated,
   onInitialSessionConsumed,
   activeRunUserId,
+  agent,
 }: {
   service: QuickStartEntryService
   runId: string
@@ -1240,6 +1249,7 @@ function QuickStartRun({
   onSessionCreated: (session: QuickStartSession) => void
   onInitialSessionConsumed: (session: QuickStartSession) => void
   activeRunUserId: string | null
+  agent: CreateQuickStartAgentOptions
 }) {
   const navigate = useNavigate()
   const location = useLocation()
@@ -1264,10 +1274,10 @@ function QuickStartRun({
   const [confirmingCandidate, setConfirmingCandidate] = useState(false)
   const [confirmingFirstFrame, setConfirmingFirstFrame] = useState(false)
   const [addingAction, setAddingAction] = useState(false)
-  const agentConversationTurns = useMemo(
-    () => readAgentRunConversation(activeRunUserId, runId),
-    [activeRunUserId, runId],
-  )
+  const initialAgentConversation = useRef(readAgentRunConversation(activeRunUserId, runId)).current
+  const [agentConversationTurns, setAgentConversationTurns] = useState(initialAgentConversation)
+  const agentConversationTurnsRef = useRef(agentConversationTurns)
+  const initialWorkflowAgentSeed = useRef(createAgentSeed(initialAgentConversation)).current
   const automaticPublishAttempt = useRef<string | null>(null)
   const transcriptScrollRegion = useRef<HTMLElement>(null)
   const workflowConflictRef = useRef(false)
@@ -1278,6 +1288,42 @@ function QuickStartRun({
     timer: ReturnType<typeof setTimeout>
   } | null>(null)
   const mountedRef = useRef(true)
+  const workflowAgentActions = useMemo<WorkflowAgentActions>(
+    () => ({
+      getContext: () =>
+        activeSessionRef.current?.getWorkflowAgentContext() ?? { availableTools: [] },
+      async regenerateCharacterTemplate() {
+        const target = activeSessionRef.current
+        if (!target) throw new Error('当前生成会话尚未恢复')
+        const updated = await target.regenerateCharacterTemplate('regenerate')
+        if (mountedRef.current && activeSessionRef.current === target) setRun(updated)
+      },
+      async refineCharacterTemplate(adjustmentPrompt) {
+        const target = activeSessionRef.current
+        if (!target) throw new Error('当前生成会话尚未恢复')
+        const updated = await target.regenerateCharacterTemplate('refine', adjustmentPrompt)
+        if (mountedRef.current && activeSessionRef.current === target) setRun(updated)
+      },
+      async regenerateFirstFrame() {
+        const target = activeSessionRef.current
+        if (!target) throw new Error('当前生成会话尚未恢复')
+        const updated = await target.regenerateFirstFrame('regenerate')
+        if (mountedRef.current && activeSessionRef.current === target) setRun(updated)
+      },
+      async refineFirstFrame(adjustmentPrompt) {
+        const target = activeSessionRef.current
+        if (!target) throw new Error('当前生成会话尚未恢复')
+        const updated = await target.regenerateFirstFrame('refine', adjustmentPrompt)
+        if (mountedRef.current && activeSessionRef.current === target) setRun(updated)
+      },
+    }),
+    [],
+  )
+  const workflowAgentSession = useQuickStartWorkflowAgent({
+    planner: agent.planner,
+    actions: workflowAgentActions,
+    initialMessages: initialWorkflowAgentSeed.messages,
+  })
   const reportWorkflowError = useCallback((cause: unknown, fallback: string) => {
     const presented = presentWorkflowError(cause, fallback)
     if (workflowConflictRef.current && !presented.conflict) return
@@ -1290,6 +1336,20 @@ function QuickStartRun({
     setError(null)
     setWorkflowConflict(false)
   }, [])
+
+  const appendRunConversationTurn = useCallback(
+    (turn: AgentConversationTurn) => {
+      const next = [...agentConversationTurnsRef.current, turn]
+      agentConversationTurnsRef.current = next
+      setAgentConversationTurns(next)
+      writeAgentConversation(
+        'localStorage',
+        agentRunConversationStorageKey(activeRunUserId, runId),
+        { turns: next },
+      )
+    },
+    [activeRunUserId, runId],
+  )
 
   useEffect(() => {
     mountedRef.current = true
@@ -1468,7 +1528,7 @@ function QuickStartRun({
   useEffect(() => {
     const region = transcriptScrollRegion.current
     region?.scrollTo?.({ top: region.scrollHeight, behavior: 'smooth' })
-  }, [actionFrames, candidates, firstFrameCandidates, run])
+  }, [actionFrames, agentConversationTurns, candidates, firstFrameCandidates, run])
 
   if (!run) {
     if (restoring) return <RestoringConversation turns={agentConversationTurns} />
@@ -1683,26 +1743,44 @@ function QuickStartRun({
       void confirmFirstFrame()
       return
     }
-    const prompt = actionDescription.trim()
-    if (!canAddAction || !prompt || !session || addingAction) return
-    setAddingAction(true)
-    clearWorkflowError()
-    try {
-      let outfitId = requestedOutfitId
-      if (!outfitId) {
-        const info = session.getCharacterInfo() ?? (await session.resolveCharacterInfo())
-        outfitId = info?.outfitId ?? null
+    const message = actionDescription.trim()
+    if (addActionIntent) {
+      if (!canAddAction || !message || !session || addingAction) return
+      setAddingAction(true)
+      clearWorkflowError()
+      try {
+        let outfitId = requestedOutfitId
+        if (!outfitId) {
+          const info = session.getCharacterInfo() ?? (await session.resolveCharacterInfo())
+          outfitId = info?.outfitId ?? null
+        }
+        if (!outfitId) throw new Error('没有找到要追加动作的角色造型')
+        const updated = await session.addAction(outfitId, message)
+        if (!mountedRef.current || activeSessionRef.current !== session) return
+        setRun(updated)
+        setActionDescription('')
+      } catch (cause) {
+        if (!mountedRef.current || activeSessionRef.current !== session) return
+        reportWorkflowError(cause, '新增动作失败，请稍后重试')
+      } finally {
+        if (mountedRef.current && activeSessionRef.current === session) setAddingAction(false)
       }
-      if (!outfitId) throw new Error('没有找到要追加动作的角色造型')
-      const updated = await session.addAction(outfitId, prompt)
-      if (!mountedRef.current || activeSessionRef.current !== session) return
-      setRun(updated)
-      setActionDescription('')
+      return
+    }
+    if (!message || workflowIsActive || workflowAgentSession.busy) return
+    clearWorkflowError()
+    appendRunConversationTurn({ role: 'user', content: message, scope: 'workflow' })
+    setActionDescription('')
+    try {
+      const result = await workflowAgentSession.submit(message)
+      appendRunConversationTurn({
+        role: 'assistant',
+        content: result.message,
+        kind: 'reply',
+        scope: 'workflow',
+      })
     } catch (cause) {
-      if (!mountedRef.current || activeSessionRef.current !== session) return
-      reportWorkflowError(cause, '新增动作失败，请稍后重试')
-    } finally {
-      if (mountedRef.current && activeSessionRef.current === session) setAddingAction(false)
+      reportWorkflowError(cause, 'Agent 修改失败，请稍后重试')
     }
   }
 
@@ -1724,16 +1802,32 @@ function QuickStartRun({
             ? '确认保存后，还可以继续描述修改…'
             : '制作中，完成后可以继续修改…'
 
+  const workflowAgentAvailable =
+    !workflowIsActive &&
+    session !== null &&
+    session.getWorkflowAgentContext().availableTools.length > 0
+  const workflowAgentMode = !isTemplateSelecting && !isFirstFrameSelecting && !addActionIntent
   const composerCanSubmit =
     (isTemplateSelecting && templateSelectionComplete) ||
     (isFirstFrameSelecting && firstFrameSelectionComplete) ||
-    (canAddAction && Boolean(actionDescription.trim()) && !addingAction)
+    (canAddAction && Boolean(actionDescription.trim()) && !addingAction) ||
+    (workflowAgentMode && workflowAgentAvailable && Boolean(actionDescription.trim()))
+  const workflowComposerDisabled = addActionIntent
+    ? !canAddAction || addingAction || workflowConflict
+    : workflowAgentMode &&
+      (workflowIsActive || !workflowAgentAvailable || workflowAgentSession.busy || workflowConflict)
   const selectedTemplateUrl = templateStep?.selectedImageUrl
   const selectedFirstFrameUrl = firstFrameStep?.selectedFirstFrameUrl
   const requestedAction = firstFrameStep?.input.prompt || firstFrameStep?.input.name
   const characterTurnIsCurrent = !firstFrameStep
   const firstFrameTurnIsCurrent = Boolean(firstFrameStep) && actionStep?.status === 'locked'
   const actionTurnIsCurrent = Boolean(actionStep && actionStep.status !== 'locked')
+  const entryAgentConversationTurns = agentConversationTurns.filter(
+    (turn) => turn.scope !== 'workflow',
+  )
+  const workflowAgentConversationTurns = agentConversationTurns.filter(
+    (turn) => turn.scope === 'workflow',
+  )
 
   return (
     <section className="relative min-h-screen overflow-hidden bg-app-canvas pt-14 text-app-ink">
@@ -1755,7 +1849,7 @@ function QuickStartRun({
             data-testid="quick-start-transcript"
             className="mx-auto grid min-h-full w-full max-w-3xl content-end gap-7 pb-8 sm:gap-9"
           >
-            {agentConversationTurns.map((turn, index) => (
+            {entryAgentConversationTurns.map((turn, index) => (
               <div
                 key={`${turn.role}:${index}:${turn.content}`}
                 data-conversation-kind="agent"
@@ -2033,6 +2127,37 @@ function QuickStartRun({
                 ) : null}
               </div>
             ) : null}
+            {workflowAgentConversationTurns.map((turn, index) => (
+              <div
+                key={`${turn.role}:workflow:${index}:${turn.content}`}
+                data-conversation-kind="agent"
+                className="min-w-0"
+              >
+                {turn.role === 'user' ? (
+                  <UserTurn>{turn.content}</UserTurn>
+                ) : (
+                  <AgentCopy lines={turn.content.split('\n')} />
+                )}
+              </div>
+            ))}
+            {workflowAgentSession.state.status === 'planning' ? (
+              <div
+                data-conversation-kind="agent"
+                role="status"
+                aria-label="Agent 正在思考"
+                className="quick-start-agent-loading min-w-0"
+              >
+                <span aria-hidden="true" className="quick-start-agent-loading-dots">
+                  {[0, 1, 2].map((dot) => (
+                    <span
+                      key={dot}
+                      className="quick-start-agent-loading-dot"
+                      style={{ '--agent-loading-index': dot } as CSSProperties}
+                    />
+                  ))}
+                </span>
+              </div>
+            ) : null}
             <div data-testid="quick-start-transcript-end" />
           </div>
         </main>
@@ -2080,6 +2205,7 @@ function QuickStartRun({
                 aria-label="继续描述你的想法"
                 value={actionDescription}
                 onChange={(event) => setActionDescription(event.target.value)}
+                disabled={workflowComposerDisabled}
                 placeholder={composerPlaceholder}
                 className="h-10 w-full min-w-0 border-0 bg-transparent px-3 text-[15px] text-app-ink outline-none placeholder:text-app-faint"
               />
@@ -2087,7 +2213,11 @@ function QuickStartRun({
             <button
               type="submit"
               aria-label={isTemplateSelecting ? '确认选择，继续下一步' : '发送'}
-              disabled={!composerCanSubmit || workflowConflict}
+              disabled={
+                !composerCanSubmit ||
+                workflowConflict ||
+                (workflowAgentMode && workflowAgentSession.busy)
+              }
               className="grid h-10 w-10 place-items-center rounded-lg bg-app-accent text-app-on-accent transition hover:bg-app-accent-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-35"
             >
               <ArrowUp aria-hidden="true" size={16} weight="bold" />

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -301,6 +301,76 @@ describe('createQuickStartService', () => {
     await expect(service.open('missing')).rejects.toThrow('not found')
   })
 
+  it('只向 Agent 暴露当前 Run 已确认结果可复用的 Controller 操作', async () => {
+    const run = actionRun()
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis([run]),
+      generationApis: pendingGenerationApis(),
+      prepareProject: vi.fn(),
+      projectApis: projectReader(),
+    })
+
+    const session = await service.open(run.id)
+
+    expect(session.getWorkflowAgentContext()).toEqual({
+      availableTools: [
+        'regenerate_character_template',
+        'refine_character_template',
+        'regenerate_first_frame',
+        'refine_first_frame',
+      ],
+    })
+  })
+
+  it('角色母版微调直接复用当前 Run 的 Controller 和上一版图片', async () => {
+    const run = actionRun()
+    const generationApis = pendingGenerationApis()
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis([run]),
+      generationApis,
+      prepareProject: vi.fn(),
+      projectApis: projectReader({ width: 96, height: 128 }),
+    })
+    const session = await service.open(run.id)
+
+    await session.regenerateCharacterTemplate('refine', '把披风改成深蓝色')
+
+    expect(generationApis.create).toHaveBeenCalledWith({
+      type: 'character_template',
+      projectId: 'project-1',
+      prompt: '像素骑士\n把披风改成深蓝色',
+      referenceMedia: ['template.png'],
+      spriteWidth: 96,
+      spriteHeight: 128,
+      direction: 'east',
+    })
+  })
+
+  it('动作首帧重新生成直接复用当前 Run 的 Controller 原始输入', async () => {
+    const run = actionRun()
+    const generationApis = pendingGenerationApis()
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis([run]),
+      generationApis,
+      prepareProject: vi.fn(),
+      projectApis: projectReader({ width: 80, height: 80 }),
+    })
+    const session = await service.open(run.id)
+
+    await session.regenerateFirstFrame('regenerate')
+
+    expect(generationApis.create).toHaveBeenCalledWith({
+      type: 'first_frame',
+      projectId: 'project-1',
+      actionType: 'custom',
+      prompt: '挥手',
+      spriteWidth: 80,
+      spriteHeight: 80,
+      referenceMedia: ['template.png'],
+      direction: 'east',
+    })
+  })
+
   it('只列出各生成节点真正失败的方向', async () => {
     const run: WorkflowRun = {
       id: 'run-failed-directions',

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -30,6 +30,13 @@ import {
 } from '@/features/workflow-controller'
 import { createProgressiveExportModel, type ExportPackageModel } from '@/features/export-package'
 import { createActionSequences } from '@/features/export'
+import {
+  REFINE_CHARACTER_TEMPLATE_TOOL,
+  REFINE_FIRST_FRAME_TOOL,
+  REGENERATE_CHARACTER_TEMPLATE_TOOL,
+  REGENERATE_FIRST_FRAME_TOOL,
+  type WorkflowAgentContext,
+} from '@/features/quick-start-agent/runtime'
 
 export { createAutoPrepareProject }
 export type { PrepareQuickStartProject }
@@ -90,6 +97,15 @@ export interface QuickStartSession {
   retryGenerationDirection(
     nodeId: WorkflowNode['id'],
     direction: ActionDirection,
+  ): Promise<WorkflowRun>
+  getWorkflowAgentContext(): WorkflowAgentContext
+  regenerateCharacterTemplate(
+    mode: 'regenerate' | 'refine',
+    adjustmentPrompt?: string,
+  ): Promise<WorkflowRun>
+  regenerateFirstFrame(
+    mode: 'regenerate' | 'refine',
+    adjustmentPrompt?: string,
   ): Promise<WorkflowRun>
   /** 按当前 Run 完成度装配统一导出包；角色母版尚未确认时返回 null。 */
   getExportModel(): Promise<ExportPackageModel | null>
@@ -799,6 +815,57 @@ export function createQuickStartService({
           referenceMedia: [],
         })
         ensureAutomaticAdvance()
+        return controller.getWorkflow()
+      },
+      getWorkflowAgentContext() {
+        const run = controller.getWorkflow()
+        const availableTools: WorkflowAgentContext['availableTools'][number][] = []
+        const template = run.nodes.find((node) => node.type === 'character-template')
+        if (
+          template?.type === 'character-template' &&
+          template.status === 'passed' &&
+          template.phase === 'completed' &&
+          template.selectedImageUrl
+        ) {
+          availableTools.push(REGENERATE_CHARACTER_TEMPLATE_TOOL, REFINE_CHARACTER_TEMPLATE_TOOL)
+        }
+        const firstFrame = latestActionFirstFrame(run)
+        if (
+          firstFrame?.type === 'action-first-frame' &&
+          firstFrame.status === 'passed' &&
+          firstFrame.phase === 'completed' &&
+          firstFrame.selectedFirstFrameUrl
+        ) {
+          availableTools.push(REGENERATE_FIRST_FRAME_TOOL, REFINE_FIRST_FRAME_TOOL)
+        }
+        return { availableTools }
+      },
+      async regenerateCharacterTemplate(mode, adjustmentPrompt) {
+        const run = controller.getWorkflow()
+        const template = templateNode(run)
+        const spriteSize =
+          knownSpriteSize ?? (await resolveProjectSpriteSize(controller.getWorkflow().projectId))
+        await controller.regenerateCharacterTemplate(template.id, {
+          spriteWidth: spriteSize.width,
+          spriteHeight: spriteSize.height,
+          mode,
+          ...(adjustmentPrompt === undefined ? {} : { adjustmentPrompt }),
+        })
+        return controller.getWorkflow()
+      },
+      async regenerateFirstFrame(mode, adjustmentPrompt) {
+        const firstFrame = latestActionFirstFrame(controller.getWorkflow())
+        if (!firstFrame || firstFrame.type !== 'action-first-frame') {
+          throw new Error('当前运行没有可重新生成的动作首帧')
+        }
+        const spriteSize =
+          knownSpriteSize ?? (await resolveProjectSpriteSize(controller.getWorkflow().projectId))
+        await controller.regenerateFirstFrame(firstFrame.id, {
+          spriteWidth: spriteSize.width,
+          spriteHeight: spriteSize.height,
+          mode,
+          ...(adjustmentPrompt === undefined ? {} : { adjustmentPrompt }),
+        })
         return controller.getWorkflow()
       },
       async approveReview() {


### PR DESCRIPTION
本 PR 让 Quick Start Agent 在工作流生成完成后继续参与，识别角色母版与动作首帧的重新生成/微调意图，并通过现有 WorkflowController 执行；运行中的输入禁用语义保持不变。

## Why

生成前的 Agent 只能优化提示词，工作流完成后用户无法继续用自然语言调整已有结果。需要把 Agent 的参与延伸到生成阶段，同时保持单一工作流状态源、付费写操作边界和现有重生成实现。

## Changes

- 为角色母版、动作首帧新增受限的重新生成与微调 Tool。
- 按当前 Run 状态动态暴露可用 Tool，未知、越权、多 Tool 和空微调描述均 fail-closed。
- 完成态继续开放对话；生成 active 时输入与发送继续禁用。
- 生成阶段消息以 workflow scope 持久化，刷新后保持在工作流结果之后。

## Implementation

- Planner 每轮最多返回一个完整 Tool call，runtime 在授权、状态与参数校验后才执行。
- Quick Start 会话只做薄适配，所有副作用进入同一个 WorkflowController，并复用现有角色母版/动作首帧重生成与微调方法。
- Run 切换或组件卸载会中止过期 Planner；Tool 执行前再次校验当前会话。
- Planner 继续动态加载，不静态进入 Quick Start 主包。

## Verification

- [x] `npm test -- src/features/quick-start-agent/boundaries.test.ts src/features/quick-start-agent/planner.test.ts src/features/quick-start-agent/react.test.tsx src/features/quick-start-agent/runtime.test.ts src/pages/quick-start/index.test.tsx src/pages/quick-start/service.test.ts`：6 files，168 tests
- [x] 修改文件 `npx oxfmt --check`：12 files
- [x] 修改文件 `npx oxlint`
- [x] `npm run build`
- [x] `git diff --check upstream/main...HEAD`
- [x] 浏览器：真实 QuickStartPage 与 Agent runtime、临时会话适配器；完成态微调和 active 禁用通过（不作为真实后端 E2E）
- [x] 独立子代理按影响面只读验收：PASS，无 P0–P3

## Review

- 关键 Prompt 摘要：让模型在生成完成后识别重新生成与微调，只允许调用 WorkflowController，并直接复用已有实现；不实现中断。
- 人工 Review 说明：功能边界已由用户确认，代码仍需维护者在 PR 中 Review 后合入。

## Scope

- 本 PR 不包含：生成中断、在途请求修改、第二套工作流状态机。
- 未执行：真实模型 A/B 与真实后端 E2E；本机 PostgreSQL 未就绪，Controller 路径由 service/controller 定向测试覆盖。

## Related Issues

Closes #595
Refs #588

## Screenshots

### Desktop

<img width="1470" height="756" alt="windup-agent-workflow-tools-preview" src="https://github.com/user-attachments/assets/be986ac2-1b5a-40b6-8697-8a3c7a49423b" />
