### PR TITLE
fix(generation): SSE 进度流改用短 session 归还连接

### DIFF
--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -78,6 +78,31 @@ def _poll_terminal_snapshot(task_id: int, project_id: int) -> tuple[str, dict] |
         session.close()
 
 
+def _load_stream_start(
+    *,
+    user_id: int,
+    project_id: int,
+    task_id: int,
+) -> tuple[str | None, dict | None]:
+    """鉴权并读终态快照。短 session,返回后连接立刻归还。
+
+    不能 ``Depends(get_session)``:FastAPI 会把 session 握到 StreamingResponse
+    结束。压测里十几路进度流就能把 QueuePool(5+10) 打满,普通 ``GET /tasks/{id}``
+    跟着 30s timeout,前端直接报错。
+    """
+    session = SessionLocal()
+    try:
+        _get_project_or_raise(session, project_id, user_id)
+        task = task_repo.get_task(session, task_id)
+        if task is None or task.project_id != project_id:
+            raise BizException("任务不存在", code=BizCode.NOT_FOUND)
+        event = task_repo.terminal_event_for(task)
+        payload = task_repo.task_event_payload(task) if event is not None else None
+        return event, payload
+    finally:
+        session.close()
+
+
 class _EventBus:
     """任务进度内存发布-订阅。
 
@@ -573,7 +598,6 @@ async def stream_task(
     task_id: int,
     request: Request,
     project_id: int = Query(..., gt=0),
-    session: Session = Depends(get_session),
 ) -> StreamingResponse:
     """SSE:实时推送任务进度与最终结果。
 
@@ -591,16 +615,17 @@ async def stream_task(
     即最终帧的对象存储 URL。两道都必须在 ``subscribe`` **之前**:放之后的话越权请求仍会
     在 EventBus 上挂一个订阅者(照样收事件、只是响应体被丢弃),订阅表还会因为没人
     unsubscribe 而增长。
+
+    鉴权/读库走短 session(见 :func:`_load_stream_start`),推流期间不占连接池。
     """
     user_id = request.state.current_user.id
-    _get_project_or_raise(session, project_id, user_id)
-    task = task_repo.get_task(session, task_id)
-    if task is None or task.project_id != project_id:
-        raise BizException("任务不存在", code=BizCode.NOT_FOUND)
-
     # 终态快照要在订阅前读,订阅要紧跟其后 —— 两者之间若任务刚好终结,事件会丢。
     # 反过来(先订阅后读)则会重复发一次终态,客户端拿到两条 completed。
-    terminal_event = task_repo.terminal_event_for(task)
+    terminal_event, terminal_payload = _load_stream_start(
+        user_id=user_id,
+        project_id=project_id,
+        task_id=task_id,
+    )
 
     queue = await event_bus.subscribe(project_id, task_id)
     logger.debug("SSE 订阅: task_id=%d project_id=%d", task_id, project_id)
@@ -608,9 +633,7 @@ async def stream_task(
     async def _event_generator():
         try:
             if terminal_event is not None:
-                payload = json.dumps(
-                    task_repo.task_event_payload(task), ensure_ascii=False
-                )
+                payload = json.dumps(terminal_payload, ensure_ascii=False)
                 yield f"event: {terminal_event}\ndata: {payload}\n\n"
                 return
             while True:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -169,12 +169,17 @@ def client(engine):
     app = create_app()
     _disable_generation_execution(app)
     from windup_app.server.orchestrator import task_repo
-    from windup_app.web.api.generation import event_bus
+    from windup_app.web.api import generation as generation_api
 
-    task_repo.bind_event_bus(event_bus)
+    previous_session_local = generation_api.SessionLocal
+    generation_api.SessionLocal = session_local
+    task_repo.bind_event_bus(generation_api.event_bus)
     app.dependency_overrides[get_session] = override_get_session
-    yield TestClient(app)
-    app.dependency_overrides.clear()
+    try:
+        yield TestClient(app)
+    finally:
+        generation_api.SessionLocal = previous_session_local
+        app.dependency_overrides.clear()
 
 
 @pytest.fixture()
@@ -199,17 +204,22 @@ def auth_client(engine):
     app = create_app()
     _disable_generation_execution(app)
     from windup_app.server.orchestrator import task_repo
-    from windup_app.web.api.generation import event_bus
+    from windup_app.web.api import generation as generation_api
 
-    task_repo.bind_event_bus(event_bus)
+    previous_session_local = generation_api.SessionLocal
+    generation_api.SessionLocal = session_local
+    task_repo.bind_event_bus(generation_api.event_bus)
     app.dependency_overrides[get_session] = override_get_session
 
     # 生成测试用 token
     token = create_access_token(1, "test@example.com")
     client = TestClient(app, headers={"Authorization": f"Bearer {token}"})
 
-    yield client
-    app.dependency_overrides.clear()
+    try:
+        yield client
+    finally:
+        generation_api.SessionLocal = previous_session_local
+        app.dependency_overrides.clear()
 
 
 @pytest.fixture()
@@ -231,16 +241,21 @@ def auth_client_b(engine):
     app = create_app()
     _disable_generation_execution(app)
     from windup_app.server.orchestrator import task_repo
-    from windup_app.web.api.generation import event_bus
+    from windup_app.web.api import generation as generation_api
 
-    task_repo.bind_event_bus(event_bus)
+    previous_session_local = generation_api.SessionLocal
+    generation_api.SessionLocal = session_local
+    task_repo.bind_event_bus(generation_api.event_bus)
     app.dependency_overrides[get_session] = override_get_session
 
     token = create_access_token(2, "other@example.com")
     client = TestClient(app, headers={"Authorization": f"Bearer {token}"})
 
-    yield client
-    app.dependency_overrides.clear()
+    try:
+        yield client
+    finally:
+        generation_api.SessionLocal = previous_session_local
+        app.dependency_overrides.clear()
 
 
 # ── 三渲二 provider 的 fixture(随 provider3d 一起迁入)──────────────────

--- a/backend/tests/test_generation_stream_auth.py
+++ b/backend/tests/test_generation_stream_auth.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from sqlalchemy.orm import sessionmaker
 
 from windup_app.server.orchestrator import task_repo
 from windup_app.server.orchestrator.model import GenerationType, TaskStatus
@@ -238,6 +239,50 @@ def test_terminal_snapshot_returns_payload_for_completed_task(session):
 def test_terminal_snapshot_ignores_non_terminal(session):
     task_id = _make_task(session, user_id=1, project_id=42, status=TaskStatus.RUNNING)
     assert task_repo.terminal_snapshot(session, task_id, project_id=42) is None
+
+
+def test_stream_start_closes_session_before_returning(engine, session):
+    """SSE 预检必须归还连接,否则压测十几路进度流打满 QueuePool,前端报错。"""
+    from conftest import insert_project
+    from windup_app.web.api import generation as gen
+
+    project = insert_project(session, user_id=1)
+    session.commit()
+    task_id = _make_task(
+        session,
+        user_id=1,
+        project_id=project.id,
+        status=TaskStatus.COMPLETED,
+    )
+
+    closed: list[bool] = []
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def SessionLocal():
+        inner = factory()
+        orig = inner.close
+
+        def close():
+            closed.append(True)
+            orig()
+
+        inner.close = close
+        return inner
+
+    previous = gen.SessionLocal
+    gen.SessionLocal = SessionLocal
+    try:
+        event, payload = gen._load_stream_start(
+            user_id=1,
+            project_id=project.id,
+            task_id=task_id,
+        )
+    finally:
+        gen.SessionLocal = previous
+
+    assert event == "completed"
+    assert payload is not None and payload["id"] == task_id
+    assert closed == [True]
 
 
 # ── ③ project_id 为空的任务发不出事件，要记 warning 而不是静默丢 ──────────────

--- a/openapi.json
+++ b/openapi.json
@@ -4342,7 +4342,7 @@
     },
     "/generation/tasks/{task_id}/stream": {
       "get": {
-        "description": "SSE:实时推送任务进度与最终结果。\n\n事件类型:\n  - ``progress``: 生成进度 (stage/current/total/note)\n  - ``completed``: 任务完成,携带最终结果\n  - ``partial``: 方向集部分失败,携带已成功方向与失败方向\n  - ``failed``: 任务失败,携带错误信息\n\n若客户端订阅时任务已处于终态,立即推送终态事件并关闭连接。\n\n归属是**两道**(2026-08-11 补齐,此前是一行 TODO):项目要属于当前用户\n(``_get_project_or_raise``),任务还要属于那个项目。只查项目不够 —— 任意已认证用户\n拿自己的 project_id 配上别人的 task_id 就能订阅到别人的流,而事件体里带 result,\n即最终帧的对象存储 URL。两道都必须在 ``subscribe`` **之前**:放之后的话越权请求仍会\n在 EventBus 上挂一个订阅者(照样收事件、只是响应体被丢弃),订阅表还会因为没人\nunsubscribe 而增长。",
+        "description": "SSE:实时推送任务进度与最终结果。\n\n事件类型:\n  - ``progress``: 生成进度 (stage/current/total/note)\n  - ``completed``: 任务完成,携带最终结果\n  - ``partial``: 方向集部分失败,携带已成功方向与失败方向\n  - ``failed``: 任务失败,携带错误信息\n\n若客户端订阅时任务已处于终态,立即推送终态事件并关闭连接。\n\n归属是**两道**(2026-08-11 补齐,此前是一行 TODO):项目要属于当前用户\n(``_get_project_or_raise``),任务还要属于那个项目。只查项目不够 —— 任意已认证用户\n拿自己的 project_id 配上别人的 task_id 就能订阅到别人的流,而事件体里带 result,\n即最终帧的对象存储 URL。两道都必须在 ``subscribe`` **之前**:放之后的话越权请求仍会\n在 EventBus 上挂一个订阅者(照样收事件、只是响应体被丢弃),订阅表还会因为没人\nunsubscribe 而增长。\n\n鉴权/读库走短 session(见 :func:`_load_stream_start`),推流期间不占连接池。",
         "operationId": "stream_task_generation_tasks__task_id__stream_get",
         "parameters": [
           {


### PR DESCRIPTION
## Summary
- 压测时 `GET /generation/tasks/{id}/stream` 用 `Depends(get_session)` 把 Postgres 连接握到 SSE 结束，15 条 QueuePool 打满后任务查询 30s timeout，前端报错。
- SSE 鉴权/读终态改为短 session，推流期间不再占连接；心跳查库路径不变。
- 测试夹具把 `SessionLocal` 指到内存库，并断言预检返回后 session 已 close。

Fixes #666

## Test plan
- [x] `pytest tests/test_generation_stream_auth.py tests/test_generation_api.py::test_task_stream_checks_project_ownership`
- [x] 压测多路 `/generation/tasks/{id}/stream` 时，`GET /generation/tasks/{id}` 不再 QueuePool timeout
- [x] 终态任务订阅仍立即推 `completed`/`failed`；跨项目订阅仍拒绝