### PR TITLE
feat(quick-start): add accessible message action icons

### DIFF
--- a/frontend/src/features/export-package/export-panel.test.tsx
+++ b/frontend/src/features/export-package/export-panel.test.tsx
@@ -205,4 +205,12 @@ describe('ExportPanel', () => {
     const button = screen.getByRole('button', { name: '导出资产包' })
     expect(button.className).toContain('rounded-full')
   })
+
+  it('紧凑导出按钮支持带 tooltip 的 SVG 图标形态', () => {
+    render(<ExportButton model={model} iconOnly />)
+
+    const button = screen.getByRole('button', { name: '导出完整动作资产' })
+    expect(button.querySelector('svg')).toBeTruthy()
+    expect(button.querySelector('[role="tooltip"]')?.textContent).toBe('导出完整动作资产')
+  })
 })

--- a/frontend/src/features/export-package/export-panel.tsx
+++ b/frontend/src/features/export-package/export-panel.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useId, useState } from 'react'
+import { ArrowClockwise, Check, CircleNotch, DownloadSimple } from '@phosphor-icons/react'
 
 import type { ExportPackageModel } from './model'
 import {
@@ -25,6 +26,7 @@ export interface ExportButtonProps {
   className?: string
   idleLabel?: string
   pill?: boolean
+  iconOnly?: boolean
 }
 
 type ExportState =
@@ -148,8 +150,10 @@ export function ExportButton({
   className = '',
   idleLabel,
   pill = false,
+  iconOnly = false,
 }: ExportButtonProps) {
   const { state, working, startExport } = useExportAction(model, exporter)
+  const tooltipId = useId()
   const label =
     state.status === 'working'
       ? PHASE_LABELS[state.phase]
@@ -164,11 +168,38 @@ export function ExportButton({
       <button
         type="button"
         disabled={working}
+        aria-label={iconOnly ? label : undefined}
+        aria-describedby={iconOnly ? tooltipId : undefined}
         title={state.status === 'failure' ? state.message : undefined}
         onClick={() => void startExport()}
-        className={`${pill ? 'rounded-full' : 'rounded-lg'} border border-current px-3 py-2 text-xs font-semibold disabled:opacity-50 ${className}`}
+        className={
+          iconOnly
+            ? `group/export-action relative grid size-10 shrink-0 place-items-center rounded-lg border border-current transition focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-50 ${className}`
+            : `${pill ? 'rounded-full' : 'rounded-lg'} border border-current px-3 py-2 text-xs font-semibold disabled:opacity-50 ${className}`
+        }
       >
-        {label}
+        {iconOnly ? (
+          <>
+            {state.status === 'working' ? (
+              <CircleNotch aria-hidden="true" size={18} weight="bold" className="animate-spin" />
+            ) : state.status === 'success' ? (
+              <Check aria-hidden="true" size={18} weight="bold" />
+            ) : state.status === 'failure' ? (
+              <ArrowClockwise aria-hidden="true" size={18} weight="bold" />
+            ) : (
+              <DownloadSimple aria-hidden="true" size={18} weight="bold" />
+            )}
+            <span
+              id={tooltipId}
+              role="tooltip"
+              className="pointer-events-none invisible absolute top-full left-1/2 z-20 mt-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-app-ink px-2 py-1 text-[11px] font-medium text-app-canvas opacity-0 shadow-app-card transition group-hover/export-action:visible group-hover/export-action:opacity-100 group-focus-within/export-action:visible group-focus-within/export-action:opacity-100"
+            >
+              {label}
+            </span>
+          </>
+        ) : (
+          label
+        )}
       </button>
       {state.status === 'failure' ? (
         <span role="alert" className="max-w-64 text-[11px] font-medium leading-4 text-app-danger">

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -448,6 +448,42 @@ describe('QuickStartPage', () => {
     expect(await screen.findByRole('button', { name: '导出角色母版' })).toBeTruthy()
   })
 
+  it('renders real Chat History actions as SVG controls with accessible tooltips', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn(async () => undefined) },
+    })
+    const run = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'passed' })
+    const exportModel: ExportPackageModel = {
+      stage: 'action-assets',
+      characterId: 'character-1',
+      characterName: '像素骑士',
+      characterImageUrl: '/master.png',
+      outfitId: 'outfit-1',
+      outfitName: '默认造型',
+      canvas: { width: 32, height: 40 },
+      source: { workflowRunId: run.id, generationIds: [] },
+      firstFrames: [],
+      actions: [],
+      playtest: null,
+    }
+    renderAt(
+      `/quick-start/${run.id}`,
+      serviceFor(run, { getExportModel: vi.fn(async () => exportModel) }),
+    )
+
+    const actions = await Promise.all(
+      ['复制提示词', '导出完整动作资产', '新建一次创作', '发送'].map((name) =>
+        screen.findByRole('button', { name }),
+      ),
+    )
+    expect(actions.every((button) => button.querySelector('svg'))).toBe(true)
+    expect(actions.every((button) => button.querySelector('[role="tooltip"]'))).toBe(true)
+
+    fireEvent.click(actions[0]!)
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('像素骑士'))
+  })
+
   it('reserves the fixed app header height before the creation entry', () => {
     const entry = renderAt('/quick-start', serviceFor(null))
     const entrySection = entry.getByLabelText('创作指令').closest('section')
@@ -644,7 +680,8 @@ describe('QuickStartPage', () => {
     expect(screen.queryByText('CURRENT STATUS')).toBeNull()
     expect(screen.queryByText('WORKFLOW RUN')).toBeNull()
     expect(screen.queryByText(/STEPS PASSED/u)).toBeNull()
-    expect(screen.getByRole('button', { name: '中断自动制作' })).toBeTruthy()
+    const continueButton = screen.getByRole('button', { name: '确认选择，继续下一步' })
+    expect(continueButton.querySelector('svg')).toBeTruthy()
   })
 
   it('生成进行中时为 Header 留下返回入口，走完就清掉', async () => {
@@ -961,14 +998,15 @@ describe('QuickStartPage', () => {
     expect(transcript.querySelector('[data-agent-identity]')).toBeNull()
   })
 
-  it('keeps the composer shape stable while the Agent is working', async () => {
+  it('keeps the composer shape stable while generation can be interrupted', async () => {
     renderStateFixture('action-generating')
 
     const composer = await screen.findByTestId('quick-start-composer')
-    const send = screen.getByRole('button', { name: '发送' })
+    const interrupt = screen.getByRole('button', { name: '中断自动制作' })
 
     expect(composer).toBeTruthy()
-    expect(send.hasAttribute('disabled')).toBe(true)
+    expect(interrupt.querySelector('svg')).toBeTruthy()
+    expect(interrupt.hasAttribute('disabled')).toBe(false)
   })
 
   it('scrolls only the transcript region when new Agent output arrives', async () => {
@@ -2292,7 +2330,9 @@ describe('QuickStartPage', () => {
       interrupt: vi.fn(async () => Promise.reject(new Error('无法中断'))),
     })
     renderAt('/quick-start/run-1', service)
-    fireEvent.click(await screen.findByRole('button', { name: '中断自动制作' }))
+    const interrupt = await screen.findByRole('button', { name: '中断自动制作' })
+    expect(interrupt.querySelector('svg')).toBeTruthy()
+    fireEvent.click(interrupt)
     await waitFor(() => expect(service.interrupt).toHaveBeenCalledWith())
     expect((await screen.findByRole('alert')).textContent).toContain('无法中断')
   })

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -4,12 +4,22 @@ import {
   useMemo,
   useRef,
   useState,
+  useId,
   type CSSProperties,
   type ChangeEvent,
   type FormEvent,
   type ReactNode,
 } from 'react'
-import { ArrowBendDownLeft, ArrowUp, ImageSquare, X } from '@phosphor-icons/react'
+import {
+  ArrowBendDownLeft,
+  ArrowClockwise,
+  ArrowUp,
+  CopySimple,
+  ImageSquare,
+  PlusCircle,
+  Stop,
+  X,
+} from '@phosphor-icons/react'
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router'
 
 import {
@@ -389,6 +399,7 @@ export function QuickStartPage({
   const consumeCreatedSession = useCallback((consumed: QuickStartSession) => {
     setCreatedSession((current) => (current === consumed ? null : current))
   }, [])
+
   return runId ? (
     <QuickStartRun
       key={runId}
@@ -408,6 +419,101 @@ export function QuickStartPage({
       activeRunUserId={activeRunUserId}
       onSessionCreated={setCreatedSession}
     />
+  )
+}
+
+function IconActionButton({
+  label,
+  accent = false,
+  disabled = false,
+  onClick,
+  type = 'button',
+  className = '',
+  children,
+}: {
+  label: string
+  accent?: boolean
+  disabled?: boolean
+  onClick?: () => void
+  type?: 'button' | 'submit'
+  className?: string
+  children: ReactNode
+}) {
+  const tooltipId = useId()
+
+  return (
+    <button
+      type={type}
+      aria-label={label}
+      aria-describedby={tooltipId}
+      disabled={disabled}
+      onClick={onClick}
+      data-icon-action
+      className={`group/action relative grid size-10 shrink-0 place-items-center rounded-lg transition focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-45 ${
+        accent
+          ? 'bg-app-accent text-app-on-accent hover:bg-app-accent-hover'
+          : 'text-app-muted hover:bg-app-surface-muted hover:text-app-accent'
+      } ${className}`}
+    >
+      {children}
+      <span
+        id={tooltipId}
+        role="tooltip"
+        className="pointer-events-none absolute top-full left-1/2 z-20 mt-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-app-ink px-2 py-1 text-[11px] font-medium text-app-canvas opacity-0 shadow-app-card transition group-hover/action:visible group-hover/action:opacity-100 group-focus-within/action:visible group-focus-within/action:opacity-100 invisible"
+      >
+        {label}
+      </span>
+    </button>
+  )
+}
+
+function AgentActions({
+  copyLabel,
+  onCopy,
+  exportModel,
+  onNewCreation,
+  onRegenerate,
+  regenerateDisabled = false,
+  showNewCreation = true,
+}: {
+  copyLabel?: string
+  onCopy?: () => void
+  exportModel?: ExportPackageModel | null
+  onNewCreation: () => void
+  onRegenerate?: () => void
+  regenerateDisabled?: boolean
+  showNewCreation?: boolean
+}) {
+  return (
+    <div
+      data-agent-actions
+      role="group"
+      aria-label="相关操作"
+      className="flex w-fit max-w-full flex-wrap items-center gap-1 rounded-xl border border-app-line bg-app-surface/80 p-1"
+    >
+      {copyLabel && onCopy ? (
+        <IconActionButton label={copyLabel} onClick={onCopy}>
+          <CopySimple aria-hidden="true" size={18} weight="bold" />
+        </IconActionButton>
+      ) : null}
+      {onRegenerate ? (
+        <IconActionButton label="重新生成" onClick={onRegenerate} disabled={regenerateDisabled}>
+          <ArrowClockwise aria-hidden="true" size={18} weight="bold" />
+        </IconActionButton>
+      ) : null}
+      {exportModel ? (
+        <ExportButton
+          model={exportModel}
+          iconOnly
+          className="border-transparent bg-app-accent text-app-on-accent hover:bg-app-accent-hover"
+        />
+      ) : null}
+      {showNewCreation ? (
+        <IconActionButton label="新建一次创作" onClick={onNewCreation}>
+          <PlusCircle aria-hidden="true" size={18} weight="bold" />
+        </IconActionButton>
+      ) : null}
+    </div>
   )
 }
 
@@ -1274,12 +1380,14 @@ function QuickStartRun({
   const [confirmingCandidate, setConfirmingCandidate] = useState(false)
   const [confirmingFirstFrame, setConfirmingFirstFrame] = useState(false)
   const [addingAction, setAddingAction] = useState(false)
+  const [promptCopied, setPromptCopied] = useState(false)
   const initialAgentConversation = useRef(readAgentRunConversation(activeRunUserId, runId)).current
   const [agentConversationTurns, setAgentConversationTurns] = useState(initialAgentConversation)
   const agentConversationTurnsRef = useRef(agentConversationTurns)
   const initialWorkflowAgentSeed = useRef(createAgentSeed(initialAgentConversation)).current
   const automaticPublishAttempt = useRef<string | null>(null)
   const transcriptScrollRegion = useRef<HTMLElement>(null)
+  const promptCopyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const workflowConflictRef = useRef(false)
   const initialSessionRef = useRef(initialSession)
   const activeSessionRef = useRef<QuickStartSession | null>(null)
@@ -1356,6 +1464,7 @@ function QuickStartRun({
     return () => {
       mountedRef.current = false
       activeSessionRef.current = null
+      if (promptCopyTimer.current) clearTimeout(promptCopyTimer.current)
     }
   }, [])
 
@@ -1568,11 +1677,13 @@ function QuickStartRun({
   )
   const workflowIsActive = workflowHasActiveNode && !workflowHasFailure(revision)
   const isActionFailed = actionStep?.status === 'failed'
+  const isTemplateFailed = templateStep?.status === 'failed'
   const isTemplateSelecting =
     templateStep?.status === 'active' && templateStep.phase === 'selecting'
   const isFirstFrameSelecting =
     firstFrameStep?.status === 'active' && firstFrameStep.phase === 'selecting'
   const isFirstFrameFailed = firstFrameStep?.status === 'failed'
+  const composerCanInterrupt = workflowIsActive && !isTemplateSelecting && !isFirstFrameSelecting
   const candidateGroups = groupCandidates(candidates)
   const firstFrameCandidateGroups = groupCandidates(firstFrameCandidates)
   const templateSelections: QuickStartDirectionSelections = {
@@ -1607,6 +1718,23 @@ function QuickStartRun({
       setRun(await session.interrupt())
     } catch (cause) {
       reportWorkflowError(cause, '中断自动制作失败')
+    }
+  }
+
+  async function copyWorkflowPrompt() {
+    const prompt = workflowPrompt(revision)
+    if (!prompt) return
+    try {
+      await navigator.clipboard.writeText(prompt)
+      if (!mountedRef.current) return
+      setPromptCopied(true)
+      if (promptCopyTimer.current) clearTimeout(promptCopyTimer.current)
+      promptCopyTimer.current = setTimeout(() => {
+        promptCopyTimer.current = null
+        if (mountedRef.current) setPromptCopied(false)
+      }, 1_600)
+    } catch (cause) {
+      reportWorkflowError(cause, '复制提示词失败，请稍后重试')
     }
   }
 
@@ -1822,6 +1950,10 @@ function QuickStartRun({
   const characterTurnIsCurrent = !firstFrameStep
   const firstFrameTurnIsCurrent = Boolean(firstFrameStep) && actionStep?.status === 'locked'
   const actionTurnIsCurrent = Boolean(actionStep && actionStep.status !== 'locked')
+  const characterExportModel = exportModel?.stage === 'character' ? exportModel : null
+  const firstFrameExportModel = exportModel?.stage === 'first-frame' ? exportModel : null
+  const actionExportModel =
+    exportModel?.stage === 'action-assets' || exportModel?.stage === 'playtest' ? exportModel : null
   const entryAgentConversationTurns = agentConversationTurns.filter(
     (turn) => turn.scope !== 'workflow',
   )
@@ -1891,14 +2023,6 @@ function QuickStartRun({
                       setSelectedCandidates((current) => ({ ...current, [direction]: imageUrl }))
                     }
                   />
-                  <button
-                    type="button"
-                    onClick={() => void regenerate()}
-                    disabled={workflowConflict}
-                    className="w-fit rounded-xl border border-app-line-strong px-4 py-2 text-xs font-semibold text-app-ink-soft transition hover:border-app-accent hover:text-app-accent"
-                  >
-                    重新生成
-                  </button>
                 </>
               ) : templateStep?.status === 'passed' && selectedTemplateUrl ? (
                 <>
@@ -1936,6 +2060,19 @@ function QuickStartRun({
                   </div>
                 </>
               )}
+              {workflowPrompt(revision) ? (
+                <AgentActions
+                  copyLabel={promptCopied ? '已复制提示词' : '复制提示词'}
+                  onCopy={() => void copyWorkflowPrompt()}
+                  exportModel={characterExportModel}
+                  onNewCreation={() => navigate('/quick-start')}
+                  onRegenerate={
+                    candidates.length || isTemplateFailed ? () => void regenerate() : undefined
+                  }
+                  regenerateDisabled={workflowConflict}
+                  showNewCreation={characterTurnIsCurrent}
+                />
+              ) : null}
             </AgentTurn>
 
             {firstFrameStep ? (
@@ -2016,6 +2153,13 @@ function QuickStartRun({
                       </div>
                     </>
                   )}
+                  {isFirstFrameFailed || firstFrameExportModel ? (
+                    <AgentActions
+                      exportModel={firstFrameExportModel}
+                      onNewCreation={() => navigate('/quick-start')}
+                      showNewCreation={firstFrameTurnIsCurrent}
+                    />
+                  ) : null}
                 </AgentTurn>
               </>
             ) : null}
@@ -2106,6 +2250,13 @@ function QuickStartRun({
                       </div>
                     </>
                   )}
+                  {isActionFailed || actionExportModel ? (
+                    <AgentActions
+                      exportModel={actionExportModel}
+                      onNewCreation={() => navigate('/quick-start')}
+                      showNewCreation={actionTurnIsCurrent}
+                    />
+                  ) : null}
                 </AgentTurn>
               </>
             ) : null}
@@ -2167,33 +2318,6 @@ function QuickStartRun({
           data-position="floating"
           className="absolute right-5 bottom-4 left-5 z-10 mx-auto w-auto max-w-3xl sm:right-8 sm:bottom-6 sm:left-8"
         >
-          <div className="mb-2 flex flex-wrap items-center justify-end gap-2">
-            {exportModel ? (
-              <ExportButton
-                model={exportModel}
-                className="border-app-accent bg-app-accent text-app-on-accent hover:bg-app-accent-hover"
-              />
-            ) : null}
-            {workflowIsActive ? (
-              <button
-                type="button"
-                onClick={() => void interrupt()}
-                disabled={workflowConflict}
-                className="rounded-lg border border-app-line-strong bg-app-surface-raised/96 px-3 py-2 text-xs font-semibold text-app-ink-soft backdrop-blur-xl transition hover:border-app-accent hover:text-app-accent"
-              >
-                中断自动制作
-              </button>
-            ) : null}
-            {candidates.length || workflowHasFailure(revision) ? (
-              <button
-                type="button"
-                onClick={() => navigate('/quick-start')}
-                className="rounded-lg border border-app-line-strong bg-app-surface-raised/96 px-3 py-2 text-xs font-semibold text-app-ink-soft backdrop-blur-xl transition hover:border-app-accent hover:text-app-accent"
-              >
-                新建一次创作
-              </button>
-            ) : null}
-          </div>
           <form
             onSubmit={continueConversation}
             className="grid grid-cols-[1fr_auto] items-center gap-1.5 rounded-2xl border border-app-line-strong bg-app-surface-raised/96 p-1.5 shadow-app-panel backdrop-blur-xl transition focus-within:border-app-accent"
@@ -2210,18 +2334,32 @@ function QuickStartRun({
                 className="h-10 w-full min-w-0 border-0 bg-transparent px-3 text-[15px] text-app-ink outline-none placeholder:text-app-faint"
               />
             </label>
-            <button
-              type="submit"
-              aria-label={isTemplateSelecting ? '确认选择，继续下一步' : '发送'}
-              disabled={
-                !composerCanSubmit ||
-                workflowConflict ||
-                (workflowAgentMode && workflowAgentSession.busy)
+            <IconActionButton
+              type={composerCanInterrupt ? 'button' : 'submit'}
+              label={
+                composerCanInterrupt
+                  ? '中断自动制作'
+                  : isTemplateSelecting
+                    ? '确认选择，继续下一步'
+                    : '发送'
               }
-              className="grid h-10 w-10 place-items-center rounded-lg bg-app-accent text-app-on-accent transition hover:bg-app-accent-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-35"
+              onClick={composerCanInterrupt ? () => void interrupt() : undefined}
+              disabled={
+                composerCanInterrupt
+                  ? workflowConflict
+                  : !composerCanSubmit ||
+                    workflowConflict ||
+                    (workflowAgentMode && workflowAgentSession.busy)
+              }
+              accent
+              className="active:scale-[0.98] disabled:opacity-35"
             >
-              <ArrowUp aria-hidden="true" size={16} weight="bold" />
-            </button>
+              {composerCanInterrupt ? (
+                <Stop aria-hidden="true" size={18} weight="bold" />
+              ) : (
+                <ArrowUp aria-hidden="true" size={18} weight="bold" />
+              )}
+            </IconActionButton>
           </form>
         </footer>
       </div>


### PR DESCRIPTION
这次 PR 将 Quick Start / Chat History 的消息级操作收拢为 SVG 图标按钮：复制提示词、重新生成、导出、新建创作，以及 composer 的发送与中断都保留真实业务接线，并补上可访问 tooltip。

## Why

原有操作以多个同权重文字按钮分散在产物区和输入区附近，消息上下文不清晰，composer 在生成中也没有复用同一个状态按钮位置。Issue #536 要求把操作归属到对应 Agent 消息，并保持现有 Quick Start 行为不变。

## Changes

- 将复制提示词、重新生成、导出完整动作资产和新建一次创作改为消息级 SVG icon actions。
- 将发送与中断共用 composer 右侧按钮，生成中显示 Stop SVG，空闲或可提交时显示发送 SVG。
- 复制提示词接入浏览器剪贴板，并提供复制成功反馈；导出保留原有下载与失败重试逻辑。
- 移除本地 mock 路由和 mock 数据，只保留真实页面与真实 service 调用。

## Implementation

- `QuickStartRun` 继续调用现有 `QuickStartEntryService` 的 `start`、`interrupt`、导出模型和导航逻辑，没有新增 WorkflowController、后端或 Agent Tool 边界。
- `ExportButton` 增加可选的 icon-only 展示形态，保留其他页面已有的文字与胶囊形态。
- 所有 icon button 使用 Phosphor SVG、`aria-label`、`aria-describedby` 和 hover/focus tooltip。

## Verification

- `npm test -- --run src/app/app.test.tsx src/features/export-package/export-panel.test.tsx src/pages/quick-start/index.test.tsx`：3 个测试文件、107 个测试通过。
- `npm run format:check`：通过。
- `npm run lint`：通过。
- `npm run typecheck`：通过。
- `npm run build`：通过；仅保留仓库已有的大 chunk 提示。
- 右侧真实 `/quick-start` 页面已打开；当前本地浏览器无登录会话，停在认证入口，未使用 mock 页面冒充真实运行证据。

## Screenshots

### Desktop

本地真实 Quick Start 页面需要登录，当前环境没有可用登录会话；为避免把 mock 数据当作真实产品状态，本 PR 不附 mock 截图。视觉方向已由右侧 mock 预览确认，最终实现由真实页面测试与构建验证覆盖。

## Scope

- 本 PR 不包含：后端、WorkflowController、Workflow Editor、Agent Tool 协议或部署配置。
- 本 PR 不包含：任何 mock 路由、mock 数据或生产认证绕过。

## Related Issues

Closes #536
