### PR TITLE
fix(active-run): preserve unfinished Quick Start progress

### DIFF
--- a/frontend/src/app/layout/active-run-monitor.test.tsx
+++ b/frontend/src/app/layout/active-run-monitor.test.tsx
@@ -49,7 +49,7 @@ afterEach(() => {
 })
 
 describe('ActiveRunMonitor', () => {
-  it('离开 Quick Start 后继续对齐终态并清除入口', async () => {
+  it('离开 Quick Start 后进入选择阶段仍保留入口', async () => {
     const harness = monitorService()
     rememberActiveRun('7', '42')
     render(<ActiveRunMonitor userId="7" pathname="/workspace" service={harness.service} />)
@@ -57,8 +57,8 @@ describe('ActiveRunMonitor', () => {
     await waitFor(() => expect(harness.service.open).toHaveBeenCalledWith('42'))
     act(() => harness.publish(run('selecting')))
 
-    await waitFor(() => expect(readActiveRun('7')).toBeNull())
-    expect(harness.dispose).toHaveBeenCalledOnce()
+    expect(readActiveRun('7')).toBe('42')
+    expect(harness.dispose).not.toHaveBeenCalled()
   })
 
   it('当前任务页面自己持有 session 时不重复恢复', async () => {
@@ -85,8 +85,11 @@ describe('ActiveRunMonitor', () => {
     expect(harness.session.resume).not.toHaveBeenCalled()
   })
 
-  it('初始快照已经结束时立即清除入口并释放 session', async () => {
-    const harness = monitorService(run('selecting'))
+  it('初始快照已经完成时立即清除入口并释放 session', async () => {
+    const harness = monitorService({
+      id: '42',
+      nodes: [{ status: 'passed', phase: 'completed', deletedAt: null }],
+    })
     rememberActiveRun('7', '42')
 
     render(<ActiveRunMonitor userId="7" pathname="/workspace" service={harness.service} />)

--- a/frontend/src/features/active-run/index.test.ts
+++ b/frontend/src/features/active-run/index.test.ts
@@ -138,10 +138,27 @@ describe('按工作流快照同步指针', () => {
     expect(readActiveRun('7')).toBe('42')
   })
 
-  it('没有节点在生成时清除这条任务', () => {
+  it('生成结束后等待用户选择时仍保留这条任务', () => {
     rememberActiveRun('7', '42')
 
     syncActiveRun('7', { id: '42', nodes: [node({ phase: 'selecting' })] })
+
+    expect(readActiveRun('7')).toBe('42')
+  })
+
+  it('等待用户审核时仍保留这条任务', () => {
+    syncActiveRun('7', { id: '42', nodes: [node({ phase: 'reviewing' })] })
+
+    expect(readActiveRun('7')).toBe('42')
+  })
+
+  it('所有节点完成后清除这条任务', () => {
+    rememberActiveRun('7', '42')
+
+    syncActiveRun('7', {
+      id: '42',
+      nodes: [node({ status: 'passed', phase: 'completed' })],
+    })
 
     expect(readActiveRun('7')).toBeNull()
   })

--- a/frontend/src/features/active-run/index.ts
+++ b/frontend/src/features/active-run/index.ts
@@ -120,15 +120,13 @@ export interface ActiveRunSnapshot {
 }
 
 /**
- * 按最新的工作流快照对齐指针。“进行中”取的是节点层面的生成态，与 Header 上
- * “有任务进行中”的说法同义；整条 Run 是否走完不在这里判断，那是用户自己的节奏。
+ * 按最新的工作流快照对齐指针。生成结束后的选择、审核仍是未完成创作，
+ * 因此以非归档的 active 节点为恢复边界，不把 generating 误当成唯一的进度。
  */
 export function syncActiveRun(userId: string, run: ActiveRunSnapshot | null): void {
   if (!run) return
-  const generating = run.nodes.some(
-    (node) => !node.deletedAt && node.status === 'active' && node.phase === 'generating',
-  )
-  if (generating) rememberActiveRun(userId, run.id)
+  const unfinished = run.nodes.some((node) => !node.deletedAt && node.status === 'active')
+  if (unfinished) rememberActiveRun(userId, run.id)
   else forgetActiveRun(userId, run.id)
 }
 

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -690,11 +690,11 @@ describe('QuickStartPage', () => {
     await waitFor(() => expect(readActiveRun('7')).toBe('run-1'))
   })
 
-  it('没有节点在生成时不留返回入口', async () => {
+  it('生成结束后等待用户选择时仍保留返回入口', async () => {
     renderStateFixture('template-selecting')
 
     await screen.findByTestId('quick-start-transcript')
-    expect(readActiveRun('7')).toBeNull()
+    expect(readActiveRun('7')).toBe('run-1')
   })
 
   it('reuses generation-copy typography and blur reveal for Agent replies without avatars', async () => {


### PR DESCRIPTION
修复 Quick Start 在用户离开后误删未完成创作恢复入口的问题，让生成结束后的选择与审核阶段仍可返回。

## Why

生产环境中 WorkflowRun 已成功持久化并从 `generating` 推进到 `active/selecting`，但前端 `syncActiveRun` 只把 `active/generating` 视为可恢复进度。离页 monitor 收到选择态快照后立即删除本地 runId，导致用户在 5–10 秒后丢失返回未完成创作的入口。

## Changes

- 将恢复边界改为“存在未归档的 `active` 节点”，覆盖生成、选择和审核阶段。
- 仅在没有未完成 active 节点时清除指针；原有 403/404 清理和旧 run 回调防护保持不变。
- 补充存储语义、离页 monitor 与 Quick Start 页面三层回归覆盖。

## Implementation

- `syncActiveRun` 仍以后端 WorkflowRun 快照为唯一真相，只调整本地恢复指针的未完成判定，不新增状态副本。

## Verification

- [x] `npm test -- src/features/active-run/index.test.ts src/app/layout/active-run-monitor.test.tsx src/pages/quick-start/index.test.tsx`：3 个测试文件、110 个用例通过。
- [x] `npm run typecheck`：通过。
- [x] `npx oxlint src/features/active-run/index.ts src/features/active-run/index.test.ts src/app/layout/active-run-monitor.test.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxfmt --check src/features/active-run/index.ts src/features/active-run/index.test.ts src/app/layout/active-run-monitor.test.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `git diff --check upstream/main...HEAD`：通过。

## Scope

- 本 PR 不包含：后端 WorkflowRun 契约、Header 视觉、Quick Start 流程或多任务恢复列表改动。
- 后续事项：无。

## Related Issues

Closes #645
