### PR TITLE
fix(gateway): retry wrapped connection errors

### DIFF
--- a/backend/packages/framework/src/windup_framework/gateway/classify.py
+++ b/backend/packages/framework/src/windup_framework/gateway/classify.py
@@ -192,7 +192,6 @@ def classify_exception(exc: BaseException) -> tuple[ModelErrorType, int | None, 
         ):
             return ModelErrorType.UNREACHED, None, edge
     for item in chain:
-        if isinstance(item, APIConnectionError) and item.__cause__ is None:
-            if item.__suppress_context__ or item.__context__ is None:
-                return ModelErrorType.UNREACHED, None, edge
+        if isinstance(item, APIConnectionError):
+            return ModelErrorType.UNREACHED, None, edge
     return ModelErrorType.UNKNOWN, None, edge

--- a/backend/tests/test_gateway_chat.py
+++ b/backend/tests/test_gateway_chat.py
@@ -321,7 +321,9 @@ def test_chat_gateway_unknown_fails_without_retry():
     assert adapter.calls == ["gpt-4o-mini"]
 
 
-def test_chat_gateway_retries_openai_connection_error(monkeypatch, caplog):
+def test_chat_gateway_retries_openai_connection_error_with_unknown_cause(
+    monkeypatch, caplog
+):
     caplog.set_level(logging.INFO, logger="windup.gateway")
     req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
     calls = {"n": 0}
@@ -333,7 +335,7 @@ def test_chat_gateway_retries_openai_connection_error(monkeypatch, caplog):
         async def ainvoke(self, messages, **kwargs):
             calls["n"] += 1
             if calls["n"] == 1:
-                cause = httpx.ConnectError("Connection error", request=req)
+                cause = RuntimeError("transport failed before response")
                 raise APIConnectionError(request=req) from cause
             return "pong"
 

--- a/backend/tests/test_gateway_classify.py
+++ b/backend/tests/test_gateway_classify.py
@@ -96,12 +96,12 @@ def test_openai_connection_error_uses_connect_cause():
     assert status is None
 
 
-def test_openai_connection_error_does_not_mask_unknown_cause():
+def test_openai_connection_error_with_unknown_cause_is_unreached():
     req = httpx.Request("POST", "https://api.modelink.ai/v1/chat/completions")
     err = APIConnectionError(request=req)
     err.__cause__ = ValueError("hook failed")
     error_type, status, _ = classify_exception(err)
-    assert error_type is ModelErrorType.UNKNOWN
+    assert error_type is ModelErrorType.UNREACHED
     assert status is None
 
 


### PR DESCRIPTION
修复 Quick Start Agent 瞬时连接错误仍被直接判定失败的问题，使其进入现有受控重试策略。

## Why

生产环境两次 `Connection error.` 分别在 6 ms 和 18 ms 内被分类为 `UNKNOWN`，且 `retry_count=0`。现有分类器只接受无未知 cause 的 `APIConnectionError`，真实 SDK 异常链因此绕过了 #575 已建立的重试能力。

## Changes

- 在已优先处理 HTTP 状态和超时后，将 OpenAI SDK 的 `APIConnectionError` 统一归为 `UNREACHED`。
- 增加带未知底层 cause 的分类器回归与 Chat Gateway 重试回归。

## Implementation

- 保留 HTTP 状态、超时、普通未知异常的原有分类顺序。
- 复用既有 `UNREACHED → RETRY_SAME` 策略，不新增重试次数、备用路由或计费逻辑。

## Verification

- [x] `UV_CACHE_DIR=/private/tmp/windup-647-uv-cache uv run ruff check packages/framework/src/windup_framework/gateway/classify.py tests/test_gateway_classify.py tests/test_gateway_chat.py`：通过
- [x] `UV_CACHE_DIR=/private/tmp/windup-647-uv-cache uv run --project packages/app pytest tests/test_gateway_classify.py tests/test_gateway_chat.py -q`：40 passed
- [x] `git diff --check upstream/main...HEAD`：通过

## Scope

- 本 PR 不包含：Quick Start 业务流程、生成授权、计费、UI、部署配置调整。
- 后续事项：服务器 Compose 配置漂移另行处理，不阻塞本修复评审。

## Related Issues

Closes #647
Refs #572
