### PR TITLE
fix(ai): 用 request_id 串起 Quick Start Agent 失败日志

### DIFF
--- a/backend/packages/app/src/windup_app/bootstrap/app.py
+++ b/backend/packages/app/src/windup_app/bootstrap/app.py
@@ -7,6 +7,7 @@
 ``main`` 是开发启动入口:``python -m windup_app`` 或 ``windup`` 命令。
 """
 
+import logging
 import os
 from contextlib import asynccontextmanager
 
@@ -48,6 +49,20 @@ from windup_framework.sse.bridge import RedisTaskEventBridge, RedisTaskEventSubs
 def _env_flag(name: str) -> bool:
     """把环境变量解析为真正的布尔值:仅 1/true/yes/on(忽略大小写与空白)视为 True。"""
     return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _configure_logging() -> None:
+    """API 进程走 uvicorn factory，不会跑 worker 的 basicConfig。
+
+    不配这一步，windup.* 的 INFO 进不了 docker logs，线上只剩 access log。
+    """
+    root = logging.getLogger()
+    if not root.handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(levelname)s:%(name)s:%(message)s",
+        )
+    logging.getLogger("windup").setLevel(logging.INFO)
 
 
 
@@ -100,6 +115,7 @@ async def _lifespan(app: FastAPI):
 
 
 def create_app() -> FastAPI:
+    _configure_logging()
     app = FastAPI(title="windup", version="0.1.0", lifespan=_lifespan)
     app.state.mq_publisher = MqPublisher()
     app.state.chat_model_factory = create_chat_model
@@ -122,6 +138,7 @@ def create_app() -> FastAPI:
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
+        expose_headers=["X-Request-Id"],
     )
     app.include_router(auth_router)
     app.include_router(project_router)

--- a/backend/packages/app/src/windup_app/web/api/agent.py
+++ b/backend/packages/app/src/windup_app/web/api/agent.py
@@ -26,6 +26,16 @@ from windup_framework.gateway import bind_call_context
 
 logger = logging.getLogger("windup.ai.proxy")
 REQUEST_ID_HEADER = "X-Request-Id"
+_REQUEST_ID_STATE = "ai_request_id"
+
+
+def _request_id_for(request: Request) -> str:
+    existing = getattr(request.state, _REQUEST_ID_STATE, None)
+    if isinstance(existing, str) and existing:
+        return existing
+    request_id = str(uuid4())
+    setattr(request.state, _REQUEST_ID_STATE, request_id)
+    return request_id
 
 
 class RequestTooLargeError(HTTPException):
@@ -42,6 +52,7 @@ class OpenAICompatibleRoute(APIRoute):
         original = super().get_route_handler()
 
         async def route_handler(request: Request) -> Response:
+            request_id = _request_id_for(request)
             content_length = request.headers.get("content-length")
             if content_length is not None:
                 try:
@@ -51,6 +62,7 @@ class OpenAICompatibleRoute(APIRoute):
                             message="请求体超过 64 KiB 上限",
                             error_type="invalid_request_error",
                             code="request_too_large",
+                            request_id=request_id,
                         )
                 except ValueError:
                     pass
@@ -76,6 +88,7 @@ class OpenAICompatibleRoute(APIRoute):
                     message="请求体超过 64 KiB 上限",
                     error_type="invalid_request_error",
                     code="request_too_large",
+                    request_id=request_id,
                 )
             except RequestValidationError:
                 return _error_response(
@@ -83,6 +96,7 @@ class OpenAICompatibleRoute(APIRoute):
                     message="请求参数无效",
                     error_type="invalid_request_error",
                     code="invalid_request",
+                    request_id=request_id,
                 )
 
         return route_handler
@@ -307,7 +321,7 @@ async def chat(
     _credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ):
     """Call the configured model once and return a non-streaming completion."""
-    request_id = str(uuid4())
+    request_id = _request_id_for(request)
     user_id = request.state.current_user.id
     proxy_settings = provider_settings.model_copy(update={"max_retries": 0})
     model_kwargs: dict[str, Any] = {"max_tokens": MAX_OUTPUT_TOKENS}

--- a/backend/packages/app/src/windup_app/web/api/agent.py
+++ b/backend/packages/app/src/windup_app/web/api/agent.py
@@ -22,8 +22,10 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, ConfigDict, Field
 
 from windup_framework.config.provider import settings as provider_settings
+from windup_framework.gateway import bind_call_context
 
 logger = logging.getLogger("windup.ai.proxy")
+REQUEST_ID_HEADER = "X-Request-Id"
 
 
 class RequestTooLargeError(HTTPException):
@@ -195,11 +197,27 @@ def _error_response(
     message: str,
     error_type: str,
     code: str,
+    request_id: str | None = None,
 ) -> JSONResponse:
-    return JSONResponse(
+    response = JSONResponse(
         status_code=status_code,
         content={"error": {"message": message, "type": error_type, "code": code}},
     )
+    if request_id:
+        response.headers[REQUEST_ID_HEADER] = request_id
+    return response
+
+
+def _completion_response(
+    payload: ChatCompletionResponse, request_id: str
+) -> JSONResponse:
+    response = JSONResponse(content=payload.model_dump(mode="json"))
+    response.headers[REQUEST_ID_HEADER] = request_id
+    return response
+
+
+def _exc_text(exc: BaseException, limit: int = 500) -> str:
+    return (str(exc).strip() or type(exc).__name__)[:limit]
 
 
 def _serialize_tool_calls(result: Any) -> list[ToolCallResponse] | None:
@@ -289,6 +307,8 @@ async def chat(
     _credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ):
     """Call the configured model once and return a non-streaming completion."""
+    request_id = str(uuid4())
+    user_id = request.state.current_user.id
     proxy_settings = provider_settings.model_copy(update={"max_retries": 0})
     model_kwargs: dict[str, Any] = {"max_tokens": MAX_OUTPUT_TOKENS}
     if body.temperature is not None:
@@ -297,13 +317,24 @@ async def chat(
     try:
         model = request.app.state.chat_model_factory(proxy_settings, **model_kwargs)
     except ValueError:
+        logger.warning(
+            "AI chat not configured request_id=%s user_id=%s", request_id, user_id
+        )
         return _error_response(
             503,
             message="AI 服务未配置",
             error_type="service_unavailable",
             code="ai_not_configured",
+            request_id=request_id,
         )
 
+    logger.info(
+        "AI chat started request_id=%s user_id=%s messages=%s tools=%s",
+        request_id,
+        user_id,
+        len(body.messages),
+        0 if not body.tools else len(body.tools),
+    )
     invoke_kwargs: dict[str, Any] = {}
     if body.tools:
         invoke_kwargs["tools"] = [
@@ -312,24 +343,66 @@ async def chat(
     if body.tool_choice is not None:
         invoke_kwargs["tool_choice"] = body.tool_choice
 
+    started = time.monotonic()
+    reset = bind_call_context(request_id=request_id, user_id=str(user_id))
     try:
         result = await model.ainvoke(
             [message.model_dump(exclude_none=True) for message in body.messages],
             **invoke_kwargs,
         )
-        configured_model = (
-            proxy_settings.chat_model or proxy_settings.model or "unknown"
-        )
-        return _serialize_completion(result, configured_model)
     except Exception as exc:
         logger.warning(
-            "AI chat provider failed user_id=%s error=%s",
-            request.state.current_user.id,
+            "AI chat upstream failed request_id=%s user_id=%s error_type=%s error=%s",
+            request_id,
+            user_id,
             type(exc).__name__,
+            _exc_text(exc),
         )
         return _error_response(
             502,
             message="AI 服务暂时不可用",
             error_type="upstream_error",
             code="ai_upstream_error",
+            request_id=request_id,
         )
+    finally:
+        reset()
+
+    try:
+        configured_model = (
+            proxy_settings.chat_model or proxy_settings.model or "unknown"
+        )
+        payload = _serialize_completion(result, configured_model)
+    except Exception as exc:
+        logger.warning(
+            "AI chat serialize failed request_id=%s user_id=%s error_type=%s error=%s",
+            request_id,
+            user_id,
+            type(exc).__name__,
+            _exc_text(exc),
+        )
+        return _error_response(
+            502,
+            message="AI 服务暂时不可用",
+            error_type="upstream_error",
+            code="ai_upstream_error",
+            request_id=request_id,
+        )
+
+    choice = payload.choices[0]
+    tool_count = 0 if not choice.message.tool_calls else len(choice.message.tool_calls)
+    logger.info(
+        "AI chat completed request_id=%s user_id=%s model=%s finish_reason=%s "
+        "tool_calls=%s latency_ms=%s",
+        request_id,
+        user_id,
+        payload.model,
+        choice.finish_reason,
+        tool_count,
+        int((time.monotonic() - started) * 1000),
+    )
+    if choice.finish_reason == "length":
+        logger.warning(
+            "AI chat truncated request_id=%s user_id=%s", request_id, user_id
+        )
+    return _completion_response(payload, request_id)

--- a/backend/packages/framework/src/windup_framework/gateway/chat.py
+++ b/backend/packages/framework/src/windup_framework/gateway/chat.py
@@ -34,6 +34,9 @@ _DEFAULT_RETRY_AFTER_S = 2.0
 _SLEEP_CAP_S = 30.0
 
 
+_ERROR_MESSAGE_LIMIT = 2_000
+
+
 @dataclass(frozen=True)
 class ChatAdapterResult:
     ok: bool
@@ -43,6 +46,7 @@ class ChatAdapterResult:
     edge_fingerprint: str = ""
     retry_after_s: float | None = None
     provider_usage: object | None = None
+    error_message: str | None = None
 
 
 def _utc_now() -> str:
@@ -62,6 +66,64 @@ def _error_type_from_exception(exc: Exception) -> tuple[ModelErrorType, int | No
     from windup_framework.gateway.classify import classify_exception
 
     return classify_exception(exc)
+
+
+def _ok_adapter_result(value: Any) -> ChatAdapterResult:
+    return ChatAdapterResult(
+        ok=True,
+        value=value,
+        provider_usage=getattr(value, "usage_metadata", None),
+    )
+
+
+def _failed_adapter_result(exc: Exception) -> ChatAdapterResult:
+    error_type, status, edge = _error_type_from_exception(exc)
+    message = str(exc).strip() or type(exc).__name__
+    return ChatAdapterResult(
+        ok=False,
+        error_type=error_type,
+        http_status=status,
+        edge_fingerprint=edge,
+        error_message=message[:_ERROR_MESSAGE_LIMIT],
+    )
+
+
+def _message_finish_reason(value: Any) -> str | None:
+    metadata = getattr(value, "response_metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    reason = metadata.get("finish_reason")
+    return str(reason) if reason else None
+
+
+def _result_detail(
+    result: ChatAdapterResult,
+    *,
+    input_hash: str,
+    policy_next_step: str,
+    upstream_reached: str,
+    model_index: int | None = None,
+    retry_after_ms: int | None = None,
+    output_bytes: int | None = None,
+) -> AttemptDetail:
+    finish_reason = None
+    has_tool_calls = None
+    if result.ok:
+        finish_reason = _message_finish_reason(result.value)
+        has_tool_calls = bool(getattr(result.value, "tool_calls", None))
+    return AttemptDetail(
+        input_hash=input_hash,
+        output_bytes=output_bytes,
+        retry_after_ms=retry_after_ms,
+        edge_fingerprint=result.edge_fingerprint or None,
+        provider_usage=result.provider_usage,
+        policy_next_step=policy_next_step,
+        upstream_reached=upstream_reached,
+        model_index=model_index,
+        error_message=None if result.ok else result.error_message,
+        finish_reason=finish_reason,
+        has_tool_calls=has_tool_calls,
+    )
 
 
 class LangChainChatAdapter:
@@ -99,41 +161,22 @@ class LangChainChatAdapter:
 
     def invoke(self, messages: Any, *, model: str, **kwargs: Any) -> ChatAdapterResult:
         try:
-            return ChatAdapterResult(ok=True, value=self._client(model).invoke(messages, **kwargs))
+            return _ok_adapter_result(self._client(model).invoke(messages, **kwargs))
         except Exception as exc:
-            error_type, status, edge = _error_type_from_exception(exc)
-            return ChatAdapterResult(
-                ok=False,
-                error_type=error_type,
-                http_status=status,
-                edge_fingerprint=edge,
-            )
+            return _failed_adapter_result(exc)
 
     async def ainvoke(self, messages: Any, *, model: str, **kwargs: Any) -> ChatAdapterResult:
         try:
-            value = await self._client(model).ainvoke(messages, **kwargs)
-            return ChatAdapterResult(ok=True, value=value)
+            return _ok_adapter_result(await self._client(model).ainvoke(messages, **kwargs))
         except Exception as exc:
-            error_type, status, edge = _error_type_from_exception(exc)
-            return ChatAdapterResult(
-                ok=False,
-                error_type=error_type,
-                http_status=status,
-                edge_fingerprint=edge,
-            )
+            return _failed_adapter_result(exc)
 
     async def astream(self, messages: Any, *, model: str, **kwargs: Any):
         try:
             async for chunk in self._client(model).astream(messages, **kwargs):
-                yield ChatAdapterResult(ok=True, value=chunk)
+                yield _ok_adapter_result(chunk)
         except Exception as exc:
-            error_type, status, edge = _error_type_from_exception(exc)
-            yield ChatAdapterResult(
-                ok=False,
-                error_type=error_type,
-                http_status=status,
-                edge_fingerprint=edge,
-            )
+            yield _failed_adapter_result(exc)
 
 
 class ChatGateway:
@@ -288,7 +331,8 @@ class ChatGateway:
                                 attempt_latency_ms=attempt_latency_ms,
                                 total_latency_ms=total_ms(),
                                 maybe_billed=maybe_billed,
-                                detail=AttemptDetail(
+                                detail=_result_detail(
+                                    result,
                                     input_hash=input_hash,
                                     policy_next_step="fail",
                                     upstream_reached=upstream_reached_label(
@@ -325,15 +369,14 @@ class ChatGateway:
                                 attempt_latency_ms=attempt_latency_ms,
                                 total_latency_ms=total_ms(),
                                 maybe_billed=maybe_billed,
-                                detail=AttemptDetail(
+                                detail=_result_detail(
+                                    result,
                                     input_hash=input_hash,
-                                    output_bytes=len(str(result.value).encode()),
-                                    retry_after_ms=retry_after_ms,
-                                    edge_fingerprint=result.edge_fingerprint or None,
-                                    provider_usage=result.provider_usage,
                                     policy_next_step="success",
                                     upstream_reached="true",
                                     model_index=model_index,
+                                    retry_after_ms=retry_after_ms,
+                                    output_bytes=len(str(result.value).encode()),
                                 ),
                             )
                         )
@@ -393,16 +436,15 @@ class ChatGateway:
                             attempt_latency_ms=attempt_latency_ms,
                             total_latency_ms=total_ms(),
                             maybe_billed=maybe_billed,
-                            detail=AttemptDetail(
+                            detail=_result_detail(
+                                result,
                                 input_hash=input_hash,
-                                retry_after_ms=retry_after_ms,
-                                edge_fingerprint=result.edge_fingerprint or None,
-                                provider_usage=result.provider_usage,
                                 policy_next_step=policy_next_step,
                                 upstream_reached=upstream_reached_label(
                                     error_type, http_status=result.http_status
                                 ),
                                 model_index=model_index,
+                                retry_after_ms=retry_after_ms,
                             ),
                         )
                     )

--- a/backend/packages/framework/src/windup_framework/gateway/ledger.py
+++ b/backend/packages/framework/src/windup_framework/gateway/ledger.py
@@ -68,6 +68,10 @@ def _audit_extra(detail: AttemptDetail) -> dict | None:
         extra["upstream_reached"] = detail.upstream_reached
     if detail.model_index is not None:
         extra["model_index"] = detail.model_index
+    if detail.finish_reason:
+        extra["finish_reason"] = detail.finish_reason
+    if detail.has_tool_calls is not None:
+        extra["has_tool_calls"] = detail.has_tool_calls
     return extra or None
 
 
@@ -129,7 +133,9 @@ def persist_attempt(trace: AttemptTrace, *, session_factory=SessionLocal) -> Non
                     task_id=_int_or_none(trace.task_id),
                     job_status=detail.job_status,
                     edge_fingerprint=detail.edge_fingerprint,
-                    error_message=None,
+                    error_message=(
+                        detail.error_message[:2000] if detail.error_message else None
+                    ),
                     provider_request_id=None,
                     provider_usage=_json_or_none(detail.provider_usage),
                     input_hash=detail.input_hash,

--- a/backend/packages/framework/src/windup_framework/gateway/trace.py
+++ b/backend/packages/framework/src/windup_framework/gateway/trace.py
@@ -33,6 +33,9 @@ class AttemptDetail:
     policy_next_step: str | None = None
     upstream_reached: str | None = None
     model_index: int | None = None
+    error_message: str | None = None
+    finish_reason: str | None = None
+    has_tool_calls: bool | None = None
 
 
 @dataclass

--- a/backend/tests/test_agent_api.py
+++ b/backend/tests/test_agent_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from collections.abc import Callable
 from functools import partial
 from typing import Any
@@ -212,6 +213,7 @@ def test_ai_chat_returns_text_from_real_provider(
         "completion_tokens": 8,
         "total_tokens": 20,
     }
+    assert response.headers["x-request-id"]
     assert provider_requests[0]["model"] == "server-model"
     assert provider_requests[0]["max_completion_tokens"] == 1_024
     assert provider_requests[0]["stream"] is False
@@ -318,6 +320,7 @@ def test_ai_chat_reports_missing_configuration(auth_client, monkeypatch):
     response = auth_client.post("/ai/chat", json=_request_body())
 
     assert response.status_code == 503
+    assert response.headers["x-request-id"]
     assert response.json()["error"] == {
         "message": "AI 服务未配置",
         "type": "service_unavailable",
@@ -328,7 +331,9 @@ def test_ai_chat_reports_missing_configuration(auth_client, monkeypatch):
 def test_ai_chat_does_not_retry_upstream_failures(
     auth_client,
     install_openai_provider: Callable[..., list[dict[str, Any]]],
+    caplog,
 ):
+    caplog.set_level(logging.INFO, logger="windup.ai.proxy")
     provider_requests = install_openai_provider(
         auth_client,
         (500, {"error": {"message": "provider unavailable"}}),
@@ -337,9 +342,75 @@ def test_ai_chat_does_not_retry_upstream_failures(
     response = auth_client.post("/ai/chat", json=_request_body())
 
     assert response.status_code == 502
+    request_id = response.headers["x-request-id"]
+    assert request_id
     assert response.json()["error"] == {
         "message": "AI 服务暂时不可用",
         "type": "upstream_error",
         "code": "ai_upstream_error",
     }
     assert len(provider_requests) == 1
+    assert any(
+        "AI chat upstream failed" in record.message and request_id in record.message
+        for record in caplog.records
+        if record.name == "windup.ai.proxy"
+    )
+
+
+def test_ai_chat_binds_user_and_request_id_into_gateway_trace(
+    auth_client,
+    install_openai_provider: Callable[..., list[dict[str, Any]]],
+    caplog,
+):
+    caplog.set_level(logging.INFO)
+    install_openai_provider(auth_client, _text_completion())
+
+    response = auth_client.post("/ai/chat", json=_request_body())
+
+    request_id = response.headers["x-request-id"]
+    assert response.status_code == 200
+    proxy_logs = [r.message for r in caplog.records if r.name == "windup.ai.proxy"]
+    assert any(f"AI chat started request_id={request_id} user_id=1" in msg for msg in proxy_logs)
+    assert any(
+        f"AI chat completed request_id={request_id} user_id=1" in msg
+        and "finish_reason=stop" in msg
+        for msg in proxy_logs
+    )
+    traces = [
+        json.loads(r.message)
+        for r in caplog.records
+        if r.name == "windup.gateway" and r.message.startswith("{")
+    ]
+    assert traces
+    assert traces[-1]["request_id"] == request_id
+    assert traces[-1]["user_id"] == "1"
+    assert traces[-1]["outcome"] == "success"
+
+
+class _UnserializableChatResult:
+    invalid_tool_calls = ["broken"]
+    tool_calls = None
+    content = "hi"
+    response_metadata = {}
+    usage_metadata = None
+    id = "chatcmpl-bad"
+
+
+def test_ai_chat_logs_serialize_failure_after_upstream_success(auth_client, caplog):
+    caplog.set_level(logging.INFO, logger="windup.ai.proxy")
+
+    class _Gateway:
+        async def ainvoke(self, *_args: Any, **_kwargs: Any):
+            return _UnserializableChatResult()
+
+    auth_client.app.state.chat_model_factory = lambda *_args, **_kwargs: _Gateway()
+
+    response = auth_client.post("/ai/chat", json=_request_body())
+
+    assert response.status_code == 502
+    request_id = response.headers["x-request-id"]
+    assert any(
+        "AI chat serialize failed" in record.message and request_id in record.message
+        for record in caplog.records
+        if record.name == "windup.ai.proxy"
+    )

--- a/backend/tests/test_agent_api.py
+++ b/backend/tests/test_agent_api.py
@@ -256,6 +256,7 @@ def test_ai_chat_rejects_oversized_history_before_provider(auth_client):
     response = auth_client.post("/ai/chat", json=_request_body(messages=messages))
 
     assert response.status_code == 422
+    assert response.headers["x-request-id"]
     assert response.json()["error"]["code"] == "invalid_request"
     assert calls == 0
 
@@ -276,6 +277,7 @@ def test_ai_chat_rejects_oversized_body_before_provider(auth_client):
     )
 
     assert response.status_code == 413
+    assert response.headers["x-request-id"]
     assert response.json()["error"]["code"] == "request_too_large"
     assert calls == 0
 
@@ -306,6 +308,7 @@ async def test_ai_chat_rejects_chunked_body_before_json_parse():
         response = await async_client.post("/ai/chat", content=chunks())
 
     assert response.status_code == 413
+    assert response.headers["x-request-id"]
     assert response.json()["error"]["code"] == "request_too_large"
 
 

--- a/backend/tests/test_gateway_chat.py
+++ b/backend/tests/test_gateway_chat.py
@@ -267,6 +267,7 @@ def test_langchain_adapter_maps_status_code(monkeypatch):
     assert not r.ok
     assert r.error_type is ModelErrorType.RATE_LIMIT
     assert r.http_status == 429
+    assert r.error_message == "quota"
 
 
 def test_langchain_adapter_maps_response_status(monkeypatch):

--- a/backend/tests/test_gateway_ledger_persistence.py
+++ b/backend/tests/test_gateway_ledger_persistence.py
@@ -55,6 +55,9 @@ def test_persist_attempt_splits_hot_and_detail_fields():
             detail=AttemptDetail(
                 edge_fingerprint="cf-ray=abc",
                 provider_usage={"total_tokens": 12},
+                error_message="upstream 429: quota exceeded",
+                finish_reason="length",
+                has_tool_calls=False,
             ),
         ),
         session_factory=session_factory,
@@ -75,3 +78,8 @@ def test_persist_attempt_splits_hot_and_detail_fields():
     assert str(hot.attempt_id) == attempt_id
     assert detail.edge_fingerprint == "cf-ray=abc"
     assert detail.provider_usage == {"total_tokens": 12}
+    assert detail.error_message == "upstream 429: quota exceeded"
+    assert detail.extra == {
+        "finish_reason": "length",
+        "has_tool_calls": False,
+    }

--- a/backend/tests/test_gateway_trace.py
+++ b/backend/tests/test_gateway_trace.py
@@ -24,6 +24,7 @@ COLD_FIELDS = {
     "input_hash", "output_hash", "output_bytes", "expected_bytes",
     "retry_after_ms", "submit_ms", "poll_ms", "download_ms", "poll_count",
     "resend_spent", "job_status", "edge_fingerprint", "provider_usage",
+    "error_message", "finish_reason", "has_tool_calls",
 }
 
 

--- a/frontend/src/features/quick-start-agent/production.test.ts
+++ b/frontend/src/features/quick-start-agent/production.test.ts
@@ -76,6 +76,27 @@ describe('Quick Start Agent composition', () => {
     expect(secondRequest.headers.get('authorization')).toBe('Bearer fresh-token')
   })
 
+  it('logs status and request id when the Agent proxy is not ok', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      new Response(JSON.stringify({ error: { message: 'AI 服务暂时不可用' } }), {
+        status: 502,
+        headers: { 'content-type': 'application/json', 'x-request-id': 'req-agent-1' },
+      }),
+    )
+    const proxyFetch = createAgentProxyFetch({ fetchFn })
+
+    const response = await proxyFetch('https://windup.test/api/ai/chat/completions', {
+      method: 'POST',
+    })
+
+    expect(response.status).toBe(502)
+    expect(consoleError).toHaveBeenCalledWith('[quick-start-agent] /ai/chat 失败', {
+      status: 502,
+      requestId: 'req-agent-1',
+    })
+  })
+
   it('forwards a tokenless GET response without invoking auth recovery', async () => {
     const fetchFn = vi.fn<typeof fetch>(async () => Response.json({ choices: [] }))
     const recoverUnauthorized = vi.fn(async () => true)

--- a/frontend/src/features/quick-start-agent/production.test.ts
+++ b/frontend/src/features/quick-start-agent/production.test.ts
@@ -78,11 +78,12 @@ describe('Quick Start Agent composition', () => {
 
   it('logs status and request id when the Agent proxy is not ok', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      new Response(JSON.stringify({ error: { message: 'AI 服务暂时不可用' } }), {
-        status: 502,
-        headers: { 'content-type': 'application/json', 'x-request-id': 'req-agent-1' },
-      }),
+    const fetchFn = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify({ error: { message: 'AI 服务暂时不可用' } }), {
+          status: 502,
+          headers: { 'content-type': 'application/json', 'x-request-id': 'req-agent-1' },
+        }),
     )
     const proxyFetch = createAgentProxyFetch({ fetchFn })
 

--- a/frontend/src/features/quick-start-agent/production.ts
+++ b/frontend/src/features/quick-start-agent/production.ts
@@ -18,6 +18,8 @@ import {
 } from '@/features/workflow-controller'
 import { getApiAccessToken, recoverApiUnauthorized, resolveApiBaseUrl } from '@/shared/api'
 
+const REQUEST_ID_HEADER = 'x-request-id'
+
 interface CreateAgentProxyFetchOptions {
   fetchFn?: typeof globalThis.fetch
   getAccessToken?: () => string | null | undefined
@@ -72,8 +74,23 @@ export function createAgentProxyFetch({
     }
 
     const response = await send()
-    if (response.status !== 401 || !(await recover())) return response
-    return send()
+    if (response.status === 401 && (await recover())) {
+      const replayed = await send()
+      if (!replayed.ok) {
+        console.error('[quick-start-agent] /ai/chat 失败', {
+          status: replayed.status,
+          requestId: replayed.headers.get(REQUEST_ID_HEADER),
+        })
+      }
+      return replayed
+    }
+    if (!response.ok) {
+      console.error('[quick-start-agent] /ai/chat 失败', {
+        status: response.status,
+        requestId: response.headers.get(REQUEST_ID_HEADER),
+      })
+    }
+    return response
   }
 }
 

--- a/frontend/src/features/quick-start-agent/react.test.tsx
+++ b/frontend/src/features/quick-start-agent/react.test.tsx
@@ -146,6 +146,7 @@ describe('useQuickStartAgent', () => {
   it.each(['生成提案参数字段无效', '请求参数无效'])(
     'keeps the internal protocol error %s out of the conversation',
     async (message) => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
       const planner = vi.fn(async () => {
         throw new Error(message)
       })
@@ -160,6 +161,11 @@ describe('useQuickStartAgent', () => {
       expect(result.current.state).toEqual({
         status: 'error',
         message: 'Agent 没有完成这次回复，请重新发送',
+      })
+      expect(consoleError).toHaveBeenCalledWith('[quick-start-agent] 本轮失败', {
+        name: 'Error',
+        message,
+        requestId: undefined,
       })
     },
   )

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -25,6 +25,21 @@ export type QuickStartAgentState =
 
 export type UseQuickStartAgentOptions = CreateQuickStartAgentOptions
 
+function requestIdFromCause(cause: unknown): string | undefined {
+  if (!cause || typeof cause !== 'object') return undefined
+  const headers = (cause as { responseHeaders?: Record<string, string> }).responseHeaders
+  if (!headers) return undefined
+  return headers['x-request-id'] ?? headers['X-Request-Id']
+}
+
+function logAgentFailure(cause: unknown): void {
+  console.error('[quick-start-agent] 本轮失败', {
+    name: cause instanceof Error ? cause.name : typeof cause,
+    message: cause instanceof Error ? cause.message : String(cause),
+    requestId: requestIdFromCause(cause),
+  })
+}
+
 function errorMessage(cause: unknown): string {
   if (!(cause instanceof Error) || !cause.message) return 'Agent 暂时不可用，请稍后重试'
   if (
@@ -114,6 +129,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
         return result
       } catch (cause) {
         if (mounted.current && !(cause instanceof Error && cause.name === 'AbortError')) {
+          logAgentFailure(cause)
           setState({ status: 'error', message: errorMessage(cause) })
         }
         throw cause
@@ -145,7 +161,10 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
       try {
         return await ensureAgent().confirmProposal(proposalId, prompt, directionalMovement)
       } catch (cause) {
-        if (mounted.current) setState({ status: 'error', message: errorMessage(cause) })
+        if (mounted.current) {
+          logAgentFailure(cause)
+          setState({ status: 'error', message: errorMessage(cause) })
+        }
         throw cause
       } finally {
         running.current = false
@@ -210,6 +229,7 @@ export function useQuickStartWorkflowAgent({
         return result
       } catch (cause) {
         if (mounted.current && !(cause instanceof Error && cause.name === 'AbortError')) {
+          logAgentFailure(cause)
           setState({ status: 'error', message: errorMessage(cause) })
         }
         throw cause


### PR DESCRIPTION
Closes #642

## Summary
- `/ai/chat` 绑定 `request_id` / `user_id`，响应带 `X-Request-Id`，并打 started / completed / upstream failed / serialize failed 日志
- Gateway ledger 写入 `error_message`、`finish_reason`、`has_tool_calls` 和 usage；API 进程补上 `windup.*` INFO，docker logs 不再只剩 access log
- Quick Start Agent 前端失败打出原始错误和 request id，页面文案仍对用户收口

今天线上 Gateway 全是 success、`POST /ai/chat` 全是 200，说明用户侧「Agent 不可用」多半发生在上游成功之后。合入后用同一条 `request_id` 就能从浏览器串到 backend，再串到 attempt / detail。

## Test plan
- [ ] 后端 `uv run pytest tests/test_agent_api.py tests/test_gateway_ledger_persistence.py tests/test_gateway_trace.py tests/test_gateway_chat.py -q --no-cov`
- [ ] 前端 `npm test -- src/features/quick-start-agent/react.test.tsx src/features/quick-start-agent/production.test.ts`
- [ ] 部署后走一遍 Quick Start 对话，确认 `docker logs windup-backend` 出现 `AI chat started/completed`
- [ ] 复现一次 Agent 失败，用响应头 / 浏览器控制台的 `request_id` 查 `windup_ai_gateway_attempt` 和 `_detail`
- [ ] 确认 ledger 的 `user_id` 有值；上游失败时 `error_message` 不再为空；成功记录能看到 `finish_reason`