### PR TITLE
fix(frontend): show Windup favicon in browser tabs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,7 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/windup-mark.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"


### PR DESCRIPTION
为 Windup 页面声明现有品牌标志为 SVG favicon，使浏览器标签页不再显示默认地球图标。

## Why

页面已有 `/windup-mark.svg`，但文档头部没有 favicon 声明，浏览器无法把品牌标志用于标签页。

## Changes

- 将 `/windup-mark.svg` 声明为 `image/svg+xml` favicon。

## Verification

- [x] `npm run build`：通过。
- [x] 构建产物 `dist/index.html` 包含 favicon 声明，`dist/windup-mark.svg` 与源文件哈希一致。
- [x] 本地真实浏览器识别 `/windup-mark.svg` 和 `image/svg+xml`。

## Related Issues

Closes #668
