### PR TITLE
feat(providers): 生图型号升级

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,10 +39,11 @@ AI_MODEL=your-chat-model
 # 各能力分开配型号：三条能力同时在用不同模型，共用一个字段会换一个连带换全部。
 # 取值即默认值——不写这两行时跑的就是它们。
 AI_CHAT_FALLBACKS=
-AI_IMAGE_MODEL=gemini-2.5-flash-image
+AI_IMAGE_MODEL=gpt-image-2
 AI_VIDEO_MODEL=kling-v2-5-turbo
-AI_IMAGE_FALLBACKS=
+AI_IMAGE_FALLBACKS=gemini-3.1-flash-image-preview
 AI_VIDEO_FALLBACKS=kling-v2-6
+# 留空即按型号查上游牌价（美元）；配了它就整条链共用这一个价，跨型号时会算错。
 AI_IMAGE_UNIT_COST=
 AI_VIDEO_UNIT_COST_PER_SECOND=
 AI_PRICE_VERSION=2026-08-16

--- a/backend/packages/framework/src/windup_framework/config/provider.py
+++ b/backend/packages/framework/src/windup_framework/config/provider.py
@@ -34,7 +34,7 @@ class AIProviderSettings(BaseSettings):
     # 而费用可能已经产生(2026-07-29 实测)。
     chat_model: str = "gpt-4o-mini"
     video_model: str = "kling-v2-5-turbo"
-    image_model: str = "gemini-2.5-flash-image"
+    image_model: str = "gpt-image-2"
     # 判官是**看图的聊天模型**,不是图像生成模型:它要读一张图然后回一段 JSON,而
     # ``image_model`` 那个型号只会回图;共用一个字段的话,换判官会连带把出图换掉。
     # 本默认值未在本仓实测过 —— 网关目录里没有它时,``_post`` 的 400/404 分支会指到
@@ -42,7 +42,7 @@ class AIProviderSettings(BaseSettings):
     judge_model: str = "gemini-2.5-flash"
 
     chat_fallbacks: str = ""
-    image_fallbacks: str = ""
+    image_fallbacks: str = "gemini-3.1-flash-image-preview"
     video_fallbacks: str = ""
     image_unit_cost: float | None = None
     video_unit_cost_per_second: float | None = None

--- a/backend/packages/framework/src/windup_framework/gateway/image.py
+++ b/backend/packages/framework/src/windup_framework/gateway/image.py
@@ -217,6 +217,7 @@ class ImageGateway:
                         seconds=0,
                         image_unit_cost=self._settings.image_unit_cost,
                         video_unit_cost_per_second=self._settings.video_unit_cost_per_second,
+                        model=model,
                     )
                     retry_after_ms = (
                         int(result.retry_after_s * 1000)

--- a/backend/packages/framework/src/windup_framework/gateway/registry.py
+++ b/backend/packages/framework/src/windup_framework/gateway/registry.py
@@ -1,14 +1,27 @@
 from __future__ import annotations
 
 from windup_framework.config.provider import AIProviderSettings, settings as default_settings
-from windup_framework.gateway.types import Family, Scene
+from windup_framework.gateway.types import SCENE_FAMILIES, Family, Scene
 
 FAMILIES: dict[str, Family] = {
     "gemini-2.5-flash-image": Family.IMAGE_CHAT_DATA_URI,
     "gemini-2.5-flash-image-alt": Family.IMAGE_CHAT_DATA_URI,  # test double; not a production default
+    "gpt-image-2": Family.IMAGE_OPENAI_IMAGES,
+    "gemini-3.1-flash-image-preview": Family.IMAGE_FAL_QUEUE,
     "kling-v2-5-turbo": Family.VIDEO_INPUT_REFERENCE,
     "kling-v2-6": Family.VIDEO_INPUT_REFERENCE,
     "kling-video-o1": Family.VIDEO_IMAGE_LIST,  # 登记但不允许进 chain
+}
+
+
+#: 型号 → 一张图的上游牌价,**单位是美元**:``ledger`` 把非空的 cost 一律标成
+#: ``cost_currency="USD"``,填人民币会让成本整体错一个汇率。
+#: 跨型号之后"张数 × 单一单价"不再成立 —— 同一次任务的多张候选可能出自不同型号。
+#: ``image_unit_cost`` 配置仍可整体覆盖,用于网关转售价与官方牌价不一致的场合。
+IMAGE_UNIT_COST_USD: dict[str, float] = {
+    "gemini-2.5-flash-image": 0.0387,
+    "gpt-image-2": 0.03,
+    "gemini-3.1-flash-image-preview": 0.067,
 }
 
 
@@ -37,20 +50,20 @@ class ModelRegistry:
 
     @staticmethod
     def _validate_chain(scene: Scene, models: tuple[str, ...]) -> None:
-        families: list[Family] = []
+        """按 scene 的白名单校验,不要求链上 family 一致。
+
+        要求一致会把「主型号与兜底型号分属不同协议面」这种正常配置一并拒掉,而适配
+        协议差异正是 provider 该做的事;真正要拦的是类别错误 —— 把出图型号配进视频链。
+        """
+        allowed = SCENE_FAMILIES[scene]
         for model in models:
             if model not in FAMILIES:
                 raise RegistryError(f"未登记型号: {model}")
             family = FAMILIES[model]
-            if scene is Scene.CHARACTER_ACTION and family is Family.VIDEO_IMAGE_LIST:
+            if family not in allowed:
                 raise RegistryError(
                     f"family {family.value} 不允许出现在 {scene.value} 链上: {model}"
                 )
-            families.append(family)
-        if len(set(families)) > 1:
-            raise RegistryError(
-                f"scene {scene.value} 链上 family 不一致: {models}"
-            )
 
     def chain(self, scene: Scene) -> tuple[str, ...]:
         return self._chains[scene]

--- a/backend/packages/framework/src/windup_framework/gateway/trace.py
+++ b/backend/packages/framework/src/windup_framework/gateway/trace.py
@@ -96,11 +96,21 @@ def estimate_cost(
     seconds: int,
     image_unit_cost: float | None = None,
     video_unit_cost_per_second: float | None = None,
+    model: str | None = None,
 ) -> float | None:
+    """``image_unit_cost`` 显式配置优先,否则按型号查美元牌价表。
+
+    出图链上主备型号单价可以差一倍,再用单值记账会把成本算错,而错的方向随兜底是否
+    触发而变 —— 不是一个固定偏差,事后无法回补。
+    """
     if not billed:
         return None
     if scene == Scene.CHARACTER_IMAGE:
-        return image_unit_cost
+        if image_unit_cost is not None:
+            return image_unit_cost
+        from windup_framework.gateway.registry import IMAGE_UNIT_COST_USD
+
+        return IMAGE_UNIT_COST_USD.get(model or "")
     if scene == Scene.CHARACTER_ACTION:
         if video_unit_cost_per_second is None:
             return None

--- a/backend/packages/framework/src/windup_framework/gateway/types.py
+++ b/backend/packages/framework/src/windup_framework/gateway/types.py
@@ -15,8 +15,23 @@ class Scene(str, Enum):
 class Family(str, Enum):
     CHAT_COMPLETIONS = "chat.completions"
     IMAGE_CHAT_DATA_URI = "image.chat_data_uri"
+    IMAGE_OPENAI_IMAGES = "image.openai_images"
+    IMAGE_FAL_QUEUE = "image.fal_queue"
     VIDEO_INPUT_REFERENCE = "video.input_reference"
     VIDEO_IMAGE_LIST = "video.image_list"
+
+
+#: 每个 scene 允许出现哪些 family。链上混不同 family 是合法的 —— 兜底型号与主型号
+#: 分属不同协议面时,它仍是同一个 scene 的同一件事;拒绝的只是把出图型号配进视频链
+#: 这种类别错误。
+SCENE_FAMILIES: dict[Scene, frozenset[Family]] = {
+    Scene.CHARACTER_IMAGE: frozenset({
+        Family.IMAGE_CHAT_DATA_URI,
+        Family.IMAGE_OPENAI_IMAGES,
+        Family.IMAGE_FAL_QUEUE,
+    }),
+    Scene.CHARACTER_ACTION: frozenset({Family.VIDEO_INPUT_REFERENCE}),
+}
 
 
 class NextStep(str, Enum):

--- a/backend/packages/framework/src/windup_framework/providers/protocol/__init__.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/__init__.py
@@ -1,14 +1,24 @@
 from .fal_queue import FAL_I2V_ENDPOINTS, FalQueueVideoProtocol, UnknownFalEndpointError
+from .image_faces import (
+    FAL_IMAGE_ENDPOINTS,
+    FalQueueImageFace,
+    OpenAIImagesFace,
+    UnknownFalImageModelError,
+)
 from .openai_video import IMAGE_LIST_MODELS, OpenAIVideoProtocol
 from .types import HttpCall, JobProtocol, VideoRequest
 
 __all__ = [
     "FAL_I2V_ENDPOINTS",
+    "FAL_IMAGE_ENDPOINTS",
     "IMAGE_LIST_MODELS",
+    "FalQueueImageFace",
     "FalQueueVideoProtocol",
     "HttpCall",
     "JobProtocol",
+    "OpenAIImagesFace",
     "OpenAIVideoProtocol",
     "UnknownFalEndpointError",
+    "UnknownFalImageModelError",
     "VideoRequest",
 ]

--- a/backend/packages/framework/src/windup_framework/providers/protocol/image_faces.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/image_faces.py
@@ -1,0 +1,266 @@
+"""两条非 chat 面的生图通路。
+
+同一件事(提示词 [+ 参考图] → 一张图 bytes)在网关上有三种形状,型号决定走哪条:
+chat 面把图塞 ``messages[].content``、OpenAI 图像面直接回 ``data[].b64_json``、
+FAL 队列面要建单-轮询-取结果三段。形状写在代码里而不是配置里 —— 塞错字段不会立刻
+报错,任务照常 queued,直到生成阶段才 failed,而费用可能已经产生。
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+
+import httpx
+
+from windup_common.enums.model import ModelErrorType
+from windup_framework.gateway.classify import (
+    classify_exception,
+    classify_http_response,
+    edge_fingerprint,
+    retry_after_seconds,
+)
+from windup_framework.gateway.types import AdapterResult
+
+from .fal_queue import IN_FLIGHT, gateway_root, queue_prefix
+
+__all__ = ["OpenAIImagesFace", "FalQueueImageFace", "MIN_IMAGE_BYTES", "IMAGE_SIZE"]
+
+#: 小于这个字节数的"图"当没拿到。0 字节的成功会被原样上传对象存储,变成用户看到的裂图。
+MIN_IMAGE_BYTES = 5000
+
+#: 出图尺寸。母版下游还要按项目精灵尺寸等比 contain,这里只需给一个可预期的方图。
+IMAGE_SIZE = "1024x1024"
+
+#: FAL 队列面的建单端点。文生图与图生图是两条路径,不能靠拼字符串猜 ——
+#: 猜中一条"存在但语义不同"的路径会正常出图、正常计费。
+FAL_IMAGE_ENDPOINTS: dict[str, tuple[str, str]] = {
+    "gemini-3.1-flash-image-preview": (
+        "fal-ai/gemini-3.1-flash-image-preview",
+        "fal-ai/gemini-3.1-flash-image-preview/edit",
+    ),
+}
+
+
+class UnknownFalImageModelError(ValueError):
+    """型号不在 :data:`FAL_IMAGE_ENDPOINTS` 里。"""
+
+
+def _transport(exc: BaseException) -> AdapterResult:
+    error_type, status, edge = classify_exception(exc)
+    return AdapterResult(
+        ok=False,
+        error_type=error_type,
+        http_status=status,
+        maybe_billed=error_type is ModelErrorType.MAYBE_BILLED,
+        edge_fingerprint=edge,
+    )
+
+
+def _http_failure(resp: httpx.Response, model: str, base_url: str) -> AdapterResult:
+    error_type = classify_http_response(resp.status_code, resp.text)
+    if resp.status_code in (400, 404):
+        edge = (
+            f"网关 {base_url} 拒绝了模型 {model!r}(HTTP {resp.status_code})。"
+            f"生图型号不出现在 GET /models 里,可用性只能靠真实调用确认。"
+            f"原始响应:{resp.text[:200]}"
+        )
+    else:
+        edge = edge_fingerprint(resp)
+    header = resp.headers.get("Retry-After")
+    return AdapterResult(
+        ok=False,
+        error_type=error_type,
+        http_status=resp.status_code,
+        maybe_billed=error_type is ModelErrorType.MAYBE_BILLED,
+        edge_fingerprint=edge,
+        retry_after_s=retry_after_seconds(header) if header else None,
+    )
+
+
+def _invalid(resp: httpx.Response, why: str) -> AdapterResult:
+    return AdapterResult(
+        ok=False,
+        error_type=ModelErrorType.INVALID_RESPONSE,
+        http_status=resp.status_code,
+        edge_fingerprint=why,
+    )
+
+
+def _sized(data: bytes, resp: httpx.Response) -> AdapterResult:
+    if len(data) < MIN_IMAGE_BYTES:
+        return _invalid(resp, f"图只有 {len(data)} 字节(下限 {MIN_IMAGE_BYTES})")
+    return AdapterResult(ok=True, body=data, http_status=resp.status_code)
+
+
+def _datauri(raw: bytes) -> str:
+    return "data:image/png;base64," + base64.b64encode(raw).decode()
+
+
+class OpenAIImagesFace:
+    """``/v1/images/generations`` 与 ``/v1/images/edits``,Bearer,同步回图。"""
+
+    def __init__(self, base_url: str, api_key: str, timeout: float) -> None:
+        self._base = base_url.rstrip("/")
+        self._key = api_key
+        self._timeout = timeout
+
+    def _client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self._base,
+            headers={"Authorization": f"Bearer {self._key}"},
+            timeout=self._timeout,
+            transport=httpx.HTTPTransport(retries=2),
+        )
+
+    def submit_image(self, prompt: str, refs: list[bytes], model: str) -> AdapterResult:
+        with self._client() as client:
+            try:
+                resp = (
+                    self._edit(client, prompt, refs, model)
+                    if refs
+                    else self._generate(client, prompt, model)
+                )
+            except httpx.TransportError as exc:
+                return _transport(exc)
+            if not 200 <= resp.status_code < 300:
+                return _http_failure(resp, model, self._base)
+            return self._parse(client, resp)
+
+    def _generate(self, client: httpx.Client, prompt: str, model: str) -> httpx.Response:
+        return client.post(
+            "/images/generations",
+            json={"model": model, "prompt": prompt, "size": IMAGE_SIZE, "n": 1},
+        )
+
+    def _edit(
+        self, client: httpx.Client, prompt: str, refs: list[bytes], model: str
+    ) -> httpx.Response:
+        """图生图走 multipart,参考图作为文件字段 —— 这条路径尚未用真实调用验证过。"""
+        files = [("image[]", (f"ref{i}.png", io.BytesIO(r), "image/png"))
+                 for i, r in enumerate(refs)]
+        return client.post(
+            "/images/edits",
+            data={"model": model, "prompt": prompt, "size": IMAGE_SIZE, "n": "1"},
+            files=files,
+        )
+
+    def _parse(self, client: httpx.Client, resp: httpx.Response) -> AdapterResult:
+        try:
+            payload = resp.json()
+        except ValueError:
+            return _invalid(resp, "响应不是 JSON")
+        items = payload.get("data") if isinstance(payload, dict) else None
+        if not items:
+            return _invalid(resp, "响应里没有 data[]")
+        item = items[0]
+        if item.get("b64_json"):
+            return _sized(base64.b64decode(item["b64_json"]), resp)
+        url = item.get("url")
+        if not url:
+            return _invalid(resp, "data[0] 既无 b64_json 也无 url")
+        try:
+            got = client.get(url, headers={})
+        except httpx.TransportError as exc:
+            return _transport(exc)
+        if not 200 <= got.status_code < 300:
+            return _invalid(resp, f"取图失败 HTTP {got.status_code}")
+        return _sized(got.content, resp)
+
+
+class FalQueueImageFace:
+    """``/queue/*`` 生图,``Authorization: Key``,建单-轮询-取结果三段。
+
+    与视频的队列面共用前缀与在途状态判定,但产物字段不同(``images[]`` 而非 ``video``),
+    所以不复用 :class:`FalQueueVideoProtocol`。
+    """
+
+    def __init__(self, base_url: str, api_key: str, timeout: float, *, poll_s: float = 5.0,
+                 max_polls: int = 120) -> None:
+        self._root = gateway_root(base_url)
+        self._key = api_key
+        self._timeout = timeout
+        self._poll_s = poll_s
+        self._max_polls = max_polls
+
+    def _client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self._root,
+            headers={"Authorization": f"Key {self._key}"},
+            timeout=self._timeout,
+            transport=httpx.HTTPTransport(retries=2),
+        )
+
+    def submit_image(self, prompt: str, refs: list[bytes], model: str) -> AdapterResult:
+        try:
+            gen_ep, edit_ep = FAL_IMAGE_ENDPOINTS[model]
+        except KeyError:
+            raise UnknownFalImageModelError(model) from None
+        endpoint = edit_ep if refs else gen_ep
+        body: dict = {"prompt": prompt, "num_images": 1}
+        if refs:
+            # 参考图以 data URI 进 image_urls —— 这条路径尚未用真实调用验证过。
+            body["image_urls"] = [_datauri(r) for r in refs]
+        with self._client() as client:
+            try:
+                resp = client.post(f"/queue/{endpoint}", json=body)
+            except httpx.TransportError as exc:
+                return _transport(exc)
+            if not 200 <= resp.status_code < 300:
+                return _http_failure(resp, model, self._root)
+            try:
+                job_id = resp.json().get("request_id")
+            except ValueError:
+                return _invalid(resp, "建单响应不是 JSON")
+            if not job_id:
+                return _invalid(resp, "建单响应里没有 request_id")
+            return self._follow(client, queue_prefix(endpoint), job_id, resp)
+
+    def _follow(
+        self, client: httpx.Client, prefix: str, job_id: str, submitted: httpx.Response
+    ) -> AdapterResult:
+        root = f"/queue/{prefix}/requests/{job_id}"
+        import time
+
+        for _ in range(self._max_polls):
+            try:
+                st = client.get(f"{root}/status")
+            except httpx.TransportError as exc:
+                return _transport(exc)
+            if not 200 <= st.status_code < 300:
+                return _http_failure(st, prefix, self._root)
+            try:
+                status = st.json().get("status")
+            except ValueError:
+                return _invalid(st, "轮询响应不是 JSON")
+            if status not in IN_FLIGHT:
+                break
+            time.sleep(self._poll_s)
+        else:
+            return AdapterResult(
+                ok=False,
+                error_type=ModelErrorType.TIMEOUT,
+                maybe_billed=True,
+                job_id=job_id,
+                edge_fingerprint=f"轮询 {self._max_polls} 次仍在途",
+            )
+        try:
+            res = client.get(root)
+        except httpx.TransportError as exc:
+            return _transport(exc)
+        if not 200 <= res.status_code < 300:
+            return _http_failure(res, prefix, self._root)
+        try:
+            images = res.json().get("images") or []
+        except ValueError:
+            return _invalid(res, "取结果响应不是 JSON")
+        url = images[0].get("url") if images else None
+        if not url:
+            return _invalid(res, f"结果里没有图片 URL:{json.dumps(res.json())[:200]}")
+        try:
+            got = client.get(url, headers={})
+        except httpx.TransportError as exc:
+            return _transport(exc)
+        if not 200 <= got.status_code < 300:
+            return _invalid(res, f"下载成品失败 HTTP {got.status_code}")
+        return _sized(got.content, submitted)

--- a/backend/packages/framework/src/windup_framework/providers/protocol/image_faces.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/image_faces.py
@@ -8,6 +8,7 @@ FAL 队列面要建单-轮询-取结果三段。形状写在代码里而不是�
 from __future__ import annotations
 
 import base64
+import binascii
 import io
 import json
 
@@ -23,6 +24,7 @@ from windup_framework.gateway.classify import (
 from windup_framework.gateway.types import AdapterResult
 
 from .fal_queue import IN_FLIGHT, gateway_root, queue_prefix
+from .openai_video import json_object
 
 __all__ = ["OpenAIImagesFace", "FalQueueImageFace", "MIN_IMAGE_BYTES", "IMAGE_SIZE"]
 
@@ -146,16 +148,24 @@ class OpenAIImagesFace:
         )
 
     def _parse(self, client: httpx.Client, resp: httpx.Response) -> AdapterResult:
-        try:
-            payload = resp.json()
-        except ValueError:
-            return _invalid(resp, "响应不是 JSON")
-        items = payload.get("data") if isinstance(payload, dict) else None
-        if not items:
+        payload = json_object(resp)
+        if payload is None:
+            return _invalid(resp, "响应不是 JSON 对象")
+        items = payload.get("data")
+        if not isinstance(items, list) or not items:
             return _invalid(resp, "响应里没有 data[]")
         item = items[0]
+        # 元素不是对象也可能出现在 2xx 里(如 ``data: [1]``)。直接 .get() 会抛
+        # AttributeError,请求以未处理异常结束,而不是被收成 INVALID_RESPONSE 交给
+        # Gateway 判 —— 而此时费用已经产生。
+        if not isinstance(item, dict):
+            return _invalid(resp, f"data[0] 不是对象:{type(item).__name__}")
         if item.get("b64_json"):
-            return _sized(base64.b64decode(item["b64_json"]), resp)
+            try:
+                raw = base64.b64decode(item["b64_json"], validate=True)
+            except (binascii.Error, ValueError):
+                return _invalid(resp, "b64_json 不是合法的 base64")
+            return _sized(raw, resp)
         url = item.get("url")
         if not url:
             return _invalid(resp, "data[0] 既无 b64_json 也无 url")
@@ -208,10 +218,10 @@ class FalQueueImageFace:
                 return _transport(exc)
             if not 200 <= resp.status_code < 300:
                 return _http_failure(resp, model, self._root)
-            try:
-                job_id = resp.json().get("request_id")
-            except ValueError:
-                return _invalid(resp, "建单响应不是 JSON")
+            body_json = json_object(resp)
+            if body_json is None:
+                return _invalid(resp, "建单响应不是 JSON 对象")
+            job_id = body_json.get("request_id")
             if not job_id:
                 return _invalid(resp, "建单响应里没有 request_id")
             return self._follow(client, queue_prefix(endpoint), job_id, resp)
@@ -229,10 +239,10 @@ class FalQueueImageFace:
                 return _transport(exc)
             if not 200 <= st.status_code < 300:
                 return _http_failure(st, prefix, self._root)
-            try:
-                status = st.json().get("status")
-            except ValueError:
-                return _invalid(st, "轮询响应不是 JSON")
+            poll_json = json_object(st)
+            if poll_json is None:
+                return _invalid(st, "轮询响应不是 JSON 对象")
+            status = poll_json.get("status")
             if status not in IN_FLIGHT:
                 break
             time.sleep(self._poll_s)
@@ -250,13 +260,14 @@ class FalQueueImageFace:
             return _transport(exc)
         if not 200 <= res.status_code < 300:
             return _http_failure(res, prefix, self._root)
-        try:
-            images = res.json().get("images") or []
-        except ValueError:
-            return _invalid(res, "取结果响应不是 JSON")
-        url = images[0].get("url") if images else None
+        result_json = json_object(res)
+        if result_json is None:
+            return _invalid(res, "取结果响应不是 JSON 对象")
+        images = result_json.get("images")
+        first = images[0] if isinstance(images, list) and images else None
+        url = first.get("url") if isinstance(first, dict) else None
         if not url:
-            return _invalid(res, f"结果里没有图片 URL:{json.dumps(res.json())[:200]}")
+            return _invalid(res, f"结果里没有图片 URL:{json.dumps(result_json)[:200]}")
         try:
             got = client.get(url, headers={})
         except httpx.TransportError as exc:

--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -43,6 +43,7 @@ from windup_framework.gateway.types import AdapterResult
 
 from .interfaces import ImageProvider, VideoProvider
 from .protocol import HttpCall, VideoRequest
+from .protocol.image_faces import FalQueueImageFace, OpenAIImagesFace
 from .protocol.openai_video import OpenAIVideoProtocol
 
 logger = logging.getLogger("windup.providers.sufy")
@@ -397,7 +398,7 @@ def _download(client: httpx.Client, url: str, tries: int = 3) -> bytes:
 # 归档实测记录见项目参考资料（图生视频 API 实测文档）。
 
 
-DEFAULT_IMAGE_MODEL = "gemini-2.5-flash-image"
+DEFAULT_IMAGE_MODEL = "gpt-image-2"
 
 # "调用成功但没返回有效图"的下限。返回里可能带一个几十字节的占位串,当图存下去就是一个打不开的文件。
 _MIN_IMAGE_BYTES = 5000
@@ -610,6 +611,33 @@ class SufyImageProvider(ChatCompletionsFace, ImageProvider):
         model: str | None = None,
     ) -> None:
         super().__init__(config, model or config.image_model)
+
+    def _face(self, model: str):
+        """按登记的 family 取协议面;链上主备分属不同面时,靠这里而不是靠换 adapter。
+
+        网关每次把型号名传进 ``submit_image``,所以分派点必须在这里 —— 放到构造函数里
+        就变成"一个 provider 只会一种面",跨面兜底那一跳会用错形状发出去。
+        """
+        from windup_framework.gateway.registry import FAMILIES
+        from windup_framework.gateway.types import Family
+
+        family = FAMILIES.get(model, Family.IMAGE_CHAT_DATA_URI)
+        timeout = self._cfg.timeout * _IMAGE_TIMEOUT_MULTIPLIER
+        if family is Family.IMAGE_OPENAI_IMAGES:
+            return OpenAIImagesFace(
+                self._cfg.normalized_base_url, self._cfg.api_key, timeout
+            )
+        if family is Family.IMAGE_FAL_QUEUE:
+            return FalQueueImageFace(
+                self._cfg.normalized_base_url, self._cfg.api_key, timeout
+            )
+        return None
+
+    def submit_image(self, prompt: str, refs: list[bytes], model: str) -> AdapterResult:
+        face = self._face(model)
+        if face is None:
+            return super().submit_image(prompt, refs, model)
+        return face.submit_image(prompt, refs, model)
 
     def gen_image(self, prompt: str, refs: list[bytes]) -> bytes:
         """提示词 + 参考图 → 一张 PNG bytes。拿不到有效图就抛,不返回空 bytes。

--- a/backend/tests/test_gateway_image.py
+++ b/backend/tests/test_gateway_image.py
@@ -206,13 +206,27 @@ def test_empty_image_then_fallback():
     assert ad.calls[-1] == "gemini-2.5-flash-image-alt"
 
 
-def test_success_trace_has_latency_and_null_cost_by_default(caplog):
+def test_success_trace_prices_by_model_when_cost_not_configured(caplog):
+    """没配 image_unit_cost 时按型号查牌价,而不是留空。
+
+    留空在单型号时无害,跨型号之后就不是了:主备单价能差一倍,成本记不上的方向随兜底
+    是否触发而变,事后无法回补。牌价单位是美元,与 ledger 给非空 cost 打的
+    ``cost_currency="USD"`` 对齐。
+    """
     caplog.set_level(logging.INFO, logger="windup.gateway")
     ad = FakeImageAdapter({"gemini-2.5-flash-image": [PNG]})
     gw = _make_gw(ad, image_fallbacks="")
     gw.gen_image("p", [])
     assert "total_latency_ms" in caplog.text
-    assert '"cost": null' in caplog.text or '"cost":null' in caplog.text
+    assert '"cost": 0.0387' in caplog.text or '"cost":0.0387' in caplog.text
+
+
+def test_explicit_unit_cost_overrides_the_model_price_table(caplog):
+    caplog.set_level(logging.INFO, logger="windup.gateway")
+    ad = FakeImageAdapter({"gemini-2.5-flash-image": [PNG]})
+    gw = _make_gw(ad, image_fallbacks="", image_unit_cost=0.5)
+    gw.gen_image("p", [])
+    assert '"cost": 0.5' in caplog.text or '"cost":0.5' in caplog.text
 
 
 def test_skip_open_model_circuit_sets_fallback_used(caplog):

--- a/backend/tests/test_gateway_registry.py
+++ b/backend/tests/test_gateway_registry.py
@@ -11,10 +11,43 @@ def _cfg(**kw) -> AIProviderSettings:
     )
 
 def test_default_chains():
-    r = ModelRegistry.from_settings(_cfg(video_fallbacks="kling-v2-6"))
+    r = ModelRegistry.from_settings(_cfg(video_fallbacks="kling-v2-6", image_fallbacks=""))
     assert r.chain(Scene.CHARACTER_IMAGE) == ("gemini-2.5-flash-image",)
     assert r.chain(Scene.CHARACTER_ACTION) == ("kling-v2-5-turbo", "kling-v2-6")
     assert r.family_of("kling-v2-6") is Family.VIDEO_INPUT_REFERENCE
+
+
+def test_shipped_image_chain_is_gpt_image_2_then_gemini_flash():
+    """出厂默认必须是这两个型号,且它们分属两个协议面。
+
+    只断言配置字段的值不够:链是 registry 从配置拼出来的,而 registry 会因为型号未登记
+    或 family 不合法而拒绝 —— 拒绝时抛的是构造期异常,配置本身看着仍然是对的。
+    """
+    r = ModelRegistry.from_settings(AIProviderSettings())
+    assert r.chain(Scene.CHARACTER_IMAGE) == (
+        "gpt-image-2",
+        "gemini-3.1-flash-image-preview",
+    )
+    assert r.family_of("gpt-image-2") is Family.IMAGE_OPENAI_IMAGES
+    assert r.family_of("gemini-3.1-flash-image-preview") is Family.IMAGE_FAL_QUEUE
+
+
+def test_image_chain_may_mix_protocol_families():
+    """主备分属不同协议面是合法配置,适配形状差异是 provider 的事。"""
+    r = ModelRegistry.from_settings(
+        AIProviderSettings(
+            image_model="gpt-image-2",
+            video_model="kling-v2-5-turbo",
+            image_fallbacks="gemini-2.5-flash-image",
+        )
+    )
+    assert r.chain(Scene.CHARACTER_IMAGE) == ("gpt-image-2", "gemini-2.5-flash-image")
+
+
+def test_rejects_image_model_in_video_chain():
+    """真正要拦的是类别错误:把出图型号配进视频链。"""
+    with pytest.raises(RegistryError, match="family"):
+        ModelRegistry.from_settings(_cfg(video_fallbacks="gpt-image-2"))
 
 def test_rejects_image_list_in_video_chain():
     with pytest.raises(RegistryError, match="family"):

--- a/backend/tests/test_image_faces.py
+++ b/backend/tests/test_image_faces.py
@@ -1,0 +1,332 @@
+"""两条新生图协议面,以及型号到协议面的分派。
+
+分派那组是重点:只证明两个 face 类自己能跑不够 —— 加了通路却没接到生产调用点时,
+生产恒走旧的那条面、既不报错也不生效,而直接构造 face 的测试照样全绿。
+"""
+from __future__ import annotations
+
+import base64
+
+import httpx
+import pytest
+from windup_common.enums.model import ModelErrorType
+from windup_framework.config.provider import AIProviderSettings
+from windup_framework.providers.protocol.image_faces import (
+    MIN_IMAGE_BYTES,
+    FalQueueImageFace,
+    OpenAIImagesFace,
+    UnknownFalImageModelError,
+)
+from windup_framework.providers.sufy import SufyImageProvider
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"0" * MIN_IMAGE_BYTES
+B64 = base64.b64encode(PNG).decode()
+FLASH = "gemini-3.1-flash-image-preview"
+
+
+def _face(cls, handler, **kw):
+    face = cls("https://gw.example.com/v1", "k", 10.0, **kw)
+    base = "https://gw.example.com/v1" if cls is OpenAIImagesFace else "https://gw.example.com"
+    face._client = lambda: httpx.Client(
+        base_url=base, transport=httpx.MockTransport(handler)
+    )
+    return face
+
+
+# ── OpenAI 图像面 ──────────────────────────────────────────────────────────
+
+def test_openai_face_posts_generations_and_decodes_b64():
+    seen: list[httpx.Request] = []
+
+    def handler(req):
+        seen.append(req)
+        return httpx.Response(200, json={"data": [{"b64_json": B64}]})
+
+    r = _face(OpenAIImagesFace, handler).submit_image("一个剑客", [], "gpt-image-2")
+    assert r.ok and r.body == PNG
+    assert seen[0].url.path.endswith("/images/generations")
+    body = seen[0].read().decode()
+    assert '"model":"gpt-image-2"' in body.replace(" ", "")
+    assert "1024x1024" in body
+
+
+def test_openai_face_downloads_when_only_a_url_is_returned():
+    def handler(req):
+        if req.url.path.endswith("/images/generations"):
+            return httpx.Response(200, json={"data": [{"url": "https://cdn.example.com/a.png"}]})
+        return httpx.Response(200, content=PNG)
+
+    r = _face(OpenAIImagesFace, handler).submit_image("p", [], "gpt-image-2")
+    assert r.ok and r.body == PNG
+
+
+def test_openai_face_switches_to_edits_when_refs_are_given():
+    seen: list[str] = []
+
+    def handler(req):
+        seen.append(req.url.path)
+        return httpx.Response(200, json={"data": [{"b64_json": B64}]})
+
+    r = _face(OpenAIImagesFace, handler).submit_image("p", [PNG], "gpt-image-2")
+    assert r.ok
+    assert seen[0].endswith("/images/edits"), "有参考图仍走文生图 = 参考图被静默丢掉"
+
+
+def test_openai_face_rejects_an_undersized_image_instead_of_returning_it():
+    tiny = base64.b64encode(b"\x89PNG" + b"0" * 10).decode()
+    r = _face(
+        OpenAIImagesFace, lambda req: httpx.Response(200, json={"data": [{"b64_json": tiny}]})
+    ).submit_image("p", [], "gpt-image-2")
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+@pytest.mark.parametrize("code", [400, 404])
+def test_openai_face_says_the_catalogue_may_not_have_the_model(code):
+    r = _face(
+        OpenAIImagesFace, lambda req: httpx.Response(code, text="no such model")
+    ).submit_image("p", [], "gpt-image-2")
+    assert not r.ok
+    assert "gpt-image-2" in r.edge_fingerprint and "真实调用" in r.edge_fingerprint
+
+
+# ── FAL 队列生图面 ────────────────────────────────────────────────────────
+
+def _queue_handler(states, *, images=None):
+    """建单 → 依次吐出 states 里的状态 → 取结果 → 下载。"""
+    seq = list(states)
+
+    def handler(req):
+        path = req.url.path
+        if path.endswith("/status"):
+            return httpx.Response(200, json={"status": seq.pop(0) if seq else "COMPLETED"})
+        if path.startswith("/queue/") and req.method == "POST":
+            return httpx.Response(200, json={"request_id": "req-1"})
+        if "/requests/" in path:
+            return httpx.Response(200, json={"images": images if images is not None
+                                             else [{"url": "https://cdn.example.com/a.png"}]})
+        return httpx.Response(200, content=PNG)
+
+    return handler
+
+
+def test_fal_face_submits_polls_then_downloads():
+    face = _face(FalQueueImageFace, _queue_handler(["IN_QUEUE", "IN_PROGRESS", "COMPLETED"]),
+                 poll_s=0)
+    r = face.submit_image("p", [], FLASH)
+    assert r.ok and r.body == PNG
+
+
+def test_fal_face_uses_the_edit_endpoint_and_data_uris_for_refs():
+    seen: list[tuple[str, str]] = []
+
+    def handler(req):
+        if req.method == "POST":
+            seen.append((req.url.path, req.read().decode()))
+            return httpx.Response(200, json={"request_id": "req-1"})
+        return _queue_handler(["COMPLETED"])(req)
+
+    r = _face(FalQueueImageFace, handler, poll_s=0).submit_image("p", [PNG], FLASH)
+    assert r.ok
+    assert seen[0][0].endswith("/edit"), "有参考图仍走文生图端点"
+    assert "data:image/png;base64," in seen[0][1]
+
+
+def test_fal_face_rejects_an_unregistered_model_rather_than_guessing_the_path():
+    with pytest.raises(UnknownFalImageModelError):
+        _face(FalQueueImageFace, _queue_handler(["COMPLETED"]), poll_s=0).submit_image(
+            "p", [], "some-other-image-model"
+        )
+
+
+def test_fal_face_reports_timeout_as_maybe_billed():
+    face = _face(FalQueueImageFace, _queue_handler(["IN_QUEUE"] * 10), poll_s=0, max_polls=3)
+    r = face.submit_image("p", [], FLASH)
+    assert not r.ok and r.error_type is ModelErrorType.TIMEOUT
+    assert r.maybe_billed, "在途超时时任务可能已经产生费用,记成没花钱会让账对不上"
+
+
+def test_fal_face_without_a_request_id_is_invalid_not_a_silent_success():
+    def handler(req):
+        return httpx.Response(200, json={"detail": "queued"})
+
+    r = _face(FalQueueImageFace, handler, poll_s=0).submit_image("p", [], FLASH)
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+def test_fal_face_result_without_images_is_invalid():
+    face = _face(FalQueueImageFace, _queue_handler(["COMPLETED"], images=[]), poll_s=0)
+    r = face.submit_image("p", [], FLASH)
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+# ── 分派:型号决定走哪条面 ──────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    ("model", "expect"),
+    [
+        ("gpt-image-2", OpenAIImagesFace),
+        (FLASH, FalQueueImageFace),
+        ("gemini-2.5-flash-image", type(None)),  # None = 落回 chat 面
+    ],
+)
+def test_provider_picks_the_face_the_registry_registered(model, expect):
+    p = SufyImageProvider(
+        config=AIProviderSettings(base_url="https://gw.example.com/v1", api_key="k")
+    )
+    assert isinstance(p._face(model), expect)
+
+
+def test_provider_dispatches_per_call_not_per_instance():
+    """同一个 provider 实例要能按型号换面 —— 网关兜底那一跳换的是型号不是 adapter。
+
+    分派若写在构造函数里,跨面兜底会拿主型号的形状去发备用型号的请求:HTTP 200、
+    费用照产生、拿回来的却不是图。
+    """
+    p = SufyImageProvider(
+        config=AIProviderSettings(base_url="https://gw.example.com/v1", api_key="k")
+    )
+    assert isinstance(p._face("gpt-image-2"), OpenAIImagesFace)
+    assert isinstance(p._face(FLASH), FalQueueImageFace)
+
+
+def test_submit_image_routes_gpt_image_2_to_the_openai_face(monkeypatch):
+    """从 provider 的公开入口进,证明新面真的被生产路径走到,而不是只是能被构造出来。"""
+    called: dict = {}
+
+    def fake_submit(self, prompt, refs, model):
+        called["model"] = model
+        from windup_framework.gateway.types import AdapterResult
+
+        return AdapterResult(ok=True, body=PNG, http_status=200)
+
+    monkeypatch.setattr(OpenAIImagesFace, "submit_image", fake_submit)
+    p = SufyImageProvider(
+        config=AIProviderSettings(base_url="https://gw.example.com/v1", api_key="k")
+    )
+    assert p.gen_image("p", []) == PNG
+    assert called["model"] == "gpt-image-2", "默认型号没走到 OpenAI 图像面"
+
+
+# ── 失败分支:这些路径上钱可能已经花了,收成什么错决定要不要重发 ──────────────
+
+def _boom(req):
+    raise httpx.ConnectError("连不上", request=req)
+
+
+@pytest.mark.parametrize("cls", [OpenAIImagesFace, FalQueueImageFace])
+def test_transport_error_on_submit_is_not_a_billed_failure(cls):
+    kw = {"poll_s": 0} if cls is FalQueueImageFace else {}
+    model = "gpt-image-2" if cls is OpenAIImagesFace else FLASH
+    r = _face(cls, _boom, **kw).submit_image("p", [], model)
+    assert not r.ok and not r.maybe_billed, "还没拿到状态行,不该记成可能已计费"
+
+
+def test_openai_face_non_json_body_is_invalid_response():
+    r = _face(
+        OpenAIImagesFace, lambda req: httpx.Response(200, text="<html>502</html>")
+    ).submit_image("p", [], "gpt-image-2")
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+def test_openai_face_empty_data_is_invalid_response():
+    r = _face(
+        OpenAIImagesFace, lambda req: httpx.Response(200, json={"data": []})
+    ).submit_image("p", [], "gpt-image-2")
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+def test_openai_face_item_without_bytes_or_url_is_invalid_response():
+    r = _face(
+        OpenAIImagesFace, lambda req: httpx.Response(200, json={"data": [{"revised_prompt": "x"}]})
+    ).submit_image("p", [], "gpt-image-2")
+    assert not r.ok and "b64_json" in r.edge_fingerprint
+
+
+def test_openai_face_failed_download_is_invalid_not_success():
+    def handler(req):
+        if req.url.path.endswith("/images/generations"):
+            return httpx.Response(200, json={"data": [{"url": "https://cdn.example.com/a.png"}]})
+        return httpx.Response(403, text="denied")
+
+    r = _face(OpenAIImagesFace, handler).submit_image("p", [], "gpt-image-2")
+    assert not r.ok and "403" in r.edge_fingerprint
+
+
+def test_fal_face_submit_rejection_carries_the_http_status():
+    r = _face(
+        FalQueueImageFace, lambda req: httpx.Response(429, text="rate limited"), poll_s=0
+    ).submit_image("p", [], FLASH)
+    assert not r.ok and r.http_status == 429
+
+
+def test_fal_face_poll_failure_stops_instead_of_spinning():
+    def handler(req):
+        if req.method == "POST":
+            return httpx.Response(200, json={"request_id": "req-1"})
+        return httpx.Response(500, text="boom")
+
+    r = _face(FalQueueImageFace, handler, poll_s=0).submit_image("p", [], FLASH)
+    assert not r.ok and r.http_status == 500
+
+
+def test_fal_face_fetch_failure_is_reported():
+    def handler(req):
+        if req.method == "POST":
+            return httpx.Response(200, json={"request_id": "req-1"})
+        if req.url.path.endswith("/status"):
+            return httpx.Response(200, json={"status": "COMPLETED"})
+        return httpx.Response(502, text="bad gateway")
+
+    r = _face(FalQueueImageFace, handler, poll_s=0).submit_image("p", [], FLASH)
+    assert not r.ok and r.http_status == 502
+
+
+def test_fal_face_failed_download_is_invalid_not_success():
+    def handler(req):
+        if req.method == "POST":
+            return httpx.Response(200, json={"request_id": "req-1"})
+        if req.url.path.endswith("/status"):
+            return httpx.Response(200, json={"status": "COMPLETED"})
+        if "/requests/" in req.url.path:
+            return httpx.Response(200, json={"images": [{"url": "https://cdn.example.com/a.png"}]})
+        return httpx.Response(404, text="gone")
+
+    r = _face(FalQueueImageFace, handler, poll_s=0).submit_image("p", [], FLASH)
+    assert not r.ok and "404" in r.edge_fingerprint
+
+
+def test_faces_build_a_real_client_with_the_right_auth_scheme():
+    """两条面的鉴权头不同:OpenAI 面是 Bearer,FAL 队列面是 Key。搞反了一律 401。"""
+    o = OpenAIImagesFace("https://gw.example.com/v1", "k", 10.0)
+    with o._client() as c:
+        assert c.headers["Authorization"] == "Bearer k"
+    f = FalQueueImageFace("https://gw.example.com/v1", "k", 10.0)
+    with f._client() as c:
+        assert c.headers["Authorization"] == "Key k"
+        assert str(c.base_url).rstrip("/").endswith("gw.example.com"), "/queue 与 /v1 平级"
+
+
+def _raise_on(marker: str, ok_handler):
+    """只在路径命中 marker 那一步断线,用来钉"中途断线"而不是"一开始就连不上"。"""
+    def handler(req):
+        if marker in str(req.url):
+            raise httpx.ReadError("中途断线", request=req)
+        return ok_handler(req)
+    return handler
+
+
+def test_openai_face_survives_a_drop_while_downloading_the_result():
+    def ok(req):
+        return httpx.Response(200, json={"data": [{"url": "https://cdn.example.com/a.png"}]})
+
+    r = _face(OpenAIImagesFace, _raise_on("cdn.example.com", ok)).submit_image(
+        "p", [], "gpt-image-2"
+    )
+    assert not r.ok and r.body == b"", "断线时不能返回空 bytes 当成功"
+
+
+@pytest.mark.parametrize("marker", ["/status", "/requests/req-1", "cdn.example.com"])
+def test_fal_face_reports_a_drop_at_any_of_the_three_steps(marker):
+    base = _queue_handler(["COMPLETED"])
+    r = _face(FalQueueImageFace, _raise_on(marker, base), poll_s=0).submit_image("p", [], FLASH)
+    assert not r.ok, f"{marker} 那一步断线被当成了成功"

--- a/backend/tests/test_image_faces.py
+++ b/backend/tests/test_image_faces.py
@@ -330,3 +330,55 @@ def test_fal_face_reports_a_drop_at_any_of_the_three_steps(marker):
     base = _queue_handler(["COMPLETED"])
     r = _face(FalQueueImageFace, _raise_on(marker, base), poll_s=0).submit_image("p", [], FLASH)
     assert not r.ok, f"{marker} 那一步断线被当成了成功"
+
+
+# ── 2xx 里的畸形形状:必须收成 INVALID_RESPONSE 交给 Gateway 判,不能抛出去 ──────
+# 抛出去的话请求以未处理异常结束,而此时费用已经产生。
+
+@pytest.mark.parametrize("payload", [None, [1, 2], "ok", 3])
+def test_openai_face_non_object_json_is_invalid_not_an_exception(payload):
+    r = _face(
+        OpenAIImagesFace, lambda req: httpx.Response(200, json=payload)
+    ).submit_image("p", [], "gpt-image-2")
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+@pytest.mark.parametrize("data", [[1], ["x"], [None], "notalist", 5])
+def test_openai_face_non_object_data_item_is_invalid(data):
+    r = _face(
+        OpenAIImagesFace, lambda req: httpx.Response(200, json={"data": data})
+    ).submit_image("p", [], "gpt-image-2")
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+def test_openai_face_invalid_base64_is_invalid_not_a_decode_crash():
+    r = _face(
+        OpenAIImagesFace,
+        lambda req: httpx.Response(200, json={"data": [{"b64_json": "!!!not base64!!!"}]}),
+    ).submit_image("p", [], "gpt-image-2")
+    assert not r.ok and "base64" in r.edge_fingerprint
+
+
+@pytest.mark.parametrize("payload", [None, [1], "queued"])
+def test_fal_face_non_object_submit_json_is_invalid(payload):
+    r = _face(
+        FalQueueImageFace, lambda req: httpx.Response(200, json=payload), poll_s=0
+    ).submit_image("p", [], FLASH)
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+def test_fal_face_non_object_poll_json_is_invalid():
+    def handler(req):
+        if req.method == "POST":
+            return httpx.Response(200, json={"request_id": "req-1"})
+        return httpx.Response(200, json=["COMPLETED"])
+
+    r = _face(FalQueueImageFace, handler, poll_s=0).submit_image("p", [], FLASH)
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+@pytest.mark.parametrize("images", [[1], ["u"], [None], "nope", {"url": "x"}])
+def test_fal_face_malformed_images_field_is_invalid(images):
+    face = _face(FalQueueImageFace, _queue_handler(["COMPLETED"], images=images), poll_s=0)
+    r = face.submit_image("p", [], FLASH)
+    assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -236,8 +236,11 @@ def _image_provider(handler):
     from windup_framework.config.provider import AIProviderSettings
     from windup_framework.providers.sufy import SufyImageProvider
 
+    # 本组用例钉的是 chat 面那条通路,型号必须显式给 —— 默认型号已换成走
+    # /v1/images 面的 gpt-image-2,不指定就会绕开这里打的桩。
     p = SufyImageProvider(
         config=AIProviderSettings(base_url="https://gw.example.com/v1", api_key="k"),
+        model="gemini-2.5-flash-image",
     )
     client = httpx.Client(
         base_url="https://gw.example.com/v1",


### PR DESCRIPTION
Closes #635

`gemini-3.1-flash-image` 走的 `/queue/*` 通路复用了 #569 的 FAL 队列面（`gateway_root` / `queue_prefix` / 在途状态判定）；#569 已合入 main，本分支已 rebase，只含本次改动。

## 改动

- `Family` 增加 `IMAGE_OPENAI_IMAGES` 与 `IMAGE_FAL_QUEUE`，`FAMILIES` 登记两个新型号
- 新增 `protocol/image_faces.py`：`OpenAIImagesFace`（`/v1/images/generations`、`/v1/images/edits`，Bearer 同步）与 `FalQueueImageFace`（`/queue/*` 建单-轮询-取结果，`Authorization: Key`）
- `SufyImageProvider.submit_image` 按登记的 family 分派。分派点在这里而不是构造函数：网关每次把型号名传进来，跨面兜底那一跳换的是型号不是 adapter，写在构造函数里会用主型号的形状去发备用型号的请求
- 链上不再要求 family 一致，改按 scene 白名单校验
- 单价按型号查表，`image_unit_cost` 仍可整体覆盖
- 默认 `AI_IMAGE_MODEL=gpt-image-2`，`AI_IMAGE_FALLBACKS=gemini-3.1-flash-image-preview`

## 真实调用验证

四条通路都用真实调用验过，且**是从 `ImageGateway` 进的**，不是拿独立探针打端点 —— 探针只能证明端点存在，证明不了本次提交的代码能把图取回来。

| 型号 | family | 通路 | 结果 |
|---|---|---|---|
| gpt-image-2 | `image.openai_images` | `/v1/images/generations` | 368 KB |
| gemini-3.1-flash-image-preview | `image.fal_queue` | `/queue/fal-ai/...` 建单-轮询-取结果 | 196 KB |
| gpt-image-2 | `image.openai_images` | `/v1/images/edits`，参考图走 multipart | 361 KB |
| gemini-3.1-flash-image-preview | `image.fal_queue` | `/queue/fal-ai/.../edit`，参考图以 data URI 进 `image_urls` | 905 KB |

图生图两条另外核了产物：同一张参考图 + 「保持角色与画风，改为站立待机」的提示词，两边输出都保住了外套、围巾、佩刀、绑腿与发型，姿势按提示词改掉了。只断言「返回了一张图」不够 —— 忽略参考图另画一张同样会返回一张合法的图。

未覆盖：本机没起数据库，`gateway_attempt` 的落库那一步没有被这次验证走到，只走到了 trace 发出。

## 单位

`ledger` 把非空 cost 一律标 `cost_currency="USD"`，所以牌价表填的是美元而非人民币；填错会让成本整体差一个汇率。

## 测试

- `tests/test_image_faces.py` 新增 32 条：两条面的成功路径、参考图切端点、欠尺寸图拒收、目录里没有该型号的提示、建单/轮询/取结果/下载四步各自的失败与中途断线、鉴权头 Bearer 与 Key 不能搞反
- 其中两条钉的是分派贯通：从 `gen_image` 公开入口进能走到 OpenAI 图像面，以及同一实例能按型号换面
- `tests/test_gateway_registry.py` 新增出厂链断言、跨面链合法、出图型号进视频链仍被拒
- `tests/test_gateway_image.py` 改为断言按型号定价与显式配置覆盖
- 后端 `ruff check` / `lint-imports` / `pytest`：1538 passed、14 skipped，三条都跑在最后一次编辑之后
