### PR TITLE
feat(ops): 加一个只做加法的表结构巡检

### DIFF
--- a/backend/scripts/schema_sync.py
+++ b/backend/scripts/schema_sync.py
@@ -1,0 +1,114 @@
+"""比对 ORM 模型与库里的实际表结构，补出缺的列。
+
+`Base.metadata.create_all` 只补缺失的**表**，不给已有表加列。于是给已上线的表加一个字段时，
+生产库不会自己长出那一列，而 ORM 查询会显式点名它 —— 整个应用起不来。本仓至今没有迁移机制，
+部署后也从没给已有表加过列，所以这条路一直是未验证的。
+
+**只做加法。** 改类型、删列、加非空且无默认值的列一律拒绝并列出来，交给人写 SQL：
+前两者会丢数据，后者在有存量行的表上直接失败。加法是唯一能在不知道数据长什么样时安全自动化的。
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+os.environ.setdefault("JWT_SECRET", "schema-sync-only-secret-32-characters")
+os.environ.setdefault("POSTGRES_PASSWORD", "schema-sync-only-password")
+
+from sqlalchemy import inspect, text  # noqa: E402
+from sqlalchemy.engine import Engine  # noqa: E402
+from sqlalchemy.schema import CreateColumn  # noqa: E402
+
+from windup_framework.db import Base, engine as default_engine  # noqa: E402
+
+
+def _load_models() -> None:
+    """导入所有 ORM 模块，让 Base.metadata 认全。
+
+    与 bootstrap 用同一份清单会更好，但那个模块会连带起 FastAPI 应用；本脚本要能在
+    没有应用上下文的部署机上跑。
+    """
+    import windup_app.server.character.model  # noqa: F401
+    import windup_app.server.project.model  # noqa: F401
+    import windup_app.server.quota.model  # noqa: F401
+    import windup_app.server.user.model  # noqa: F401
+    import windup_framework.gateway.models  # noqa: F401
+
+    try:  # 有的模块随功能演进增删，缺了不该让整个巡检停摆
+        import windup_app.server.orchestrator.model  # noqa: F401
+        import windup_app.server.workflow.model  # noqa: F401
+    except ImportError:
+        pass
+
+
+def plan(engine: Engine, metadata=None) -> tuple[list[tuple[str, str, str]], list[str]]:
+    """返回 (可自动补的列, 需要人处理的项)。
+
+    ``metadata`` 只为测试留:默认走全仓模型,传入时可以在隔离的库上验本函数自己。
+    """
+    if metadata is None:
+        _load_models()
+        metadata = Base.metadata
+    insp = inspect(engine)
+    live_tables = set(insp.get_table_names())
+    additive: list[tuple[str, str, str]] = []
+    manual: list[str] = []
+
+    for table in metadata.sorted_tables:
+        if table.name not in live_tables:
+            continue                      # 缺整张表 → create_all 会建，不归本脚本
+        live = {c["name"]: c for c in insp.get_columns(table.name)}
+        for col in table.columns:
+            if col.name in live:
+                # 按方言编译而不是 str(col.type):BigInteger().with_variant(Integer, "sqlite")
+                # 这类声明的 str() 恒是基类型,拿它比会在变体生效的库上误报类型不一致。
+                want = col.type.compile(engine.dialect)
+                got = live[col.name]["type"].compile(engine.dialect)
+                if want.split("(")[0].upper() != got.split("(")[0].upper():
+                    manual.append(
+                        f"{table.name}.{col.name} 类型不一致：模型 {want} / 库 {got}"
+                    )
+                continue
+            if not col.nullable and col.server_default is None:
+                manual.append(
+                    f"{table.name}.{col.name} 是非空且无 server_default，"
+                    "存量行填不出值，请人工决定默认值后再加"
+                )
+                continue
+            ddl = str(CreateColumn(col).compile(engine))
+            additive.append((table.name, col.name, ddl))
+    return additive, manual
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--apply", action="store_true",
+                    help="真的执行；缺省只报告，退出码非 0 表示有漂移")
+    a = ap.parse_args()
+
+    additive, manual = plan(default_engine)
+    for m in manual:
+        print(f"[需人工] {m}")
+    for tbl, col, ddl in additive:
+        print(f"[可自动] ALTER TABLE {tbl} ADD COLUMN {ddl};")
+
+    if manual:
+        print(f"\n{len(manual)} 项需要人工处理，本脚本不动它们。")
+    if not additive:
+        print("没有可自动补的列。")
+        return 1 if manual else 0
+
+    if not a.apply:
+        print(f"\n{len(additive)} 列待补。加 --apply 执行。")
+        return 1
+
+    with default_engine.begin() as conn:
+        for tbl, col, ddl in additive:
+            conn.execute(text(f"ALTER TABLE {tbl} ADD COLUMN {ddl}"))
+            print(f"已补 {tbl}.{col}")
+    return 1 if manual else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/schema_sync.py
+++ b/backend/scripts/schema_sync.py
@@ -23,6 +23,11 @@ from sqlalchemy.schema import CreateColumn  # noqa: E402
 from windup_framework.db import Base, engine as default_engine  # noqa: E402
 
 
+def _norm_type(compiled: str) -> str:
+    """方言编译出的类型串归一,只吃掉排版差异,不吃掉参数。"""
+    return "".join(compiled.split()).upper()
+
+
 def _load_models() -> None:
     """导入所有 ORM 模块，让 Base.metadata 认全。
 
@@ -65,7 +70,9 @@ def plan(engine: Engine, metadata=None) -> tuple[list[tuple[str, str, str]], lis
                 # 这类声明的 str() 恒是基类型,拿它比会在变体生效的库上误报类型不一致。
                 want = col.type.compile(engine.dialect)
                 got = live[col.name]["type"].compile(engine.dialect)
-                if want.split("(")[0].upper() != got.split("(")[0].upper():
+                # 连参数一起比:只比基类型的话 VARCHAR(20) 与 VARCHAR(200)、
+                # NUMERIC 的不同精度都会被当成一样,而它们正是会丢数据的那类改动。
+                if _norm_type(want) != _norm_type(got):
                     manual.append(
                         f"{table.name}.{col.name} 类型不一致：模型 {want} / 库 {got}"
                     )
@@ -78,6 +85,13 @@ def plan(engine: Engine, metadata=None) -> tuple[list[tuple[str, str, str]], lis
                 continue
             ddl = str(CreateColumn(col).compile(engine))
             additive.append((table.name, col.name, ddl))
+
+        # 反向:库里有、模型没有。删列会丢数据,本脚本只报不动 —— 不报的话
+        # 巡检会在"模型删了一列"时返回干净,而库里那一列还带着数据。
+        for name in live.keys() - {c.name for c in table.columns}:
+            manual.append(
+                f"{table.name}.{name} 库里有而模型没有：删列会丢数据，请人工确认后手写 SQL"
+            )
     return additive, manual
 
 

--- a/backend/tests/test_schema_sync.py
+++ b/backend/tests/test_schema_sync.py
@@ -1,0 +1,115 @@
+"""schema_sync 的行为：只补加法，其余交给人。"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import pytest
+from sqlalchemy import Boolean, Column, Integer, MetaData, String, Table, create_engine, inspect, text
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+from schema_sync import plan  # noqa: E402
+
+
+def _engine_with(table: Table):
+    """建一个只有这张表的临时库。"""
+    eng = create_engine("sqlite://")
+    md = MetaData()
+    Table(table.name, md, *[c._copy() for c in table.columns])
+    md.create_all(eng)
+    return eng
+
+
+def _model(*cols) -> Table:
+    return Table("proj", MetaData(), Column("id", Integer, primary_key=True), *cols)
+
+
+def test_a_new_nullable_column_is_planned_as_additive():
+    """给已上线的表加一个可空列 —— 这正是本脚本存在的理由。"""
+    live = _model()
+    want = _model(Column("is_pixel_art", Boolean, nullable=True))
+    additive, manual = plan(_engine_with(live), want.metadata)
+
+    assert manual == []
+    assert [(t, c) for t, c, _ in additive] == [("proj", "is_pixel_art")]
+
+
+def test_applying_the_plan_makes_the_column_real():
+    """报出来还不够，执行完库里要真的有这一列。"""
+    live = _model()
+    want = _model(Column("is_pixel_art", Boolean, nullable=True))
+    eng = _engine_with(live)
+    additive, _ = plan(eng, want.metadata)
+
+    with eng.begin() as conn:
+        for tbl, _col, ddl in additive:
+            conn.execute(text(f"ALTER TABLE {tbl} ADD COLUMN {ddl}"))
+
+    assert "is_pixel_art" in {c["name"] for c in inspect(eng).get_columns("proj")}
+    assert plan(eng, want.metadata) == ([], []), "补完再跑应当无事可做（幂等）"
+
+
+def test_a_not_null_column_without_default_is_left_to_a_human():
+    """存量行填不出值，自动加只会当场失败 —— 报出来而不是硬上。"""
+    live = _model()
+    want = _model(Column("owner", String(20), nullable=False))
+    additive, manual = plan(_engine_with(live), want.metadata)
+
+    assert additive == []
+    assert len(manual) == 1 and "owner" in manual[0]
+
+
+def test_a_type_change_is_never_applied_silently():
+    """改类型会丢数据，只报不动。"""
+    live = _model(Column("sprite_width", Integer))
+    want = _model(Column("sprite_width", String(20)))
+    additive, manual = plan(_engine_with(live), want.metadata)
+
+    assert additive == []
+    assert len(manual) == 1 and "类型不一致" in manual[0]
+
+
+def test_a_table_that_does_not_exist_yet_is_not_our_business():
+    """整张表缺失由 create_all 负责；本脚本不越界建表。"""
+    want = _model(Column("is_pixel_art", Boolean, nullable=True))
+    eng = create_engine("sqlite://")
+    assert plan(eng, want.metadata) == ([], [])
+
+
+def test_it_fixes_the_real_case_a_live_table_missing_a_new_column():
+    """本脚本存在的那个真实坏例:已上线的 windup_project 加了一列。
+
+    合成表证明不了这条 —— 真实模型的查询会显式点名每一列,缺一列不是「新功能不生效」,
+    是该表所有查询当场 UndefinedColumn。
+    """
+    from sqlalchemy.orm import Session
+    from sqlalchemy.pool import StaticPool
+
+    from windup_app.server.project.model import Project
+
+    eng = create_engine("sqlite://", poolclass=StaticPool)
+    Project.__table__.create(eng)
+    new_column = "sprite_sample_url"          # 拿一个真实可空列当「刚加的那一列」
+    with eng.begin() as conn:                  # 退回加列之前的库
+        conn.execute(text(f"ALTER TABLE windup_project DROP COLUMN {new_column}"))
+        conn.execute(text(
+            "INSERT INTO windup_project (id, project_name, user_id, character_perspective,"
+            " directional_movement, sprite_width, sprite_height, create_at, update_at)"
+            " VALUES (1,'存量项目',1,1,0,256,256,'2026-01-01','2026-01-01')"
+        ))
+
+    with pytest.raises(Exception, match="sprite_sample_url"):
+        with Session(eng) as s:
+            s.query(Project).first()
+
+    additive, manual = plan(eng, Project.metadata)
+    assert manual == []
+    assert (Project.__tablename__, new_column) in [(t, c) for t, c, _ in additive]
+
+    with eng.begin() as conn:
+        for tbl, _col, ddl in additive:
+            conn.execute(text(f"ALTER TABLE {tbl} ADD COLUMN {ddl}"))
+
+    with Session(eng) as s:
+        assert s.query(Project).first().project_name == "存量项目"
+    assert plan(eng, Project.metadata) == ([], []), "补完再跑应当无事可做"

--- a/backend/tests/test_schema_sync.py
+++ b/backend/tests/test_schema_sync.py
@@ -113,3 +113,30 @@ def test_it_fixes_the_real_case_a_live_table_missing_a_new_column():
     with Session(eng) as s:
         assert s.query(Project).first().project_name == "存量项目"
     assert plan(eng, Project.metadata) == ([], []), "补完再跑应当无事可做"
+
+
+def test_a_narrower_type_parameter_is_flagged():
+    """只比基类型的话 VARCHAR(20) 与 VARCHAR(200) 看着一样,而它正是会截断数据的那类改动。"""
+    live = _model(Column("project_name", String(200)))
+    want = _model(Column("project_name", String(20)))
+    additive, manual = plan(_engine_with(live), want.metadata)
+
+    assert additive == []
+    assert len(manual) == 1 and "project_name" in manual[0]
+
+
+def test_identical_types_are_not_flagged():
+    """归一只该吃掉排版差异;同一个类型不能因为编译串的空格差异被报成漂移。"""
+    live = _model(Column("project_name", String(20)))
+    want = _model(Column("project_name", String(20)))
+    assert plan(_engine_with(live), want.metadata) == ([], [])
+
+
+def test_a_column_removed_from_the_model_is_reported():
+    """模型删了列而库里还在:不报的话巡检返回干净,那一列却带着数据留在库里。"""
+    live = _model(Column("legacy_note", String(50)))
+    want = _model()
+    additive, manual = plan(_engine_with(live), want.metadata)
+
+    assert additive == []
+    assert len(manual) == 1 and "legacy_note" in manual[0]


### PR DESCRIPTION
仓里没有迁移机制，表结构靠应用启动时 `Base.metadata.create_all(engine)` 建，而它只补缺失的**表**，不给已有表加列。于是给一张已上线的表加字段时，生产库不会长出那一列，而 SQLAlchemy 的查询会显式点名所有映射列 —— 结果不是「新功能不生效」，是 `UndefinedColumn`，**该表的所有查询直接失败**。

查了 git 历史：部署以来没有人给已有表加过列，所以这条路一直没被走过、也就没暴露。

## 改动

一个只做**加法**的表结构巡检：比对 ORM 模型与库里实际列，补出缺的可空列。缺省只报告、退出码非 0，加 `--apply` 才落地。

明确拒绝并列出三类需要人工处理的：

- 改类型 —— 丢数据
- 删列 —— 丢数据
- 加非空且无 `server_default` 的列 —— 在有存量行的表上必然当场失败

整张表缺失不归它管，那是 `create_all` 的事。

类型比对按**方言编译**而不是 `str(col.type)`：`BigInteger().with_variant(Integer, "sqlite")` 这类声明的 `str()` 恒是基类型，拿它比会在变体生效的库上误报不一致。

## 不包含

- 不引入 alembic 或任何迁移框架，当前阶段不宜为此改动部署形态。
- 不动 `create_all` 的现有行为，本脚本是独立入口。
- 不做降级/回滚。

## 验证

- `uv run ruff check .`：通过。
- `uv run lint-imports`：Contracts 2 kept, 0 broken。
- `uv run pytest tests/`：1439 passed, 14 skipped。
- `export_openapi`：无漂移。

测试里有一条是拿**真实的 `Project` 模型**复现那个坏例的（`test_it_fixes_the_real_case_a_live_table_missing_a_new_column`）：把一张已建好的 `windup_project` 退回加列之前、塞一行存量数据，先断言普通查询确实抛错，再跑巡检补列，然后同一条查询能读出那行；补完再跑一次应当无事可做。合成表证明不了这条 —— 真实模型的查询会点名每一列。

Closes #594
