### PR TITLE
refactor(orchestrator): 从 executor 抽出 generation_io

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -14,15 +14,12 @@
 
 from __future__ import annotations
 
-import contextvars
 import dataclasses
 import logging
-import os
 import threading
-from collections.abc import Callable, Sequence
-from concurrent.futures import Future, ThreadPoolExecutor
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from sqlalchemy.orm import Session
 
@@ -35,7 +32,7 @@ from windup_framework.gateway.registry import ModelRegistry
 from windup_framework.gateway.types import Scene
 from windup_framework.config.quality_gate import settings as gate_settings
 
-from windup_app.server.orchestrator import billing, i2v_poll, quality_gate, task_repo
+from windup_app.server.orchestrator import billing, generation_io, i2v_poll, quality_gate, task_repo
 from windup_app.server.orchestrator._failure import user_message
 from windup_app.server.orchestrator.i2v_poll import ActionAwaitingVideo
 from windup_app.server.orchestrator._fetch import fetch_own_media
@@ -57,83 +54,6 @@ _ACTION_RESULT = "character_action"  # task_repo._deserialize_result 按此标�
 
 class _PollSkip(Exception):
     """续跑时任务已终态,直接 ACK。"""
-
-
-T = TypeVar("T")
-R = TypeVar("R")
-
-
-def _env_int(name: str, default: int) -> int:
-    raw = os.getenv(name, "").strip()
-    return int(raw) if raw else default
-
-
-# 进程级 IO 池:上传 / 参考图下载 / 多图 gen_image 共用。
-# 必须从 handler 线程往里 submit,禁止在池内任务再 _io_map(同池会死锁)。
-_IO_POOL_SIZE = max(1, _env_int("WINDUP_IO_POOL_SIZE", 32))
-_io_pool_lock = threading.Lock()
-_io_pool: ThreadPoolExecutor | None = None
-
-
-def _shared_io_pool() -> ThreadPoolExecutor:
-    global _io_pool
-    if _io_pool is None:
-        with _io_pool_lock:
-            if _io_pool is None:
-                _io_pool = ThreadPoolExecutor(
-                    max_workers=_IO_POOL_SIZE,
-                    thread_name_prefix="windup-io",
-                )
-    return _io_pool
-
-
-def _submit_io(fn: Callable[[T], R], items: Sequence[T]) -> list[Future[R]]:
-    """把独立 IO 丢进共享池。每个任务一份 Context 快照——同一 Context 不能被两线程同时 enter。"""
-    pool = _shared_io_pool()
-    futs: list[Future[R]] = []
-    for item in items:
-        ctx = contextvars.copy_context()
-        futs.append(pool.submit(ctx.run, fn, item))
-    return futs
-
-
-def _io_map(fn: Callable[[T], R], items: Sequence[T]) -> list[R]:
-    if not items:
-        return []
-    if len(items) == 1:
-        return [fn(items[0])]
-    return [fut.result() for fut in _submit_io(fn, items)]
-
-
-def _upload_frames(upload: Callable[[bytes], str], pngs: Sequence[bytes]) -> list[str]:
-    """并行上传各帧,返回 URL 列表,下标与 ``pngs`` 对齐。
-
-    失败语义与串行相同:已成功的 PUT 会留在桶里(孤儿),任务仍 FAILED。
-    """
-    return _io_map(upload, pngs)
-
-
-def _using_session(
-    session: Session | None,
-    factory: Callable[[], Session],
-    fn: Callable[[Session], T],
-) -> T:
-    """自开的 session 只包住 fn:commit 后立刻 close,生成/上传期间不占连接池。
-
-    调用方传入的 session 不提交、不关闭(测试事务)。
-    """
-    if session is not None:
-        return fn(session)
-    owned = factory()
-    try:
-        out = fn(owned)
-        owned.commit()
-        return out
-    except Exception:
-        owned.rollback()
-        raise
-    finally:
-        owned.close()
 
 
 def _settle_credit(session: Session, task_id: int, *, success: bool) -> None:
@@ -350,7 +270,7 @@ class ActionTaskExecutor:
                 task_repo.update_status(s, task_id, TaskStatus.RUNNING)
                 return (self._fetch_constraints or _load_constraints)(s, project_id)
 
-            cons = _using_session(session, self._make_session, _mark_running)
+            cons = generation_io.using_session(session, self._make_session, _mark_running)
             reset = bind_call_context(
                 task_id=str(task_id),
                 start_from_model=_resolve_video_model(input.video_model),
@@ -361,7 +281,7 @@ class ActionTaskExecutor:
                 task_repo.update_result(s, task_id, _ACTION_RESULT, result)
                 _settle_credit(s, task_id, success=True)
 
-            _using_session(session, self._make_session, _complete)
+            generation_io.using_session(session, self._make_session, _complete)
         except ActionAwaitingVideo:
             logger.info("动作任务 %s 已提交 i2v,等待延迟轮询", task_id)
         except PromptRejected as exc:
@@ -373,7 +293,7 @@ class ActionTaskExecutor:
             def _reject(s: Session) -> None:
                 task_repo.fail_task(s, task_id, error_message=error_message)
 
-            _using_session(session, self._make_session, _reject)
+            generation_io.using_session(session, self._make_session, _reject)
         except Exception as exc:  # noqa: BLE001 —— 兜底任何生成/上传/网络异常
             logger.exception("动作任务 %s 失败", task_id)
             if session is not None:
@@ -384,7 +304,7 @@ class ActionTaskExecutor:
                 task_repo.fail_task(s, task_id, error_message=error_message)
                 _settle_credit(s, task_id, success=False)
 
-            _using_session(session, self._make_session, _fail)
+            generation_io.using_session(session, self._make_session, _fail)
         finally:
             if reset is not None:
                 reset()
@@ -522,7 +442,7 @@ class ActionTaskExecutor:
                 return (self._fetch_constraints or _load_constraints)(s, project_id)
 
             try:
-                cons = _using_session(session, self._make_session, _mark_running)
+                cons = generation_io.using_session(session, self._make_session, _mark_running)
             except _PollSkip:
                 return
 
@@ -554,7 +474,7 @@ class ActionTaskExecutor:
                 task_repo.update_result(s, task_id, _ACTION_RESULT, result)
                 _settle_credit(s, task_id, success=True)
 
-            _using_session(session, self._make_session, _complete)
+            generation_io.using_session(session, self._make_session, _complete)
         except PromptRejected as exc:
             logger.info("动作任务 %s 的描述被措辞门禁拒绝: %s", task_id, exc.code.value)
             error_message = user_message(exc)
@@ -562,7 +482,7 @@ class ActionTaskExecutor:
             def _reject(s: Session) -> None:
                 task_repo.fail_task(s, task_id, error_message=error_message)
 
-            _using_session(session, self._make_session, _reject)
+            generation_io.using_session(session, self._make_session, _reject)
         except Exception as exc:  # noqa: BLE001
             logger.exception("动作任务 %s 轮询失败", task_id)
             if session is not None:
@@ -573,7 +493,7 @@ class ActionTaskExecutor:
                 task_repo.fail_task(s, task_id, error_message=error_message)
                 _settle_credit(s, task_id, success=False)
 
-            _using_session(session, self._make_session, _fail)
+            generation_io.using_session(session, self._make_session, _fail)
         finally:
             if reset is not None:
                 reset()
@@ -621,14 +541,14 @@ class ActionTaskExecutor:
         checked = [_require_size(png, cons.sprite_w, cons.sprite_h) for png in generated.frames]
         # 上传与判官都是网络 IO 且互不依赖:判官读内存 bytes。handler 线程跑 review,
         # IO 池跑 PUT,避免 32 帧传完再打一次视觉模型。
-        upload_futs = _submit_io(upload, checked) if len(checked) > 1 else None
+        upload_futs = generation_io.submit_io(upload, checked) if len(checked) > 1 else None
         decision = quality_gate.review(
             self._get_judge(), checked, master, _judged_action(input)
         )
         urls = (
             [fut.result() for fut in upload_futs]
             if upload_futs is not None
-            else _upload_frames(upload, checked)
+            else generation_io.upload_frames(upload, checked)
         )
         frames = [
             {"index": i, "image_url": url, "duration_ms": dur}
@@ -838,7 +758,7 @@ class ImageTaskExecutor:
                 task_repo.update_status(s, task_id, TaskStatus.RUNNING)
                 return _load_constraints(s, project_id)
 
-            cons = _using_session(session, self._make_session, _mark_running)
+            cons = generation_io.using_session(session, self._make_session, _mark_running)
             reset = bind_call_context(task_id=str(task_id))
             urls, quality = self._produce_image(input, cons)
 
@@ -856,7 +776,7 @@ class ImageTaskExecutor:
                 )
                 _settle_credit(s, task_id, success=True)
 
-            _using_session(session, self._make_session, _complete)
+            generation_io.using_session(session, self._make_session, _complete)
         except Exception as exc:  # noqa: BLE001 —— 兜底
             logger.exception("图片任务 %s 失败", task_id)
             if session is not None:
@@ -867,7 +787,7 @@ class ImageTaskExecutor:
                 task_repo.fail_task(s, task_id, error_message=error_message)
                 _settle_credit(s, task_id, success=False)
 
-            _using_session(session, self._make_session, _fail)
+            generation_io.using_session(session, self._make_session, _fail)
         finally:
             if reset is not None:
                 reset()
@@ -903,7 +823,7 @@ class ImageTaskExecutor:
                 return None
 
         if want_char and want_style:
-            char_bytes, style_bytes = _io_map(
+            char_bytes, style_bytes = generation_io.io_map(
                 lambda item: fetch(item[1]) if item[0] == "char" else _fetch_style(item[1]),
                 (("char", char_url), ("style", style_url)),
             )
@@ -961,8 +881,8 @@ class ImageTaskExecutor:
             finally:
                 reset_call()
 
-        # 多张候选各自一次付费调用,彼此独立;ContextVar 由 _io_map 拷进 IO 线程。
-        raws = _io_map(_gen_one, range(max(1, input.num_images)))
+        # 多张候选各自一次付费调用,彼此独立;ContextVar 由 io_map 拷进 IO 线程。
+        raws = generation_io.io_map(_gen_one, range(max(1, input.num_images)))
         # 抠图走 ONNX,同一会话不能并发 Run;上传再并行。
         cut: list[Image.Image] = []
         pngs: list[bytes] = []
@@ -977,7 +897,7 @@ class ImageTaskExecutor:
             png = _fit_to(matte.cutout(img), input.width, input.height, smooth=True)
             cut.append(Image.open(io.BytesIO(png)).convert("RGBA"))
             pngs.append(png)
-        urls = _upload_frames(upload, pngs)
+        urls = generation_io.upload_frames(upload, pngs)
         # 同一份 alpha 顺手数一次主体数(#427):此前多主体母版要等下一个动作任务才留痕,
         # 而那时钱已经花在错的母版上了。只记账,不在此处判成败 —— 与动作那条同一立场。
         return urls, {"subject_blobs": list(subject_blobs(cut))}

--- a/backend/packages/app/src/windup_app/server/orchestrator/generation_io.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/generation_io.py
@@ -1,0 +1,89 @@
+"""生成链路的 IO 与短 session:共享线程池、并行上传、连接尽快归还。
+
+执行器只协调阶段结果;本模块持有进程级 IO 池。必须从 handler 线程往里
+submit,禁止在池内任务再 ``io_map``(同池会死锁)。
+
+失败语义与串行相同:已成功的 PUT 会留在桶里(孤儿),任务仍 FAILED。
+"""
+
+from __future__ import annotations
+
+import contextvars
+import os
+import threading
+from collections.abc import Callable, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import TypeVar
+
+from sqlalchemy.orm import Session
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    return int(raw) if raw else default
+
+
+_IO_POOL_SIZE = max(1, _env_int("WINDUP_IO_POOL_SIZE", 32))
+_io_pool_lock = threading.Lock()
+_io_pool: ThreadPoolExecutor | None = None
+
+
+def _shared_io_pool() -> ThreadPoolExecutor:
+    global _io_pool
+    if _io_pool is None:
+        with _io_pool_lock:
+            if _io_pool is None:
+                _io_pool = ThreadPoolExecutor(
+                    max_workers=_IO_POOL_SIZE,
+                    thread_name_prefix="windup-io",
+                )
+    return _io_pool
+
+
+def submit_io(fn: Callable[[T], R], items: Sequence[T]) -> list[Future[R]]:
+    """把独立 IO 丢进共享池。每个任务一份 Context 快照——同一 Context 不能被两线程同时 enter。"""
+    pool = _shared_io_pool()
+    futs: list[Future[R]] = []
+    for item in items:
+        ctx = contextvars.copy_context()
+        futs.append(pool.submit(ctx.run, fn, item))
+    return futs
+
+
+def io_map(fn: Callable[[T], R], items: Sequence[T]) -> list[R]:
+    if not items:
+        return []
+    if len(items) == 1:
+        return [fn(items[0])]
+    return [fut.result() for fut in submit_io(fn, items)]
+
+
+def upload_frames(upload: Callable[[bytes], str], pngs: Sequence[bytes]) -> list[str]:
+    """并行上传各帧,返回 URL 列表,下标与 ``pngs`` 对齐。"""
+    return io_map(upload, pngs)
+
+
+def using_session(
+    session: Session | None,
+    factory: Callable[[], Session],
+    fn: Callable[[Session], T],
+) -> T:
+    """自开的 session 只包住 fn:commit 后立刻 close,生成/上传期间不占连接池。
+
+    调用方传入的 session 不提交、不关闭(测试事务)。
+    """
+    if session is not None:
+        return fn(session)
+    owned = factory()
+    try:
+        out = fn(owned)
+        owned.commit()
+        return out
+    except Exception:
+        owned.rollback()
+        raise
+    finally:
+        owned.close()

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -28,8 +28,8 @@ from windup_app.server.orchestrator.model import (
 from windup_app.server.orchestrator.executor import (
     ActionTaskExecutor,
     ProjectConstraints,
-    _upload_frames,
 )
+from windup_app.server.orchestrator.generation_io import upload_frames
 from windup_ai_engine.ports import ActionQuality, GeneratedAction
 from windup_app.server.orchestrator.service import AiGenerationService
 from windup_ai_engine.impl import CharacterGenerator
@@ -111,14 +111,14 @@ def test_upload_frames_preserves_index_when_later_frames_finish_first():
             first_may_finish.set()
         return f"https://cdn.example.com/f{i}.png"
 
-    urls = _upload_frames(_upload, [bytes([i]) for i in range(4)])
+    urls = upload_frames(_upload, [bytes([i]) for i in range(4)])
     assert urls == [f"https://cdn.example.com/f{i}.png" for i in range(4)]
     assert finished and finished[0] != 0
 
 
 def test_upload_frames_single_does_not_need_a_pool():
-    assert _upload_frames(lambda png: f"u-{png.decode()}", [b"a"]) == ["u-a"]
-    assert _upload_frames(lambda png: "u", []) == []
+    assert upload_frames(lambda png: f"u-{png.decode()}", [b"a"]) == ["u-a"]
+    assert upload_frames(lambda png: "u", []) == []
 
 
 def test_action_task_opens_a_fresh_session_after_generate(session_factory):


### PR DESCRIPTION
## Summary
- 把进程级 IO 池、`io_map` / `upload_frames`、短 session 从 `ActionTaskExecutor` / `ImageTaskExecutor` 抽到 `orchestrator/generation_io.py`，执行器只协调阶段结果。
- 并行上传、ContextVar 拷贝进 IO 线程、短 session 在生成/上传期间不占连接池，行为与现网一致。
- 失败语义不变：已成功的 PUT 可留孤儿，任务仍 FAILED。不改 i2v 延迟队列契约，不引入 MQ handler 注册表或新中间件。

Closes #597
Refs #570 #571

## Test plan
- [ ] `backend` 下 `uv run pytest tests/test_generation_orchestration.py tests/test_i2v_poll.py tests/test_gateway_executor.py tests/test_generation_quota.py tests/test_orchestrator_hardening.py tests/test_master_cutout.py tests/test_ground_contact_anchor.py tests/test_full_direction_integration.py tests/test_custom_action.py tests/test_quality_judge.py`
- [ ] 确认 `executor.py` 不再定义进程级 IO 池
- [ ] 图/动作生成仍走并行上传 + 短 session（现有编排 / 抽帧 / 上传测试覆盖）