### PR TITLE
fix(frontend): 401 重放限定安全方法并支持 replayAfterAuth 显式重放

### DIFF
--- a/frontend/src/entities/media/api.test.ts
+++ b/frontend/src/entities/media/api.test.ts
@@ -33,24 +33,15 @@ describe('MediaApis.upload', () => {
     expect(new Headers(init.headers).get('authorization')).toBe('Bearer access-token')
   })
 
-  it('登录令牌过期时刷新令牌并重放同一次上传', async () => {
+  it('登录令牌过期时刷新会话但不自动重放上传请求', async () => {
     vi.stubEnv('VITE_API_BASE_URL', 'http://127.0.0.1:8000')
     let accessToken = 'expired-token'
     const authorizations: (string | null)[] = []
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       authorizations.push(new Request(input, init).headers.get('authorization'))
-      if (authorizations.length === 1) {
-        return new Response(JSON.stringify({ code: 401, message: '登录状态已过期', data: null }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      }
-      return jsonResponse({
-        url: 'https://cdn.example.com/media/reference.png',
-        object_key: 'media/general/reference.png',
-        filename: 'reference.png',
-        content_type: 'image/png',
-        size: 4,
+      return new Response(JSON.stringify({ code: 401, message: '登录状态已过期', data: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
       })
     })
     vi.stubGlobal('fetch', fetchMock)
@@ -61,15 +52,17 @@ describe('MediaApis.upload', () => {
     })
 
     try {
-      await expect(createMediaApis().upload(imageFile())).resolves.toBe(
-        'https://cdn.example.com/media/reference.png',
-      )
+      await expect(createMediaApis().upload(imageFile())).rejects.toMatchObject({
+        kind: 'business',
+        code: 401,
+      })
     } finally {
       unregisterRecovery()
       unregisterToken()
     }
 
-    expect(authorizations).toEqual(['Bearer expired-token', 'Bearer renewed-token'])
+    // 会话已恢复（token 刷新），但 POST 上传不自动重放，避免重复写入。
+    expect(authorizations).toEqual(['Bearer expired-token'])
   })
   it('把图片和默认查询分类交给后端，并返回经过校验的媒体引用', async () => {
     vi.stubEnv('VITE_API_BASE_URL', 'http://127.0.0.1:8000')

--- a/frontend/src/entities/user/api.test.ts
+++ b/frontend/src/entities/user/api.test.ts
@@ -239,23 +239,7 @@ describe('createUserApis', () => {
     unregister()
   })
 
-  it.each([
-    ['current-user', (apis: ReturnType<typeof createUserApis>) => apis.me(), tokenResponse.user],
-    [
-      'nickname-update',
-      (apis: ReturnType<typeof createUserApis>) => apis.updateNickname('New Reader'),
-      tokenResponse.user,
-    ],
-    [
-      'password-change',
-      (apis: ReturnType<typeof createUserApis>) =>
-        apis.changePassword({
-          oldPassword: 'password-123',
-          newPassword: 'new-password-123',
-        }),
-      null,
-    ],
-  ])('recovers and replays protected %s requests', async (_label, invoke, data) => {
+  it('recovers and replays protected GET requests', async () => {
     const recover = vi.fn(async () => true)
     const unregister = registerApiUnauthorizedRecovery(recover)
     const fetchFn = vi
@@ -266,14 +250,54 @@ describe('createUserApis', () => {
         }),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ code: 200, message: 'ok', data }), { status: 200 }),
+        new Response(JSON.stringify({ code: 200, message: 'ok', data: tokenResponse.user }), {
+          status: 200,
+        }),
       )
     const apis = createUserApis({ baseUrl: 'https://api.windup.test', fetchFn })
 
     try {
-      await invoke(apis)
+      await expect(apis.me()).resolves.toMatchObject({ id: '7', email: 'reader@example.com' })
       expect(recover).toHaveBeenCalledTimes(1)
       expect(fetchFn).toHaveBeenCalledTimes(2)
+    } finally {
+      unregister()
+    }
+  })
+
+  it.each([
+    [
+      'nickname-update',
+      (apis: ReturnType<typeof createUserApis>) => apis.updateNickname('New Reader'),
+    ],
+    [
+      'password-change',
+      (apis: ReturnType<typeof createUserApis>) =>
+        apis.changePassword({
+          oldPassword: 'password-123',
+          newPassword: 'new-password-123',
+        }),
+    ],
+  ])('recovers the session but does not replay protected %s requests', async (_label, invoke) => {
+    const recover = vi.fn(async () => true)
+    const unregister = registerApiUnauthorizedRecovery(recover)
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 401, message: 'access token expired', data: null }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 200, message: 'ok', data: null }), { status: 200 }),
+      )
+    const apis = createUserApis({ baseUrl: 'https://api.windup.test', fetchFn })
+
+    try {
+      await expect(invoke(apis)).rejects.toMatchObject({ kind: 'business', code: 401 })
+      // token 已刷新，手动重试可以成功；但写请求本身不自动重放。
+      expect(recover).toHaveBeenCalledTimes(1)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
     } finally {
       unregister()
     }

--- a/frontend/src/shared/api/index.test.ts
+++ b/frontend/src/shared/api/index.test.ts
@@ -188,6 +188,64 @@ describe('createApiClient', () => {
     unregister()
   })
 
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'])(
+    '刷新会话但不自动重放 %s 等非幂等请求',
+    async (method) => {
+      const recover = vi.fn(async () => true)
+      const unregister = registerApiUnauthorizedRecovery(recover)
+      const fetchFn = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ code: 401, message: '登录状态已过期', data: null }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      )
+      const client = createApiClient({ baseUrl: 'https://api.windup.test', fetchFn })
+
+      await expect(
+        client.request('/resources', { method, json: { name: 'sample' } }),
+      ).rejects.toMatchObject({ kind: 'business', code: 401 })
+      // 会话恢复照常执行（token 已刷新），只是不再自动重放本次写请求。
+      expect(recover).toHaveBeenCalledTimes(1)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+      unregister()
+    },
+  )
+
+  it('按显式声明重放写请求', async () => {
+    let accessToken = 'expired-token'
+    const authorizations: (string | null)[] = []
+    const unregister = registerApiUnauthorizedRecovery(async () => {
+      accessToken = 'renewed-token'
+      return true
+    })
+    const client = createApiClient({
+      baseUrl: 'https://api.windup.test',
+      getAccessToken: () => accessToken,
+      fetchFn: async (input, init) => {
+        authorizations.push(new Request(input, init).headers.get('authorization'))
+        const payload =
+          authorizations.length === 1
+            ? { code: 401, message: '登录状态已过期', data: null }
+            : { code: 200, message: 'success', data: { id: 7 } }
+        return new Response(JSON.stringify(payload), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      },
+    })
+
+    await expect(
+      client.request('/resources', {
+        method: 'POST',
+        json: { name: 'sample' },
+        replayAfterAuth: true,
+      }),
+    ).resolves.toEqual({ id: 7 })
+    expect(authorizations).toEqual(['Bearer expired-token', 'Bearer renewed-token'])
+    unregister()
+  })
+
   it('keeps the original 401 when recovery fails and lets clients opt out', async () => {
     const recover = vi.fn(async () => {
       throw new Error('refresh failed')

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -4,6 +4,11 @@ export type ApiRequestOptions = Omit<RequestInit, 'body'> & {
   body?: BodyInit | null
   json?: unknown
   query?: Record<string, ApiQueryValue>
+  /**
+   * 写请求默认不在 401 恢复后自动重放（非幂等方法重放可能重复创建资源）；
+   * 调用方确认后端语义可安全重放时显式声明。
+   */
+  replayAfterAuth?: boolean
 }
 
 /** 后端 ListResponse 解包后的传输结果。 */
@@ -231,9 +236,22 @@ export function createApiClient({
     }
   }
 
+  /** RFC 9110 语义上无副作用的方法；重放它们不会改变服务端状态。 */
+  const REPLAYABLE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+  /**
+   * 401 后是否自动重放本次请求：
+   * - ReadableStream 等一次性 body 无法重新消费，禁止重放；
+   * - 默认只重放安全方法（GET/HEAD/OPTIONS），写请求重复执行可能造成
+   *   重复创建等副作用，须由调用方显式声明 replayAfterAuth；
+   * - 未声明 method 视为 GET。
+   */
   function canReplay(options: ApiRequestOptions | undefined): boolean {
     const body = options?.body
-    return !(typeof ReadableStream !== 'undefined' && body instanceof ReadableStream)
+    if (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream) return false
+    if (options?.replayAfterAuth) return true
+    const method = options?.method?.toUpperCase() ?? 'GET'
+    return REPLAYABLE_METHODS.has(method)
   }
 
   async function receiveEnvelope(
@@ -250,8 +268,7 @@ export function createApiClient({
       recoverUnauthorized &&
       response.status === 200 &&
       envelope.code === 401 &&
-      recovery &&
-      canReplay(options)
+      recovery
     ) {
       let recovered = false
       try {
@@ -259,7 +276,9 @@ export function createApiClient({
       } catch {
         // 恢复失败仍应向调用方交付原始 401，而不是泄漏 refresh 的错误。
       }
-      if (recovered) return receiveEnvelope(path, options, true)
+      // 会话恢复总是执行，让 token 重新生效；但只有可重放的请求才自动重放，
+      // 写请求即使恢复了会话也返回原始 401，由用户手动重试，避免重复执行副作用。
+      if (recovered && canReplay(options)) return receiveEnvelope(path, options, true)
     }
 
     return { response, envelope }


### PR DESCRIPTION
Fixes #207

## Summary
- `canReplay` 默认只放行 GET/HEAD/OPTIONS（未声明 method 视为 GET），POST/PUT/PATCH/DELETE 在 401 恢复后不再自动重放，避免非幂等请求重复执行造成重复创建资源等副作用
- `ApiRequestOptions` 新增 `replayAfterAuth`，调用方确认后端语义可安全重放时显式声明（对应 issue 讨论中 fennoai 给出的方向）
- 会话恢复与请求重放解耦：401 始终尝试刷新 token，仅可重放请求自动重放，写请求返回原始 401 由用户手动重试——直接在 `canReplay` 拦截会让手动重试时 token 依然过期、陷入 401 死循环，解耦后手动重试一次即可成功
- 一次性 body（ReadableStream）禁止重放的原有行为保留

## Test plan
- [x] `index.test.ts`：POST/PUT/PATCH/DELETE 断言恢复会话但只发一次请求并返回原始 401；`replayAfterAuth: true` 断言带新 token 重放成功
- [x] `user/api.test.ts`：`me()`（GET）保留自动重放断言；`updateNickname`（PATCH）/`changePassword`（POST）改为断言不重放
- [x] `media/api.test.ts`：上传（POST）改为断言刷新会话但不自动重放
- [x] 前端全量 vitest（73 files / 1059 tests）、typecheck、lint、format 全绿