### PR TITLE
fix(generation): 像素项目的母版按像素画缩放

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -115,8 +115,9 @@ def _load_constraints(session: Session, project_id: int | None) -> ProjectConstr
 def _fit_to(png: bytes, w: int, h: int, *, smooth: bool = False) -> bytes:
     """把图等比 contain 进 w×h(透明补边),落实尺寸约束。
 
-    ``smooth`` 决定重采样:序列帧是像素画,必须 NEAREST(插值会把硬边糊成灰边、
-    并引入调色板外的颜色);全彩角色母版反过来,NEAREST 缩图会明显锯齿,用 LANCZOS。
+    ``smooth`` 决定重采样:全彩图缩小用 LANCZOS(NEAREST 会明显锯齿);像素画反过来,
+    必须 NEAREST —— 插值会把硬边糊成灰边、并引入调色板外的颜色。实测一张 8px 块、
+    6 色的母版压到 256:LANCZOS 后网格检不出、逻辑高错一倍、**100% 的像素落在色板外**。
     """
     import io
 
@@ -716,7 +717,15 @@ class ImageTaskExecutor:
             # 请求里的 width/height 此前被丢掉:入口收下并校验过它们(_validate_project_size),
             # 而 ImageProvider.gen_image 没有尺寸参数,模型出多大就返多大 —— 又一个"接了不
             # 履约"的字段。模型本身不吃宽高,所以在这里落实。
-            png = _fit_to(matte.cutout(img), input.width, input.height, smooth=True)
+            # 像素项目的母版按像素画缩:上传出去的就是这一张,动作生成再取回来提色板与
+            # 逻辑高(strategy.concrete.master_pixel_spec)。LANCZOS 缩完色板里已经没有
+            # 一个原色,后面吸附的目标本身就是坏的(#607)。
+            png = _fit_to(
+                matte.cutout(img),
+                input.width,
+                input.height,
+                smooth=cons.stylize != "pixel",
+            )
             cut.append(Image.open(io.BytesIO(png)).convert("RGBA"))
             urls.append(upload(png))
         # 同一份 alpha 顺手数一次主体数(#427):此前多主体母版要等下一个动作任务才留痕,

--- a/backend/tests/test_master_resample.py
+++ b/backend/tests/test_master_resample.py
@@ -1,0 +1,64 @@
+"""母版缩到项目尺寸时的重采样:像素项目必须保住网格与色板。"""
+
+import io
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from windup_app.server.orchestrator.executor import _fit_to
+from windup_ai_engine.postprocess.pixelate import detect_pixel_size, master_pixel_spec
+
+BLOCK = 8
+CANVAS = 1024
+PALETTE = np.array(
+    [(220, 40, 40), (40, 200, 90), (40, 90, 220), (240, 220, 60), (30, 30, 40)],
+    np.uint8,
+)
+
+
+def _pixel_master() -> bytes:
+    """真值可控:块边长、色板、逻辑高都已知,读数不对能立刻分清是量具还是被测对象。"""
+    rng = np.random.default_rng(7)
+    a = np.zeros((CANVAS, CANVAS, 4), np.uint8)
+    for by in range(24, 104):                       # 主体 640px 高 → 逻辑高 80
+        for bx in range(40, 88):
+            y, x = by * BLOCK, bx * BLOCK
+            a[y : y + BLOCK, x : x + BLOCK, :3] = PALETTE[rng.integers(0, len(PALETTE))]
+            a[y : y + BLOCK, x : x + BLOCK, 3] = 255
+    buf = io.BytesIO()
+    Image.fromarray(a, "RGBA").save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _read(png: bytes) -> tuple[int, int, float]:
+    im = Image.open(io.BytesIO(png)).convert("RGBA")
+    arr = np.asarray(im)
+    visible = arr[arr[:, :, 3] > 128][:, :3]
+    logical_h, _ = master_pixel_spec(im)
+    off_palette = 1.0 - np.isin(visible, PALETTE).all(1).mean()
+    return detect_pixel_size(im), logical_h, float(off_palette)
+
+
+def test_pixel_master_keeps_its_grid_and_palette():
+    """像素母版缩完仍是同一张像素画;插值会让色板里一个原色都不剩。"""
+    block, logical_h, off = _read(_fit_to(_pixel_master(), 256, 256, smooth=False))
+
+    assert off == 0.0, f"缩放引入了色板外颜色:{off:.1%}"
+    assert logical_h == 80, f"逻辑高应保持 80,实际 {logical_h}"
+    assert block > 1, "网格被抹掉了(检不出块边长)"
+
+
+def test_smoothing_a_pixel_master_destroys_it():
+    """记录被修的那个坏例,免得哪天有人把 smooth 改回恒 True 而没有一处会红。"""
+    block, logical_h, off = _read(_fit_to(_pixel_master(), 256, 256, smooth=True))
+
+    assert off > 0.9
+    assert logical_h != 80
+    assert block == 1
+
+
+@pytest.mark.parametrize("smooth", [True, False])
+def test_fit_to_always_lands_on_the_requested_canvas(smooth):
+    png = _fit_to(_pixel_master(), 256, 256, smooth=smooth)
+    assert Image.open(io.BytesIO(png)).size == (256, 256)


### PR DESCRIPTION
母版从模型输出尺寸压到项目 sprite 尺寸时无条件走 LANCZOS，而前端生成母版发的宽高就是项目 sprite 尺寸（生产项目多为 256），模型出 1024 时这是一次 4 倍降采样。对像素画母版这一步是毁灭性的。

拿真值可控的合成母版量（1024 画布 / 8px 块 / 5 色 / 逻辑高 80）：

| | 块边长 | 逻辑高 | 色板外像素 |
|---|---|---|---|
| 原始母版 | 8 | 80 | 0.0% |
| LANCZOS→256（当前行为） | 1（检不出网格） | 160 | 100.0% |
| NEAREST→256（本 PR） | 2 | 80 | 0.0% |

上传出去的就是缩放后那张，动作生成再取回来提色板与逻辑高（`master_pixel_spec`）。色板提自一张 100% 像素都在色板外的图，吸附的目标本身是坏的；逻辑高读成 160，像素化按错一倍的网格降采样。24 张真实生产母版里 11 张 `detect_pixel_size` 返回 1，与这条机制一致。

## 改动

母版的重采样滤波按 `cons.stylize` 选：像素项目 NEAREST，其余保持 LANCZOS。序列帧那一侧本来就是 NEAREST，不动。

## 不包含

不改母版目标尺寸，也不改前端发什么宽高 —— 目标分辨率该是项目级还是角色级是另一条线（#589）。不做存量母版的重新生成。

## 验证

- `uv run ruff check .`：通过。
- `uv run lint-imports`：Contracts 2 kept, 0 broken。
- `uv run pytest tests/`：1356 passed, 14 skipped。
- `export_openapi`：无漂移。

新增测试里有一条是把被修的坏例本身锁住的（`test_smoothing_a_pixel_master_destroys_it`）：如果哪天有人把 `smooth` 改回恒 `True`，不锁住的话没有一处会红。

Closes #607
