### PR TITLE
部署拆分：应用层与数据层 Docker 编排分离

### DIFF
--- a/.env.app.example
+++ b/.env.app.example
@@ -1,0 +1,128 @@
+# ── Windup 应用服务器 .env（docker-compose.app.yml 专用）─────────────
+# 复制为 .env 放到应用服务器上：cp .env.app.example .env
+# 然后替换下面的 <DB服务器IP> / 密码 为实际值。
+# 密码必须与 DB 服务器 .env 里设置的一致。
+
+# ── PostgreSQL（远端 DB 服务器） ──
+POSTGRES_USER=root
+POSTGRES_PASSWORD=<与DB服务器一致的密码>
+POSTGRES_DB=windup
+POSTGRES_HOST=<DB服务器IP>
+# DB 服务器上对外发布的端口（docker-compose.db.yml 的 POSTGRES_EXTERNAL_PORT）
+POSTGRES_PORT=7856
+# 连接池：web 与 worker 各一份池，上限 pool+overflow，合计 20 个并发连接。
+# DB 服务器是 2C4G，保持 5+5（合计 20）合适；看到
+# "QueuePool limit ... reached, connection timed out" 报错再上调 overflow。
+POSTGRES_POOL_SIZE=5
+POSTGRES_MAX_OVERFLOW=5
+
+# ── Redis（远端 DB 服务器） ──
+# redis://:<密码>@<DB服务器IP>:6379/0，密码即 DB 服务器 .env 的 REDIS_PASSWORD
+REDIS_URL=redis://:<DB服务器Redis密码>@<DB服务器IP>:6379/0
+
+# ── 搜索 API ──
+SERPAPI_API_KEY=your-serpapi-key
+
+# ── 七牛云存储 ──
+QINIU_ACCESS_KEY=your-access-key
+QINIU_SECRET_KEY=your-secret-key
+QINIU_BUCKET_NAME=your-bucket
+# Bucket 绑定的浏览器可访问 HTTPS Kodo/CDN 域名，不能填 *.s3.*.qiniucs.com API 端点
+QINIU_BUCKET_DOMAIN=https://cdn.example.com
+QINIU_PRIVATE_SPACE=false
+
+# ── AI Provider ──
+# 键名前缀必须是 AI_，由 framework/config/provider.py 的 env_prefix 决定。
+AI_BASE_URL=https://api.qnaigc.com/v1
+AI_API_KEY=your-ai-api-key
+AI_MODEL=your-chat-model
+# 各能力分开配型号：三条能力同时在用不同模型，共用一个字段会换一个连带换全部。
+# 取值即默认值——不写这两行时跑的就是它们。
+AI_CHAT_FALLBACKS=
+AI_IMAGE_MODEL=gemini-2.5-flash-image
+AI_VIDEO_MODEL=kling-v2-5-turbo
+AI_IMAGE_FALLBACKS=
+AI_VIDEO_FALLBACKS=kling-v2-6
+AI_IMAGE_UNIT_COST=
+AI_VIDEO_UNIT_COST_PER_SECOND=
+AI_PRICE_VERSION=2026-08-16
+# Gateway 路由试运行：primary 留空时复用 AI_BASE_URL / AI_API_KEY；
+# fallback 三项都填才启用，用来验证 525 / SSL / 断连等 base_url 级故障切换。
+# 同入口多个 key 用逗号分隔：429 换下一个 key，522/525 跳过该入口剩余 key。
+AI_ROUTE_PRIMARY_NAME=qnaigc-primary
+AI_ROUTE_PRIMARY_BASE_URL=
+AI_ROUTE_PRIMARY_API_KEY=
+AI_ROUTE_PRIMARY_API_KEYS=
+AI_ROUTE_FALLBACK_NAME=
+AI_ROUTE_FALLBACK_BASE_URL=
+AI_ROUTE_FALLBACK_API_KEY=
+AI_ROUTE_FALLBACK_API_KEYS=
+# 示例：AI_ROUTE_FALLBACK_NAME=qnaigc-backup
+# 示例：AI_ROUTE_FALLBACK_BASE_URL=https://backup.example.com/v1
+# 示例：AI_ROUTE_FALLBACK_API_KEY=your-backup-ai-api-key
+AI_GATEWAY_LEDGER_ENABLED=true
+# 判官(看图问答)。必须填一个**能读图的聊天模型**,不是出图模型:它要回 JSON 不是回图。
+AI_JUDGE_MODEL=gemini-2.5-flash
+
+# ── 判官闸口 ──
+# 开了才会调判官,每交付一个动作多一次付费调用。
+QUALITY_GATE_ENABLED=false
+# 判官说有问题就不交付。攒够 shadow 数据、定出判据之前别开:
+# 误杀掉的是用户已付过钱的产物,退不回来。
+QUALITY_GATE_ENFORCE=false
+
+# ── 积分定价 ──
+QUOTA_REGISTER_GIFT_AMOUNT=300
+QUOTA_INVITE_REWARD_AMOUNT=200
+QUOTA_INVITE_REWARD_DAILY_LIMIT=3
+QUOTA_INVITE_CODE_TTL_DAYS=30
+QUOTA_GENERATE_IMAGE_COST=10
+QUOTA_GENERATE_ACTION_COST=50
+
+# ── 服务配置 ──
+WINDUP_HOST=0.0.0.0
+WINDUP_PORT=8000
+# 前端构建期写入的后端地址。默认相对路径，由宿主机 nginx 反代给 backend；
+# 只有在前端要指向外部后端时才改成完整 URL，那时后端需同步配 WINDUP_CORS_ORIGINS
+VITE_API_BASE_URL=/api
+# 跨域来源（逗号分隔，默认覆盖 localhost:5173/3000）
+WINDUP_CORS_ORIGINS=
+# 跨域正则匹配（默认关闭；如需 Vercel 预览域名，请限制到自己的项目名前缀）
+WINDUP_CORS_ORIGIN_REGEX=
+
+# ── MQ（Redis Stream 轻量消息队列） ──
+# 须同时起 web + worker，否则生成任务会一直 PENDING、邮件不会发出。
+#   docker compose -f docker-compose.app.yml up -d backend worker
+# Stream / 消费（默认值即注释，可不写）
+WINDUP_MQ_STREAM_MAXLEN=10000
+WINDUP_MQ_PEL_CLAIM_IDLE_MS=1800000
+WINDUP_MQ_PEL_CLAIM_INTERVAL_SECONDS=30
+WINDUP_MQ_MAX_PUBLISH_ATTEMPTS=10
+WINDUP_MQ_MAX_CONSUME_ATTEMPTS=5
+WINDUP_MQ_CONSUME_LEASE_SECONDS=1800
+WINDUP_MQ_EMAIL_HANDLER_RETRIES=3
+# worker 内 handler 并行度（单进程内 ThreadPoolExecutor）
+# 生成期间不占 Postgres 连接，可按机器内存与上游配额上调。
+WINDUP_MQ_EMAIL_CONCURRENCY=8
+WINDUP_MQ_GENERATION_IMAGE_CONCURRENCY=16
+WINDUP_MQ_GENERATION_ACTION_CONCURRENCY=8
+# poll 使用独立线程池,不与图/动作共享槽位
+WINDUP_MQ_GENERATION_POLL_CONCURRENCY=16
+# i2v 轮询走 ZSET 延迟队列,到期促进到 Stream;不用 Redis 过期事件
+WINDUP_MQ_DELAYED_ZSET=windup:zset:delayed
+WINDUP_MQ_DELAYED_CLAIM_LIMIT=50
+WINDUP_MQ_DELAYED_TICK_SECONDS=1
+# 上传 / 参考图下载 / 多图 gen_image 共用的 IO 线程池
+WINDUP_IO_POOL_SIZE=32
+# 生成任务排队 / 孤儿 RUNNING 超时（秒）
+WINDUP_GENERATION_PENDING_MAX_AGE=86400
+WINDUP_GENERATION_RUNNING_STALE_SECONDS=1800
+# SSE 跨进程桥接：worker publish → web subscribe → EventBus
+WINDUP_SSE_REDIS_CHANNEL=windup:pubsub:generation-task-events
+
+# ── 三渲二（可选）─────────────────────────────────────────────────────
+# 出模型与自动绑骨走腾讯云 ai3d，按量计费；不填则该路线在运行时报缺凭证，
+# 其余功能不受影响。worker 镜像还需 target=runtime-render3d（node/playwright/three）。
+TENCENT_SECRET_ID=
+TENCENT_SECRET_KEY=
+TENCENT_REGION=ap-guangzhou

--- a/.env.db.example
+++ b/.env.db.example
@@ -1,0 +1,19 @@
+# ── 数据库服务器 .env（docker-compose.db.yml 专用）──────────────────
+# 复制为 .env 放到 DB 服务器上：cp .env.db.example .env
+
+# ── PostgreSQL ──
+POSTGRES_USER=root
+POSTGRES_PASSWORD=change-me-strong-password
+POSTGRES_DB=windup
+# 对外发布端口（沿用单机版 7856，应用侧 POSTGRES_PORT 要一致）
+POSTGRES_EXTERNAL_PORT=7856
+# 数据持久化目录
+POSTGRES_DATA_DIR=./data/postgres
+
+# ── Redis ──
+# 网络暴露后必填，不能留空（compose 会直接报错拒绝启动）
+REDIS_PASSWORD=change-me-redis-password
+# 对外发布端口
+REDIS_EXTERNAL_PORT=6379
+# 数据持久化目录
+REDIS_DATA_DIR=./data/redis

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ venv/
 .env
 .env.*
 !.env.example
+!.env.app.example
+!.env.db.example
 
 # Docker 数据
 data/

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,97 @@
+# ── Windup 数据层部署（独立 DB 服务器专用）─────────────────────────
+# 用于把 Postgres / Redis 单独部署到一台数据库服务器上，
+# 应用服务器（前后端 + 网关）通过内网/公网 TCP 连接过来。
+#
+# 使用方式:
+#   启动:   docker compose -f docker-compose.db.yml up -d
+#   日志:   docker compose -f docker-compose.db.yml logs -f [service]
+#   停止:   docker compose -f docker-compose.db.yml down
+#   清数据: docker compose -f docker-compose.db.yml down -v  (⚠️ 删除数据)
+#
+# ⚠️ 与单机版 docker-compose.yml 的关键差异：
+#   1. 两个服务都对外发布端口（应用在另一台机器，走 TCP 而非 Docker 内网）。
+#   2. Redis 端口一旦对网络暴露，必须设密码（--requirepass），否则等于裸奔。
+#   3. 应用服务器的 .env 里 REDIS_URL / POSTGRES_HOST 要改成本机 DB 服务器的地址。
+#
+# 建议：用云厂商安全组 / 防火墙把 5432、6379 只放行给应用服务器 IP，
+#       不要直接对公网开放。
+
+services:
+  # ── Redis 缓存（验证码 / refresh_token / MQ）──
+  redis:
+    image: redis:7-alpine
+    container_name: windup-redis
+    restart: unless-stopped
+    # 网络暴露后必须带密码。密码从 .env 的 REDIS_PASSWORD 读取。
+    # 2C4G 小机：给 Redis 内存上限（默认无上限，会吃到 OOM 被内核杀）。
+    # 本机数据都是短命缓存（验证码/token/MQ），正常只有几十 MB，256mb 是保护机器的安全阀。
+    # allkeys-lru：万一真满了，LRU 淘汰最久未用的键，保证 Redis 不会拖垮整机。
+    command:
+      - redis-server
+      - --requirepass
+      - ${REDIS_PASSWORD:?REDIS_PASSWORD 必填，勿裸奔}
+      - --appendonly
+      - "yes"
+      - --maxmemory
+      - 256mb
+      - --maxmemory-policy
+      - allkeys-lru
+    ports:
+      - "${REDIS_EXTERNAL_PORT:-6379}:6379"
+    volumes:
+      - ${REDIS_DATA_DIR:-./data/redis}:/data
+    healthcheck:
+      # redis-cli 未鉴权 ping 会被拒；带上密码。
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" ping | grep -q PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      # 供 healthcheck 内 $$REDIS_PASSWORD 展开
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD 必填，勿裸奔}
+    networks:
+      - windup-db-net
+
+  # ── PostgreSQL 数据库 ──
+  postgres:
+    image: postgres:16-alpine
+    container_name: windup-postgres
+    restart: unless-stopped
+    # 2C4G 小机：收敛连接上限与内存占用。默认 max_connections=100、
+    # shared_buffers=128MB 在 4GB 内存下偏浪费/偏激进，这里显式收紧。
+    # 应用侧连接池合计上限约 20（web+worker 各 5+5），50 留足余量。
+    command:
+      - -c
+      - max_connections=50
+      - -c
+      - shared_buffers=512MB
+      - -c
+      - effective_cache_size=2GB
+      - -c
+      - maintenance_work_mem=64MB
+      - -c
+      - work_mem=8MB
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-root}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD 必填}
+      POSTGRES_DB: ${POSTGRES_DB:-windup}
+    ports:
+      # 沿用单机版的外部端口 7856，应用侧 POSTGRES_PORT 保持一致即可。
+      - "${POSTGRES_EXTERNAL_PORT:-7856}:5432"
+    volumes:
+      - ${POSTGRES_DATA_DIR:-./data/postgres}:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-root} -d ${POSTGRES_DB:-windup}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - windup-db-net
+
+networks:
+  windup-db-net:
+    driver: bridge
+    # 与单机版同样的 MTU 处理：宿主机链路 MTU 1480，compose 自建网络默认 1500，
+    # 大包被丢会表现为连接超时。保守设 1450。
+    driver_opts:
+      com.docker.network.driver.mtu: "1450"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,41 +7,6 @@
 #   重新构建: docker compose up -d --build
 
 services:
-  # ── Redis 缓存（验证码 / refresh_token） ──
-  redis:
-    image: redis:7-alpine
-    container_name: windup-redis
-    restart: unless-stopped
-    volumes:
-      - ${REDIS_DATA_DIR:-./data/redis}:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - windup-net
-
-  # ── PostgreSQL 数据库 ──
-  postgres:
-    image: postgres:16-alpine
-    container_name: windup-postgres
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER:-root}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-W1ndup@2026!Secure}
-      POSTGRES_DB: ${POSTGRES_DB:-windup}
-    ports:
-      - "${POSTGRES_EXTERNAL_PORT:-7856}:5432"
-    volumes:
-      - ${POSTGRES_DATA_DIR:-./data/postgres}:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-root} -d ${POSTGRES_DB:-windup}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - windup-net
 
   # ── 后端 API 服务 ──
   backend:
@@ -50,18 +15,8 @@ services:
       dockerfile: Dockerfile
     container_name: windup-backend
     restart: unless-stopped
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
     env_file:
       - .env
-    environment:
-      # 容器内部通信用 Docker 主机名，覆盖 .env 中的本地开发值
-      REDIS_URL: redis://redis:6379/0
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
     ports:
       - "${WINDUP_PORT:-8000}:8000"
     networks:
@@ -76,17 +31,8 @@ services:
       target: runtime-render3d
     container_name: windup-worker
     restart: unless-stopped
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
     env_file:
       - .env
-    environment:
-      REDIS_URL: redis://redis:6379/0
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
     command: ["python", "-m", "windup_app.worker"]
     healthcheck:
       disable: true


### PR DESCRIPTION
## 背景

原 `docker-compose.yml` 把 Postgres / Redis / backend / worker / frontend 全部绑在一台机器上。新部署架构改为两台服务器：一台跑应用层（前后端 + 网关），一台跑数据层（Postgres + Redis）。数据库对网络暴露后，需要独立编排 + 防火墙放行方案。

## 改动

- `docker-compose.yml`：改为应用层专属（backend / worker / frontend），删除内嵌 redis/postgres 及写死 Docker 内网主机名的 `environment` 覆盖，DB 连接改由 `.env` 提供远端地址。
- `docker-compose.db.yml`（新增）：数据层专属，Postgres / Redis 独立部署，对外发布 7856 / 6379。
- `.env.app.example`（新增）：应用服务器 env 模板。
- `.env.db.example`（新增）：DB 服务器 env 模板。
- `.gitignore`：白名单补充两个新示例文件。

## 关键设计

- **Redis 网络暴露必须设密码**：`--requirepass` + compose 强制校验（`REDIS_PASSWORD` 留空拒绝启动），healthcheck 同步带密码。
- **DB 为 2C4G 小机**：Postgres 收敛 `max_connections=50` / `shared_buffers=512MB`；Redis 加 `maxmemory 256mb` + `allkeys-lru` 防 OOM。
- **应用连接池收敛** `5/5` × web/worker 两进程 = 上限 20 连接。
- 沿用单机版 MTU 1450 处理（宿主机链路 1480）。
- 建议安全组 / ufw 仅放行应用服务器 IP 访问 7856/6379。

Closes #615