### PR TITLE
feat(project): 画风字段从自由文本改为受控枚举

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session
 from windup_ai_engine.ports import PromptRejected
 from windup_ai_engine.slicing.quality import subject_blobs
 from windup_common.directions import direction_prompt
+from windup_common.enums import ArtStyle
 from windup_common.models import ActionSpec, ActionType as EngineActionType, CharacterCard
 from windup_framework.gateway import bind_call_context, fresh_gateway_request
 from windup_framework.gateway.registry import ModelRegistry
@@ -102,8 +103,8 @@ class ProjectConstraints:
     directions: int = 1  # directional_movement → 方向数(1/4/8)
     sprite_w: int = 256  # 输出/切帧尺寸(关键)
     sprite_h: int = 256
-    style: str = ""  # game_style 画风
-    stylize: str = "none"  # 由 style 推:像素游戏 → pixel
+    style: str = ""  # 进提示词的画风短语(ArtStyle.prompt_phrase)
+    stylize: str = "none"  # 像素化开关,只有 ArtStyle.PIXEL 打开
     sprite_sample_url: str = ""  # 项目风格参考图 URL
 
 
@@ -116,8 +117,7 @@ def _load_constraints(session: Session, project_id: int | None) -> ProjectConstr
     p = SqlAlchemyProjectService().get_project(session, project_id)
     if p is None:
         return ProjectConstraints()
-    style = p.game_style or ""
-    is_pixel = "pixel" in style.lower() or "像素" in style
+    art_style = ArtStyle.from_stored(p.game_style)
     return ProjectConstraints(
         facing=_PERSPECTIVE_FACING.get(p.character_perspective, "side"),
         view=_PERSPECTIVE_VIEW.get(p.character_perspective, _PERSPECTIVE_VIEW[1]),
@@ -125,8 +125,8 @@ def _load_constraints(session: Session, project_id: int | None) -> ProjectConstr
         directions=_MOVEMENT_DIRECTIONS.get(p.directional_movement, 1),
         sprite_w=p.sprite_width,
         sprite_h=p.sprite_height,
-        style=style,
-        stylize="pixel" if is_pixel else "none",
+        style=art_style.prompt_phrase,
+        stylize="pixel" if art_style.wants_pixelation else "none",
         sprite_sample_url=p.sprite_sample_url or "",
     )
 
@@ -332,7 +332,7 @@ class ActionTaskExecutor:
     ) -> dict:
         """母版 → ai_engine 按项目尺寸出帧 → 逐帧上传 → 组结果 dict。
 
-        项目约束落实:``facing`` 随视角、``stylize`` 随画风(像素游戏→像素化)、
+        项目约束落实:``facing`` 随视角、``stylize`` 随项目画风(只有像素档打开)、
         输出帧尺寸随 ``sprite_w×sprite_h``。四向/八向项目由上层为每个必需方向
         创建独立任务；本任务只生成 ``input.direction``，不会用镜像替代西向或斜向。
 

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -125,7 +125,7 @@ def _load_constraints(session: Session, project_id: int | None) -> ProjectConstr
         directions=_MOVEMENT_DIRECTIONS.get(p.directional_movement, 1),
         sprite_w=p.sprite_width,
         sprite_h=p.sprite_height,
-        style=art_style.prompt_phrase,
+        style=ArtStyle.phrase_from_stored(p.game_style),
         stylize="pixel" if art_style.wants_pixelation else "none",
         sprite_sample_url=p.sprite_sample_url or "",
     )

--- a/backend/packages/app/src/windup_app/server/project/interface.py
+++ b/backend/packages/app/src/windup_app/server/project/interface.py
@@ -15,6 +15,16 @@ from sqlalchemy.orm import Session
 from windup_app.server.project.model import Project
 
 
+class UnsetType:
+    """「这个字段没出现在请求里」——与「显式传了 null」区分开。"""
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+
+UNSET = UnsetType()
+
+
 class ProjectService(ABC):
     """项目 CRUD 用例的抽象边界。"""
 
@@ -61,9 +71,13 @@ class ProjectService(ABC):
         project: Project,
         *,
         project_name: str | None = None,
-        game_style: str | None = None,
+        game_style: str | None | UnsetType = UNSET,
     ) -> Project:
-        """改已完成归属校验的项目;``None`` 表示该字段不动。"""
+        """改已完成归属校验的项目。
+
+        ``game_style`` 用哨兵而不是 ``None`` 区分「没传」与「显式清空」:画风的
+        「不指定」落库就是 NULL,拿 None 当「不动」会让它永远清不掉。
+        """
 
     @abstractmethod
     def delete_project(self, session: Session, project_id: int) -> bool:

--- a/backend/packages/app/src/windup_app/server/project/interface.py
+++ b/backend/packages/app/src/windup_app/server/project/interface.py
@@ -55,10 +55,15 @@ class ProjectService(ABC):
         """一次查询当前页项目的资产预览，结果包含所有传入项目 ID。"""
 
     @abstractmethod
-    def rename_project(
-        self, session: Session, project: Project, *, project_name: str
+    def update_project(
+        self,
+        session: Session,
+        project: Project,
+        *,
+        project_name: str | None = None,
+        game_style: str | None = None,
     ) -> Project:
-        """修改已完成归属校验的项目名称。"""
+        """改已完成归属校验的项目;``None`` 表示该字段不动。"""
 
     @abstractmethod
     def delete_project(self, session: Session, project_id: int) -> bool:

--- a/backend/packages/app/src/windup_app/server/project/service.py
+++ b/backend/packages/app/src/windup_app/server/project/service.py
@@ -11,7 +11,7 @@ rollback,故本实现只 ``flush``(把变更发到当前事务、取回生成的
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from windup_app.server.project.interface import ProjectService
+from windup_app.server.project.interface import UNSET, ProjectService, UnsetType
 from windup_app.server.project.model import Project
 from windup_app.server.character.model import Character
 
@@ -132,11 +132,11 @@ class SqlAlchemyProjectService(ProjectService):
         project: Project,
         *,
         project_name: str | None = None,
-        game_style: str | None = None,
+        game_style: str | None | UnsetType = UNSET,
     ) -> Project:
         if project_name is not None:
             project.project_name = project_name
-        if game_style is not None:
+        if not isinstance(game_style, UnsetType):
             project.game_style = game_style
         session.flush()
         return project

--- a/backend/packages/app/src/windup_app/server/project/service.py
+++ b/backend/packages/app/src/windup_app/server/project/service.py
@@ -126,10 +126,18 @@ class SqlAlchemyProjectService(ProjectService):
                 )
         return previews
 
-    def rename_project(
-        self, session: Session, project: Project, *, project_name: str
+    def update_project(
+        self,
+        session: Session,
+        project: Project,
+        *,
+        project_name: str | None = None,
+        game_style: str | None = None,
     ) -> Project:
-        project.project_name = project_name
+        if project_name is not None:
+            project.project_name = project_name
+        if game_style is not None:
+            project.game_style = game_style
         session.flush()
         return project
 

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -23,16 +23,30 @@ logger = logging.getLogger("windup.project.api")
 router = APIRouter(prefix="/projects", tags=["projects"])
 
 
-def _legacy_style_or_none(value: object) -> ArtStyle | None:
-    """画风枚举化之前发的是自由文本;直接拒会让还没换下拉的客户端改不了项目。"""
-    if value is None:
+def _legacy_style_or_none(value: object) -> ArtStyle | str | None:
+    """画风枚举化之前发的是自由文本;直接拒会让还没换下拉的客户端改不了项目。
+
+    认不出的取值**原样留着**:归到 ``UNSPECIFIED`` 会把用户已有的画风约束静默抹掉。
+    等所有入口都改发枚举码之后,这条兼容连同 ``str`` 分支一起收紧。
+    """
+    if value is None or isinstance(value, ArtStyle):
+        return value
+    if not isinstance(value, str):
+        return value
+    try:
+        return ArtStyle(value.strip())
+    except ValueError:
+        return ArtStyle.PIXEL if ArtStyle.from_stored(value) is ArtStyle.PIXEL else value
+
+
+def _stored_style(style: ArtStyle | str | None) -> str | None:
+    """``UNSPECIFIED`` 落库存 NULL —— 现有前端把这一列原样显示,写字面量会让它显示出来。
+
+    非枚举的存量自由文本原样落库,交给 ``ArtStyle.phrase_from_stored`` 在生成时读回。
+    """
+    if style is None or style is ArtStyle.UNSPECIFIED:
         return None
-    return ArtStyle.from_stored(value) if isinstance(value, str) else value
-
-
-def _stored_style(style: ArtStyle | None) -> str | None:
-    """``UNSPECIFIED`` 落库存 NULL —— 现有前端把这一列原样显示,写字面量会让它显示出来。"""
-    return None if style is None or style is ArtStyle.UNSPECIFIED else style.value
+    return style.value if isinstance(style, ArtStyle) else style.strip() or None
 
 
 class ProjectCreate(BaseModel):
@@ -44,20 +58,21 @@ class ProjectCreate(BaseModel):
     directional_movement: int = Field(ge=1, le=3)
     sprite_width: int = Field(ge=32, le=2048)
     sprite_height: int = Field(ge=32, le=2048)
-    game_style: ArtStyle = ArtStyle.UNSPECIFIED
+    game_style: ArtStyle | str = ArtStyle.UNSPECIFIED
     sprite_sample_url: str | None = None
 
     @field_validator("game_style", mode="before")
     @classmethod
-    def _accept_legacy_free_text(cls, value: object) -> ArtStyle:
-        return _legacy_style_or_none(value) or ArtStyle.UNSPECIFIED
+    def _accept_legacy_free_text(cls, value: object) -> ArtStyle | str:
+        got = _legacy_style_or_none(value)
+        return ArtStyle.UNSPECIFIED if got is None else got
 
 
 class ProjectPatch(BaseModel):
     """改项目请求;只改传上来的那些字段。"""
 
     project_name: str | None = Field(default=None, min_length=1, max_length=20)
-    game_style: ArtStyle | None = None
+    game_style: ArtStyle | str | None = None
 
     _accept_legacy = field_validator("game_style", mode="before")(
         _legacy_style_or_none

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -15,11 +15,19 @@ from windup_common.result import ListResponse, Response
 from windup_framework.db import get_session
 
 from windup_app.server.character.service import service as character_service
+from windup_app.server.project.interface import UNSET
 from windup_app.server.project.service import service
 
 logger = logging.getLogger("windup.project.api")
 
 router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+def _legacy_style_or_none(value: object) -> ArtStyle | None:
+    """画风枚举化之前发的是自由文本;直接拒会让还没换下拉的客户端改不了项目。"""
+    if value is None:
+        return None
+    return ArtStyle.from_stored(value) if isinstance(value, str) else value
 
 
 def _stored_style(style: ArtStyle | None) -> str | None:
@@ -42,10 +50,7 @@ class ProjectCreate(BaseModel):
     @field_validator("game_style", mode="before")
     @classmethod
     def _accept_legacy_free_text(cls, value: object) -> ArtStyle:
-        """画风枚举化之前建项目发的是自由文本;直接拒会让还没换下拉的客户端建不了项目。"""
-        if value is None:
-            return ArtStyle.UNSPECIFIED
-        return ArtStyle.from_stored(value) if isinstance(value, str) else value
+        return _legacy_style_or_none(value) or ArtStyle.UNSPECIFIED
 
 
 class ProjectPatch(BaseModel):
@@ -53,6 +58,10 @@ class ProjectPatch(BaseModel):
 
     project_name: str | None = Field(default=None, min_length=1, max_length=20)
     game_style: ArtStyle | None = None
+
+    _accept_legacy = field_validator("game_style", mode="before")(
+        _legacy_style_or_none
+    )
 
     @model_validator(mode="after")
     def _at_least_one(self) -> "ProjectPatch":
@@ -179,7 +188,9 @@ def update_project(
             session,
             project,
             project_name=rename_to,
-            game_style=_stored_style(body.game_style) if body.game_style else None,
+            game_style=(
+                UNSET if body.game_style is None else _stored_style(body.game_style)
+            ),
         )
     except IntegrityError:
         session.rollback()

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -4,10 +4,11 @@ import logging
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, Query, Request
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from windup_common.enums import ArtStyle
 from windup_common.enums.biz_code import BizCode
 from windup_common.exceptions import BizException
 from windup_common.result import ListResponse, Response
@@ -21,6 +22,11 @@ logger = logging.getLogger("windup.project.api")
 router = APIRouter(prefix="/projects", tags=["projects"])
 
 
+def _stored_style(style: ArtStyle | None) -> str | None:
+    """``UNSPECIFIED`` 落库存 NULL —— 现有前端把这一列原样显示,写字面量会让它显示出来。"""
+    return None if style is None or style is ArtStyle.UNSPECIFIED else style.value
+
+
 class ProjectCreate(BaseModel):
     """创建项目请求。"""
 
@@ -30,14 +36,29 @@ class ProjectCreate(BaseModel):
     directional_movement: int = Field(ge=1, le=3)
     sprite_width: int = Field(ge=32, le=2048)
     sprite_height: int = Field(ge=32, le=2048)
-    game_style: str | None = None
+    game_style: ArtStyle = ArtStyle.UNSPECIFIED
     sprite_sample_url: str | None = None
 
+    @field_validator("game_style", mode="before")
+    @classmethod
+    def _accept_legacy_free_text(cls, value: object) -> ArtStyle:
+        """画风枚举化之前建项目发的是自由文本;直接拒会让还没换下拉的客户端建不了项目。"""
+        if value is None:
+            return ArtStyle.UNSPECIFIED
+        return ArtStyle.from_stored(value) if isinstance(value, str) else value
 
-class ProjectRename(BaseModel):
-    """重命名项目请求。"""
 
-    project_name: str = Field(min_length=1, max_length=20)
+class ProjectPatch(BaseModel):
+    """改项目请求;只改传上来的那些字段。"""
+
+    project_name: str | None = Field(default=None, min_length=1, max_length=20)
+    game_style: ArtStyle | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one(self) -> "ProjectPatch":
+        if self.project_name is None and self.game_style is None:
+            raise ValueError("至少要改一个字段")
+        return self
 
 
 class ProjectOut(BaseModel):
@@ -81,7 +102,9 @@ def create_project(
         )
         raise BizException("项目名称已存在", code=BizCode.BAD_REQUEST)
     try:
-        project = service.create_project(session, user_id=user_id, **body.model_dump())
+        fields = body.model_dump()
+        fields["game_style"] = _stored_style(body.game_style)
+        project = service.create_project(session, user_id=user_id, **fields)
     except IntegrityError:
         logger.warning(
             "[WINDUP] 创建拒绝-并发冲突 | user_id=%s project_name=%s",
@@ -136,9 +159,9 @@ def get_project(
 
 
 @router.patch("/{project_id}", response_model=Response[ProjectOut])
-def rename_project(
+def update_project(
     project_id: int,
-    body: ProjectRename,
+    body: ProjectPatch,
     request: Request,
     session: Session = Depends(get_session),
 ) -> Response[ProjectOut]:
@@ -146,22 +169,22 @@ def rename_project(
     project = service.get_project(session, project_id, for_update=True)
     if project is None or project.user_id != user_id:
         raise BizException("项目不存在", code=BizCode.NOT_FOUND)
-    if project.project_name == body.project_name:
-        return Response.success(
-            ProjectOut.model_validate(project), message="重命名成功"
-        )
-    if service.project_name_exists(
-        session, user_id=user_id, project_name=body.project_name
+    rename_to = body.project_name if body.project_name != project.project_name else None
+    if rename_to is not None and service.project_name_exists(
+        session, user_id=user_id, project_name=rename_to
     ):
         raise BizException("项目名称已存在", code=BizCode.BAD_REQUEST)
     try:
-        project = service.rename_project(
-            session, project, project_name=body.project_name
+        project = service.update_project(
+            session,
+            project,
+            project_name=rename_to,
+            game_style=_stored_style(body.game_style) if body.game_style else None,
         )
     except IntegrityError:
         session.rollback()
         raise BizException("项目名称已存在", code=BizCode.BAD_REQUEST) from None
-    return Response.success(ProjectOut.model_validate(project), message="重命名成功")
+    return Response.success(ProjectOut.model_validate(project), message="修改成功")
 
 
 @router.delete("/{project_id}", response_model=Response[None])

--- a/backend/packages/common/src/windup_common/enums/__init__.py
+++ b/backend/packages/common/src/windup_common/enums/__init__.py
@@ -1,7 +1,8 @@
 """共享枚举。"""
 
+from windup_common.enums.art_style import ArtStyle
 from windup_common.enums.biz_code import BizCode
 from windup_common.enums.character import CharacterStatus
 from windup_common.enums.model import ModelErrorType
 
-__all__ = ["BizCode", "CharacterStatus", "ModelErrorType"]
+__all__ = ["ArtStyle", "BizCode", "CharacterStatus", "ModelErrorType"]

--- a/backend/packages/common/src/windup_common/enums/art_style.py
+++ b/backend/packages/common/src/windup_common/enums/art_style.py
@@ -1,0 +1,56 @@
+"""项目画风枚举。"""
+
+from enum import Enum
+
+
+class ArtStyle(str, Enum):
+    """项目的美术风格。
+
+    只有 ``PIXEL`` 改变管线行为(出帧吸附母版像素网格、颜色吸回母版色板),其余取值
+    只进提示词。像素网格密度不在这一维 —— 它由目标分辨率定,两处各定一遍会打架。
+    """
+
+    PIXEL = "pixel"
+    CARTOON = "cartoon"
+    HAND_DRAWN = "hand_drawn"
+    REALISTIC = "realistic"
+    UNSPECIFIED = "unspecified"
+
+    @property
+    def wants_pixelation(self) -> bool:
+        """出帧要不要走像素化后处理。"""
+        return self is ArtStyle.PIXEL
+
+    @property
+    def prompt_phrase(self) -> str:
+        """进生成提示词的英文短语;``UNSPECIFIED`` 返回空串表示不加这一句。
+
+        三种非像素画风在管线里同走一条路,分开的理由是用户一眼可辨:卡通有粗描线平涂、
+        手绘有笔触、写实无描线走渐变。短语必须把这个差别说出来,否则分档形同虚设。
+        """
+        return _PROMPT_PHRASES[self]
+
+    @classmethod
+    def from_stored(cls, value: str | None) -> "ArtStyle":
+        """把库里的画风字段读成枚举。
+
+        存量项目存的是不受限的自由文本,按枚举严格解析会让它们全部落到 ``UNSPECIFIED``、
+        静默丢掉像素化 —— 而帧数、时长、成色全都正常,没有一处会红。
+        """
+        if not value:
+            return cls.UNSPECIFIED
+        text = value.strip()
+        try:
+            return cls(text)
+        except ValueError:
+            pass
+        return cls.PIXEL if ("pixel" in text.lower() or "像素" in text) else cls.UNSPECIFIED
+
+
+_PROMPT_PHRASES = {
+    ArtStyle.PIXEL: "pixel art",
+    ArtStyle.CARTOON: "cartoon, bold clean outlines, flat cel shading",
+    ArtStyle.HAND_DRAWN: "hand-drawn illustration, visible brush strokes, textured paper",
+    ArtStyle.REALISTIC: "painterly realism, no outlines, soft gradients and volumetric shading",
+    ArtStyle.UNSPECIFIED: "",
+}

--- a/backend/packages/common/src/windup_common/enums/art_style.py
+++ b/backend/packages/common/src/windup_common/enums/art_style.py
@@ -67,6 +67,11 @@ _PROMPT_PHRASES = {
     ArtStyle.PIXEL: "pixel art",
     ArtStyle.CARTOON: "cartoon, bold clean outlines, flat cel shading",
     ArtStyle.HAND_DRAWN: "hand-drawn illustration, visible brush strokes, textured paper",
-    ArtStyle.REALISTIC: "painterly realism, no outlines, soft gradients and volumetric shading",
+    # 不写「no outlines」:这条通路没有 negative_prompt,模型不处理否定极性、只把名词
+    # latch 进画面,写「不要 X」等于点名要 X(与 ai_engine.prompt.lint 的否定式规则同一机制)。
+    ArtStyle.REALISTIC: (
+        "painterly realism, forms defined by light and shadow, "
+        "soft gradients and volumetric shading"
+    ),
     ArtStyle.UNSPECIFIED: "",
 }

--- a/backend/packages/common/src/windup_common/enums/art_style.py
+++ b/backend/packages/common/src/windup_common/enums/art_style.py
@@ -31,6 +31,22 @@ class ArtStyle(str, Enum):
         return _PROMPT_PHRASES[self]
 
     @classmethod
+    def phrase_from_stored(cls, value: str | None) -> str:
+        """库里那一列该往提示词里放什么。
+
+        存量项目存的是自由文本(如「中世纪厚涂」),枚举化之前它是原样进提示词的。
+        把它一律归到 ``UNSPECIFIED`` 会静默抹掉用户已有的画风约束,而帧数、时长、
+        成色全都正常,没有一处会红 —— 所以认不出的取值原样交出去。
+        """
+        if not value:
+            return ""
+        text = value.strip()
+        try:
+            return cls(text).prompt_phrase
+        except ValueError:
+            return text
+
+    @classmethod
     def from_stored(cls, value: str | None) -> "ArtStyle":
         """把库里的画风字段读成枚举。
 

--- a/backend/tests/test_art_style.py
+++ b/backend/tests/test_art_style.py
@@ -1,0 +1,139 @@
+"""项目画风枚举:存量兼容、入参约束、以及它对生成约束的影响。"""
+
+import pytest
+
+from windup_common.enums import ArtStyle
+
+
+def _payload(**overrides):
+    base = {
+        "project_name": "画风",
+        "character_perspective": 1,
+        "directional_movement": 2,
+        "sprite_width": 64,
+        "sprite_height": 64,
+    }
+    base.update(overrides)
+    return base
+
+
+# -- 存量兼容 ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stored, wants_pixel",
+    [
+        # 生产库里实际出现过的两种取值(133 个项目里 9 个填了画风,只有这两种)
+        ("像素风格", True),
+        ("像素风", True),
+        ("pixel art", True),
+        ("Pixel Art", True),
+        ("中世纪写实", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_legacy_free_text_keeps_the_branch_it_used_to_take(stored, wants_pixel):
+    """枚举化不能改变已建项目走哪一支 —— 那种改变不会让任何一处报错。"""
+    assert ArtStyle.from_stored(stored).wants_pixelation is wants_pixel
+
+
+def test_stored_enum_value_round_trips():
+    for style in ArtStyle:
+        assert ArtStyle.from_stored(style.value) is style
+
+
+def test_only_pixel_turns_on_pixelation():
+    assert [s for s in ArtStyle if s.wants_pixelation] == [ArtStyle.PIXEL]
+
+
+def test_every_style_but_unspecified_carries_a_distinct_prompt_phrase():
+    """三种非像素画风在管线里同走一条路,只有提示词能把它们分开。"""
+    phrases = [s.prompt_phrase for s in ArtStyle if s is not ArtStyle.UNSPECIFIED]
+    assert all(phrases)
+    assert len(set(phrases)) == len(phrases)
+    assert ArtStyle.UNSPECIFIED.prompt_phrase == ""
+
+
+# -- 入参约束 ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "free_text, expected",
+    [("低饱和像素风", "pixel"), ("中世纪厚涂", None)],
+)
+def test_legacy_free_text_still_creates_a_project(auth_client, free_text, expected):
+    """还没换成下拉的客户端仍在发自由文本,拒掉会让它们建不了项目。"""
+    created = auth_client.post(
+        "/projects", json=_payload(game_style=free_text)
+    ).json()["data"]
+    assert created["game_style"] == expected
+
+
+def test_created_project_reports_the_chosen_style(auth_client):
+    created = auth_client.post(
+        "/projects", json=_payload(game_style="pixel")
+    ).json()["data"]
+    assert created["game_style"] == "pixel"
+
+
+def test_unspecified_is_stored_as_null(auth_client):
+    """现有前端把这一列原样显示,写字面量会让「不指定」四个字变成 unspecified。"""
+    created = auth_client.post("/projects", json=_payload()).json()["data"]
+    assert created["game_style"] is None
+
+
+# -- 改画风 ------------------------------------------------------------------
+
+
+def test_patch_can_change_style_without_renaming(auth_client):
+    created = auth_client.post(
+        "/projects", json=_payload(project_name="原名")
+    ).json()["data"]
+
+    body = auth_client.patch(
+        f"/projects/{created['id']}", json={"game_style": "cartoon"}
+    ).json()
+
+    assert body["code"] == 200
+    assert body["data"]["game_style"] == "cartoon"
+    assert body["data"]["project_name"] == "原名"
+
+
+def test_patch_with_no_field_is_rejected(auth_client):
+    created = auth_client.post("/projects", json=_payload()).json()["data"]
+    resp = auth_client.patch(f"/projects/{created['id']}", json={})
+    assert resp.json()["code"] == 400
+
+
+# -- 落到生成约束 ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stored, stylize, phrase",
+    [
+        ("pixel", "pixel", "pixel art"),
+        ("cartoon", "none", ArtStyle.CARTOON.prompt_phrase),
+        ("像素风格", "pixel", "pixel art"),
+        (None, "none", ""),
+    ],
+)
+def test_constraints_follow_the_project_style(db_session, stored, stylize, phrase):
+    from windup_app.server.orchestrator.executor import _load_constraints
+    from windup_app.server.project.model import Project
+
+    project = Project(
+        user_id=1,
+        project_name=f"约束-{stored}",
+        character_perspective=1,
+        directional_movement=1,
+        sprite_width=64,
+        sprite_height=64,
+        game_style=stored,
+    )
+    db_session.add(project)
+    db_session.flush()
+
+    cons = _load_constraints(db_session, project.id)
+    assert cons.stylize == stylize
+    assert cons.style == phrase

--- a/backend/tests/test_art_style.py
+++ b/backend/tests/test_art_style.py
@@ -60,10 +60,13 @@ def test_every_style_but_unspecified_carries_a_distinct_prompt_phrase():
 
 @pytest.mark.parametrize(
     "free_text, expected",
-    [("低饱和像素风", "pixel"), ("中世纪厚涂", None)],
+    [("低饱和像素风", "pixel"), ("中世纪厚涂", "中世纪厚涂")],
 )
 def test_legacy_free_text_still_creates_a_project(auth_client, free_text, expected):
-    """还没换成下拉的客户端仍在发自由文本,拒掉会让它们建不了项目。"""
+    """还没换成下拉的客户端仍在发自由文本,拒掉会让它们建不了项目。
+
+    认得出像素的归到枚举码;认不出的原样留着 —— 压成 NULL 会把用户的画风约束抹掉。
+    """
     created = auth_client.post(
         "/projects", json=_payload(game_style=free_text)
     ).json()["data"]
@@ -114,7 +117,7 @@ def test_patch_with_no_field_is_rejected(auth_client):
     [
         ("pixel", "pixel", "pixel art"),
         ("cartoon", "none", ArtStyle.CARTOON.prompt_phrase),
-        ("像素风格", "pixel", "pixel art"),
+        ("像素风格", "pixel", "像素风格"),
         (None, "none", ""),
     ],
 )
@@ -188,3 +191,19 @@ def test_patch_accepts_legacy_free_text(auth_client):
 
     assert body["code"] == 200
     assert body["data"]["game_style"] == "pixel"
+
+
+def test_a_non_pixel_legacy_style_still_reaches_the_prompt(auth_client, db_session):
+    """枚举化之前「中世纪厚涂」是原样进提示词的;归到不指定等于静默删掉用户的约束。"""
+    from windup_app.server.orchestrator.executor import _load_constraints
+    from windup_app.server.project.model import Project
+
+    created = auth_client.post(
+        "/projects", json=_payload(game_style="中世纪厚涂")
+    ).json()["data"]
+
+    db_session.expire_all()
+    assert db_session.get(Project, created["id"]).game_style == "中世纪厚涂"
+    cons = _load_constraints(db_session, created["id"])
+    assert cons.style == "中世纪厚涂"
+    assert cons.stylize == "none"

--- a/backend/tests/test_art_style.py
+++ b/backend/tests/test_art_style.py
@@ -137,3 +137,54 @@ def test_constraints_follow_the_project_style(db_session, stored, stylize, phras
     cons = _load_constraints(db_session, project.id)
     assert cons.stylize == stylize
     assert cons.style == phrase
+
+
+# -- 「没传」与「显式不指定」是两件事 ------------------------------------------
+
+
+def test_patch_to_unspecified_actually_clears_the_style(auth_client, db_session):
+    """把画风改回「不指定」必须真的落库,否则接口回成功而生成仍走旧约束。"""
+    from windup_app.server.orchestrator.executor import _load_constraints
+    from windup_app.server.project.model import Project
+
+    created = auth_client.post(
+        "/projects", json=_payload(game_style="pixel")
+    ).json()["data"]
+    assert _load_constraints(db_session, created["id"]).stylize == "pixel"
+
+    body = auth_client.patch(
+        f"/projects/{created['id']}", json={"game_style": "unspecified"}
+    ).json()
+
+    assert body["code"] == 200
+    db_session.expire_all()
+    assert db_session.get(Project, created["id"]).game_style is None
+    assert _load_constraints(db_session, created["id"]).stylize == "none"
+
+
+def test_patch_without_game_style_leaves_it_alone(auth_client, db_session):
+    """只改名时不能顺手把画风清掉 —— 哨兵要真的区分开这两种情况。"""
+    from windup_app.server.project.model import Project
+
+    created = auth_client.post(
+        "/projects", json=_payload(project_name="原名", game_style="cartoon")
+    ).json()["data"]
+
+    auth_client.patch(f"/projects/{created['id']}", json={"project_name": "新名"})
+
+    db_session.expire_all()
+    project = db_session.get(Project, created["id"])
+    assert project.project_name == "新名"
+    assert project.game_style == "cartoon"
+
+
+def test_patch_accepts_legacy_free_text(auth_client):
+    """PATCH 不能比 POST 还严:还没换下拉的客户端仍在发自由文本。"""
+    created = auth_client.post("/projects", json=_payload()).json()["data"]
+
+    body = auth_client.patch(
+        f"/projects/{created['id']}", json={"game_style": "低饱和像素风"}
+    ).json()
+
+    assert body["code"] == 200
+    assert body["data"]["game_style"] == "pixel"

--- a/backend/tests/test_art_style.py
+++ b/backend/tests/test_art_style.py
@@ -207,3 +207,14 @@ def test_a_non_pixel_legacy_style_still_reaches_the_prompt(auth_client, db_sessi
     cons = _load_constraints(db_session, created["id"])
     assert cons.style == "中世纪厚涂"
     assert cons.stylize == "none"
+
+
+@pytest.mark.parametrize("style", list(ArtStyle), ids=lambda s: s.value)
+def test_no_phrase_uses_a_negation(style):
+    """这条通路没有 negative_prompt。模型不处理否定极性、只把名词 latch 进画面,
+    所以「no outlines」是在点名要 outlines —— 与它想表达的正好相反。
+    """
+    from windup_ai_engine.prompt.lint import lint
+
+    errors = [i for i in lint(style.prompt_phrase, kind="still") if i.level == "error"]
+    assert errors == [], f"{style.value}: {[i.message for i in errors]}"

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import io
 import threading
 
+import numpy as np
 import pytest
 from PIL import Image
 from sqlalchemy import create_engine
@@ -845,3 +846,88 @@ def test_close_failed_does_not_overwrite_completed(session_factory):
         done = task_repo.get_task(s, task.id)
     assert done.status is TaskStatus.COMPLETED
     assert done.result is not None
+# -- 画风落到交付帧 ----------------------------------------------------------
+
+
+def _gradient_frame(shift: int = 0) -> Image.Image:
+    """多色渐变主体;像素化前后色数差得开,单色方块看不出这条支路走没走。"""
+    img = Image.new("RGBA", (64, 96), (0, 0, 0, 0))
+    for y in range(20, 80):
+        for x in range(24 + shift, 44 + shift):
+            img.putpixel((x, y), (60 + x * 2 % 190, 40 + y * 3 % 200, 200 - y % 150, 255))
+    return img
+
+
+def _pixel_master() -> bytes:
+    """8 像素块、4 色的像素画母版;逻辑高 > 8 才会走「锁母版色板」那一支。"""
+    img = Image.new("RGBA", (128, 128), (0, 0, 0, 0))
+    palette = [(220, 40, 40), (40, 200, 90), (40, 90, 220), (240, 220, 60)]
+    for by in range(4, 14):
+        for bx in range(4, 12):
+            img.paste(
+                palette[(bx + by) % 4] + (255,),
+                (bx * 8, by * 8, bx * 8 + 8, by * 8 + 8),
+            )
+    buf = io.BytesIO()
+    img.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _delivered_colors(game_style: str | None, session_factory, monkeypatch) -> int:
+    """建一个该画风的项目,跑完一条动作任务,数交付帧的色数。"""
+    monkeypatch.setattr(
+        "windup_ai_engine.strategy.concrete.extract_all_frames_bytes",
+        lambda video, cap=150: [_gradient_frame(i % 6) for i in range(24)],
+    )
+    with session_factory() as s:
+        project = Project(
+            user_id=1, project_name=f"画风-{game_style}", character_perspective=1,
+            directional_movement=1, sprite_width=64, sprite_height=64,
+            game_style=game_style,
+        )
+        s.add(project)
+        s.commit()
+        project_id = project.id
+
+    uploaded: list[bytes] = []
+    executor = ActionTaskExecutor(
+        generator=CharacterGenerator(
+            {GenRoute.VIDEO_I2V: VideoFrameStrategy(_StubVideo(), _StubMatte())}
+        ),
+        upload=lambda png: (uploaded.append(png), "https://cdn.example.com/f.png")[1],
+        fetch_master=lambda _input: _pixel_master(),
+        session_factory=session_factory,
+    )
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=4,
+    )
+    with session_factory() as s:
+        task = AiGenerationService().generate_character_action(s, user_id=1, input=action_input)
+        s.commit()
+        task_id = task.id
+    executor.run_action_task(task_id, action_input, project_id)
+
+    with session_factory() as s:
+        done = AiGenerationService().get_task(s, project_id=project_id, task_id=task_id)
+    assert done is not None and done.status is TaskStatus.COMPLETED, "任务没跑完,色数无从谈起"
+    assert uploaded, "没有帧被上传"
+    colors = set()
+    for png in uploaded:
+        a = np.asarray(Image.open(io.BytesIO(png)).convert("RGBA"))
+        colors |= {tuple(px) for px in a[a[:, :, 3] > 128][:, :3]}
+    return len(colors)
+
+
+def test_pixel_style_actually_pixelates_the_delivered_frames(session_factory, monkeypatch):
+    """只差项目画风一个字段,交付帧必须真的不一样。
+
+    断言参数传到了不够 —— 加了入参却没贯通到消费点时,生产恒走默认分支、空操作还不
+    报错,而直接构造下游对象的测试照样全绿。
+    """
+    pixel_colors = _delivered_colors("pixel", session_factory, monkeypatch)
+    plain_colors = _delivered_colors(None, session_factory, monkeypatch)
+
+    assert pixel_colors < plain_colors, (
+        f"像素档没有生效:像素 {pixel_colors} 色 / 不指定 {plain_colors} 色"
+    )
+    assert pixel_colors <= 48, f"像素档应吸附回母版色板,实际 {pixel_colors} 色"

--- a/backend/tests/test_project_api.py
+++ b/backend/tests/test_project_api.py
@@ -241,7 +241,7 @@ def test_rename_success_persists_the_new_name(auth_client):
 
     body = resp.json()
     assert body["code"] == 200
-    assert body["message"] == "重命名成功"
+    assert body["message"] == "修改成功"
     assert body["data"]["project_name"] == "重命名后"
     persisted = auth_client.get(f"/projects/{created['id']}").json()["data"]
     assert persisted["project_name"] == "重命名后"

--- a/openapi.json
+++ b/openapi.json
@@ -1973,8 +1973,16 @@
             "type": "integer"
           },
           "game_style": {
-            "$ref": "#/components/schemas/ArtStyle",
-            "default": "unspecified"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtStyle"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "default": "unspecified",
+            "title": "Game Style"
           },
           "project_name": {
             "maxLength": 20,
@@ -2222,9 +2230,13 @@
                 "$ref": "#/components/schemas/ArtStyle"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
-            ]
+            ],
+            "title": "Game Style"
           },
           "project_name": {
             "anyOf": [

--- a/openapi.json
+++ b/openapi.json
@@ -56,6 +56,18 @@
         "title": "ActionType",
         "type": "string"
       },
+      "ArtStyle": {
+        "description": "项目的美术风格。\n\n只有 ``PIXEL`` 改变管线行为(出帧吸附母版像素网格、颜色吸回母版色板),其余取值\n只进提示词。像素网格密度不在这一维 —— 它由目标分辨率定,两处各定一遍会打架。",
+        "enum": [
+          "pixel",
+          "cartoon",
+          "hand_drawn",
+          "realistic",
+          "unspecified"
+        ],
+        "title": "ArtStyle",
+        "type": "string"
+      },
       "AssistantMessageResponse": {
         "properties": {
           "content": {
@@ -1961,15 +1973,8 @@
             "type": "integer"
           },
           "game_style": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Game Style"
+            "$ref": "#/components/schemas/ArtStyle",
+            "default": "unspecified"
           },
           "project_name": {
             "maxLength": 20,
@@ -2208,20 +2213,34 @@
         "title": "ProjectOut",
         "type": "object"
       },
-      "ProjectRename": {
-        "description": "重命名项目请求。",
+      "ProjectPatch": {
+        "description": "改项目请求;只改传上来的那些字段。",
         "properties": {
+          "game_style": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtStyle"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "project_name": {
-            "maxLength": 20,
-            "minLength": 1,
-            "title": "Project Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "maxLength": 20,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Name"
           }
         },
-        "required": [
-          "project_name"
-        ],
-        "title": "ProjectRename",
+        "title": "ProjectPatch",
         "type": "object"
       },
       "RefreshRequest": {
@@ -4438,7 +4457,7 @@
         ]
       },
       "patch": {
-        "operationId": "rename_project_projects__project_id__patch",
+        "operationId": "update_project_projects__project_id__patch",
         "parameters": [
           {
             "in": "path",
@@ -4454,7 +4473,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ProjectRename"
+                "$ref": "#/components/schemas/ProjectPatch"
               }
             }
           },
@@ -4482,7 +4501,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Rename Project",
+        "summary": "Update Project",
         "tags": [
           "projects"
         ]


### PR DESCRIPTION
`game_style` 目前是不受限的自由文本，而序列帧走不走像素化后处理由对它做子串匹配决定（`executor.py`：`is_pixel = "pixel" in style.lower() or "像素" in style`）。写「复古 8bit」「点阵风」推不出 pixel，像素角色于是走 LANCZOS 重采样，硬边被糊成灰边并引入色板外颜色，而帧数、时长、成色全部正常，没有一道会红。

生产库 133 个项目里只有 9 个填过这个字段，取值只有「像素风格」与「像素风」，92% 为空即恒走 `stylize=none`；而人工标注的 24 张真实生产母版里 21 张是像素画，所属项目全部为空 —— 100% 跳过像素化。

## 改动

- 新增 `ArtStyle` 枚举：`pixel` / `cartoon` / `hand_drawn` / `realistic` / `unspecified`。只有 `pixel` 改变管线行为，其余取值只进提示词，各带一句自己的英文短语（卡通粗描线平涂、手绘有笔触、写实无描线走渐变 —— 它们在管线里同走一条路，只有提示词能把它们分开）。
- 像素密度不进这一维，由目标分辨率那条线定义（#589）。
- 不加新列。`from_stored` 把存量自由文本读成枚举，命中「像素/pixel」的仍判 pixel，与今天的子串匹配逐例一致。
- `PATCH /projects/{id}` 从只能改名扩成可以只改画风。

## 不包含

- 前端下拉与画布上的可编辑入口，另一条分支。
- 收紧入参（拒绝自由文本）与响应归一到枚举 —— 要等前端换成下拉之后再做，现在做会让还没换的客户端建不了项目、并让列表页显示 slug。所以本 PR 里 `unspecified` 落库存 NULL、响应形状不变。
- 画风补充描述需要新列，被 #594 挡着。

## 验证

- `uv run ruff check .`：通过。
- `uv run lint-imports`：Contracts 2 kept, 0 broken。
- `uv run pytest tests/`：1372 passed, 14 skipped。
- `uv run python -m scripts.export_openapi`：已重新导出并提交。

Closes #599
