### PR TITLE
feat(quick-start): refine agent response presentation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@phosphor-icons/react": "^2.1.10",
         "@xyflow/react": "^12.11.2",
         "ai": "^7.0.68",
+        "markdown-to-jsx": "^9.10.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router": "^8.3.0"
@@ -656,9 +657,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -676,9 +674,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -696,9 +691,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -716,9 +708,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -736,9 +725,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -756,9 +742,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -776,9 +759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -796,9 +776,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,9 +980,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1023,9 +997,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1043,9 +1014,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,9 +1031,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1083,9 +1048,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,9 +1065,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1123,9 +1082,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,9 +1099,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1329,9 +1282,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1349,9 +1299,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1369,9 +1316,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1389,9 +1333,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1409,9 +1350,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1429,9 +1367,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1683,9 +1618,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1707,9 +1639,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1731,9 +1660,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1755,9 +1681,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1930,9 +1853,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1950,9 +1870,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1970,9 +1887,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1990,9 +1904,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3212,9 +3123,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3236,9 +3144,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3260,9 +3165,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3284,9 +3186,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3399,6 +3298,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "9.10.2",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-9.10.2.tgz",
+      "integrity": "sha512-iR9GadlIox0q1uXnpqdxpF02Vb1WDmZ/QIXWjBR5htzjUEEhyIWbM65LuVKavdwJaVo4q95C/F2OOyNjWe91ig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "react": ">= 16.0.0",
+        "solid-js": ">=1.0.0",
+        "vue": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/mdn-data": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@xyflow/react": "^12.11.2",
     "ai": "^7.0.68",
+    "markdown-to-jsx": "^9.10.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router": "^8.3.0"

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -17,6 +17,7 @@ import { QuickStartPage } from './index'
 
 afterEach(() => {
   cleanup()
+  Reflect.deleteProperty(document, 'startViewTransition')
   window.localStorage.clear()
   window.sessionStorage.clear()
   window.history.replaceState(null, '', '/')
@@ -506,26 +507,21 @@ describe('QuickStartPage', () => {
     expect(entry.className).not.toContain('shadow-app-page')
   })
 
-  it('uses a centered creation desk with style prompts before the composer', () => {
+  it('uses a centered creation desk without preset style cards', () => {
     const entry = renderAt('/quick-start', serviceFor(null))
     const entrySection = entry.getByLabelText('创作指令').closest('section')
     const entryLayout = entrySection?.querySelector('[data-layout="quick-start-entry"]')
     const composer = entrySection?.querySelector('[data-layout="quick-start-composer"]')
-    const starters = entrySection?.querySelector('[data-layout="quick-start-starters"]')
 
     expect(entryLayout?.className).toContain('min-h-[calc(100dvh-3.5rem)]')
     expect(entryLayout?.className).toContain('grid-rows-[1fr_auto]')
     expect(composer?.className).toContain('max-w-3xl')
     expect(composer?.querySelector('form')).toBeTruthy()
     expect(composer?.querySelector('form')?.className).toContain('sm:grid-cols-[1fr_auto_auto]')
-    expect(starters).toBeTruthy()
-    expect(
-      Boolean(
-        starters &&
-        composer &&
-        starters.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING,
-      ),
-    ).toBe(true)
+    expect(entrySection?.querySelector('[data-layout="quick-start-starters"]')).toBeNull()
+    expect(screen.queryByRole('button', { name: /16-bit 日式 RPG/u })).toBeNull()
+    expect(screen.queryByRole('button', { name: /暗黑哥特像素/u })).toBeNull()
+    expect(screen.queryByRole('button', { name: /温暖手绘像素/u })).toBeNull()
   })
 
   it('removes non-actionable explanatory copy from the creation workspace', () => {
@@ -590,37 +586,56 @@ describe('QuickStartPage', () => {
     expect(heading.textContent).toBe('用文字塑造你的角色……')
   })
 
-  it('keeps style prompt space stable while dissolving the cards once creation begins', () => {
+  it('shows the animated Agent mark above the entry title', () => {
     const entry = renderAt('/quick-start', serviceFor(null))
-    const entrySection = entry.getByLabelText('创作指令').closest('section')
-    const starters = entrySection?.querySelector('[data-layout="quick-start-starters"]')
+    const heading = screen.getByRole('heading', { name: '想做一个什么角色？' })
+    const bot = entry.container.querySelector('[data-quick-start-agent-bot]')
 
-    expect(screen.getByRole('heading', { name: '想做一个什么角色？' })).toBeTruthy()
-    expect(starters?.querySelectorAll('img')).toHaveLength(0)
-    expect(screen.getByRole('button', { name: /16-bit 日式 RPG/u })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /暗黑哥特像素/u })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /温暖手绘像素/u })).toBeTruthy()
-
-    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
-      target: { value: '戴银色面具的游侠' },
-    })
-    expect(entrySection?.querySelector('[data-layout="quick-start-starters"]')).toBe(starters)
-    expect(starters?.getAttribute('data-presence')).toBe('hidden')
-    expect(starters?.getAttribute('aria-hidden')).toBe('true')
-    expect(screen.queryByRole('button', { name: /暗黑哥特像素/u })).toBeNull()
+    expect(bot).toBeTruthy()
+    expect(
+      Boolean(bot && bot.compareDocumentPosition(heading) & Node.DOCUMENT_POSITION_FOLLOWING),
+    ).toBe(true)
   })
 
-  it('offers style prompts only, without the retired role-example shortcuts', () => {
-    renderAt('/quick-start', serviceFor(null))
-
-    // 入口只保留三张风格卡：角色样例会让人误以为这些形象是现成资产。
-    expect(screen.queryByRole('button', { name: '像素守夜人' })).toBeNull()
-    expect(screen.queryByRole('button', { name: '轻装信使' })).toBeNull()
-
-    fireEvent.click(screen.getByRole('button', { name: /16-bit 日式 RPG/u }))
-    expect((screen.getByRole('textbox', { name: '创作指令' }) as HTMLInputElement).value).toBe(
-      '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',
+  it('moves the title bot into the first Agent turn with a shared-element transition', async () => {
+    const planning = deferred<PlannerResult>()
+    const startViewTransition = vi.fn((update: () => void) => {
+      update()
+      return { ready: Promise.resolve() }
+    })
+    Object.defineProperty(document, 'startViewTransition', {
+      configurable: true,
+      value: startViewTransition,
+    })
+    const view = renderAt(
+      '/quick-start',
+      serviceFor(null),
+      agentFor({ planner: vi.fn(() => planning.promise) }),
     )
+
+    expect(
+      view.container.querySelector('[data-quick-start-agent-bot][data-placement="title"]'),
+    ).toBeTruthy()
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '住在云端的机械师' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+
+    await waitFor(() => expect(startViewTransition).toHaveBeenCalledTimes(1))
+    const thinking = await screen.findByRole('status', { name: 'Agent 正在思考' })
+    expect(
+      thinking.querySelector('[data-quick-start-agent-bot][data-placement="thinking"]'),
+    ).toBeTruthy()
+    expect(
+      thinking
+        .querySelector('[data-quick-start-agent-bot][data-placement="thinking"]')
+        ?.getAttribute('data-transition-mode'),
+    ).toBe('shared')
+    expect(
+      view.container.querySelector('[data-quick-start-agent-bot][data-placement="title"]'),
+    ).toBeNull()
+
+    planning.resolve({ text: '收到。', finishReason: 'stop', toolCalls: [] })
   })
 
   it('keeps the entry composer compact without a textarea baseline gap', () => {
@@ -697,30 +712,22 @@ describe('QuickStartPage', () => {
     expect(readActiveRun('7')).toBeNull()
   })
 
-  it('reuses generation-copy typography and blur reveal for Agent replies without avatars', async () => {
+  it('renders Agent replies with the animated bot and Markdown structure', async () => {
     renderStateFixture('action-generating')
 
     const transcript = await screen.findByTestId('quick-start-transcript')
     const agentCopies = Array.from(transcript.querySelectorAll<HTMLElement>('[data-agent-copy]'))
-    const standaloneAvatar = Array.from(transcript.querySelectorAll('span')).find(
-      (element) => element.textContent === 'W',
-    )
 
     expect(agentCopies.length).toBeGreaterThan(0)
     expect(
       agentCopies.every((copy) => {
-        const motion = copy.querySelector<HTMLElement>('[data-copy-motion-mode="characters"]')
         return (
           copy.className.includes('font-serif') &&
-          copy.className.includes('generation-progress-copy--conversation') &&
-          motion &&
-          !motion.className.includes('generation-progress-copy') &&
-          copy.querySelectorAll('.kinetic-copy-character').length > 0 &&
-          copy.querySelectorAll('[data-agent-character]').length === 0
+          copy.querySelector('[data-quick-start-agent-bot]') &&
+          copy.querySelector('[data-agent-markdown]')
         )
       }),
     ).toBe(true)
-    expect(standaloneAvatar).toBeUndefined()
   })
 
   it('keeps an unbound Agent draft in its current Quick Start history entry', async () => {
@@ -781,6 +788,27 @@ describe('QuickStartPage', () => {
 
     expect(screen.queryByText('我想做一个住在云端的机械师。')).toBeNull()
     expect(screen.queryByText('可以。你最想保留哪个外观特征？')).toBeNull()
+  })
+
+  it('renders Markdown emphasis and lists in a Planner reply', async () => {
+    const planner = vi.fn(async (_input: PlannerInput) => ({
+      text: '**建议先定住轮廓：**\n\n- 银色面具\n- 深色披风',
+      finishReason: 'stop',
+      toolCalls: [],
+    }))
+    renderAt('/quick-start', serviceFor(null), agentFor({ planner }))
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '帮我整理这个角色。' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+
+    const reply = await screen.findByLabelText('Agent 回答')
+    expect(reply.querySelector('strong')?.textContent).toBe('建议先定住轮廓：')
+    expect(Array.from(reply.querySelectorAll('li')).map((item) => item.textContent)).toEqual([
+      '银色面具',
+      '深色披风',
+    ])
   })
 
   it('moves the Agent draft into a run-scoped sidecar when generation starts', async () => {
@@ -1287,7 +1315,7 @@ describe('QuickStartPage', () => {
     const transcript = await screen.findByTestId('quick-start-transcript')
     const topLevelText = Array.from(transcript.children).map(
       (element) =>
-        element.querySelector('[data-agent-copy] [aria-label]')?.getAttribute('aria-label') ??
+        element.querySelector('[data-agent-copy]')?.getAttribute('aria-label') ??
         element.textContent ??
         '',
     )
@@ -1425,11 +1453,8 @@ describe('QuickStartPage', () => {
     )
 
     expect(screen.getByRole('textbox', { name: '创作指令' })).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: /16-bit 日式 RPG/u }))
-    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe(
-      '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',
-    )
-    expect(screen.queryByRole('button', { name: /暗黑哥特像素/u })).toBeNull()
+    expect(screen.queryByRole('button', { name: /16-bit 日式 RPG/u })).toBeNull()
+    expect(screen.getByRole('heading', { name: '想做一个什么角色？' })).toBeTruthy()
   })
 
   it('asks once, then presents a user-facing proposal without internal assumptions', async () => {
@@ -1561,7 +1586,9 @@ describe('QuickStartPage', () => {
 
     expect((screen.getByRole('radio', { name: '单向' }) as HTMLInputElement).checked).toBe(true)
     fireEvent.click(screen.getByRole('radio', { name: '四向' }))
-    fireEvent.click(screen.getByRole('button', { name: /16-bit 日式 RPG/u }))
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色' },
+    })
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
     expect(startCharacterGeneration).not.toHaveBeenCalled()
     await confirmAgentGeneration()

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -10,6 +10,7 @@ import {
   type FormEvent,
   type ReactNode,
 } from 'react'
+import { flushSync } from 'react-dom'
 import {
   ArrowBendDownLeft,
   ArrowClockwise,
@@ -20,6 +21,7 @@ import {
   Stop,
   X,
 } from '@phosphor-icons/react'
+import Markdown from 'markdown-to-jsx'
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router'
 
 import {
@@ -65,24 +67,6 @@ export type {
   QuickStartEntryService,
   QuickStartSession,
 } from './service'
-
-const STYLE_PROMPTS = [
-  {
-    title: '16-bit 日式 RPG',
-    detail: '清晰轮廓 · 明亮配色',
-    prompt: '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',
-  },
-  {
-    title: '暗黑哥特像素',
-    detail: '低饱和 · 强烈明暗',
-    prompt: '暗黑哥特像素风，低饱和配色，强烈明暗对比',
-  },
-  {
-    title: '温暖手绘像素',
-    detail: '柔和色彩 · 纸张质感',
-    prompt: '温暖手绘像素风，柔和配色，细腻纸张质感',
-  },
-] as const
 
 const QUICK_START_DIRECTIONAL_MOVEMENTS: readonly DirectionalMovement[] = [
   'single',
@@ -541,6 +525,7 @@ function QuickStartInput({
   const [directionalMovement, setDirectionalMovement] = useState<DirectionalMovement>('single')
   const [templateFile, setTemplateFile] = useState<File | null>(null)
   const [submitting, setSubmitting] = useState(false)
+  const [revealingFirstAgentTurn, setRevealingFirstAgentTurn] = useState(false)
   const [entryTransition, setEntryTransition] = useState<'idle' | 'leaving'>('idle')
   const [promptState, setPromptState] = useState<
     'collecting' | 'rewriting' | 'ready' | 'confirmed'
@@ -574,13 +559,12 @@ function QuickStartInput({
   })
   const unavailableReason = service.unavailableReason
   const agentPlanning = agentSession.state.status === 'planning'
+  const agentThinking = agentPlanning || revealingFirstAgentTurn
   const generationStarting = promptState === 'confirmed'
-  const entryBusy = submitting || agentPlanning || promptState === 'rewriting' || generationStarting
+  const entryBusy = submitting || agentThinking || promptState === 'rewriting' || generationStarting
   const hasPrompt = Boolean(prompt.trim())
   const hasConversation = conversationTurns.length > 0
-  const showStylePrompts =
-    !hasPrompt && !templateFile && !hasConversation && agentSession.state.status === 'idle'
-  const showConversation = hasConversation || agentPlanning || agentSession.state.status === 'error'
+  const showConversation = hasConversation || agentThinking || agentSession.state.status === 'error'
   const promptMessage = useMemo<readonly KineticCopyMessage[]>(
     () => [{ lines: [prompt] }],
     [prompt],
@@ -637,6 +621,36 @@ function QuickStartInput({
     },
     [persistDraftConversation],
   )
+
+  async function revealFirstAgentTurn(turn: AgentConversationTurn) {
+    const transitionDocument = document as Document & {
+      startViewTransition?: (update: () => void) => { ready: Promise<void> }
+    }
+    const reducedMotion =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const titleBot = document.querySelector('[data-quick-start-agent-bot][data-placement="title"]')
+    const update = () => {
+      appendConversationTurn(turn)
+      setRevealingFirstAgentTurn(true)
+    }
+
+    if (!titleBot || reducedMotion || !transitionDocument.startViewTransition) {
+      update()
+      return
+    }
+
+    let updated = false
+    try {
+      const transition = transitionDocument.startViewTransition(() => {
+        updated = true
+        flushSync(update)
+      })
+      await transition.ready
+    } catch {
+      if (!updated) update()
+    }
+  }
 
   useEffect(
     () => () => {
@@ -746,10 +760,13 @@ function QuickStartInput({
       if (agentSession.state.status === 'proposal') {
         updateProposalStatus(agentSession.state.proposalId, 'superseded')
       }
-      appendConversationTurn({ role: 'user', content: normalizedPrompt })
+      const userTurn: AgentConversationTurn = { role: 'user', content: normalizedPrompt }
+      if (hasConversation) appendConversationTurn(userTurn)
+      else await revealFirstAgentTurn(userTurn)
       setPrompt('')
       try {
         const result = await agentSession.submit(normalizedPrompt)
+        setRevealingFirstAgentTurn(false)
         if (result.kind === 'message') {
           appendConversationTurn({
             role: 'assistant',
@@ -770,6 +787,7 @@ function QuickStartInput({
           })
         }
       } catch (cause) {
+        setRevealingFirstAgentTurn(false)
         if (!(cause instanceof Error && cause.name === 'AbortError')) {
           setEntryTransition('idle')
           setPromptState('collecting')
@@ -892,14 +910,15 @@ function QuickStartInput({
                   )}
                 </div>
               ))}
-              {agentPlanning ? (
+              {agentThinking ? (
                 <div
                   data-conversation-kind="agent"
                   data-agent-loading
                   role="status"
                   aria-label="Agent 正在思考"
-                  className="quick-start-agent-loading min-w-0"
+                  className="quick-start-agent-loading grid min-w-0 grid-cols-[2rem_auto] gap-3"
                 >
+                  <QuickStartAgentBot placement="thinking" />
                   <span aria-hidden="true" className="quick-start-agent-loading-dots">
                     {[0, 1, 2].map((dot) => (
                       <span
@@ -919,42 +938,18 @@ function QuickStartInput({
             </div>
           ) : (
             <>
-              <KineticCopyCycle
-                active={!templateFile && !entryBusy}
-                as="h1"
-                ariaLabel="想做一个什么角色？"
-                motionMode="characters"
-                firstCycleMs={2_400}
-                loopStartIndex={1}
-                messages={hasPrompt ? ROLE_DEFAULT_MESSAGE : ROLE_IDEA_MESSAGES}
-                className="min-h-12 text-center font-serif text-[clamp(1.75rem,4vw,2.65rem)] leading-none font-medium tracking-[-0.045em]"
-              />
-
-              <div
-                data-layout="quick-start-starters"
-                data-presence={showStylePrompts ? 'visible' : 'hidden'}
-                aria-hidden={!showStylePrompts}
-                className={`grid gap-2 transition-[opacity,transform,filter] duration-[460ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none sm:grid-cols-3 ${
-                  showStylePrompts
-                    ? 'translate-y-0 scale-100 opacity-100 blur-0'
-                    : 'pointer-events-none -translate-y-2 scale-[0.985] opacity-0 blur-[6px]'
-                }`}
-              >
-                {STYLE_PROMPTS.map((stylePrompt) => (
-                  <button
-                    key={stylePrompt.title}
-                    type="button"
-                    disabled={!showStylePrompts}
-                    aria-label={`${stylePrompt.title}：${stylePrompt.detail}`}
-                    onClick={() => setPrompt(stylePrompt.prompt)}
-                    className="group grid min-h-16 content-center gap-1 rounded-xl border border-app-line bg-app-surface/70 px-4 py-3 text-left transition duration-200 hover:-translate-y-0.5 hover:border-app-line-strong hover:bg-app-surface-raised hover:shadow-app-card focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent motion-reduce:transform-none"
-                  >
-                    <strong className="text-sm font-semibold text-app-ink">
-                      {stylePrompt.title}
-                    </strong>
-                    <span className="text-[11px] text-app-muted">{stylePrompt.detail}</span>
-                  </button>
-                ))}
+              <div className="grid justify-items-center gap-5">
+                <QuickStartAgentBot placement="title" />
+                <KineticCopyCycle
+                  active={!templateFile && !entryBusy}
+                  as="h1"
+                  ariaLabel="想做一个什么角色？"
+                  motionMode="characters"
+                  firstCycleMs={2_400}
+                  loopStartIndex={1}
+                  messages={hasPrompt ? ROLE_DEFAULT_MESSAGE : ROLE_IDEA_MESSAGES}
+                  className="min-h-12 text-center font-serif text-[clamp(1.75rem,4vw,2.65rem)] leading-none font-medium tracking-[-0.045em]"
+                />
               </div>
             </>
           )}
@@ -1172,29 +1167,59 @@ function AgentCopy({
   animate?: boolean
 }) {
   const copy = lines.join('\n')
-  const messages = useMemo<readonly KineticCopyMessage[]>(
-    () => [{ lines: copy.split('\n') }],
-    [copy],
-  )
 
   return (
     <div
       data-agent-copy
       aria-label={lines.join(' ')}
-      className={`quick-start-agent-copy generation-progress-copy generation-progress-copy--conversation font-serif ${
+      className={`quick-start-agent-copy grid grid-cols-[2rem_minmax(0,1fr)] items-start gap-3 font-serif ${
         tone === 'danger' ? 'text-app-danger' : 'text-app-ink-soft'
-      }`}
+      } ${animate ? 'quick-start-agent-copy--entering' : ''}`}
     >
-      <span aria-hidden="true" className="sr-only">
-        {lines.join(' ')}
-      </span>
-      <KineticCopyCycle
-        active={animate}
-        messages={messages}
-        motionMode="characters"
-        className="quick-start-agent-copy font-serif"
-      />
+      <QuickStartAgentBot placement="answer" />
+      <div
+        aria-label="Agent 回答"
+        data-agent-markdown
+        className="quick-start-agent-markdown min-w-0"
+      >
+        <Markdown>{copy}</Markdown>
+      </div>
     </div>
+  )
+}
+
+function QuickStartAgentBot({ placement }: { placement: 'title' | 'thinking' | 'answer' }) {
+  const transitionMode =
+    typeof document !== 'undefined' && 'startViewTransition' in document ? 'shared' : 'fallback'
+  return (
+    <span
+      aria-hidden="true"
+      data-quick-start-agent-bot
+      data-placement={placement}
+      data-transition-mode={transitionMode}
+      className="quick-start-agent-bot"
+    >
+      <svg fill="none" viewBox="0 0 24 24">
+        <g className="quick-start-agent-bot__face">
+          <rect
+            className="quick-start-agent-bot__frame"
+            height="14"
+            stroke="currentColor"
+            strokeWidth="2"
+            vectorEffect="non-scaling-stroke"
+            width="16"
+            x="4"
+            y="5"
+          />
+          <g className="quick-start-agent-bot__gaze">
+            <g className="quick-start-agent-bot__blink" fill="currentColor">
+              <rect className="quick-start-agent-bot__eye" height="3" width="3" x="8" y="10" />
+              <rect className="quick-start-agent-bot__eye" height="3" width="3" x="13" y="10" />
+            </g>
+          </g>
+        </g>
+      </svg>
+    </span>
   )
 }
 

--- a/frontend/src/pages/quick-start/quick-start-motion.css
+++ b/frontend/src/pages/quick-start/quick-start-motion.css
@@ -2,6 +2,215 @@
   width: 100%;
 }
 
+.quick-start-agent-bot {
+  width: 2rem;
+  aspect-ratio: 1;
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: color-mix(in srgb, var(--color-app-ink) 76%, transparent);
+  animation: quick-start-agent-bot-presence 5.6s ease-in-out infinite;
+}
+
+.quick-start-agent-bot[data-placement='title'] {
+  width: clamp(3rem, 4.6vw, 3.5rem);
+}
+
+.quick-start-agent-bot[data-placement='title'],
+.quick-start-agent-bot[data-placement='thinking'] {
+  view-transition-name: quick-start-agent-bot;
+}
+
+.quick-start-agent-bot[data-placement='thinking'][data-transition-mode='fallback'] {
+  animation: quick-start-agent-bot-flight-fallback 760ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+::view-transition-group(quick-start-agent-bot) {
+  z-index: 50;
+  animation-duration: 760ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+::view-transition-image-pair(quick-start-agent-bot),
+::view-transition-old(quick-start-agent-bot),
+::view-transition-new(quick-start-agent-bot) {
+  animation-duration: 760ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  mix-blend-mode: normal;
+}
+
+.quick-start-agent-bot svg {
+  width: 100%;
+  height: 100%;
+}
+
+.quick-start-agent-bot__face,
+.quick-start-agent-bot__gaze,
+.quick-start-agent-bot__frame,
+.quick-start-agent-bot__blink {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.quick-start-agent-bot__face {
+  animation: quick-start-agent-bot-face 8s cubic-bezier(0.5, 0, 0.15, 1) infinite;
+}
+
+.quick-start-agent-bot__gaze {
+  animation: quick-start-agent-bot-gaze 8s cubic-bezier(0.5, 0, 0.15, 1) infinite;
+}
+
+.quick-start-agent-bot__frame {
+  animation: quick-start-agent-bot-frame 8s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+}
+
+.quick-start-agent-bot__blink {
+  animation: quick-start-agent-bot-blink 4.3s cubic-bezier(0.4, 0, 0.55, 1) infinite;
+}
+
+.quick-start-agent-copy--entering {
+  animation: quick-start-agent-answer-enter 680ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.quick-start-agent-markdown {
+  font-size: 1.0625rem;
+  font-weight: 500;
+  line-height: 1.75;
+  letter-spacing: -0.02em;
+  text-wrap: pretty;
+}
+
+.quick-start-agent-markdown > :first-child {
+  margin-top: 0;
+}
+
+.quick-start-agent-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.quick-start-agent-markdown p,
+.quick-start-agent-markdown ul,
+.quick-start-agent-markdown ol {
+  margin: 0.75em 0;
+}
+
+.quick-start-agent-markdown ul,
+.quick-start-agent-markdown ol {
+  padding-left: 1.35em;
+}
+
+.quick-start-agent-markdown ul {
+  list-style: disc;
+}
+
+.quick-start-agent-markdown ol {
+  list-style: decimal;
+}
+
+.quick-start-agent-markdown li {
+  margin: 0.3em 0;
+  padding-left: 0.12em;
+}
+
+@keyframes quick-start-agent-bot-presence {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+  30% {
+    transform: translate3d(0, -1.5px, 0) rotate(-0.5deg);
+  }
+  65% {
+    transform: translate3d(0, 0.5px, 0) rotate(0.4deg);
+  }
+}
+
+@keyframes quick-start-agent-bot-flight-fallback {
+  from {
+    opacity: 0.35;
+    filter: blur(2px);
+    transform: translate3d(min(22rem, 42vw), -18vh, 0) scale(1.72);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes quick-start-agent-bot-face {
+  0%,
+  44%,
+  100% {
+    transform: rotate(0deg);
+  }
+  52%,
+  64% {
+    transform: rotate(-3deg);
+  }
+  72%,
+  84% {
+    transform: rotate(3deg);
+  }
+}
+
+@keyframes quick-start-agent-bot-gaze {
+  0%,
+  18%,
+  100% {
+    transform: translate(0, 0);
+  }
+  24%,
+  42% {
+    transform: translate(-1.7px, 0);
+  }
+  48%,
+  66% {
+    transform: translate(1.7px, -0.35px);
+  }
+  72%,
+  88% {
+    transform: translate(0, -1.2px);
+  }
+}
+
+@keyframes quick-start-agent-bot-frame {
+  0%,
+  88%,
+  100% {
+    transform: scale(1);
+  }
+  92% {
+    transform: scale(1.04, 0.97);
+  }
+  96% {
+    transform: scale(0.99, 1.02);
+  }
+}
+
+@keyframes quick-start-agent-bot-blink {
+  0%,
+  92%,
+  100% {
+    transform: scaleY(1);
+  }
+  95% {
+    transform: scaleY(0.12);
+  }
+}
+
+@keyframes quick-start-agent-answer-enter {
+  from {
+    opacity: 0;
+    filter: blur(7px);
+    transform: translate3d(-12px, 10px, 0) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
 .quick-start-agent-loading {
   min-height: 1.75rem;
   display: flex;
@@ -140,6 +349,22 @@
     filter: none;
     transform: none;
     animation: none;
+  }
+
+  .quick-start-agent-bot,
+  .quick-start-agent-bot__face,
+  .quick-start-agent-bot__gaze,
+  .quick-start-agent-bot__frame,
+  .quick-start-agent-bot__blink,
+  .quick-start-agent-copy--entering {
+    animation: none;
+    filter: none;
+    transform: none;
+  }
+
+  .quick-start-agent-bot[data-placement='title'],
+  .quick-start-agent-bot[data-placement='thinking'] {
+    view-transition-name: none;
   }
 
   .quick-start-generated-frame {


### PR DESCRIPTION
本 PR 优化 Quick Start 的 Agent 展示：删除入口预设卡片，补齐机器人从标题上方迁移到回答左侧的动画，并为回答内容加入轻量 Markdown 渲染；业务流程、视觉效果与数据契约保持不变。

## Why

原 Quick Start 的三张预设卡片与当前入口交互重复，Agent 回答缺少明确的角色位置变化和结构化文本呈现，影响信息层级与阅读体验。

## Changes

- 删除 Quick Start 入口的三张预设风格卡片。
- 初始状态在标题上方显示方形机器人；回答出现时，机器人迁移至内容左侧。
- 支持回答中的段落、加粗与列表结构。
- 尊重系统的减少动态效果设置。

## Implementation

- 支持 View Transitions 的浏览器使用 `document.startViewTransition` 与 `flushSync` 完成共享元素迁移。
- 不支持 View Transitions 的环境使用 760ms CSS 飞行动画兜底。
- 使用零传递依赖的 `markdown-to-jsx` 渲染回答，避免引入完整 Markdown 工具链。
- 未改动 Quick Start 的 API、工作流步骤、生成授权、Planner、知识库、Prompt、Schema 或持久化数据契约。

## Verification

- [x] `npm test -- --run src/pages/quick-start/index.test.tsx`：88 项测试通过。
- [x] `npm run typecheck`：通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run build`：通过，仅保留仓库原有的大 chunk 提示。
- [x] `git diff --check 757a2af...HEAD`：通过。
- [x] 本地真实浏览器验证：回答排版、机器人尺寸与位置、卡片删除均保持预期。

## Scope

- 本 PR 不包含后端逻辑、业务流程、知识库调用逻辑或数据契约变更。
- 本 PR 不包含生产部署或合并操作。

## Related Issues

Closes #658