### PR TITLE
ci(workflows): keep per-commit CI runs on main

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,9 +4,12 @@ on:
   push:
   pull_request:
 
-# 同一 ref 新 run 取消旧的,省额度
+# 分支和 PR 上,同一 ref 新 run 取消旧的,省额度。
+# main 例外:每个 commit 单独成组。main 上所有 push 共用一个 ref,连着合几个 PR 时
+# 先合的 run 会被后合的掐掉,提交页面留下的是「取消」(显示成红叉),而不是这个 commit
+# 自己的 CI 结论——真挂了也看不出来。加 sha 让每个合入点各自跑完。
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: true
 
 # 开源项目最小权限

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -10,8 +10,10 @@ on:
 permissions:
   contents: read
 
+# main 上每个 commit 单独成组,理由同 backend.yml:main 的 push 共用一个 ref,
+# 连续合并会让先合的 run 被后合的取消,红叉掩盖掉真实结论。
 concurrency:
-  group: frontend-ci-${{ github.event.pull_request.number || github.ref }}
+  group: frontend-ci-${{ github.event.pull_request.number || github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
把两个 CI workflow 的并发组在 main 上按 commit 拆开，让每个合并提交都能跑完属于自己的 CI，不再被下一次合并取消。分支和 PR 上的行为一点没变，仍然是新 run 取消旧 run。

## Why

`backend.yml` 和 `frontend-ci.yml` 都开着 `cancel-in-progress: true`，并发组按 ref 划分。在分支和 PR 上这是对的，同一分支新 push 取消旧 run，省额度；但 main 上所有 push 共用 `refs/heads/main` 这一个组，后一次合并会把前一次还在跑的 run 掐掉。

8/24 05:30:45 到 05:32:31 两分钟内连着合了五个 PR，前四个的前后端 CI 全被后面的取消，提交列表里五行都是红叉。代价不只是难看：GitHub 把 `cancelled` 汇总进 failure 状态，被取消和真失败长得一模一样。

把这十个 run 逐个补跑之后才能确认全部为绿，其间 `6908e2b` 的 Frontend checks 还先跑出过一次 `failure`（`src/pages/playtest/index.test.tsx` 的八向用例），同一 sha 不改代码再跑一次又过了——是条不稳定用例，main 当时并没真的红。也就是说，取消、真失败、不稳定用例偶发失败，在提交列表上是同一个红叉，只能靠手动逐个重跑分辨。

## Changes

- main 上的 push 每个 commit 单独成组，各自跑完，提交列表里不再出现 `cancelled`
- 其他分支与 PR 行为不变：同一 ref 新 run 仍然取消旧 run，额度照省
- 两个 workflow 用同一套口径，并把理由写在注释里

## Implementation

并发组末尾按条件追加 sha，只在 `github.ref == 'refs/heads/main'` 时拼上：

```yaml
group: ci-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
```

`pull_request` 事件的 `github.ref` 是 `refs/pull/<n>/merge`，条件为假，表达式退回空串，组名与改动前逐字相同——这是选择在组名上做条件、而不是把 `cancel-in-progress` 改成条件表达式的原因：后者会让 main 的 run 排队串行，前者让它们各自并行跑完，更快也更省。

## Verification

- [x] `python3 -c "yaml.safe_load(...)"` 解析两个 workflow：通过，`concurrency.group` 与 `cancel-in-progress` 取值符合预期
- [ ] `actionlint`：Not run（本机未安装）
- [ ] 前后端测试套件：Not run（改动只涉及 workflow 元数据，不进入任何被测代码路径；worktree 未装依赖）
- [ ] main 上的实际效果：Not run（`push: main` 分支的表达式取值只有合并后才会被求值。本 PR 自身的 CI run 能正常起来即可证明表达式合法，main 上的分组效果需在合并后连续合并两个 PR 时观察）

## Scope

- 本 PR 不包含：CI 检查内容、触发条件、权限声明的任何改动；不引入 merge queue；不改 main 分支保护规则
- 后续事项：上面暴露的不稳定用例 `src/pages/playtest/index.test.tsx > uses the project movement mode to play an eight-way diagonal sequence` 另行跟进

## Related Issues

Closes #608
