### PR TITLE
feat(project): 画风改为可选择的受控档位

### DIFF
--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -97,16 +97,27 @@ class ProjectOut(BaseModel):
     directional_movement: int
     sprite_width: int
     sprite_height: int
-    game_style: ArtStyle
+    game_style: ArtStyle | str
     sprite_sample_url: str | None
     create_at: datetime
     update_at: datetime
 
     @field_validator("game_style", mode="before")
     @classmethod
-    def _normalize_style(cls, value: object) -> ArtStyle:
-        """库里既有枚举值也有存量自由文本;不归一的话前端会把「像素风格」显示成不指定。"""
-        return ArtStyle.from_stored(value if isinstance(value, str) else None)
+    def _normalize_style(cls, value: object) -> ArtStyle | str:
+        """库里既有枚举码也有存量自由文本。
+
+        认得出的归一成枚举码,认不出的**原样交出去** —— 压成 ``UNSPECIFIED`` 会让接口
+        与生成时实际用的画风对不上:库里存着「中世纪厚涂」、提示词里也用着它,而接口说
+        这个项目没设画风。
+        """
+        if not isinstance(value, str) or not value.strip():
+            return ArtStyle.UNSPECIFIED
+        text = value.strip()
+        try:
+            return ArtStyle(text)
+        except ValueError:
+            return ArtStyle.PIXEL if ArtStyle.from_stored(text) is ArtStyle.PIXEL else text
 
 
 class ProjectListOut(ProjectOut):

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -97,10 +97,16 @@ class ProjectOut(BaseModel):
     directional_movement: int
     sprite_width: int
     sprite_height: int
-    game_style: str | None
+    game_style: ArtStyle
     sprite_sample_url: str | None
     create_at: datetime
     update_at: datetime
+
+    @field_validator("game_style", mode="before")
+    @classmethod
+    def _normalize_style(cls, value: object) -> ArtStyle:
+        """库里既有枚举值也有存量自由文本;不归一的话前端会把「像素风格」显示成不指定。"""
+        return ArtStyle.from_stored(value if isinstance(value, str) else None)
 
 
 class ProjectListOut(ProjectOut):

--- a/backend/tests/test_art_style.py
+++ b/backend/tests/test_art_style.py
@@ -235,3 +235,15 @@ def test_no_phrase_uses_a_negation(style):
 
     errors = [i for i in lint(style.prompt_phrase, kind="still") if i.level == "error"]
     assert errors == [], f"{style.value}: {[i.message for i in errors]}"
+
+
+def test_reading_a_non_pixel_legacy_row_tells_the_truth(auth_client, db_session):
+    """接口不能说「没设画风」而生成时又在用那段文字 —— 认不出的原样交出去。"""
+    from windup_app.server.project.model import Project
+
+    created = auth_client.post("/projects", json=_payload()).json()["data"]
+    db_session.get(Project, created["id"]).game_style = "中世纪厚涂"
+    db_session.commit()
+
+    body = auth_client.get(f"/projects/{created['id']}").json()
+    assert body["data"]["game_style"] == "中世纪厚涂"

--- a/backend/tests/test_art_style.py
+++ b/backend/tests/test_art_style.py
@@ -80,10 +80,27 @@ def test_created_project_reports_the_chosen_style(auth_client):
     assert created["game_style"] == "pixel"
 
 
-def test_unspecified_is_stored_as_null(auth_client):
-    """现有前端把这一列原样显示,写字面量会让「不指定」四个字变成 unspecified。"""
+def test_unspecified_is_stored_as_null(auth_client, db_session):
+    """库里存 NULL 而不是字面量;响应侧再归一成枚举交给前端。"""
+    from windup_app.server.project.model import Project
+
     created = auth_client.post("/projects", json=_payload()).json()["data"]
-    assert created["game_style"] is None
+    assert created["game_style"] == "unspecified"
+    assert db_session.get(Project, created["id"]).game_style is None
+
+
+def test_reading_a_legacy_row_reports_the_branch_it_takes(auth_client, db_session):
+    """存量存的是自由文本,不归一的话前端会把「像素风格」显示成不指定。"""
+    from windup_app.server.project.model import Project
+
+    created = auth_client.post("/projects", json=_payload()).json()["data"]
+    project = db_session.get(Project, created["id"])
+    project.game_style = "像素风格"
+    db_session.commit()
+
+    body = auth_client.get(f"/projects/{created['id']}").json()
+    assert body["code"] == 200
+    assert body["data"]["game_style"] == "pixel"
 
 
 # -- 改画风 ------------------------------------------------------------------

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -23,13 +23,18 @@ export type {
 
 /* 项目 —— 全局约束：视角、朝向、精灵尺寸、画风 */
 export {
+  ART_STYLE,
+  ART_STYLE_HINT,
+  ART_STYLE_OPTIONS,
   CHARACTER_PERSPECTIVE,
+  isArtStyle,
   DIRECTIONAL_MOVEMENT,
   ProjectHasCharactersError,
   ProjectNameConflictError,
 } from './project'
 export { projectApis } from './project'
 export type {
+  ArtStyle,
   CharacterPerspective,
   CreateProjectInput,
   DirectionalMovement,

--- a/frontend/src/entities/project/index.test.ts
+++ b/frontend/src/entities/project/index.test.ts
@@ -60,7 +60,7 @@ describe('projectApis', () => {
           perspective: 'isometric',
           directionalMovement: 'four-way',
           spriteSize: { width: 64, height: 96 },
-          gameStyle: null,
+          gameStyle: 'unspecified',
           sampleImageUrl: 'https://cdn.windup.test/style.png',
           previewUrl: 'https://cdn.windup.test/project-preview.png',
           createdAt: '2026-08-01T08:00:00Z',
@@ -87,7 +87,7 @@ describe('projectApis', () => {
       perspective: 'isometric',
       directionalMovement: 'four-way',
       spriteSize: { width: 64, height: 96 },
-      gameStyle: null,
+      gameStyle: 'unspecified',
       sampleImageUrl: 'https://cdn.windup.test/style.png',
     })
 
@@ -100,7 +100,7 @@ describe('projectApis', () => {
       directional_movement: 2,
       sprite_width: 64,
       sprite_height: 96,
-      game_style: null,
+      game_style: 'unspecified',
       sprite_sample_url: 'https://cdn.windup.test/style.png',
     })
   })

--- a/frontend/src/entities/project/index.ts
+++ b/frontend/src/entities/project/index.ts
@@ -9,7 +9,7 @@ export interface Project {
   perspective: CharacterPerspective
   directionalMovement: DirectionalMovement
   spriteSize: { width: number; height: number }
-  gameStyle: string | null
+  gameStyle: ArtStyle
   sampleImageUrl: string | null
   /** 项目列表已经解析好的卡片预览；详情响应不承诺提供。 */
   previewUrl?: string | null
@@ -27,7 +27,7 @@ export interface CreateProjectInput {
   perspective: CharacterPerspective
   directionalMovement: DirectionalMovement
   spriteSize: { width: number; height: number }
-  gameStyle?: string | null
+  gameStyle?: ArtStyle
   sampleImageUrl?: string | null
 }
 
@@ -75,12 +75,41 @@ export const DIRECTIONAL_MOVEMENT: Record<DirectionalMovement, string> = {
   'eight-way': '八向',
 }
 
+/** 后端 game_style；只有 pixel 会改变出帧管线，其余只进提示词。 */
+export type ArtStyle = 'pixel' | 'cartoon' | 'hand_drawn' | 'realistic' | 'unspecified'
+
+export const ART_STYLE: Record<ArtStyle, string> = {
+  pixel: '像素',
+  cartoon: '卡通',
+  hand_drawn: '手绘',
+  realistic: '写实',
+  unspecified: '不指定',
+}
+
+/** 选项旁的一句说明；用户选画风时看不到管线，得把差别讲出来。 */
+export const ART_STYLE_HINT: Record<ArtStyle, string> = {
+  pixel: '出帧吸附母版像素网格，颜色吸回母版色板',
+  cartoon: '粗描线、平涂',
+  hand_drawn: '有笔触与纸纹',
+  realistic: '无描线，走渐变与体积光',
+  unspecified: '不给模型画风约束',
+}
+
+export const ART_STYLE_OPTIONS: ArtStyle[] = [
+  'pixel',
+  'cartoon',
+  'hand_drawn',
+  'realistic',
+  'unspecified',
+]
+
 /** Project 对应的一组后端接口。 */
 export interface ProjectApis {
   list(query?: ProjectPageQuery): Promise<Paged<Project>>
   get(id: Project['id']): Promise<Project>
   create(input: CreateProjectInput): Promise<Project>
   rename(id: Project['id'], name: string): Promise<Project>
+  setGameStyle(id: Project['id'], gameStyle: ArtStyle): Promise<Project>
   remove(id: Project['id']): Promise<void>
 }
 
@@ -97,6 +126,15 @@ interface ProjectDto {
   preview_url?: string | null
   create_at: string
   update_at: string
+}
+
+export function isArtStyle(value: unknown): value is ArtStyle {
+  return typeof value === 'string' && value in ART_STYLE
+}
+
+/** 后端已经把存量自由文本归一成枚举；这里只兜住 null 与未知取值。 */
+function artStyleFromDto(value: string | null): ArtStyle {
+  return isArtStyle(value) ? value : 'unspecified'
 }
 
 const perspectiveFromDto: Record<number, CharacterPerspective> = {
@@ -154,7 +192,7 @@ function mapProject(dto: ProjectDto): Project {
       'directional_movement',
     ),
     spriteSize: { width: dto.sprite_width, height: dto.sprite_height },
-    gameStyle: dto.game_style,
+    gameStyle: artStyleFromDto(dto.game_style),
     sampleImageUrl: dto.sprite_sample_url,
     previewUrl: dto.preview_url ?? dto.sprite_sample_url,
     createdAt: dto.create_at,
@@ -238,6 +276,15 @@ export const projectApis: ProjectApis = {
       }
       throw error
     }
+  },
+
+  async setGameStyle(id, gameStyle) {
+    return mapProject(
+      await getApiClient().request<ProjectDto>(`/projects/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        json: { game_style: gameStyle },
+      }),
+    )
   },
 
   async remove(id) {

--- a/frontend/src/features/export-package/character-export.test.ts
+++ b/frontend/src/features/export-package/character-export.test.ts
@@ -11,7 +11,7 @@ const project: Project = {
   perspective: 'side',
   directionalMovement: 'single',
   spriteSize: { width: 64, height: 80 },
-  gameStyle: null,
+  gameStyle: 'unspecified',
   sampleImageUrl: null,
   createdAt: '2026-08-01T08:00:00Z',
   updatedAt: '2026-08-01T08:00:00Z',

--- a/frontend/src/features/export-package/progressive-export.test.ts
+++ b/frontend/src/features/export-package/progressive-export.test.ts
@@ -11,7 +11,7 @@ const project: Project = {
   perspective: 'side',
   directionalMovement: 'single',
   spriteSize: { width: 32, height: 40 },
-  gameStyle: null,
+  gameStyle: 'unspecified',
   sampleImageUrl: null,
   createdAt: '2026-08-01T08:00:00Z',
   updatedAt: '2026-08-01T08:00:00Z',

--- a/frontend/src/features/quick-start-agent/production.ts
+++ b/frontend/src/features/quick-start-agent/production.ts
@@ -1,4 +1,5 @@
 import {
+  isArtStyle,
   createAuthenticatedGenerationApis,
   projectApis,
   workflowRunApis,
@@ -133,6 +134,7 @@ export function createProductionQuickStartAgentDependencies(
       return planner(input)
     },
     async startCharacterGeneration(input) {
+      const gameStyle = isArtStyle(input.gameStyle) ? input.gameStyle : undefined
       generationApis ??= createAuthenticatedGenerationApis()
       const controller = createController({
         workflowRunApis: runApis,
@@ -141,7 +143,7 @@ export function createProductionQuickStartAgentDependencies(
         onAsyncError: reportError,
       })
       try {
-        return await controller.startCharacterGeneration(input)
+        return await controller.startCharacterGeneration({ prompt: input.prompt, gameStyle })
       } finally {
         controller.dispose()
       }

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -102,10 +102,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
   ])
 
   const submit = useCallback(
-    async (
-      input: string,
-      { gameStyle }: { gameStyle?: string } = {},
-    ): Promise<QuickStartAgentResult> => {
+    async (input: string): Promise<QuickStartAgentResult> => {
       if (running.current) throw new Error('Planner 正在处理上一条输入')
       running.current = true
       const controller = new AbortController()
@@ -116,7 +113,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
         const activeAgent = ensureAgent()
         const runTurn = started.current ? activeAgent.continue : activeAgent.start
         started.current = true
-        const result = await runTurn(input, { signal: controller.signal, gameStyle })
+        const result = await runTurn(input, { signal: controller.signal })
         if (mounted.current) {
           if (result.kind === 'message') {
             setState({
@@ -148,6 +145,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
     async (
       prompt: string,
       directionalMovement: QuickStartDirectionalMovement = 'single',
+      options?: { gameStyle?: string },
     ): Promise<QuickStartAgentResult> => {
       if (running.current) throw new Error('Planner 正在处理上一条输入')
       if (state.status !== 'proposal') throw new Error('提示词提案已失效')
@@ -162,7 +160,12 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
         })
       }
       try {
-        return await ensureAgent().confirmProposal(proposalId, prompt, directionalMovement)
+        return await ensureAgent().confirmProposal(
+          proposalId,
+          prompt,
+          directionalMovement,
+          options,
+        )
       } catch (cause) {
         if (mounted.current) {
           logAgentFailure(cause)

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -102,7 +102,10 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
   ])
 
   const submit = useCallback(
-    async (input: string): Promise<QuickStartAgentResult> => {
+    async (
+      input: string,
+      { gameStyle }: { gameStyle?: string } = {},
+    ): Promise<QuickStartAgentResult> => {
       if (running.current) throw new Error('Planner 正在处理上一条输入')
       running.current = true
       const controller = new AbortController()
@@ -113,7 +116,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
         const activeAgent = ensureAgent()
         const runTurn = started.current ? activeAgent.continue : activeAgent.start
         started.current = true
-        const result = await runTurn(input, { signal: controller.signal })
+        const result = await runTurn(input, { signal: controller.signal, gameStyle })
         if (mounted.current) {
           if (result.kind === 'message') {
             setState({

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -65,7 +65,10 @@ export type QuickStartAgentResult =
 
 export interface QuickStartAgentTurnOptions {
   signal?: AbortSignal
-  /** 入口处选的画风，原样透传给宿主；取值范围由宿主定义,本模块不认识业务对象。 */
+}
+
+export interface ConfirmProposalOptions {
+  /** 画风原样透传给宿主；取值范围由宿主定义，本模块不认识业务对象。 */
   gameStyle?: string
 }
 
@@ -76,6 +79,7 @@ export interface QuickStartAgent {
     proposalId: string,
     prompt: string,
     directionalMovement?: QuickStartDirectionalMovement,
+    options?: ConfirmProposalOptions,
   ): Promise<QuickStartAgentResult>
   revoke(): void
 }
@@ -226,8 +230,6 @@ export function createQuickStartAgent({
   let running = false
   let messages: PlannerMessage[] = [...initialMessages]
   let currentProposal = initialProposal
-  /** 画风在入口那一轮就选定了,而真正下单在用户确认提案之后,中间要存住。 */
-  let pendingGameStyle: string | undefined
 
   function assertAuthorized() {
     if (revoked) throw new Error('生成授权已失效')
@@ -236,10 +238,9 @@ export function createQuickStartAgent({
 
   async function runTurn(
     input: string,
-    { signal, gameStyle }: QuickStartAgentTurnOptions = {},
+    { signal }: QuickStartAgentTurnOptions = {},
   ): Promise<QuickStartAgentResult> {
     assertAuthorized()
-    if (gameStyle !== undefined) pendingGameStyle = gameStyle
     if (running) throw new Error('Planner 正在处理上一条输入')
     const normalizedInput = input.trim()
     if (!normalizedInput) throw new Error('请先描述想要创建的角色')
@@ -289,6 +290,7 @@ export function createQuickStartAgent({
     proposalId: string,
     prompt: string,
     directionalMovement: QuickStartDirectionalMovement = 'single',
+    { gameStyle }: ConfirmProposalOptions = {},
   ): Promise<QuickStartAgentResult> {
     assertAuthorized()
     if (running) throw new Error('Planner 正在处理上一条输入')
@@ -308,7 +310,7 @@ export function createQuickStartAgent({
       const { runId } = await startCharacterGeneration({
         prompt: effectivePrompt,
         directionalMovement,
-        gameStyle: pendingGameStyle,
+        gameStyle,
       })
       return { kind: 'generated', runId, ...proposal, optimizedPrompt: effectivePrompt }
     } finally {

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -65,6 +65,8 @@ export type QuickStartAgentResult =
 
 export interface QuickStartAgentTurnOptions {
   signal?: AbortSignal
+  /** 入口处选的画风，原样透传给宿主；取值范围由宿主定义,本模块不认识业务对象。 */
+  gameStyle?: string
 }
 
 export interface QuickStartAgent {
@@ -82,6 +84,7 @@ export interface QuickStartAgent {
 export type StartCharacterGenerationAction = (input: {
   prompt: string
   directionalMovement?: QuickStartDirectionalMovement
+  gameStyle?: string
 }) => Promise<{ runId: string }>
 
 export interface CreateQuickStartAgentOptions {
@@ -223,6 +226,8 @@ export function createQuickStartAgent({
   let running = false
   let messages: PlannerMessage[] = [...initialMessages]
   let currentProposal = initialProposal
+  /** 画风在入口那一轮就选定了,而真正下单在用户确认提案之后,中间要存住。 */
+  let pendingGameStyle: string | undefined
 
   function assertAuthorized() {
     if (revoked) throw new Error('生成授权已失效')
@@ -231,9 +236,10 @@ export function createQuickStartAgent({
 
   async function runTurn(
     input: string,
-    { signal }: QuickStartAgentTurnOptions = {},
+    { signal, gameStyle }: QuickStartAgentTurnOptions = {},
   ): Promise<QuickStartAgentResult> {
     assertAuthorized()
+    if (gameStyle !== undefined) pendingGameStyle = gameStyle
     if (running) throw new Error('Planner 正在处理上一条输入')
     const normalizedInput = input.trim()
     if (!normalizedInput) throw new Error('请先描述想要创建的角色')
@@ -302,6 +308,7 @@ export function createQuickStartAgent({
       const { runId } = await startCharacterGeneration({
         prompt: effectivePrompt,
         directionalMovement,
+        gameStyle: pendingGameStyle,
       })
       return { kind: 'generated', runId, ...proposal, optimizedPrompt: effectivePrompt }
     } finally {

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -329,7 +329,9 @@ describe('WorkflowController', () => {
       directionalMovement: 'four-way',
     })
 
-    expect(prepareProject).toHaveBeenCalledWith('四向像素骑士', 'four-way')
+    expect(prepareProject).toHaveBeenCalledWith('四向像素骑士', 'four-way', {
+      gameStyle: undefined,
+    })
     expect(generation.apis.create).toHaveBeenCalledTimes(4)
     expect(vi.mocked(generation.apis.create).mock.calls.map(([input]) => input.direction)).toEqual([
       'east',

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -280,7 +280,9 @@ describe('WorkflowController', () => {
       controller.startCharacterGeneration({ prompt: '  银发像素骑士  ' }),
     ).resolves.toEqual({ runId: 'run-1' })
 
-    expect(prepareProject).toHaveBeenCalledWith('银发像素骑士', 'single')
+    expect(prepareProject).toHaveBeenCalledWith('银发像素骑士', 'single', {
+      gameStyle: undefined,
+    })
     expect(workflow.apis.create).toHaveBeenCalledWith({
       projectId: 'project-agent',
       nodes: [

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -29,6 +29,7 @@ import type {
   DirectionalMovement,
 } from '@/entities'
 import {
+  type ArtStyle,
   getDirectionProfile,
   isImageCandidateCount,
   ProjectNameConflictError,
@@ -101,14 +102,20 @@ export interface ApplyGenerationResultInput {
   generation: Generation
 }
 
+export interface PrepareQuickStartProjectOptions {
+  gameStyle?: ArtStyle
+}
+
 export type PrepareQuickStartProject = (
   prompt: string,
   directionalMovement?: DirectionalMovement,
+  options?: PrepareQuickStartProjectOptions,
 ) => Promise<Pick<Project, 'id' | 'spriteSize'> & Partial<Pick<Project, 'directionalMovement'>>>
 
 export interface StartCharacterGenerationInput {
   prompt: string
   directionalMovement?: DirectionalMovement
+  gameStyle?: ArtStyle
 }
 
 export interface StartCharacterGenerationResult {
@@ -245,7 +252,7 @@ function boundedProjectName(value: string, maxLength: number): string {
 export function createAutoPrepareProject(
   projectApis: Pick<ProjectApis, 'create'>,
 ): PrepareQuickStartProject {
-  return async (prompt, directionalMovement = 'single') => {
+  return async (prompt, directionalMovement = 'single', options) => {
     const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
     let lastConflict: unknown
 
@@ -260,6 +267,7 @@ export function createAutoPrepareProject(
           perspective: 'side',
           directionalMovement,
           spriteSize: { width: 256, height: 256 },
+          gameStyle: options?.gameStyle,
         })
         return {
           id: project.id,
@@ -390,13 +398,16 @@ export function createWorkflowController({
   async function startCharacterGeneration({
     prompt,
     directionalMovement: selectedDirectionalMovement = 'single',
+    gameStyle,
   }: StartCharacterGenerationInput): Promise<StartCharacterGenerationResult> {
     ensureRunning()
     if (!prepareProject) {
       throw new Error('WorkflowController 未配置 Quick Start 项目准备能力')
     }
     const normalizedPrompt = nonEmpty(prompt, '角色描述')
-    const project = await prepareProject(normalizedPrompt, selectedDirectionalMovement)
+    const project = await prepareProject(normalizedPrompt, selectedDirectionalMovement, {
+      gameStyle,
+    })
     generationDirections = getDirectionProfile(
       project.directionalMovement ?? selectedDirectionalMovement,
     ).generationDirections

--- a/frontend/src/features/workflow-controller/index.ts
+++ b/frontend/src/features/workflow-controller/index.ts
@@ -6,6 +6,7 @@ export type {
   GenerateActionOptions,
   GenerateCharacterTemplateOptions,
   PrepareQuickStartProject,
+  PrepareQuickStartProjectOptions,
   StartCharacterGenerationInput,
   StartCharacterGenerationResult,
   WorkflowController,

--- a/frontend/src/pages/project-create/index.test.tsx
+++ b/frontend/src/pages/project-create/index.test.tsx
@@ -173,7 +173,7 @@ describe('ProjectCreatePage', () => {
     fireEvent.change(screen.getByLabelText('游戏视角'), { target: { value: 'top-down' } })
     fireEvent.change(screen.getByLabelText('朝向'), { target: { value: 'eight-way' } })
     fireEvent.click(screen.getByRole('button', { name: '512 × 512' }))
-    fireEvent.change(screen.getByLabelText('画风约束'), { target: { value: '低饱和像素绘本' } })
+    fireEvent.change(screen.getByLabelText('画风'), { target: { value: 'pixel' } })
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
 
     expect(await screen.findByRole('heading', { name: '雾港来信' })).toBeTruthy()
@@ -186,7 +186,7 @@ describe('ProjectCreatePage', () => {
       directional_movement: 3,
       sprite_width: 512,
       sprite_height: 512,
-      game_style: '低饱和像素绘本',
+      game_style: 'pixel',
     })
     // 归属由后端从 JWT 取；请求体再带 user_id 就等于宣称可以替别人建项目。
     expect(Object.hasOwn(body, 'user_id')).toBe(false)
@@ -217,11 +217,11 @@ describe('ProjectCreatePage', () => {
     await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '点灯人 · MVP' } })
-    fireEvent.change(screen.getByLabelText('画风约束'), { target: { value: '低饱和像素绘本' } })
+    fireEvent.change(screen.getByLabelText('画风'), { target: { value: 'pixel' } })
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
 
     expect((await screen.findByRole('alert')).textContent).toBe('项目名称已存在')
-    expect((screen.getByLabelText('画风约束') as HTMLTextAreaElement).value).toBe('低饱和像素绘本')
+    expect((screen.getByLabelText('画风') as HTMLSelectElement).value).toBe('pixel')
   })
 
   it('连续点击创建只发出一次请求', async () => {

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -2,10 +2,14 @@ import { useRef, useState, type FormEvent } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
 
 import {
+  ART_STYLE,
+  ART_STYLE_HINT,
+  ART_STYLE_OPTIONS,
   CHARACTER_PERSPECTIVE,
   DIRECTIONAL_MOVEMENT,
   projectApis,
   workflowRunApis,
+  type ArtStyle,
   type CharacterPerspective,
   type DirectionalMovement,
   type Project,
@@ -31,12 +35,6 @@ const SPRITE_MAX = 2048
 /** 常用档位只是快捷填充，用户仍可以填这三档之外的任意合法宽高。 */
 const SPRITE_PRESETS = [128, 256, 512]
 
-/**
- * 画风约束的长度上限只存在于前端：后端 `game_style` 是没有长度约束的 Text。
- * 定这个数是为了让它维持在「一句风格描述」的量级，不是契约要求。
- */
-const GAME_STYLE_MAX_LENGTH = 240
-
 /** 创建真实项目；首页画布入口与项目中心的新建按钮共用这一页。 */
 export function ProjectCreatePage() {
   const navigate = useNavigate()
@@ -54,7 +52,7 @@ export function ProjectCreatePage() {
   const [directionalMovement, setDirectionalMovement] = useState<DirectionalMovement>('single')
   const [spriteWidth, setSpriteWidth] = useState('256')
   const [spriteHeight, setSpriteHeight] = useState('256')
-  const [gameStyle, setGameStyle] = useState('')
+  const [gameStyle, setGameStyle] = useState<ArtStyle>('unspecified')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [createdProject, setCreatedProject] = useState<Project | null>(null)
@@ -88,7 +86,7 @@ export function ProjectCreatePage() {
           perspective,
           directionalMovement,
           spriteSize: { width, height },
-          gameStyle: gameStyle.trim() || null,
+          gameStyle,
         })
         if (opensWorkflowEditor) setCreatedProject(project)
       }
@@ -264,18 +262,24 @@ export function ProjectCreatePage() {
 
           <div className="grid gap-2">
             <label className="text-xs font-semibold text-app-ink-soft" htmlFor="project-style">
-              画风约束
+              画风
             </label>
-            <textarea
+            <select
               id="project-style"
-              rows={3}
               value={gameStyle}
               disabled={createdProject !== null}
-              maxLength={GAME_STYLE_MAX_LENGTH}
-              placeholder="例如：低饱和像素风、细长比例、深灰旅行服"
-              onChange={(event) => setGameStyle(event.target.value)}
-              className="resize-none rounded-xl border border-app-line bg-app-surface px-4 py-3 text-sm outline-none focus-visible:border-app-accent"
-            />
+              onChange={(event) => setGameStyle(event.target.value as ArtStyle)}
+              className="rounded-xl border border-app-line bg-app-surface px-4 py-3 text-sm outline-none focus-visible:border-app-accent"
+            >
+              {ART_STYLE_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {ART_STYLE[value]}
+                </option>
+              ))}
+            </select>
+            <small className="text-[11px] leading-5 text-app-muted">
+              {ART_STYLE_HINT[gameStyle]}
+            </small>
           </div>
 
           {error ? (

--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -183,7 +183,7 @@ describe('ProjectsPage', () => {
     expect(previewProject.textContent).toContain('08/04')
     expect(previewProject.textContent).toContain('横版视角 · 四向')
     expect(previewProject.textContent).toContain('64 × 64 px')
-    expect(previewProject.textContent).toContain('低饱和像素绘本')
+    expect(previewProject.textContent).toContain('像素')
     expect(screen.queryByText('项目名称')).toBeNull()
     expect(screen.queryByRole('link', { name: /查看角色/ })).toBeNull()
     const gallery = screen.getByRole('heading', { name: '最近项目 · 02' }).closest('section')

--- a/frontend/src/pages/projects/index.tsx
+++ b/frontend/src/pages/projects/index.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router'
 
 import assetLibraryArtwork from '@/assets/workspace/asset-library.png'
 import {
+  ART_STYLE,
   CHARACTER_PERSPECTIVE,
   DIRECTIONAL_MOVEMENT,
   projectApis,
@@ -313,7 +314,7 @@ function ProjectGalleryTile({
           {project.spriteSize.height} px
         </p>
         <p className="mt-1 truncate px-0.5 font-mono text-[0.65rem] tracking-[0.02em] text-app-faint">
-          {project.gameStyle || '未设置游戏风格'}
+          {ART_STYLE[project.gameStyle]}
         </p>
       </Link>
       <ProjectActions project={project} onRename={onRename} onDelete={onDelete} />

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -966,6 +966,7 @@ describe('QuickStartPage', () => {
     expect(startCharacterGeneration).toHaveBeenCalledWith({
       prompt: '云端工坊的银发机械师，佩戴黄铜护目镜',
       directionalMovement: 'single',
+      gameStyle: 'unspecified',
     })
   })
 
@@ -1596,6 +1597,7 @@ describe('QuickStartPage', () => {
       expect(startCharacterGeneration).toHaveBeenCalledWith({
         prompt: '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',
         directionalMovement: 'four-way',
+        gameStyle: 'unspecified',
       }),
     )
     expect(service.start).not.toHaveBeenCalled()
@@ -1615,6 +1617,7 @@ describe('QuickStartPage', () => {
         '挥手',
         expect.any(AbortSignal),
         'eight-way',
+        { gameStyle: 'unspecified' },
       ),
     )
   })

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -811,6 +811,44 @@ describe('QuickStartPage', () => {
     ])
   })
 
+  it('keeps the chosen art style across a page refresh', async () => {
+    // 画风选择器在有对话之后就隐藏了；不随草稿存住的话，刷新后它悄悄回到「不指定」，
+    // 用户看不见也改不了，最终建出来的项目画风是错的。
+    const service = serviceFor(null)
+    const agent = agentFor({
+      planner: vi.fn(async () => ({
+        text: '想保留哪个特征？',
+        finishReason: 'stop',
+        toolCalls: [],
+      })),
+    })
+    window.history.replaceState(null, '', '/quick-start')
+    const firstView = renderInBrowserHistory(service, agent)
+
+    fireEvent.change(screen.getByLabelText('画风'), { target: { value: 'pixel' } })
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '一个住在云端的机械师。' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    expect(await screen.findByText('想保留哪个特征？')).toBeTruthy()
+
+    const draftId = window.history.state?.windupQuickStartAgentDraftId
+    const key = `windup.quick-start.agent-chat.v2:draft:7:${draftId}`
+    expect(window.sessionStorage.getItem(key)).toContain('"gameStyle":"pixel"')
+
+    firstView.unmount()
+    renderInBrowserHistory(service, agent)
+    expect(screen.getByText('想保留哪个特征？')).toBeTruthy()
+
+    // 再发一句触发重新持久化：状态若已被重置成「不指定」，这次就会把它写回去。
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '再补一句。' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '继续' }))
+    await screen.findByText('再补一句。')
+    expect(window.sessionStorage.getItem(key)).toContain('"gameStyle":"pixel"')
+  })
+
   it('moves the Agent draft into a run-scoped sidecar when generation starts', async () => {
     vi.useFakeTimers()
     const createdRun = workflow(setupAndTemplate({ phase: 'generating' }), 'run-created')

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -28,6 +28,7 @@ import {
   ART_STYLE,
   ART_STYLE_OPTIONS,
   DIRECTIONAL_MOVEMENT,
+  isArtStyle,
   type ActionFirstFrameWorkflowNode,
   type ArtStyle,
   type CharacterTemplateWorkflowNode,
@@ -168,6 +169,8 @@ type AgentConversationTurn =
 
 type AgentConversationRecord = {
   turns: readonly AgentConversationTurn[]
+  /** 入口处选的画风；不随草稿存住的话，刷新后画风选择器已隐藏而值悄悄回到不指定。 */
+  gameStyle?: ArtStyle
 }
 
 type AgentConversationStorageName = 'localStorage' | 'sessionStorage'
@@ -194,6 +197,20 @@ function readAgentDraftId(): string | null {
     return typeof draftId === 'string' && draftId ? draftId : null
   } catch {
     return null
+  }
+}
+
+function readAgentDraftGameStyle(key: string): ArtStyle {
+  try {
+    const stored = window.sessionStorage.getItem(key)
+    if (!stored) return 'unspecified'
+    const parsed: unknown = JSON.parse(stored)
+    if (typeof parsed !== 'object' || parsed === null || !('gameStyle' in parsed)) {
+      return 'unspecified'
+    }
+    return isArtStyle(parsed.gameStyle) ? parsed.gameStyle : 'unspecified'
+  } catch {
+    return 'unspecified'
   }
 }
 
@@ -527,7 +544,14 @@ function QuickStartInput({
   const [prompt, setPrompt] = useState('')
   const [directionalMovement, setDirectionalMovement] = useState<DirectionalMovement>('single')
   const [templateFile, setTemplateFile] = useState<File | null>(null)
-  const [gameStyle, setGameStyle] = useState<ArtStyle>('unspecified')
+  const [gameStyle, setGameStyle] = useState<ArtStyle>(() => {
+    const draftId = readAgentDraftId()
+    return draftId
+      ? readAgentDraftGameStyle(agentDraftConversationStorageKey(activeRunUserId, draftId))
+      : 'unspecified'
+  })
+  const gameStyleRef = useRef(gameStyle)
+  gameStyleRef.current = gameStyle
   const [submitting, setSubmitting] = useState(false)
   const [revealingFirstAgentTurn, setRevealingFirstAgentTurn] = useState(false)
   const [entryTransition, setEntryTransition] = useState<'idle' | 'leaving'>('idle')
@@ -589,7 +613,7 @@ function QuickStartInput({
       writeAgentConversation(
         'sessionStorage',
         agentDraftConversationStorageKey(activeRunUserId, draftId),
-        { turns },
+        { turns, gameStyle: gameStyleRef.current },
       )
     },
     [activeRunUserId, ensureDraftId],
@@ -749,7 +773,9 @@ function QuickStartInput({
       if (!normalizedPrompt) return
       setPromptState('confirmed')
       try {
-        const result = await agentSession.confirmProposal(normalizedPrompt, directionalMovement)
+        const result = await agentSession.confirmProposal(normalizedPrompt, directionalMovement, {
+          gameStyle,
+        })
         if (result.kind === 'generated') await handoffGenerated(result)
       } catch {
         setPromptState('ready')
@@ -769,7 +795,7 @@ function QuickStartInput({
       else await revealFirstAgentTurn(userTurn)
       setPrompt('')
       try {
-        const result = await agentSession.submit(normalizedPrompt, { gameStyle })
+        const result = await agentSession.submit(normalizedPrompt)
         setRevealingFirstAgentTurn(false)
         if (result.kind === 'message') {
           appendConversationTurn({
@@ -1099,7 +1125,18 @@ function QuickStartInput({
                   value={gameStyle}
                   disabled={entryBusy}
                   aria-label="画风"
-                  onChange={(event) => setGameStyle(event.target.value as ArtStyle)}
+                  onChange={(event) => {
+                    const next = event.target.value as ArtStyle
+                    setGameStyle(next)
+                    const draftId = draftIdRef.current
+                    if (draftId) {
+                      writeAgentConversation(
+                        'sessionStorage',
+                        agentDraftConversationStorageKey(activeRunUserId, draftId),
+                        { turns: conversationTurnsRef.current, gameStyle: next },
+                      )
+                    }
+                  }}
                   className="rounded-md border border-app-line bg-app-surface px-2 py-1 text-xs text-app-ink-soft outline-none focus-visible:border-app-accent"
                 >
                   {ART_STYLE_OPTIONS.map((value) => (

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -25,8 +25,11 @@ import Markdown from 'markdown-to-jsx'
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router'
 
 import {
+  ART_STYLE,
+  ART_STYLE_OPTIONS,
   DIRECTIONAL_MOVEMENT,
   type ActionFirstFrameWorkflowNode,
+  type ArtStyle,
   type CharacterTemplateWorkflowNode,
   type DirectionalMovement,
   type WorkflowRun,
@@ -524,6 +527,7 @@ function QuickStartInput({
   const [prompt, setPrompt] = useState('')
   const [directionalMovement, setDirectionalMovement] = useState<DirectionalMovement>('single')
   const [templateFile, setTemplateFile] = useState<File | null>(null)
+  const [gameStyle, setGameStyle] = useState<ArtStyle>('unspecified')
   const [submitting, setSubmitting] = useState(false)
   const [revealingFirstAgentTurn, setRevealingFirstAgentTurn] = useState(false)
   const [entryTransition, setEntryTransition] = useState<'idle' | 'leaving'>('idle')
@@ -765,7 +769,7 @@ function QuickStartInput({
       else await revealFirstAgentTurn(userTurn)
       setPrompt('')
       try {
-        const result = await agentSession.submit(normalizedPrompt)
+        const result = await agentSession.submit(normalizedPrompt, { gameStyle })
         setRevealingFirstAgentTurn(false)
         if (result.kind === 'message') {
           appendConversationTurn({
@@ -807,6 +811,7 @@ function QuickStartInput({
         normalizedPrompt,
         abortController.signal,
         directionalMovement,
+        { gameStyle },
       )
       const handoffPromise = new Promise<void>((resolve) => {
         handoffTimer.current = setTimeout(() => {
@@ -1086,6 +1091,24 @@ function QuickStartInput({
                 <ImageSquare aria-hidden="true" size={17} weight="duotone" />
                 添加母版
               </button>
+            ) : null}
+            {!hasConversation ? (
+              <label className="inline-flex h-10 items-center gap-1.5 rounded-lg px-2 text-xs font-semibold whitespace-nowrap text-app-muted">
+                画风
+                <select
+                  value={gameStyle}
+                  disabled={entryBusy}
+                  aria-label="画风"
+                  onChange={(event) => setGameStyle(event.target.value as ArtStyle)}
+                  className="rounded-md border border-app-line bg-app-surface px-2 py-1 text-xs text-app-ink-soft outline-none focus-visible:border-app-accent"
+                >
+                  {ART_STYLE_OPTIONS.map((value) => (
+                    <option key={value} value={value}>
+                      {ART_STYLE[value]}
+                    </option>
+                  ))}
+                </select>
+              </label>
             ) : null}
             <button
               type="submit"

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -1101,7 +1101,7 @@ describe('createQuickStartService', () => {
       'four-way',
     )
 
-    expect(prepareProject).toHaveBeenCalledWith('挥手', 'four-way')
+    expect(prepareProject).toHaveBeenCalledWith('挥手', 'four-way', undefined)
     const calls = vi.mocked(generationApis.create).mock.calls.map(([input]) => input)
     expect(
       calls.filter((input) => input.type === 'character_template').map((input) => input.direction),

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -27,6 +27,7 @@ import {
   createAutoPrepareProject,
   createWorkflowController,
   type PrepareQuickStartProject,
+  type PrepareQuickStartProjectOptions,
   type WorkflowController,
 } from '@/features/workflow-controller'
 import { createProgressiveExportModel, type ExportPackageModel } from '@/features/export-package'
@@ -40,7 +41,7 @@ import {
 } from '@/features/quick-start-agent/runtime'
 
 export { createAutoPrepareProject }
-export type { PrepareQuickStartProject }
+export type { PrepareQuickStartProject, PrepareQuickStartProjectOptions }
 
 export interface QuickStartFrame {
   index: number
@@ -114,12 +115,17 @@ export interface QuickStartSession {
 
 export interface QuickStartEntryService {
   readonly unavailableReason: string | null
-  start(prompt: string, directionalMovement?: DirectionalMovement): Promise<QuickStartSession>
+  start(
+    prompt: string,
+    directionalMovement?: DirectionalMovement,
+    options?: PrepareQuickStartProjectOptions,
+  ): Promise<QuickStartSession>
   startWithUploadedTemplate(
     file: File,
     actionDescription: string,
     signal?: AbortSignal,
     directionalMovement?: DirectionalMovement,
+    options?: PrepareQuickStartProjectOptions,
   ): Promise<QuickStartSession>
   open(runId: WorkflowRun['id']): Promise<QuickStartSession>
 }
@@ -1005,10 +1011,10 @@ export function createQuickStartService({
   return {
     unavailableReason: null,
 
-    async start(prompt, directionalMovement = 'single') {
+    async start(prompt, directionalMovement = 'single', options) {
       const normalizedPrompt = prompt.trim()
       if (!normalizedPrompt) throw new Error('请先描述想要创建的角色')
-      const project = await prepareProject(normalizedPrompt, directionalMovement)
+      const project = await prepareProject(normalizedPrompt, directionalMovement, options)
       const projectDirectionalMovement = project.directionalMovement ?? directionalMovement
       projectSpriteSizes.set(project.id, project.spriteSize)
       projectDirectionalMovements.set(project.id, projectDirectionalMovement)
@@ -1029,11 +1035,12 @@ export function createQuickStartService({
       actionDescription,
       signal,
       directionalMovement = 'single',
+      options,
     ) {
       if (!mediaApis) throw new Error('媒体上传服务尚未配置，不能使用角色母版')
       const prompt = actionDescription.trim() || file.name.trim()
       if (!prompt) throw new Error('请提供动作描述或有效的图片文件')
-      const project = await prepareProject(prompt, directionalMovement)
+      const project = await prepareProject(prompt, directionalMovement, options)
       const projectDirectionalMovement = project.directionalMovement ?? directionalMovement
       projectSpriteSizes.set(project.id, project.spriteSize)
       projectDirectionalMovements.set(project.id, projectDirectionalMovement)

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -2294,7 +2294,7 @@ function projectFixture(): Project {
     perspective: 'side',
     directionalMovement: 'single',
     spriteSize: { width: 64, height: 64 },
-    gameStyle: null,
+    gameStyle: 'unspecified',
     sampleImageUrl: null,
     createdAt: '2026-08-10T00:00:00.000Z',
     updatedAt: '2026-08-10T00:00:00.000Z',

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -11,6 +11,8 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useLocation, useParams } from 'react-router'
 
 import {
+  projectApis,
+  type ArtStyle,
   type ActionPreset,
   type ActionFirstFrameWorkflowNode,
   type ActionDirection,
@@ -139,6 +141,8 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
   const [actionMenuLevel, setActionMenuLevel] = useState<ActionMenuLevel>('root')
   const [selectedOutfitId, setSelectedOutfitId] = useState<string | null>(null)
   const [canvasNodeState, setCanvasNodeState] = useState<WorkflowCardNode[]>([])
+  /** 画风改完只影响后续生成，重拉整个 session 太重，本页自己记住新值。 */
+  const [gameStyleOverride, setGameStyleOverride] = useState<ArtStyle | null>(null)
   const [actionPresets, setActionPresets] = useState<ActionPreset[] | null>(null)
   const [actionPresetError, setActionPresetError] = useState<string | null>(null)
 
@@ -276,7 +280,11 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
 
   return (
     <WorkflowEditorView
-      project={session.project}
+      project={
+        gameStyleOverride === null
+          ? session.project
+          : { ...session.project, gameStyle: gameStyleOverride }
+      }
       run={run}
       nodes={canvasNodes}
       edges={projected.edges}
@@ -286,6 +294,10 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
       generationReadError={!error && !resumeError ? generationReadError : null}
       reloadTo={`${location.pathname}${location.search}${location.hash}`}
       onRetryGenerations={retryGenerations}
+      onGameStyleChange={(gameStyle) => {
+        setGameStyleOverride(gameStyle)
+        void projectApis.setGameStyle(session.project.id, gameStyle)
+      }}
       onNodesChange={onNodesChange}
     />
   )

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -143,6 +143,8 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
   const [canvasNodeState, setCanvasNodeState] = useState<WorkflowCardNode[]>([])
   /** 画风改完只影响后续生成，重拉整个 session 太重，本页自己记住新值。 */
   const [gameStyleOverride, setGameStyleOverride] = useState<ArtStyle | null>(null)
+  const [gameStyleSaving, setGameStyleSaving] = useState(false)
+  const [gameStyleError, setGameStyleError] = useState<string | null>(null)
   const [actionPresets, setActionPresets] = useState<ActionPreset[] | null>(null)
   const [actionPresetError, setActionPresetError] = useState<string | null>(null)
 
@@ -276,7 +278,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
     return <EditorBoundary message="正在恢复 WorkflowRun" />
   }
 
-  const visibleError = error ?? resumeError ?? generationReadError
+  const visibleError = error ?? resumeError ?? generationReadError ?? gameStyleError
 
   return (
     <WorkflowEditorView
@@ -294,9 +296,20 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
       generationReadError={!error && !resumeError ? generationReadError : null}
       reloadTo={`${location.pathname}${location.search}${location.hash}`}
       onRetryGenerations={retryGenerations}
-      onGameStyleChange={(gameStyle) => {
-        setGameStyleOverride(gameStyle)
-        void projectApis.setGameStyle(session.project.id, gameStyle)
+      gameStyleSaving={gameStyleSaving}
+      onGameStyleChange={async (gameStyle) => {
+        // 先落库再改显示：反过来的话保存失败会让画布显示新画风、而生成仍按旧画风走，
+        // 两者不一致且没有一处会报错。保存期间禁用选择器，避免连点排队。
+        setGameStyleSaving(true)
+        setGameStyleError(null)
+        try {
+          await projectApis.setGameStyle(session.project.id, gameStyle)
+          setGameStyleOverride(gameStyle)
+        } catch (cause) {
+          setGameStyleError(errorMessage(cause, '保存画风失败'))
+        } finally {
+          setGameStyleSaving(false)
+        }
       }}
       onNodesChange={onNodesChange}
     />

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -1191,7 +1191,7 @@ function projectFixture(): Project {
     perspective: 'side',
     directionalMovement: 'single',
     spriteSize: { width: 64, height: 64 },
-    gameStyle: null,
+    gameStyle: 'unspecified',
     sampleImageUrl: null,
     createdAt: '2026-08-10T00:00:00.000Z',
     updatedAt: '2026-08-10T00:00:00.000Z',

--- a/frontend/src/pages/workflow-editor/workflow-editor-view.tsx
+++ b/frontend/src/pages/workflow-editor/workflow-editor-view.tsx
@@ -11,8 +11,11 @@ import { useEffect, type ReactNode } from 'react'
 import { Link } from 'react-router'
 
 import {
+  ART_STYLE,
+  ART_STYLE_OPTIONS,
   CHARACTER_PERSPECTIVE,
   DIRECTIONAL_MOVEMENT,
+  type ArtStyle,
   type Project,
   type WorkflowNode,
   type WorkflowRun,
@@ -38,6 +41,7 @@ interface WorkflowEditorViewProps {
   generationReadError: string | null
   reloadTo: string
   onRetryGenerations(): void
+  onGameStyleChange(gameStyle: ArtStyle): void
   onNodesChange(changes: NodeChange<WorkflowCardNode>[]): void
 }
 
@@ -52,13 +56,13 @@ export function WorkflowEditorView({
   generationReadError,
   reloadTo,
   onRetryGenerations,
+  onGameStyleChange,
   onNodesChange,
 }: WorkflowEditorViewProps) {
   const constraints = [
     CHARACTER_PERSPECTIVE[project.perspective],
     DIRECTIONAL_MOVEMENT[project.directionalMovement],
     `${project.spriteSize.width} × ${project.spriteSize.height}`,
-    project.gameStyle ?? '未设置画风',
   ]
 
   return (
@@ -74,6 +78,21 @@ export function WorkflowEditorView({
         <p className="m-0 overflow-hidden text-ellipsis whitespace-nowrap text-[9px] leading-[1.5] text-app-faint">
           {constraints.join(' / ')}
         </p>
+        <label className="pointer-events-auto m-0 flex items-center gap-1.5 text-[9px] leading-[1.5] text-app-faint">
+          画风
+          <select
+            value={project.gameStyle}
+            aria-label="项目画风"
+            onChange={(event) => onGameStyleChange(event.target.value as ArtStyle)}
+            className="rounded border border-app-line bg-app-surface px-1.5 py-0.5 text-[9px] text-app-ink-soft outline-none focus-visible:border-app-accent"
+          >
+            {ART_STYLE_OPTIONS.map((value) => (
+              <option key={value} value={value}>
+                {ART_STYLE[value]}
+              </option>
+            ))}
+          </select>
+        </label>
         <div className="mt-1 flex justify-end">
           <small className="font-mono text-[8px] font-bold text-[var(--color-app-muted)]">
             Run {run.id} · v{run.version}

--- a/frontend/src/pages/workflow-editor/workflow-editor-view.tsx
+++ b/frontend/src/pages/workflow-editor/workflow-editor-view.tsx
@@ -41,6 +41,7 @@ interface WorkflowEditorViewProps {
   generationReadError: string | null
   reloadTo: string
   onRetryGenerations(): void
+  gameStyleSaving: boolean
   onGameStyleChange(gameStyle: ArtStyle): void
   onNodesChange(changes: NodeChange<WorkflowCardNode>[]): void
 }
@@ -56,6 +57,7 @@ export function WorkflowEditorView({
   generationReadError,
   reloadTo,
   onRetryGenerations,
+  gameStyleSaving,
   onGameStyleChange,
   onNodesChange,
 }: WorkflowEditorViewProps) {
@@ -83,6 +85,7 @@ export function WorkflowEditorView({
           <select
             value={project.gameStyle}
             aria-label="项目画风"
+            disabled={gameStyleSaving}
             onChange={(event) => onGameStyleChange(event.target.value as ArtStyle)}
             className="rounded border border-app-line bg-app-surface px-1.5 py-0.5 text-[9px] text-app-ink-soft outline-none focus-visible:border-app-accent"
           >

--- a/frontend/src/test/project-assets-backend.ts
+++ b/frontend/src/test/project-assets-backend.ts
@@ -23,7 +23,7 @@ const projectDtos: ProjectDto[] = [
     directional_movement: 2,
     sprite_width: 64,
     sprite_height: 64,
-    game_style: '低饱和像素绘本',
+    game_style: 'pixel',
     sprite_sample_url: null,
     preview_url: 'https://cdn.windup.test/messenger-outfit.png',
     create_at: '2026-08-01T08:00:00Z',
@@ -307,7 +307,7 @@ export function createProjectAssetsBackend({
         }
         project.project_name = body.project_name
         project.update_at = '2026-08-07T00:00:00Z'
-        return response(project, '重命名成功')
+        return response(project, '修改成功')
       }
       if (request.method === 'DELETE' && project) {
         projects = projects.filter((item) => item.id !== projectId)

--- a/openapi.json
+++ b/openapi.json
@@ -2109,15 +2109,7 @@
             "type": "integer"
           },
           "game_style": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Game Style"
+            "$ref": "#/components/schemas/ArtStyle"
           },
           "id": {
             "title": "Id",
@@ -2208,15 +2200,7 @@
             "type": "integer"
           },
           "game_style": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Game Style"
+            "$ref": "#/components/schemas/ArtStyle"
           },
           "id": {
             "title": "Id",

--- a/openapi.json
+++ b/openapi.json
@@ -2109,7 +2109,15 @@
             "type": "integer"
           },
           "game_style": {
-            "$ref": "#/components/schemas/ArtStyle"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtStyle"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Game Style"
           },
           "id": {
             "title": "Id",
@@ -2200,7 +2208,15 @@
             "type": "integer"
           },
           "game_style": {
-            "$ref": "#/components/schemas/ArtStyle"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ArtStyle"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Game Style"
           },
           "id": {
             "title": "Id",


### PR DESCRIPTION
> 叠在 #600 上，先合 #600。本 PR 的自有改动只有最上面那个 commit（`feat(project): 画风改为可选择的受控档位`）。

#600 把 `game_style` 收敛成枚举，但它单独上线不改变任何生产行为 —— 新老项目这一列都是 NULL，没有入口会送出枚举值，`stylize` 仍恒为 `none`。这条 PR 是让它真的生效的那一半。

## 改动

- 创建页的自由文本框换成档位选择，Quick Start 入口与画布左下角的约束条也加上同一份，每档配一句说明（用户选画风时看不到管线，差别得讲出来）。
- 画布上改画风只影响后续生成，本页记住新值，不重拉整个 session。
- `ProjectOut.game_style` 归一成枚举。不归一会有一处两边不一致：存量项目存的是「像素风格」，后端判它是像素，而前端不做子串匹配（也不该做）会显示成「不指定」。
- Quick Start 的画风经宿主注入，`quick-start-agent` 仍不认识业务对象，只做透传。

## 不包含

- 收紧入参（拒绝自由文本）。本 PR 之后所有入口都送枚举，可以另开一条收尾。
- 参考图入口、体型轴（#563）、画风补充描述（需要新列，被 #594 挡着）。
- 每种画风的提示词调优（#465）。

## 验证

- 前端 `format:check` / `lint` / `typecheck` / `test`（72 文件 1037 用例）/ `build`：全过。
- 后端 `ruff` / `pytest`（1374 passed, 14 skipped）/ `export_openapi` 无漂移：全过。

Closes #602
