### PR TITLE
fix(generation): MQ 重建出图张数不再另写默认值

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -78,8 +78,14 @@ class CharacterImageInput:
     width: int = 1024
     height: int = 1024
     # 候选数量由调用方决定；API 默认请求 3 张，并把可付费调用次数限制在 1–4。
-    num_images: int = 2
+    # ``None`` = 调用方没指定,在 __post_init__ 里解析成本层默认 2。解析放在这层
+    # 而不是各个构造点:MQ 重建时若另写一份默认值,缺省就会从 2 变成另一份数。
+    num_images: int | None = None
     direction: ActionDirection = ActionDirection.EAST
+
+    def __post_init__(self) -> None:
+        if self.num_images is None:
+            self.num_images = 2
 
 
 @dataclass

--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -64,13 +64,16 @@ def handle_verification_code(payload: dict[str, Any]) -> None:
 
 
 def _image_input(payload: dict) -> CharacterImageInput:
+    # 张数缺失时原样传 None,交给入参自己的默认值:在这里兜一个数就是第二份约定,
+    # 它与 CharacterImageInput 分叉时同一请求经不经过 MQ 出图张数不同,没有一处会红。
+    raw_num_images = payload.get("num_images")
     return CharacterImageInput(
         reference_image_url=payload.get("reference_image_url"),
         prompt=payload.get("prompt") or "",
         negative_prompt=payload.get("negative_prompt") or "",
         width=int(payload.get("width") or 1024),
         height=int(payload.get("height") or 1024),
-        num_images=int(payload.get("num_images") or 1),
+        num_images=int(raw_num_images) if raw_num_images is not None else None,
         direction=ActionDirection(payload.get("direction") or ActionDirection.EAST.value),
     )
 

--- a/backend/tests/test_mq_worker.py
+++ b/backend/tests/test_mq_worker.py
@@ -1060,3 +1060,25 @@ def test_action_input_keeps_the_stored_frame_count():
     rebuilt = _action_input({"character_id": 1, "action_type": "idle", "num_frames": 20})
 
     assert rebuilt.num_frames == 20
+
+
+def test_image_input_uses_model_default_when_payload_omits_num_images():
+    """MQ 重建入参时缺张数就用 CharacterImageInput 自己的默认值,不在这层另写一份。
+
+    生产走的就是这条重建路径:这里兜 1 而入参默认是 2 时,同一请求经不经过 MQ
+    出图张数不同,费用跟着偏,没有一处会红。
+    """
+    from windup_app.worker.handlers import _image_input
+
+    rebuilt = _image_input({"prompt": "hero"})
+
+    assert rebuilt.num_images == CharacterImageInput().num_images
+
+
+def test_image_input_keeps_explicit_zero_num_images():
+    """显式 0 与没传必须能区分:or 会把 0 吃成另一份默认值。"""
+    from windup_app.worker.handlers import _image_input
+
+    rebuilt = _image_input({"prompt": "hero", "num_images": 0})
+
+    assert rebuilt.num_images == 0


### PR DESCRIPTION
Fixes #593

## Summary
- Worker 从任务载荷重建 `CharacterImageInput` 时，缺 `num_images` 不再兜成 1，交给入参自己的默认值 2
- 用 `is None` 判断，显式 `num_images=0` 不再被 `or` 吃成 1
- 补 MQ 重建用例：载荷缺字段时与 `CharacterImageInput` 默认值一致；显式 0 原样保留

## Test plan
- [x] `test_image_input_uses_model_default_when_payload_omits_num_images`：缺 `num_images` 时重建结果为 2
- [x] `test_image_input_keeps_explicit_zero_num_images`：显式 0 不再被改写成 1
- [ ] CI 全量