### PR TITLE
fix(generation): 任务终态跟网关最终结果，积分结算幂等

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -137,14 +137,27 @@ def _using_session(
 
 
 def _settle_credit(session: Session, task_id: int, *, success: bool) -> None:
-    """任务终态时结清预付费：成功扣减，失败解冻。"""
+    """任务终态时结清预付费：成功扣减，失败解冻。无开放冻结则跳过。"""
     task = task_repo.get_task(session, task_id)
     if task is None or task.id is None:
+        return
+    if not billing.has_open_freeze(session, task.id):
         return
     if success:
         billing.capture_for_task(session, user_id=task.user_id, task_id=task.id)
     else:
         billing.release_for_task(session, user_id=task.user_id, task_id=task.id)
+
+
+def _close_failed(session: Session, task_id: int, error_message: str) -> None:
+    """失败终态：已 COMPLETED 的产物不被并发/重投的失败路径覆盖。"""
+    task = task_repo.get_task(session, task_id)
+    if task is None or task.id is None:
+        return
+    if task.status is TaskStatus.COMPLETED:
+        return
+    task_repo.fail_task(session, task_id, error_message=error_message)
+    _settle_credit(session, task_id, success=False)
 
 
 # ── 项目全局约束(Project 表)→ 统合喂给生成逻辑 ─────────────────────────
@@ -381,8 +394,7 @@ class ActionTaskExecutor:
             error_message = user_message(exc)
 
             def _fail(s: Session) -> None:
-                task_repo.fail_task(s, task_id, error_message=error_message)
-                _settle_credit(s, task_id, success=False)
+                _close_failed(s, task_id, error_message)
 
             _using_session(session, self._make_session, _fail)
         finally:
@@ -570,8 +582,7 @@ class ActionTaskExecutor:
             error_message = user_message(exc)
 
             def _fail(s: Session) -> None:
-                task_repo.fail_task(s, task_id, error_message=error_message)
-                _settle_credit(s, task_id, success=False)
+                _close_failed(s, task_id, error_message)
 
             _using_session(session, self._make_session, _fail)
         finally:
@@ -864,8 +875,7 @@ class ImageTaskExecutor:
             error_message = user_message(exc)
 
             def _fail(s: Session) -> None:
-                task_repo.fail_task(s, task_id, error_message=error_message)
-                _settle_credit(s, task_id, success=False)
+                _close_failed(s, task_id, error_message)
 
             _using_session(session, self._make_session, _fail)
         finally:

--- a/backend/packages/app/src/windup_app/server/orchestrator/i2v_poll.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/i2v_poll.py
@@ -103,32 +103,38 @@ def inspect(
     *,
     poll_video: Callable[..., bytes | None],
 ) -> Ready | Waiting:
-    """探一次上游。未完成则再挂单并返回 Waiting;完成则返回 Ready。"""
+    """探一次上游。未完成则再挂单并返回 Waiting;完成则返回 Ready。
+
+    超时也先 poll 一次：成片已就绪就交付，避免网关最终成功却把任务写成失败。
+    等待态被其它轮询清掉时返回 Waiting，不把任务打失败。
+    """
     state = load_i2v_state(task_id)
     if state is None or not state.get("job_id"):
-        raise RuntimeError(f"任务 {task_id} 没有 i2v 状态,无法续跑轮询")
+        logger.info("任务 %s 无 i2v 状态，视为已被其它轮询接管", task_id)
+        return Waiting()
 
     elapsed = time.time() - float(state["started_at"] or 0)
-    if elapsed >= I2V_MAX_WAIT_S:
-        raise RuntimeError("i2v 未取得视频 URL(超时或失败)")
+    timed_out = elapsed >= I2V_MAX_WAIT_S
 
     route_id = state.get("route_id") or None
     video = poll_video(state["job_id"], route_id=route_id)
-    if video is None:
-        nxt = min(float(state["next_wait"]) * 2, I2V_POLL_INTERVAL_S)
-        schedule(
-            task_id,
-            {
-                "job_id": state["job_id"],
-                "route_id": state.get("route_id") or "",
-                "model": state.get("model") or "",
-            },
-            poll_count=int(state["poll_count"]) + 1,
-            next_wait=nxt,
-            started_at=float(state["started_at"]),
-        )
-        return Waiting()
-    return Ready(video=video, route_id=route_id)
+    if video is not None:
+        return Ready(video=video, route_id=route_id)
+    if timed_out:
+        raise RuntimeError("i2v 未取得视频 URL(超时或失败)")
+    nxt = min(float(state["next_wait"]) * 2, I2V_POLL_INTERVAL_S)
+    schedule(
+        task_id,
+        {
+            "job_id": state["job_id"],
+            "route_id": state.get("route_id") or "",
+            "model": state.get("model") or "",
+        },
+        poll_count=int(state["poll_count"]) + 1,
+        next_wait=nxt,
+        started_at=float(state["started_at"]),
+    )
+    return Waiting()
 
 
 def clear(task_id: int) -> None:

--- a/backend/packages/app/src/windup_app/server/quota/interface.py
+++ b/backend/packages/app/src/windup_app/server/quota/interface.py
@@ -49,6 +49,7 @@ class QuotaService(ABC):
         """预付费扣减：冻结转消耗。
 
         若 actual_amount < frozen_amount，差额自动退回可用余额。
+        同一 ``ref_id`` 已扣减过则跳过。
 
         :raises BizException: 冻结额度不足。
         """
@@ -58,6 +59,8 @@ class QuotaService(ABC):
         self, session: Session, user_id: int, amount: int, ref_id: str
     ) -> None:
         """预付费解冻：冻结退回可用余额（任务失败时调用）。
+
+        同一 ``ref_id`` 已解冻过则跳过。
 
         :raises BizException: 冻结额度不足。
         """

--- a/backend/packages/app/src/windup_app/server/quota/service.py
+++ b/backend/packages/app/src/windup_app/server/quota/service.py
@@ -164,6 +164,16 @@ class SqlAlchemyQuotaService(QuotaService):
         session.add(txn)
         return txn
 
+    def _txn_for(
+        self, session: Session, ref_id: str, reason: int
+    ) -> CreditTransaction | None:
+        return session.scalar(
+            select(CreditTransaction).where(
+                CreditTransaction.ref_id == ref_id,
+                CreditTransaction.reason == reason,
+            )
+        )
+
     # -- 预付费：冻结 / 扣减 / 解冻 ----------------------------------------
 
     def reserve_credit(
@@ -211,8 +221,12 @@ class SqlAlchemyQuotaService(QuotaService):
         """预付费扣减：frozen -= frozen_amount, total_spent += actual_amount。
 
         若 actual_amount < frozen_amount，差额退回 balance。
+        同一 ``ref_id`` 已有 CAPTURED 流水则跳过（MQ 重投幂等）。
         """
         account = self._get_account_for_update(session, user_id)
+        if self._txn_for(session, ref_id, int(CreditReason.CAPTURED)) is not None:
+            logger.info("[WINDUP] 积分扣减已落地，跳过 | ref_id=%s", ref_id)
+            return
 
         if account.frozen < frozen_amount:
             raise BizException(
@@ -267,8 +281,14 @@ class SqlAlchemyQuotaService(QuotaService):
     def release_credit(
         self, session: Session, user_id: int, amount: int, ref_id: str
     ) -> None:
-        """预付费解冻：frozen -= amount, balance += amount。"""
+        """预付费解冻：frozen -= amount, balance += amount。
+
+        同一 ``ref_id`` 已有解冻流水则跳过（MQ 重投幂等）。
+        """
         account = self._get_account_for_update(session, user_id)
+        if self._txn_for(session, f"{ref_id}:release", int(CreditReason.REFUND)) is not None:
+            logger.info("[WINDUP] 积分解冻已落地，跳过 | ref_id=%s", ref_id)
+            return
 
         if account.frozen < amount:
             raise BizException(

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -708,3 +708,140 @@ def test_resume_action_poll_does_not_fetch_master_while_pending(
     with session_factory() as s:
         done = service.get_task(s, project_id=1, task_id=task_id)
     assert done.status is TaskStatus.RUNNING
+
+
+def test_resume_action_poll_completes_after_credit_already_released(
+    session_factory, monkeypatch,
+):
+    """失败已解冻后，成片轮询仍写成 completed，不得再抛冻结额度不足。"""
+    png = _tiny_png()
+
+    class _AsyncGen:
+        def poll_video(self, job_id, route_id=None):
+            return b"mp4"
+
+        def finish_video(self, video, *args, **kwargs):
+            return GeneratedAction(
+                frames=[png],
+                durations=[80],
+                quality=ActionQuality(
+                    motion_scale=0.2,
+                    dead_frames=(),
+                    loop_seam=None,
+                    limbs={},
+                    subject_blobs=(1,),
+                ),
+                prompt_version="test",
+            )
+
+    import time as _time
+    from windup_app.server.orchestrator import billing, task_repo
+
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.i2v_poll.load_i2v_state",
+        lambda task_id: {
+            "job_id": "job-ready",
+            "poll_count": 0,
+            "next_wait": 5.0,
+            "started_at": _time.time(),
+            "route_id": "primary",
+            "model": "kling-v2-5-turbo",
+        },
+    )
+    monkeypatch.setattr("windup_app.server.orchestrator.i2v_poll.clear", lambda task_id: None)
+    service = AiGenerationService()
+    executor = ActionTaskExecutor(
+        generator=_AsyncGen(),
+        upload=lambda _png: "https://cdn.example.com/f.png",
+        fetch_master=lambda _input: png,
+        session_factory=session_factory,
+        fetch_constraints=lambda _s, _pid: ProjectConstraints(sprite_w=64, sprite_h=96),
+    )
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=1,
+    )
+    with session_factory() as s:
+        task = service.generate_character_action(s, user_id=1, input=action_input)
+        s.commit()
+        task_id = task.id
+        task_repo.update_status(s, task_id, TaskStatus.RUNNING)
+        billing.release_for_task(s, user_id=1, task_id=task_id)
+        s.commit()
+    executor.resume_action_poll(task_id, action_input)
+    with session_factory() as s:
+        done = service.get_task(s, project_id=1, task_id=task_id)
+        from windup_app.server.quota.model import CreditAccount
+        from sqlalchemy import select
+        account = s.scalar(select(CreditAccount).where(CreditAccount.user_id == 1))
+    assert done.status is TaskStatus.COMPLETED
+    assert account.frozen == 0
+    assert account.total_spent == 0
+
+
+def test_resume_action_poll_timeout_without_video_fails(session_factory, monkeypatch):
+    class _AsyncGen:
+        def poll_video(self, job_id, route_id=None):
+            return None
+
+        def finish_video(self, *args, **kwargs):
+            raise AssertionError("未成片不该 finish")
+
+    import time as _time
+    from windup_app.server.orchestrator import task_repo
+
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.i2v_poll.load_i2v_state",
+        lambda task_id: {
+            "job_id": "job-late",
+            "poll_count": 8,
+            "next_wait": 60.0,
+            "started_at": _time.time() - 10_000,
+            "route_id": "primary",
+            "model": "kling-v2-5-turbo",
+        },
+    )
+    service = AiGenerationService()
+    executor = ActionTaskExecutor(
+        generator=_AsyncGen(),
+        fetch_master=lambda _input: _tiny_png(),
+        session_factory=session_factory,
+        fetch_constraints=lambda _s, _pid: ProjectConstraints(sprite_w=64, sprite_h=96),
+    )
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=1,
+    )
+    with session_factory() as s:
+        task = service.generate_character_action(s, user_id=1, input=action_input)
+        s.commit()
+        task_id = task.id
+        task_repo.update_status(s, task_id, TaskStatus.RUNNING)
+        s.commit()
+    executor.resume_action_poll(task_id, action_input)
+    with session_factory() as s:
+        done = service.get_task(s, project_id=1, task_id=task_id)
+    assert done.status is TaskStatus.FAILED
+
+
+def test_close_failed_does_not_overwrite_completed(session_factory):
+    from windup_app.server.orchestrator import billing, task_repo
+    from windup_app.server.orchestrator.executor import _close_failed
+
+    service = AiGenerationService()
+    with session_factory() as s:
+        task = service.generate_character_action(
+            s, user_id=1,
+            input=CharacterActionInput(
+                character_id=1, action_type=ActionType.WALK, num_frames=1,
+            ),
+        )
+        s.commit()
+        task_repo.update_result(
+            s, task.id, "character_action",
+            {"type": "character_action", "frames": []},
+        )
+        billing.capture_for_task(s, user_id=1, task_id=task.id)
+        _close_failed(s, task.id, "生成没能完成，请稍后重试。若反复失败请联系我们。")
+        s.commit()
+        done = task_repo.get_task(s, task.id)
+    assert done.status is TaskStatus.COMPLETED
+    assert done.result is not None

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -208,6 +208,48 @@ def test_action_failure_releases_reserved_credit(session_factory):
         assert CreditReason.REFUND in _reasons(session, 1)
 
 
+def test_action_failure_redelivery_does_not_raise(session_factory):
+    """失败已解冻后 MQ 重投同一失败路径，不得再抛冻结额度不足。"""
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    service = AiGenerationService()
+
+    def _boom(_input):
+        raise RuntimeError("母版下载失败")
+
+    executor = ActionTaskExecutor(
+        generator=None,
+        fetch_master=_boom,
+        session_factory=session_factory,
+    )
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=2,
+    )
+    with session_factory() as session:
+        task = service.generate_character_action(session, user_id=1, input=action_input)
+        session.commit()
+        task_id = task.id
+
+    executor.run_action_task(task_id, action_input)
+    executor.run_action_task(task_id, action_input)
+
+    with session_factory() as session:
+        done = service.get_task(session, project_id=1, task_id=task_id)
+        account = _account(session, 1)
+        refunds = [
+            row for row in session.scalars(
+                select(CreditTransaction).where(CreditTransaction.user_id == 1)
+            )
+            if row.reason == CreditReason.REFUND
+        ]
+        assert done.status is TaskStatus.FAILED
+        assert account.frozen == 0
+        assert account.balance == quota_settings.register_gift_amount
+        assert len(refunds) == 1
+
+
 def test_generate_character_action_without_account_raises(session_factory):
     service = AiGenerationService()
     action_input = CharacterActionInput(

--- a/backend/tests/test_i2v_poll.py
+++ b/backend/tests/test_i2v_poll.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import time
 
+import pytest
+
 from windup_app.server.orchestrator.i2v_poll import (
     Ready,
     Waiting,
@@ -110,3 +112,56 @@ def test_reschedule_if_waiting_enqueues_soon(monkeypatch):
     assert reschedule_if_waiting(9) is True
     assert delayed["delay_s"] == 1
     assert delayed["dedupe_key"] == "generation:9:poll:3"
+
+
+def _expired_state() -> dict:
+    return {
+        "job_id": "j1",
+        "poll_count": 8,
+        "next_wait": 60.0,
+        "started_at": time.time() - 10_000,
+        "route_id": "primary",
+        "model": "m",
+    }
+
+
+def test_inspect_last_poll_after_timeout_returns_ready(monkeypatch):
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.i2v_poll.load_i2v_state",
+        lambda task_id: _expired_state(),
+    )
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.i2v_poll.schedule",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("超时成片不该再挂单")),
+    )
+
+    out = inspect(9, poll_video=lambda *_a, **_k: b"mp4")
+    assert isinstance(out, Ready)
+    assert out.video == b"mp4"
+
+
+def test_inspect_timeout_without_video_still_fails(monkeypatch):
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.i2v_poll.load_i2v_state",
+        lambda task_id: _expired_state(),
+    )
+    with pytest.raises(RuntimeError, match="未取得视频 URL"):
+        inspect(9, poll_video=lambda *_a, **_k: None)
+
+
+def test_inspect_missing_state_returns_waiting_without_poll(monkeypatch):
+    polled: list[int] = []
+    parked: list[int] = []
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.i2v_poll.load_i2v_state",
+        lambda task_id: None,
+    )
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.i2v_poll.schedule",
+        lambda task_id, job, **kw: parked.append(task_id),
+    )
+
+    out = inspect(9, poll_video=lambda *_a, **_k: polled.append(1) or None)
+    assert isinstance(out, Waiting)
+    assert polled == []
+    assert parked == []

--- a/backend/tests/test_quota.py
+++ b/backend/tests/test_quota.py
@@ -217,6 +217,26 @@ class TestCaptureCredit:
         with pytest.raises(BizException, match="积分账户不存在"):
             quota_service.capture_credit(db_session, 99999, 10, "task:x", 10)
 
+    def test_capture_idempotent(self, db_session, quota_service, user_with_account):
+        uid = user_with_account.id
+        cost = quota_settings.generate_image_cost
+        quota_service.reserve_credit(db_session, uid, cost, "task:idem-c")
+        quota_service.capture_credit(db_session, uid, cost, "task:idem-c", cost)
+        quota_service.capture_credit(db_session, uid, cost, "task:idem-c", cost)
+
+        account = db_session.scalar(
+            select(CreditAccount).where(CreditAccount.user_id == uid)
+        )
+        assert account.frozen == 0
+        assert account.total_spent == cost
+        captured = db_session.scalars(
+            select(CreditTransaction).where(
+                CreditTransaction.ref_id == "task:idem-c",
+                CreditTransaction.reason == CreditReason.CAPTURED,
+            )
+        ).all()
+        assert len(captured) == 1
+
 
 # -- 预付费：解冻 -----------------------------------------------------------
 
@@ -265,6 +285,26 @@ class TestReleaseCredit:
     def test_release_nonexistent_account(self, db_session, quota_service):
         with pytest.raises(BizException, match="积分账户不存在"):
             quota_service.release_credit(db_session, 99999, 10, "task:x")
+
+    def test_release_idempotent(self, db_session, quota_service, user_with_account):
+        uid = user_with_account.id
+        cost = quota_settings.generate_image_cost
+        quota_service.reserve_credit(db_session, uid, cost, "task:idem-r")
+        quota_service.release_credit(db_session, uid, cost, "task:idem-r")
+        quota_service.release_credit(db_session, uid, cost, "task:idem-r")
+
+        account = db_session.scalar(
+            select(CreditAccount).where(CreditAccount.user_id == uid)
+        )
+        assert account.frozen == 0
+        assert account.balance == quota_settings.register_gift_amount
+        released = db_session.scalars(
+            select(CreditTransaction).where(
+                CreditTransaction.ref_id == "task:idem-r:release",
+                CreditTransaction.reason == CreditReason.REFUND,
+            )
+        ).all()
+        assert len(released) == 1
 
 
 # -- 入账 -------------------------------------------------------------------


### PR DESCRIPTION
Fixes #625

## Summary
- 动作任务终态只认网关/轮询的终端结果：i2v 超时前先再 poll 一次，成片已就绪则交付 `completed`；等待态被其它轮询清掉时不再把任务打成 `failed`
- 预付费 `capture` / `release` 按 `ref_id` 幂等；没有开放冻结时跳过结算。已 `COMPLETED` 的任务不会被并发/重投的失败路径改回 `failed` 或再次解冻
- 失败已解冻后 MQ 重投不再抛「冻结额度不足」，consumer 可以 ACK

## Test plan
- [x] `test_quota.py`：同一 `ref_id` 重复 capture / release，余额与流水只变一次
- [x] `test_i2v_poll.py`：超时后成片仍 Ready；无成片仍失败；无 i2v 状态不 poll、不挂单
- [x] `test_generation_orchestration.py`：解冻后成片仍 completed；真超时仍 failed；`_close_failed` 不覆盖 completed
- [x] `test_generation_quota.py`：失败解冻后重投同一失败路径不抛冻结额度不足
- [ ] CI 全量