### PR TITLE
fix(quick-start): restore prompt proposal flow

### DIFF
--- a/frontend/src/features/quick-start-agent/planner.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.test.ts
@@ -109,4 +109,28 @@ describe('createAiSdkQuickStartPlanner', () => {
     expect(options?.tools?.refine_character_template?.execute).toBeUndefined()
     expect(options?.tools?.regenerate_first_frame).toBeUndefined()
   })
+
+  it('keeps the request within the backend message limit while preserving the latest turn', async () => {
+    const generate = vi.fn<QuickStartGenerateText>(async () => ({
+      text: '可以继续。',
+      finishReason: 'stop',
+      toolCalls: [],
+    }))
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      generateText: generate,
+    })
+    const messages = Array.from({ length: 19 }, (_, index) => ({
+      role: (index % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+      content: `消息 ${index + 1}`,
+    }))
+
+    await planner({ messages, clarificationUsed: true })
+
+    expect(generate.mock.calls[0]?.[0].messages).toEqual(messages.slice(-15))
+    expect(generate.mock.calls[0]?.[0].messages.at(-1)).toEqual({
+      role: 'user',
+      content: '消息 19',
+    })
+  })
 })

--- a/frontend/src/features/quick-start-agent/planner.ts
+++ b/frontend/src/features/quick-start-agent/planner.ts
@@ -44,6 +44,9 @@ export interface CreateAiSdkQuickStartPlannerOptions {
   generateText?: QuickStartGenerateText
 }
 
+// AI SDK 会在 messages 前加入一条 instructions system message；后端总上限为 16 条。
+const MAX_PLANNER_HISTORY_MESSAGES = 15
+
 const quickStartDecisionTool = tool({
   description:
     '返回本轮唯一决策：正常回复、一次必要澄清、无法继续的说明，或供用户选择采用的角色母版提示词提案。',
@@ -177,7 +180,7 @@ export function createAiSdkQuickStartPlanner({
       instructions: workflow
         ? quickStartWorkflowInstructions(workflow)
         : quickStartPlannerInstructions(clarificationUsed),
-      messages,
+      messages: messages.slice(-MAX_PLANNER_HISTORY_MESSAGES),
       tools,
       toolChoice: workflow ? 'auto' : 'required',
       maxRetries: 0,

--- a/frontend/src/features/quick-start-agent/react.test.tsx
+++ b/frontend/src/features/quick-start-agent/react.test.tsx
@@ -142,6 +142,27 @@ describe('useQuickStartAgent', () => {
     await act(async () => firstTurn)
   })
 
+  it.each(['生成提案参数字段无效', '请求参数无效'])(
+    'keeps the internal protocol error %s out of the conversation',
+    async (message) => {
+      const planner = vi.fn(async () => {
+        throw new Error(message)
+      })
+      const { result } = renderHook(() =>
+        useQuickStartAgent({ planner, startCharacterGeneration: vi.fn() }),
+      )
+
+      await act(async () => {
+        await expect(result.current.submit('直接生成')).rejects.toThrow(message)
+      })
+
+      expect(result.current.state).toEqual({
+        status: 'error',
+        message: 'Agent 没有完成这次回复，请重新发送',
+      })
+    },
+  )
+
   it('revokes pending work when the host unmounts', async () => {
     const planner = vi.fn(
       async ({ signal }: PlannerInput) =>

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -27,7 +27,7 @@ export type UseQuickStartAgentOptions = CreateQuickStartAgentOptions
 function errorMessage(cause: unknown): string {
   if (!(cause instanceof Error) || !cause.message) return 'Agent 暂时不可用，请稍后重试'
   if (
-    /Tool|Planner|quick_start_decision|optimizedPrompt|optimizationSummary|生成授权/u.test(
+    /Tool|Planner|quick_start_decision|optimizedPrompt|optimizationSummary|生成提案|请求参数无效|生成授权/u.test(
       cause.message,
     )
   ) {

--- a/frontend/src/features/quick-start-agent/runtime.test.ts
+++ b/frontend/src/features/quick-start-agent/runtime.test.ts
@@ -55,7 +55,7 @@ describe('Planner decisions', () => {
 
   it.each([
     [{ kind: 'reply', message: '' }, 'Planner 的文字决策无效'],
-    [{ kind: 'reply', message: '可以', optimizedPrompt: '多余字段' }, 'Planner 文字决策字段无效'],
+    [{ kind: 'reply', message: '可以', unexpected: '多余字段' }, 'Planner 文字决策字段无效'],
     [
       { kind: 'proposal', optimizedPrompt: '骑士', optimizationSummary: '' },
       '生成提案的 optimizationSummary 无效',
@@ -63,6 +63,21 @@ describe('Planner decisions', () => {
     [{ kind: 'unknown', message: '未知' }, 'Planner 决策类型无效'],
   ])('rejects malformed decision %#', (input, message) => {
     expect(() => parseQuickStartDecision(input)).toThrow(message)
+  })
+
+  it('ignores schema-declared fields that do not belong to the selected decision branch', () => {
+    expect(
+      parseQuickStartDecision({
+        kind: 'proposal',
+        message: '下面是整理后的提案。',
+        optimizedPrompt: '银发像素骑士全身像',
+        optimizationSummary: '我会保留银发骑士特征。',
+      }),
+    ).toEqual({
+      kind: 'proposal',
+      optimizedPrompt: '银发像素骑士全身像',
+      optimizationSummary: '我会保留银发骑士特征。',
+    })
   })
 
   it('fails closed for text-only, duplicate, or unknown decisions', () => {

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -9,6 +9,12 @@ export const REFINE_FIRST_FRAME_TOOL = 'refine_first_frame' as const
 const MAX_PROMPT_LENGTH = 4_000
 const MAX_MESSAGE_LENGTH = 2_000
 const MAX_OPTIMIZATION_SUMMARY_LENGTH = 600
+const QUICK_START_DECISION_FIELDS = new Set([
+  'kind',
+  'message',
+  'optimizedPrompt',
+  'optimizationSummary',
+])
 
 export interface PlannerMessage {
   role: 'user' | 'assistant'
@@ -131,9 +137,7 @@ export function parseCharacterGenerationPlan(value: unknown): CharacterGeneratio
   if (!isRecord(value)) throw new Error('生成提案参数必须是对象')
   const keys = Object.keys(value)
   if (
-    keys.some(
-      (key) => key !== 'kind' && key !== 'optimizedPrompt' && key !== 'optimizationSummary',
-    ) ||
+    keys.some((key) => !QUICK_START_DECISION_FIELDS.has(key)) ||
     (keys.includes('kind') && value.kind !== 'proposal') ||
     !keys.includes('optimizedPrompt') ||
     !keys.includes('optimizationSummary')
@@ -156,14 +160,14 @@ export function parseCharacterGenerationPlan(value: unknown): CharacterGeneratio
 
 export function parseQuickStartDecision(value: unknown): QuickStartDecision {
   if (!isRecord(value)) throw new Error('Planner 决策必须是对象')
+  const keys = Object.keys(value)
   if (value.kind === 'proposal') {
     return { kind: 'proposal', ...parseCharacterGenerationPlan(value) }
   }
   if (value.kind !== 'reply' && value.kind !== 'clarification' && value.kind !== 'blocked') {
     throw new Error('Planner 决策类型无效')
   }
-  const keys = Object.keys(value)
-  if (keys.some((key) => key !== 'kind' && key !== 'message') || !keys.includes('message')) {
+  if (keys.some((key) => !QUICK_START_DECISION_FIELDS.has(key)) || !keys.includes('message')) {
     throw new Error('Planner 文字决策字段无效')
   }
   return { kind: value.kind, message: parseMessage(value.message) }


### PR DESCRIPTION
修复 Quick Start 在提示词拟写阶段被 Planner 参数校验阻断的问题，使合法提案和长对话都能继续进入既有确认生成流程。

## Why

Planner 的扁平 Tool Schema 允许不同决策分支的字段同时出现，但运行时会拒绝分支无关字段；同时完整对话历史会连同 system message 超过后端 16 条限制。这两条路径分别向用户暴露“生成提案参数字段无效”和“请求参数无效”，导致提示词拟写无法继续。

## Changes

- 仅忽略 Tool Schema 已声明但当前决策分支不使用的字段，未知字段仍保持拒绝。
- 将发送给 Planner 的历史限制为最近 15 条，为 SDK 注入的 system message 保留 1 条额度。
- 将提案和请求契约错误收口为现有可重试提示，不再显示内部协议文案。

## Implementation

- 校验仍集中在 Quick Start Agent runtime，未放宽必填字段、长度和未知字段限制。
- 历史裁剪位于 Planner 请求边界，同时覆盖初始角色拟写和生成后工作流对话。
- 未改动生成授权、WorkflowController、页面步骤或付费调用语义。

## Verification

- [x] `npm test -- src/features/quick-start-agent src/pages/quick-start/index.test.tsx --configLoader runner`：7 个文件、138 个测试通过。
- [x] `npm run format:check`：209 个文件通过。
- [x] `npm run lint`：通过。
- [x] `npm run build`：TypeScript 与 Vite 生产构建通过。
- [x] 预发 `a.windup.xin`：部署 PR head `22455e0`，backend/PostgreSQL/Redis 健康，公网 `/api/health` 返回 200。

## Scope

- 本 PR 不包含：生成流程、WorkflowController、页面交互和部署配置改动。
- 后续事项：合并后再按 main 同步生产环境。

## Related Issues

Closes #601
