### PR TITLE
refactor(mq): 用 handler/spec 注册扩展消息类型

### DIFF
--- a/backend/packages/app/src/windup_app/server/mq/catalog.py
+++ b/backend/packages/app/src/windup_app/server/mq/catalog.py
@@ -1,4 +1,21 @@
-"""MQ Stream 清单与并发配置。"""
+"""MQ Stream 清单、消息类型注册与并发配置。
+
+加一种 generation ``msg_type`` 时只改这里的 :func:`type_specs`，再在
+``windup_app.worker.handlers`` 登记 handler。不要改 consumer 的提交路径：
+它按本表选线程池和信号量。
+
+步骤::
+
+    1. 增加 ``MSG_TYPE_*`` 常量
+    2. 在 :func:`type_specs` 加一条 :class:`TypeSpec`
+       - ``pool=POOL_SHARED``：与同 Stream 其它共享池类型共用执行器
+       - ``pool`` 换新名字：独立线程池（如 poll，避免被 image 占满）
+       - ``limit=True``：该类型单独信号量，并发即 ``concurrency``
+       - ``recover_as``：PENDING 任务按此 GenerationType 值重入队；轮询类留 None
+    3. 在 handlers 的 ``HANDLERS`` 登记可调用对象
+
+不在此表里塞积分账本或 SSE EventBus。是否新开 Stream 仍按 SLA 决定。
+"""
 
 from __future__ import annotations
 
@@ -23,6 +40,9 @@ MSG_TYPE_CHARACTER_IMAGE = "character_image"
 MSG_TYPE_CHARACTER_ACTION = "character_action"
 MSG_TYPE_CHARACTER_ACTION_POLL = "character_action_poll"
 
+POOL_SHARED = "shared"
+POOL_POLL = "poll"
+
 
 def _env_int(name: str, default: int) -> int:
     raw = os.getenv(name, "").strip()
@@ -38,26 +58,16 @@ class StreamSpec:
     concurrency: int
 
 
-def email_stream_spec() -> StreamSpec:
-    return StreamSpec(
-        stream=EMAIL_STREAM,
-        group=EMAIL_GROUP,
-        concurrency=_env_int("WINDUP_MQ_EMAIL_CONCURRENCY", 8),
-    )
+@dataclass(frozen=True)
+class TypeSpec:
+    """Stream 内一种 ``msg_type`` 的并发池、信号量与恢复策略。"""
 
-
-def generation_worker_pool_size() -> int:
-    # image/action 共用一个线程池。poll 走独立执行器,不能加进这个数字,
-    # 否则 image 占满线程后 poll 只能排队。
-    return generation_image_concurrency() + generation_action_concurrency()
-
-
-def generation_stream_spec() -> StreamSpec:
-    return StreamSpec(
-        stream=GENERATION_STREAM,
-        group=GENERATION_GROUP,
-        concurrency=generation_worker_pool_size(),
-    )
+    msg_type: str
+    stream: str
+    pool: str
+    concurrency: int
+    limit: bool
+    recover_as: str | None = None
 
 
 def generation_image_concurrency() -> int:
@@ -72,6 +82,90 @@ def generation_action_concurrency() -> int:
 def generation_poll_concurrency() -> int:
     # 单次 inspect + 偶尔下载,不 sleep,默认高于 action 建单并发。
     return _env_int("WINDUP_MQ_GENERATION_POLL_CONCURRENCY", 16)
+
+
+def type_specs() -> tuple[TypeSpec, ...]:
+    return (
+        TypeSpec(
+            msg_type=MSG_TYPE_VERIFICATION_CODE,
+            stream=EMAIL_STREAM,
+            pool=POOL_SHARED,
+            concurrency=_env_int("WINDUP_MQ_EMAIL_CONCURRENCY", 8),
+            limit=False,
+        ),
+        TypeSpec(
+            msg_type=MSG_TYPE_CHARACTER_IMAGE,
+            stream=GENERATION_STREAM,
+            pool=POOL_SHARED,
+            concurrency=generation_image_concurrency(),
+            limit=True,
+            recover_as=MSG_TYPE_CHARACTER_IMAGE,
+        ),
+        TypeSpec(
+            msg_type=MSG_TYPE_CHARACTER_ACTION,
+            stream=GENERATION_STREAM,
+            pool=POOL_SHARED,
+            concurrency=generation_action_concurrency(),
+            limit=True,
+            recover_as=MSG_TYPE_CHARACTER_ACTION,
+        ),
+        TypeSpec(
+            msg_type=MSG_TYPE_CHARACTER_ACTION_POLL,
+            stream=GENERATION_STREAM,
+            pool=POOL_POLL,
+            concurrency=generation_poll_concurrency(),
+            limit=True,
+        ),
+    )
+
+
+def type_spec(msg_type: str) -> TypeSpec | None:
+    for spec in type_specs():
+        if spec.msg_type == msg_type:
+            return spec
+    return None
+
+
+def types_for_stream(stream: str) -> tuple[TypeSpec, ...]:
+    return tuple(spec for spec in type_specs() if spec.stream == stream)
+
+
+def msg_type_for_generation(task_type: str) -> str:
+    """PENDING 重入队 / API 投递用的 msg_type。轮询类型没有 recover_as。"""
+    for spec in type_specs():
+        if spec.recover_as == task_type:
+            return spec.msg_type
+    raise ValueError(f"未知任务类型: {task_type}")
+
+
+def _pool_size(stream: str, pool: str) -> int:
+    return sum(
+        spec.concurrency
+        for spec in type_specs()
+        if spec.stream == stream and spec.pool == pool
+    )
+
+
+def email_stream_spec() -> StreamSpec:
+    return StreamSpec(
+        stream=EMAIL_STREAM,
+        group=EMAIL_GROUP,
+        concurrency=_pool_size(EMAIL_STREAM, POOL_SHARED),
+    )
+
+
+def generation_worker_pool_size() -> int:
+    # image/action 共用一个线程池。poll 走独立 pool 名,不能加进这个数字,
+    # 否则 image 占满线程后 poll 只能排队。
+    return _pool_size(GENERATION_STREAM, POOL_SHARED)
+
+
+def generation_stream_spec() -> StreamSpec:
+    return StreamSpec(
+        stream=GENERATION_STREAM,
+        group=GENERATION_GROUP,
+        concurrency=generation_worker_pool_size(),
+    )
 
 
 def all_stream_specs() -> tuple[StreamSpec, StreamSpec]:
@@ -90,8 +184,11 @@ __all__ = [
     "MSG_TYPE_CHARACTER_ACTION_POLL",
     "MSG_TYPE_CHARACTER_IMAGE",
     "MSG_TYPE_VERIFICATION_CODE",
+    "POOL_POLL",
+    "POOL_SHARED",
     "SSE_REDIS_CHANNEL",
     "StreamSpec",
+    "TypeSpec",
     "all_stream_specs",
     "email_stream_spec",
     "generation_action_concurrency",
@@ -99,4 +196,8 @@ __all__ = [
     "generation_poll_concurrency",
     "generation_stream_spec",
     "generation_worker_pool_size",
+    "msg_type_for_generation",
+    "type_spec",
+    "type_specs",
+    "types_for_stream",
 ]

--- a/backend/packages/app/src/windup_app/server/orchestrator/recover.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/recover.py
@@ -17,14 +17,12 @@ from sqlalchemy.orm import Session
 from windup_app.server.mq.catalog import (
     GENERATION_RUNNING_STALE_SECONDS,
     GENERATION_STREAM,
-    MSG_TYPE_CHARACTER_ACTION,
-    MSG_TYPE_CHARACTER_IMAGE,
+    msg_type_for_generation,
 )
 from windup_app.server.orchestrator import billing, task_repo
 from windup_app.server.orchestrator.i2v_poll import reschedule_if_waiting
 from windup_app.server.orchestrator.model import (
     GenerationTask,
-    GenerationType,
     TaskStatus,
 )
 from windup_framework.mq.publisher import MqPublisher
@@ -99,23 +97,18 @@ def _requeue_pending(
 ) -> None:
     assert task.id is not None
     try:
-        if task.task_type is GenerationType.CHARACTER_IMAGE:
-            msg_type = MSG_TYPE_CHARACTER_IMAGE
-        elif task.task_type is GenerationType.CHARACTER_ACTION:
-            msg_type = MSG_TYPE_CHARACTER_ACTION
-        else:
-            raise ValueError(f"未知任务类型: {task.task_type}")
+        task_type = (
+            task.task_type.value
+            if hasattr(task.task_type, "value")
+            else str(task.task_type)
+        )
         message_id = publisher.enqueue(
             session,
             stream=GENERATION_STREAM,
-            msg_type=msg_type,
+            msg_type=msg_type_for_generation(task_type),
             payload={
                 "task_id": task.id,
-                "task_type": (
-                    task.task_type.value
-                    if hasattr(task.task_type, "value")
-                    else str(task.task_type)
-                ),
+                "task_type": task_type,
             },
             dedupe_key=f"generation:{task.id}",
         )

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -37,8 +37,7 @@ from windup_app.server.character.model import Character, CharacterData
 from windup_app.server.orchestrator import task_repo
 from windup_app.server.mq.catalog import (
     GENERATION_STREAM,
-    MSG_TYPE_CHARACTER_ACTION,
-    MSG_TYPE_CHARACTER_IMAGE,
+    msg_type_for_generation,
 )
 from windup_app.server.orchestrator.service import service as generation_service
 from windup_app.server.orchestrator.model import (
@@ -371,11 +370,7 @@ def _publish_generation_after_commit(
     task_type: str,
 ) -> None:
     """注册 after_commit 回调:session 提交成功后再投递到 Redis Stream。"""
-    msg_type = (
-        MSG_TYPE_CHARACTER_IMAGE
-        if task_type == MSG_TYPE_CHARACTER_IMAGE
-        else MSG_TYPE_CHARACTER_ACTION
-    )
+    msg_type = msg_type_for_generation(task_type)
     message_id = publisher.enqueue(
         session,
         stream=GENERATION_STREAM,

--- a/backend/packages/app/src/windup_app/worker/consumer.py
+++ b/backend/packages/app/src/windup_app/worker/consumer.py
@@ -13,14 +13,14 @@ from dataclasses import dataclass
 from typing import Any
 
 from windup_app.server.mq.catalog import (
-    GENERATION_GROUP,
     MSG_TYPE_CHARACTER_ACTION,
     MSG_TYPE_CHARACTER_ACTION_POLL,
     MSG_TYPE_CHARACTER_IMAGE,
+    POOL_POLL,
+    POOL_SHARED,
     StreamSpec,
-    generation_action_concurrency,
-    generation_image_concurrency,
-    generation_poll_concurrency,
+    type_spec,
+    types_for_stream,
 )
 from windup_app.worker.handlers import HandlerDeferred, dispatch_handler
 from windup_framework.db.redis import get_redis
@@ -58,22 +58,30 @@ class StreamConsumer:
         self._resume_action_poll = resume_action_poll
         self._stop = stop_event
         self._consumer_name = f"{socket.gethostname()}-{threading.get_ident()}"
-        self._executor = ThreadPoolExecutor(
-            max_workers=config.concurrency,
-            thread_name_prefix=f"windup-{config.group}",
-        )
-        # poll 必须有自己的线程:共享池里 image 会在 acquire 前占满 worker。
-        self._poll_executor = (
-            ThreadPoolExecutor(
-                max_workers=generation_poll_concurrency(),
-                thread_name_prefix="windup-generation-poll",
+        self._executors: dict[str, ThreadPoolExecutor] = {}
+        self._semaphores: dict[str, threading.Semaphore] = {}
+        pool_sizes: dict[str, int] = {}
+        for spec in types_for_stream(config.stream):
+            pool_sizes[spec.pool] = pool_sizes.get(spec.pool, 0) + spec.concurrency
+            if spec.limit:
+                self._semaphores[spec.msg_type] = threading.Semaphore(spec.concurrency)
+        if not pool_sizes:
+            pool_sizes[POOL_SHARED] = config.concurrency
+        for pool_name, size in pool_sizes.items():
+            prefix = (
+                f"windup-{config.group}"
+                if pool_name == POOL_SHARED
+                else f"windup-{config.group}-{pool_name}"
             )
-            if config.group == GENERATION_GROUP
-            else None
-        )
-        self._image_sem = threading.Semaphore(generation_image_concurrency())
-        self._action_sem = threading.Semaphore(generation_action_concurrency())
-        self._poll_sem = threading.Semaphore(generation_poll_concurrency())
+            self._executors[pool_name] = ThreadPoolExecutor(
+                max_workers=max(1, size),
+                thread_name_prefix=prefix,
+            )
+        self._executor = self._executors[POOL_SHARED]
+        self._poll_executor = self._executors.get(POOL_POLL)
+        self._image_sem = self._semaphores.get(MSG_TYPE_CHARACTER_IMAGE)
+        self._action_sem = self._semaphores.get(MSG_TYPE_CHARACTER_ACTION)
+        self._poll_sem = self._semaphores.get(MSG_TYPE_CHARACTER_ACTION_POLL)
         self._claim_cursor = "0-0"
         self._last_claim_at = 0.0
 
@@ -87,9 +95,8 @@ class StreamConsumer:
         return thread
 
     def shutdown(self, *, wait_timeout: float = 30.0) -> None:
-        self._executor.shutdown(wait=True, cancel_futures=False)
-        if self._poll_executor is not None:
-            self._poll_executor.shutdown(wait=True, cancel_futures=False)
+        for executor in self._executors.values():
+            executor.shutdown(wait=True, cancel_futures=False)
 
     def _loop(self) -> None:
         redis_client = get_redis()
@@ -142,16 +149,14 @@ class StreamConsumer:
         self._executor_for(fields).submit(self._process_message, stream_id, fields)
 
     def _executor_for(self, fields: dict[str, str]) -> ThreadPoolExecutor:
-        poll = self._poll_executor
-        if poll is None:
-            return self._executor
         try:
             msg_type = str(mq_client.parse_envelope(fields)["type"])
         except Exception:
             return self._executor
-        if msg_type == MSG_TYPE_CHARACTER_ACTION_POLL:
-            return poll
-        return self._executor
+        spec = type_spec(msg_type)
+        if spec is None or spec.pool == POOL_SHARED:
+            return self._executor
+        return self._executors.get(spec.pool, self._executor)
 
     def _process_message(self, stream_id: str, fields: dict[str, str]) -> None:
         redis_client = get_redis()
@@ -232,13 +237,7 @@ class StreamConsumer:
                 sem.release()
 
     def _semaphore_for(self, msg_type: str) -> threading.Semaphore | None:
-        if msg_type == MSG_TYPE_CHARACTER_IMAGE:
-            return self._image_sem
-        if msg_type == MSG_TYPE_CHARACTER_ACTION:
-            return self._action_sem
-        if msg_type == MSG_TYPE_CHARACTER_ACTION_POLL:
-            return self._poll_sem
-        return None
+        return self._semaphores.get(msg_type)
 
     def _defer_message(self, message_id: uuid.UUID | None) -> None:
         """释放 processing 认领但不 XACK，留 PEL 待 XAUTOCLAIM 重投。"""

--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -170,19 +170,49 @@ def dispatch_handler(
     run_action_task: Callable[..., Any],
     resume_action_poll: Callable[..., Any] | None = None,
 ) -> None:
-    if msg_type == MSG_TYPE_VERIFICATION_CODE:
-        handle_verification_code(payload)
-        return
-    if msg_type in (MSG_TYPE_CHARACTER_IMAGE, MSG_TYPE_CHARACTER_ACTION):
-        handle_generation(
-            payload,
-            run_image_task=run_image_task,
-            run_action_task=run_action_task,
-        )
-        return
-    if msg_type == MSG_TYPE_CHARACTER_ACTION_POLL:
-        if resume_action_poll is None:
-            raise RuntimeError("未注入 resume_action_poll")
-        handle_action_poll(payload, resume_action_poll=resume_action_poll)
-        return
-    raise ValueError(f"未知消息类型: {msg_type}")
+    handler = HANDLERS.get(msg_type)
+    if handler is None:
+        raise ValueError(f"未知消息类型: {msg_type}")
+    handler(
+        payload,
+        run_image_task=run_image_task,
+        run_action_task=run_action_task,
+        resume_action_poll=resume_action_poll,
+    )
+
+
+def _dispatch_verification_code(payload: dict[str, Any], **_deps: Any) -> None:
+    handle_verification_code(payload)
+
+
+def _dispatch_generation(
+    payload: dict[str, Any],
+    *,
+    run_image_task: Callable[..., Any],
+    run_action_task: Callable[..., Any],
+    **_deps: Any,
+) -> None:
+    handle_generation(
+        payload,
+        run_image_task=run_image_task,
+        run_action_task=run_action_task,
+    )
+
+
+def _dispatch_action_poll(
+    payload: dict[str, Any],
+    *,
+    resume_action_poll: Callable[..., Any] | None = None,
+    **_deps: Any,
+) -> None:
+    if resume_action_poll is None:
+        raise RuntimeError("未注入 resume_action_poll")
+    handle_action_poll(payload, resume_action_poll=resume_action_poll)
+
+
+HANDLERS: dict[str, Callable[..., None]] = {
+    MSG_TYPE_VERIFICATION_CODE: _dispatch_verification_code,
+    MSG_TYPE_CHARACTER_IMAGE: _dispatch_generation,
+    MSG_TYPE_CHARACTER_ACTION: _dispatch_generation,
+    MSG_TYPE_CHARACTER_ACTION_POLL: _dispatch_action_poll,
+}

--- a/backend/tests/test_mq_catalog.py
+++ b/backend/tests/test_mq_catalog.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import pytest
+
 from windup_app.server.mq.catalog import (
     EMAIL_GROUP,
     EMAIL_STREAM,
     GENERATION_GROUP,
     GENERATION_STREAM,
+    MSG_TYPE_CHARACTER_ACTION,
+    MSG_TYPE_CHARACTER_ACTION_POLL,
+    MSG_TYPE_CHARACTER_IMAGE,
+    MSG_TYPE_VERIFICATION_CODE,
+    POOL_POLL,
+    POOL_SHARED,
     all_stream_specs,
     email_stream_spec,
     generation_action_concurrency,
@@ -14,6 +22,9 @@ from windup_app.server.mq.catalog import (
     generation_poll_concurrency,
     generation_stream_spec,
     generation_worker_pool_size,
+    msg_type_for_generation,
+    type_spec,
+    type_specs,
 )
 
 
@@ -62,3 +73,30 @@ def test_catalog_respects_env_overrides(monkeypatch):
     assert generation_action_concurrency() == 5
     assert generation_poll_concurrency() == 4
     assert generation_stream_spec().concurrency == 15
+
+
+def test_type_specs_register_pool_limit_and_recover():
+    by_type = {spec.msg_type: spec for spec in type_specs()}
+    assert by_type[MSG_TYPE_VERIFICATION_CODE].stream == EMAIL_STREAM
+    assert by_type[MSG_TYPE_VERIFICATION_CODE].pool == POOL_SHARED
+    assert by_type[MSG_TYPE_VERIFICATION_CODE].limit is False
+    assert by_type[MSG_TYPE_CHARACTER_IMAGE].pool == POOL_SHARED
+    assert by_type[MSG_TYPE_CHARACTER_IMAGE].limit is True
+    assert by_type[MSG_TYPE_CHARACTER_IMAGE].recover_as == MSG_TYPE_CHARACTER_IMAGE
+    assert by_type[MSG_TYPE_CHARACTER_ACTION].recover_as == MSG_TYPE_CHARACTER_ACTION
+    assert by_type[MSG_TYPE_CHARACTER_ACTION_POLL].pool == POOL_POLL
+    assert by_type[MSG_TYPE_CHARACTER_ACTION_POLL].recover_as is None
+    assert type_spec("unknown") is None
+
+
+def test_msg_type_for_generation_skips_poll_types():
+    assert msg_type_for_generation(MSG_TYPE_CHARACTER_IMAGE) == MSG_TYPE_CHARACTER_IMAGE
+    assert msg_type_for_generation(MSG_TYPE_CHARACTER_ACTION) == MSG_TYPE_CHARACTER_ACTION
+    with pytest.raises(ValueError, match="未知任务类型"):
+        msg_type_for_generation(MSG_TYPE_CHARACTER_ACTION_POLL)
+
+
+def test_handlers_cover_every_registered_type():
+    from windup_app.worker.handlers import HANDLERS
+
+    assert {spec.msg_type for spec in type_specs()} == set(HANDLERS)

--- a/backend/tests/test_mq_worker.py
+++ b/backend/tests/test_mq_worker.py
@@ -773,6 +773,46 @@ def test_consumer_routes_poll_to_reserved_executor():
         consumer.shutdown()
 
 
+def test_consumer_routes_new_dedicated_pool_from_registry(monkeypatch):
+    """加 type 只改 catalog 注册表时,consumer 提交路径不必再写特判。"""
+    from windup_app.server.mq.catalog import TypeSpec, type_specs as live_specs
+
+    extra = TypeSpec(
+        msg_type="character_probe",
+        stream="windup:stream:generation",
+        pool="probe",
+        concurrency=1,
+        limit=True,
+    )
+    current = live_specs()
+    monkeypatch.setattr(
+        "windup_app.server.mq.catalog.type_specs",
+        lambda: (*current, extra),
+    )
+
+    consumer = StreamConsumer(
+        ConsumerConfig(stream="windup:stream:generation", group="generation", concurrency=2),
+        run_image_task=MagicMock(),
+        run_action_task=MagicMock(),
+        stop_event=threading.Event(),
+    )
+    try:
+        fields = {
+            "data": json.dumps({
+                "v": 1,
+                "id": str(uuid.uuid4()),
+                "type": "character_probe",
+                "payload": {"task_id": 1},
+            })
+        }
+        assert "probe" in consumer._executors
+        assert consumer._executor_for(fields) is consumer._executors["probe"]
+        assert consumer._semaphore_for("character_probe") is not None
+        assert consumer._executor_for(fields) is not consumer._executor
+    finally:
+        consumer.shutdown()
+
+
 def test_poll_message_runs_while_image_workers_are_busy(
     engine, worker_session, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- 在 `catalog.type_specs` 集中登记 `msg_type` → Stream、线程池、信号量、PENDING 恢复策略；加类型的步骤写在该模块文档里。
- consumer 按注册表选执行器与许可，poll 仍走独立池，但提交路径不再特判 `character_action_poll`。
- handler 走 `HANDLERS` 字典；recover / 生成 API 用 `msg_type_for_generation`，避免再抄一份 image/action 映射。

Closes #598
Refs #570 #571

## Test plan
- [ ] `backend` 下 `uv run pytest tests/test_mq_catalog.py tests/test_mq_worker.py tests/test_mq.py tests/test_mq_delayed.py tests/test_generation_quota.py tests/test_i2v_poll.py`
- [ ] 确认 email / image / action / poll 行为不变（含 poll 不被 image 占满）
- [ ] 新增 type 只需改 `type_specs` + `HANDLERS`，不必改 consumer 提交路径（见 `test_consumer_routes_new_dedicated_pool_from_registry`）