### PR TITLE
feat(generation): 候选母版跨型号铺开

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -889,15 +889,25 @@ class ImageTaskExecutor:
         matte = self._get_matte()
         upload = self._upload or self._upload_image
 
-        def _gen_one(_i: int) -> bytes:
-            reset_call = fresh_gateway_request()
+        from windup_framework.gateway.registry import ModelRegistry, candidate_models
+        from windup_framework.gateway.types import Scene
+
+        n_images = max(1, input.num_images)
+        spread = candidate_models(
+            ModelRegistry.from_settings().chain(Scene.CHARACTER_IMAGE), n_images
+        )
+
+        def _gen_one(i: int) -> bytes:
+            # 每张候选指定自己的起始型号,Gateway 仍会按链轮转兜底 —— 指定的是"从谁开始",
+            # 不是"只能用谁"。
+            reset_call = fresh_gateway_request(start_from_model=spread[i])
             try:
                 return image_gen.gen_image(prompt, refs)
             finally:
                 reset_call()
 
         # 多张候选各自一次付费调用,彼此独立;ContextVar 由 io_map 拷进 IO 线程。
-        raws = generation_io.io_map(_gen_one, range(max(1, input.num_images)))
+        raws = generation_io.io_map(_gen_one, range(n_images))
         # 抠图走 ONNX,同一会话不能并发 Run;上传再并行。
         cut: list[Image.Image] = []
         pngs: list[bytes] = []

--- a/backend/packages/framework/src/windup_framework/gateway/image.py
+++ b/backend/packages/framework/src/windup_framework/gateway/image.py
@@ -66,8 +66,11 @@ class ImageGateway:
 
         chain = list(self._registry.chain(Scene.CHARACTER_IMAGE))
         if ctx.start_from_model and ctx.start_from_model in chain:
+            # 轮转而不是截断:候选铺开会把最后一个型号指给某一张候选,截断的话那一张
+            # 一旦上游整体不可用就没有任何兜底,而其余候选还好好的 —— 一次任务里
+            # 单张失败与整任务失败是两回事。
             start_i = chain.index(ctx.start_from_model)
-            models = chain[start_i:]
+            models = chain[start_i:] + chain[:start_i]
         else:
             start_i = 0
             models = chain

--- a/backend/packages/framework/src/windup_framework/gateway/registry.py
+++ b/backend/packages/framework/src/windup_framework/gateway/registry.py
@@ -25,6 +25,24 @@ IMAGE_UNIT_COST_USD: dict[str, float] = {
 }
 
 
+def candidate_models(chain: tuple[str, ...], count: int) -> tuple[str, ...]:
+    """一次任务的多张候选各自用哪个型号。
+
+    与兜底链正交:兜底是"前一个失败了才换",这里是"同一次任务里同时用不同型号"。
+    同型号出 N 张时,候选之间的差异只来自采样随机性,用户挑中哪张不携带任何型号信息;
+    跨型号之后那一次挑选就是一条偏好数据,而这条数据零额外成本。
+
+    规则是最后一张交给链上第二个型号,其余走主型号 —— 多数张保持主型号的稳定表现,
+    同时只要不止一张就一定有一张来自另一条协议面。链上只有一个型号时全部用它。
+    """
+    if not chain:
+        return ()
+    n = max(1, count)
+    if n == 1 or len(chain) == 1:
+        return (chain[0],) * n
+    return (chain[0],) * (n - 1) + (chain[1],)
+
+
 class RegistryError(ValueError):
     pass
 

--- a/backend/packages/framework/src/windup_framework/providers/protocol/image_faces.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/image_faces.py
@@ -11,6 +11,7 @@ import base64
 import binascii
 import io
 import json
+from dataclasses import replace
 
 import httpx
 
@@ -80,6 +81,25 @@ def _http_failure(resp: httpx.Response, model: str, base_url: str) -> AdapterRes
     )
 
 
+def _billed(exc: BaseException, job_id: str) -> AdapterResult:
+    """建单之后的失败:必须带上 job_id 并标 MAYBE_BILLED。
+
+    到这一步 FAL 已经收下任务、可能在计费。通用 ``_transport`` 会把典型读断线分成
+    ``UNREACHED`` 且 ``maybe_billed=False``,而 Gateway 对第一次 UNREACHED 是 RETRY_SAME
+    —— 于是轮询/取结果/下载任一步的瞬时断线都会重新 POST 建第二个任务,而第一个还在跑、
+    照样收钱。标 MAYBE_BILLED 才能让 Gateway 走不重发的那条分支。
+    """
+    error_type, status, edge = classify_exception(exc)
+    return AdapterResult(
+        ok=False,
+        error_type=ModelErrorType.MAYBE_BILLED,
+        http_status=status,
+        maybe_billed=True,
+        job_id=job_id,
+        edge_fingerprint=f"建单后失败(job={job_id}),不重新建单:{edge}",
+    )
+
+
 def _invalid(resp: httpx.Response, why: str) -> AdapterResult:
     return AdapterResult(
         ok=False,
@@ -97,6 +117,19 @@ def _sized(data: bytes, resp: httpx.Response) -> AdapterResult:
 
 def _datauri(raw: bytes) -> str:
     return "data:image/png;base64," + base64.b64encode(raw).decode()
+
+
+def _fetch_result(client: httpx.Client, url: str) -> httpx.Response:
+    """取成品图。跨源目标要摘掉 client 级凭证。
+
+    ``headers={}`` 不够:httpx 把它与 client 默认头**合并**而不是替换,``Authorization``
+    照样发出去。而这个 URL 来自网关响应,正常指向 CDN、异常可以是任意地址 —— 等于把
+    API key 交给那个域名。同源时必须保留:网关也会签发自家域名下的下载链接。
+    判定复用 ``sufy._download_request``,不在这里造第二份同源逻辑。
+    """
+    from ..sufy import _download_request
+
+    return client.send(_download_request(client, url))
 
 
 class OpenAIImagesFace:
@@ -170,7 +203,7 @@ class OpenAIImagesFace:
         if not url:
             return _invalid(resp, "data[0] 既无 b64_json 也无 url")
         try:
-            got = client.get(url, headers={})
+            got = _fetch_result(client, url)
         except httpx.TransportError as exc:
             return _transport(exc)
         if not 200 <= got.status_code < 300:
@@ -236,12 +269,12 @@ class FalQueueImageFace:
             try:
                 st = client.get(f"{root}/status")
             except httpx.TransportError as exc:
-                return _transport(exc)
+                return _billed(exc, job_id)
             if not 200 <= st.status_code < 300:
-                return _http_failure(st, prefix, self._root)
+                return replace(_http_failure(st, prefix, self._root), job_id=job_id)
             poll_json = json_object(st)
             if poll_json is None:
-                return _invalid(st, "轮询响应不是 JSON 对象")
+                return replace(_invalid(st, "轮询响应不是 JSON 对象"), job_id=job_id)
             status = poll_json.get("status")
             if status not in IN_FLIGHT:
                 break
@@ -257,21 +290,23 @@ class FalQueueImageFace:
         try:
             res = client.get(root)
         except httpx.TransportError as exc:
-            return _transport(exc)
+            return _billed(exc, job_id)
         if not 200 <= res.status_code < 300:
-            return _http_failure(res, prefix, self._root)
+            return replace(_http_failure(res, prefix, self._root), job_id=job_id)
         result_json = json_object(res)
         if result_json is None:
-            return _invalid(res, "取结果响应不是 JSON 对象")
+            return replace(_invalid(res, "取结果响应不是 JSON 对象"), job_id=job_id)
         images = result_json.get("images")
         first = images[0] if isinstance(images, list) and images else None
         url = first.get("url") if isinstance(first, dict) else None
         if not url:
-            return _invalid(res, f"结果里没有图片 URL:{json.dumps(result_json)[:200]}")
+            return replace(
+                _invalid(res, f"结果里没有图片 URL:{json.dumps(result_json)[:200]}"), job_id=job_id
+            )
         try:
-            got = client.get(url, headers={})
+            got = _fetch_result(client, url)
         except httpx.TransportError as exc:
-            return _transport(exc)
+            return _billed(exc, job_id)
         if not 200 <= got.status_code < 300:
-            return _invalid(res, f"下载成品失败 HTTP {got.status_code}")
+            return replace(_invalid(res, f"下载成品失败 HTTP {got.status_code}"), job_id=job_id)
         return _sized(got.content, submitted)

--- a/backend/tests/test_candidate_spread.py
+++ b/backend/tests/test_candidate_spread.py
@@ -1,0 +1,151 @@
+"""候选跨型号铺开。
+
+分配函数自己对不够 —— 算出一张表却没接到出图那个循环时,生产仍旧三张同型号,
+既不报错也不生效。所以有一组用例从 ImageTaskExecutor 进,数实际发出去的型号。
+"""
+from __future__ import annotations
+
+import pytest
+from windup_framework.config.provider import AIProviderSettings
+from windup_framework.gateway.circuit import CircuitBreaker
+from windup_framework.gateway.context import bind_call_context
+from windup_framework.gateway.image import ImageGateway
+from windup_framework.gateway.registry import ModelRegistry, candidate_models
+from windup_common.enums.model import ModelErrorType
+
+GPT = "gpt-image-2"
+FLASH = "gemini-3.1-flash-image-preview"
+CHAIN = (GPT, FLASH)
+
+
+@pytest.mark.parametrize(
+    ("n", "expect"),
+    [
+        (1, (GPT,)),
+        (2, (GPT, FLASH)),
+        (3, (GPT, GPT, FLASH)),          # 三张候选:两张主 + 一张备
+        (4, (GPT, GPT, GPT, FLASH)),
+    ],
+)
+def test_spread_gives_the_last_candidate_to_the_second_model(n, expect):
+    assert candidate_models(CHAIN, n) == expect
+
+
+def test_single_model_chain_uses_it_for_every_candidate():
+    assert candidate_models((GPT,), 3) == (GPT, GPT, GPT)
+
+
+def test_empty_chain_yields_nothing_rather_than_a_bogus_model():
+    assert candidate_models((), 3) == ()
+
+
+def test_spread_never_returns_fewer_slots_than_candidates():
+    """少一格会让出图循环按下标取时越界,越界发生在付费调用之前还是之后取决于顺序。"""
+    for n in range(1, 9):
+        assert len(candidate_models(CHAIN, n)) == n
+
+
+# ── 网关:指定起点后仍要有兜底 ──────────────────────────────────────────────
+
+class _FakeAdapter:
+    """按型号给结果;记下实际被调用的型号顺序。"""
+
+    def __init__(self, results: dict[str, list]) -> None:
+        self.results = results
+        self.seen: list[str] = []
+
+    def submit_image(self, prompt, refs, model):
+        self.seen.append(model)
+        from windup_framework.gateway.types import AdapterResult
+
+        out = self.results.get(model)
+        if not out:
+            # UPSTREAM_FAILED 才是"这个型号不行、换下一个"的那类失败;没有 error_type 的
+            # 失败会被判成不可重试,链根本不会往下走。
+            return AdapterResult(ok=False, error_type=ModelErrorType.INVALID_RESPONSE)
+        return out.pop(0)
+
+
+def _gw(adapter):
+    cfg = AIProviderSettings(image_model=GPT, image_fallbacks=FLASH, video_model="kling-v2-5-turbo")
+    return ImageGateway(ModelRegistry.from_settings(cfg), adapter, CircuitBreaker(), cfg)
+
+
+def _ok(body=b"\x89PNG" + b"0" * 6000):
+    from windup_framework.gateway.types import AdapterResult
+
+    return AdapterResult(ok=True, body=body, http_status=200)
+
+
+def test_starting_at_the_last_model_still_falls_back_to_the_first():
+    """轮转而非截断:否则被指到链尾的那张候选一旦上游挂掉就没有任何退路。"""
+    ad = _FakeAdapter({GPT: [_ok()]})          # FLASH 一律失败
+    reset = bind_call_context(start_from_model=FLASH)
+    try:
+        assert _gw(ad).gen_image("p", []).startswith(b"\x89PNG")
+    finally:
+        reset()
+    assert ad.seen[0] == FLASH, f"没有从指定的型号起跑:{ad.seen}"
+    assert ad.seen[-1] == GPT, f"链尾型号失败后没有轮转回链首:{ad.seen}"
+
+
+def test_starting_at_the_first_model_keeps_the_original_order():
+    ad = _FakeAdapter({GPT: [_ok()]})
+    reset = bind_call_context(start_from_model=GPT)
+    try:
+        _gw(ad).gen_image("p", [])
+    finally:
+        reset()
+    assert ad.seen == [GPT]
+
+
+# ── 贯通:出图循环真的按分配表发请求 ────────────────────────────────────────
+
+def test_three_candidates_actually_call_two_different_models(monkeypatch):
+    """从 ImageTaskExecutor 的出图段进,数网关实际收到的起始型号。"""
+    from windup_app.server.orchestrator import executor as ex
+    from windup_framework.gateway.context import current_call_context
+
+    seen: list[str | None] = []
+
+    import io as _io
+
+    from PIL import Image
+
+    def _png() -> bytes:
+        """要真能被 PIL 打开:_produce_image 会解码它,假头会在解码那步就炸,
+        测不到型号铺开这件事。"""
+        im = Image.new("RGBA", (64, 96), (0, 0, 0, 0))
+        im.paste((200, 60, 60, 255), (16, 8, 48, 88))
+        buf = _io.BytesIO()
+        im.save(buf, "PNG")
+        return buf.getvalue()
+
+    class _Gen:
+        def gen_image(self, prompt, refs):
+            seen.append(current_call_context().start_from_model)
+            return _png()
+
+    class _Matte:
+        def cutout(self, png):
+            return png
+
+    e = ex.ImageTaskExecutor(image=_Gen(), matte=_Matte(),
+                             upload=lambda png: "https://cdn.example.com/a.png")
+    inp = ex.CharacterImageInput(prompt="一个剑客", num_images=3)
+    e._produce_image(inp, ex.ProjectConstraints(sprite_w=64, sprite_h=96))
+
+    assert len(seen) == 3, f"应发三次付费调用,实际 {len(seen)}"
+    assert seen.count(GPT) == 2 and seen.count(FLASH) == 1, (
+        f"三张候选没有跨型号铺开,实际 {seen}"
+    )
+
+
+def test_candidate_output_does_not_leak_which_model_made_it():
+    """型号留在服务端。前端看得见型号,用户的选择就带上品牌先验,那次挑选也就不再是盲选。"""
+    from dataclasses import fields
+
+    from windup_app.server.orchestrator.model import CharacterImageOutput
+
+    names = {f.name for f in fields(CharacterImageOutput)}
+    assert not {n for n in names if "model" in n}, f"出参里出现了型号字段:{names}"

--- a/backend/tests/test_image_faces.py
+++ b/backend/tests/test_image_faces.py
@@ -382,3 +382,110 @@ def test_fal_face_malformed_images_field_is_invalid(images):
     face = _face(FalQueueImageFace, _queue_handler(["COMPLETED"], images=images), poll_s=0)
     r = face.submit_image("p", [], FLASH)
     assert not r.ok and r.error_type is ModelErrorType.INVALID_RESPONSE
+
+
+# ── 建单之后:任何失败都不能让 Gateway 重新建单 ─────────────────────────────
+# 到那一步 FAL 已经收下任务、可能在计费。通用 _transport 会分成 UNREACHED 且
+# maybe_billed=False，而 Gateway 对第一次 UNREACHED 是 RETRY_SAME —— 一次瞬时断线
+# 就会 POST 出第二个付费任务，而第一个还在跑。
+
+def _submitted_then(handler):
+    """建单成功，之后按 handler 处理。"""
+    def h(req):
+        if req.method == "POST":
+            return httpx.Response(200, json={"request_id": "req-1"})
+        return handler(req)
+    return h
+
+
+@pytest.mark.parametrize("marker", ["/status", "/requests/req-1", "cdn.example.com"])
+def test_drop_after_submit_is_marked_billed_and_keeps_the_job_id(marker):
+    base = _queue_handler(["COMPLETED"])
+    r = _face(FalQueueImageFace, _raise_on(marker, base), poll_s=0).submit_image("p", [], FLASH)
+    assert not r.ok
+    assert r.maybe_billed, f"{marker} 断线没标 maybe_billed，Gateway 会重新建单"
+    assert r.error_type is ModelErrorType.MAYBE_BILLED
+    assert r.job_id == "req-1", "丢了 job_id，无从续查那个已计费的任务"
+
+
+def test_http_failure_after_submit_keeps_the_job_id():
+    r = _face(FalQueueImageFace, _submitted_then(lambda q: httpx.Response(500, text="boom")),
+              poll_s=0).submit_image("p", [], FLASH)
+    assert not r.ok and r.job_id == "req-1"
+
+
+def test_malformed_result_after_submit_keeps_the_job_id():
+    face = _face(FalQueueImageFace, _queue_handler(["COMPLETED"], images=[]), poll_s=0)
+    r = face.submit_image("p", [], FLASH)
+    assert not r.ok and r.job_id == "req-1"
+
+
+def test_timeout_keeps_the_job_id_too():
+    face = _face(FalQueueImageFace, _queue_handler(["IN_QUEUE"] * 10), poll_s=0, max_polls=2)
+    r = face.submit_image("p", [], FLASH)
+    assert not r.ok and r.maybe_billed and r.job_id == "req-1"
+
+
+# ── 取成品图不能把网关凭证发给 CDN ────────────────────────────────────────
+# headers={} 只与 client 默认头合并、不删除 Authorization。这个 URL 来自网关响应，
+# 正常指向 CDN、异常可以是任意地址 —— 等于把 API key 交出去。
+
+def _capture_auth(store):
+    def h(req):
+        if req.method == "POST":
+            return httpx.Response(200, json={"request_id": "req-1"})
+        if req.url.path.endswith("/status"):
+            return httpx.Response(200, json={"status": "COMPLETED"})
+        if "/requests/" in req.url.path:
+            return httpx.Response(200, json={"images": [{"url": "https://cdn.elsewhere.test/a.png"}]})
+        store["auth"] = req.headers.get("Authorization")
+        store["host"] = req.url.host
+        return httpx.Response(200, content=PNG)
+    return h
+
+
+def test_fal_face_strips_credentials_when_fetching_from_another_origin():
+    store = {}
+    r = _face(FalQueueImageFace, _capture_auth(store), poll_s=0).submit_image("p", [], FLASH)
+    assert r.ok
+    assert store["host"] == "cdn.elsewhere.test"
+    assert store.get("auth") is None, f"API key 被发给了 CDN: {store.get('auth')!r}"
+
+
+def test_openai_face_strips_credentials_when_fetching_from_another_origin():
+    store = {}
+
+    def h(req):
+        if req.url.path.endswith("/images/generations"):
+            return httpx.Response(200, json={"data": [{"url": "https://cdn.elsewhere.test/a.png"}]})
+        store["auth"] = req.headers.get("Authorization")
+        store["host"] = req.url.host
+        return httpx.Response(200, content=PNG)
+
+    r = _face(OpenAIImagesFace, h).submit_image("p", [], "gpt-image-2")
+    assert r.ok and store["host"] == "cdn.elsewhere.test"
+    assert store.get("auth") is None, f"API key 被发给了 CDN: {store.get('auth')!r}"
+
+
+def test_same_origin_download_keeps_credentials():
+    """网关也会签发自家域名下的链接，那条路径摘了头就是 401。
+
+    这里要自己带上 Authorization 建 client —— 上面 `_face` 那个桩为了简单没设默认头，
+    用它测「摘不摘」只会永远读到 None。
+    """
+    store = {}
+
+    def h(req):
+        if req.url.path.endswith("/images/generations"):
+            return httpx.Response(200, json={"data": [{"url": "https://gw.example.com/v1/dl/a.png"}]})
+        store["auth"] = req.headers.get("Authorization")
+        return httpx.Response(200, content=PNG)
+
+    face = OpenAIImagesFace("https://gw.example.com/v1", "k", 10.0)
+    face._client = lambda: httpx.Client(
+        base_url="https://gw.example.com/v1",
+        headers={"Authorization": "Bearer k"},
+        transport=httpx.MockTransport(h),
+    )
+    r = face.submit_image("p", [], "gpt-image-2")
+    assert r.ok and store.get("auth") == "Bearer k", "同源下载不该摘凭证"


### PR DESCRIPTION
Closes #636

叠在 #638 上：候选铺开要有两个不同协议面的型号才成立，#638 合入后会 rebase 到 main。

## 改动

- `candidate_models(chain, n)`：最后一张交给链上第二个型号，其余走主型号。三张候选即两张主 + 一张备；链上只有一个型号时全部用它
- `_produce_image` 的出图循环按候选序号取起始型号，经 `fresh_gateway_request(start_from_model=...)` 交给网关，不新增旁路
- `ImageGateway` 改为按起始型号**轮转**链而非截断

## 为什么必须是轮转

截断（`chain[start_i:]`）时，被指到链尾的那张候选一旦该型号整体不可用就没有任何退路，而同一次任务里其余候选还好好的。一次任务里单张失败与整任务失败是两回事。视频链的 `start_from_model` 语义不动：那边是用户显式选型号，回退到用户没选的型号不合适。

## 分配表与兜底链是两件事

兜底是「前一个失败了才换」，铺开是「同一次任务里同时用不同型号」。两者正交，不能塞进同一个元组表达，所以分配表另立，指定的是「从谁开始」而不是「只能用谁」。

## 候选不带型号

出参里没有型号字段，用户挑选时看不到它是哪个模型出的。前端能看见型号，那次选择就带上品牌先验，也就不再是盲选。有一条用例钉住出参不出现型号字段。

## 测试

- `tests/test_candidate_spread.py` 11 条：分配表在 n=1..4 与单型号链、空链下的取值；槽位数永不少于候选数；从链尾起跑仍能轮转回链首兜底；从链首起跑顺序不变；出参不带型号
- 其中一条从 `ImageTaskExecutor._produce_image` 进，数网关实际收到的起始型号——只测分配函数不够，算出一张表却没接到出图循环时，生产仍旧三张同型号，既不报错也不生效
- 后端 `ruff check` / `lint-imports` / `pytest`：1549 passed、14 skipped，三条都跑在最后一次编辑之后

## 不包含

选择结果落成偏好记录是 #640。
