### PR TITLE
feat(quick-start): refine composer interactions

### DIFF
--- a/frontend/src/features/quick-start-agent/react.test.tsx
+++ b/frontend/src/features/quick-start-agent/react.test.tsx
@@ -191,6 +191,47 @@ describe('useQuickStartAgent', () => {
     await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
     expect(startCharacterGeneration).not.toHaveBeenCalled()
   })
+
+  it('stops pending planning from the composer and returns to idle', async () => {
+    let finishFirstPlanning!: (result: PlannerResult) => void
+    const planner = vi
+      .fn()
+      .mockImplementationOnce(
+        async (_input: PlannerInput) =>
+          new Promise<PlannerResult>((resolve) => {
+            finishFirstPlanning = resolve
+          }),
+      )
+      .mockResolvedValueOnce({ text: '可以继续。', finishReason: 'stop', toolCalls: [] })
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-agent' }))
+    const { result } = renderHook(() => useQuickStartAgent({ planner, startCharacterGeneration }))
+
+    let pending!: Promise<unknown>
+    act(() => {
+      pending = result.current.submit('银发骑士')
+    })
+    expect(result.current.state).toEqual({ status: 'planning' })
+
+    act(() => result.current.cancel())
+    await waitFor(() => expect(result.current.state).toEqual({ status: 'idle' }))
+    let retryResult!: Awaited<ReturnType<typeof result.current.submit>>
+    await act(async () => {
+      retryResult = await result.current.submit('银发骑士')
+    })
+    expect(retryResult).toMatchObject({
+      kind: 'message',
+      message: '可以继续。',
+    })
+    act(() => finishFirstPlanning({ text: '过期回复。', finishReason: 'stop', toolCalls: [] }))
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+    expect(result.current.state).toMatchObject({
+      status: 'awaiting-input',
+      message: '可以继续。',
+    })
+    expect(planner).toHaveBeenCalledTimes(2)
+    expect(startCharacterGeneration).not.toHaveBeenCalled()
+  })
 })
 
 describe('useQuickStartWorkflowAgent', () => {

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -40,6 +40,12 @@ function logAgentFailure(cause: unknown): void {
   })
 }
 
+function isAbortError(cause: unknown): boolean {
+  return (
+    typeof cause === 'object' && cause !== null && 'name' in cause && cause.name === 'AbortError'
+  )
+}
+
 function errorMessage(cause: unknown): string {
   if (!(cause instanceof Error) || !cause.message) return 'Agent 暂时不可用，请稍后重试'
   if (
@@ -114,7 +120,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
         const runTurn = started.current ? activeAgent.continue : activeAgent.start
         started.current = true
         const result = await runTurn(input, { signal: controller.signal })
-        if (mounted.current) {
+        if (mounted.current && abortController.current === controller) {
           if (result.kind === 'message') {
             setState({
               status: 'awaiting-input',
@@ -128,17 +134,25 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
         }
         return result
       } catch (cause) {
-        if (mounted.current && !(cause instanceof Error && cause.name === 'AbortError')) {
+        const isCurrent = abortController.current === controller
+        if (isAbortError(cause) && isCurrent) {
+          agent.current?.revoke()
+          agent.current = null
+          started.current = Boolean(initialMessages?.length)
+          if (mounted.current) setState({ status: 'idle' })
+        } else if (!isAbortError(cause) && isCurrent && mounted.current) {
           logAgentFailure(cause)
           setState({ status: 'error', message: errorMessage(cause) })
         }
         throw cause
       } finally {
-        running.current = false
-        if (abortController.current === controller) abortController.current = null
+        if (abortController.current === controller) {
+          running.current = false
+          abortController.current = null
+        }
       }
     },
-    [ensureAgent],
+    [ensureAgent, initialMessages],
   )
 
   const confirmProposal = useCallback(
@@ -174,11 +188,23 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
     [ensureAgent, state],
   )
 
+  const cancel = useCallback(() => {
+    if (!running.current) return
+    abortController.current?.abort()
+    agent.current?.revoke()
+    agent.current = null
+    started.current = Boolean(initialMessages?.length)
+    abortController.current = null
+    running.current = false
+    if (mounted.current) setState({ status: 'idle' })
+  }, [initialMessages])
+
   return {
     state,
     busy: state.status === 'planning' || state.status === 'dispatching',
     submit,
     confirmProposal,
+    cancel,
   }
 }
 

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1,5 +1,13 @@
 import { StrictMode } from 'react'
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  act,
+  cleanup,
+  createEvent,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import { BrowserRouter, MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -515,11 +523,12 @@ describe('QuickStartPage', () => {
     const entryLayout = entrySection?.querySelector('[data-layout="quick-start-entry"]')
     const composer = entrySection?.querySelector('[data-layout="quick-start-composer"]')
 
-    expect(entryLayout?.className).toContain('min-h-[calc(100dvh-3.5rem)]')
+    expect(entryLayout?.className).toContain('h-[calc(100dvh-3.5rem)]')
     expect(entryLayout?.className).toContain('grid-rows-[1fr_auto]')
+    expect(entryLayout?.className).toContain('sm:pb-4')
     expect(composer?.className).toContain('max-w-3xl')
     expect(composer?.querySelector('form')).toBeTruthy()
-    expect(composer?.querySelector('form')?.className).toContain('sm:grid-cols-[1fr_auto_auto]')
+    expect(composer?.querySelector('form')?.className).toContain('relative')
     expect(entrySection?.querySelector('[data-layout="quick-start-starters"]')).toBeNull()
     expect(screen.queryByRole('button', { name: /16-bit 日式 RPG/u })).toBeNull()
     expect(screen.queryByRole('button', { name: /暗黑哥特像素/u })).toBeNull()
@@ -649,20 +658,174 @@ describe('QuickStartPage', () => {
     renderAt('/quick-start', serviceFor(null))
     const composer = screen.getByRole('textbox', { name: '创作指令' })
     const editingSurface = composer.closest('label')
+    const form = composer.closest('form')
+    const controls = form?.querySelector('[data-layout="quick-start-composer-controls"]')
 
     expect(composer.tagName).toBe('TEXTAREA')
     expect((composer as HTMLTextAreaElement).rows).toBe(1)
-    expect(composer.className).toContain('min-h-10')
+    expect(composer.className).toContain('min-h-[52px]')
     expect(composer.className).toContain('[field-sizing:content]')
     expect(composer.className).toContain('block')
-    expect(composer.className).toContain('px-4')
-    expect(editingSurface?.className).toContain('ml-2')
-    expect(editingSurface?.className).toContain('rounded-lg')
-    expect(editingSurface?.className).not.toContain('bg-app-surface')
-    expect(screen.getByRole('button', { name: '生成角色' }).className).toContain('self-end')
-    expect(composer.closest('form')?.className).toContain(
+    expect(composer.className).toContain('pl-4')
+    expect(composer.className).toContain('pr-14')
+    expect(editingSurface?.className).toContain('rounded-[18px]')
+    expect(editingSurface?.className).toContain('bg-app-surface-raised')
+    expect(screen.getByRole('button', { name: '生成角色' }).className).toContain('rounded-full')
+    expect(form?.className).toContain('flex-col')
+    expect(controls?.className).toContain('order-first')
+    expect(controls?.className).toContain('mb-2')
+    expect(screen.getByRole('button', { name: '生成角色' }).className).toContain('bottom-[6px]')
+    expect(editingSurface?.className).toContain(
       'focus-within:shadow-[var(--shadow-app-composer-focus)]',
     )
+  })
+
+  it('submits the entry with Enter', async () => {
+    const planner = vi.fn(async () => ({
+      text: '收到。',
+      finishReason: 'stop' as const,
+      toolCalls: [],
+    }))
+    renderAt('/quick-start', serviceFor(null), agentFor({ planner }))
+    const composer = screen.getByRole('textbox', { name: '创作指令' })
+
+    fireEvent.change(composer, { target: { value: '银发骑士' } })
+    const enter = createEvent.keyDown(composer, { key: 'Enter', code: 'Enter' })
+    fireEvent(composer, enter)
+
+    expect(enter.defaultPrevented).toBe(true)
+    await waitFor(() => expect(planner).toHaveBeenCalledTimes(1))
+  })
+
+  it('leaves Command+Enter available for a textarea newline', () => {
+    const planner = vi.fn()
+    renderAt('/quick-start', serviceFor(null), agentFor({ planner }))
+    const composer = screen.getByRole('textbox', { name: '创作指令' })
+
+    fireEvent.change(composer, { target: { value: '银发骑士' } })
+    const commandEnter = createEvent.keyDown(composer, {
+      key: 'Enter',
+      code: 'Enter',
+      metaKey: true,
+    })
+    fireEvent(composer, commandEnter)
+
+    expect(commandEnter.defaultPrevented).toBe(false)
+    expect(planner).not.toHaveBeenCalled()
+  })
+
+  it('does not submit Enter while an IME composition is active', () => {
+    const planner = vi.fn()
+    renderAt('/quick-start', serviceFor(null), agentFor({ planner }))
+    const composer = screen.getByRole('textbox', { name: '创作指令' })
+
+    fireEvent.change(composer, { target: { value: '银发骑士' } })
+    const composingEnter = createEvent.keyDown(composer, {
+      key: 'Enter',
+      code: 'Enter',
+      isComposing: true,
+    })
+    fireEvent(composer, composingEnter)
+
+    expect(composingEnter.defaultPrevented).toBe(false)
+    expect(planner).not.toHaveBeenCalled()
+  })
+
+  it('restores one editable prompt after stopping Agent planning', async () => {
+    const planning = deferred<PlannerResult>()
+    const planner = vi
+      .fn()
+      .mockImplementationOnce(async () => planning.promise)
+      .mockResolvedValueOnce({ text: '可以继续。', finishReason: 'stop', toolCalls: [] })
+    renderAt('/quick-start', serviceFor(null), agentFor({ planner }))
+    const composer = screen.getByRole('textbox', { name: '创作指令' }) as HTMLTextAreaElement
+
+    fireEvent.change(composer, { target: { value: '银发骑士' } })
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' })
+    fireEvent.click(await screen.findByRole('button', { name: '停止生成' }))
+
+    await waitFor(() => {
+      expect(composer.disabled).toBe(false)
+      expect(composer.value).toBe('银发骑士')
+    })
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' })
+
+    await waitFor(() => expect(planner).toHaveBeenCalledTimes(2))
+    planning.resolve({ text: '过期回复。', finishReason: 'stop', toolCalls: [] })
+    expect(await screen.findByText('可以继续。')).toBeTruthy()
+    const userTurns = Array.from(
+      screen.getByTestId('quick-start-transcript').querySelectorAll('[data-user-turn]'),
+    ).filter((turn) => turn.textContent === '银发骑士')
+    expect(userTurns).toHaveLength(1)
+  })
+
+  it('aborts uploaded-template startup and restores its prompt', async () => {
+    let startupSignal: AbortSignal | null = null
+    const service = serviceFor(null, {
+      startWithUploadedTemplate: vi.fn(
+        async (_file, _prompt, signal) =>
+          new Promise<QuickStartSession>((_resolve, reject) => {
+            startupSignal = signal
+            signal.addEventListener('abort', () =>
+              reject(new DOMException('aborted', 'AbortError')),
+            )
+          }),
+      ),
+    })
+    renderAt('/quick-start', service)
+    const composer = screen.getByRole('textbox', { name: '创作指令' }) as HTMLTextAreaElement
+    const file = new File(['pixels'], 'hero.png', { type: 'image/png' })
+
+    fireEvent.change(screen.getByLabelText('上传角色母版'), { target: { files: [file] } })
+    fireEvent.change(composer, { target: { value: '挥手' } })
+    fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' })
+    fireEvent.click(await screen.findByRole('button', { name: '停止生成' }))
+
+    await waitFor(() => {
+      expect(startupSignal?.aborted).toBe(true)
+      expect(composer.disabled).toBe(false)
+      expect(composer.value).toBe('挥手')
+    })
+  })
+
+  it('uses a larger template icon and shows the selected art style on the right', () => {
+    renderAt('/quick-start', serviceFor(null))
+
+    const template = screen.getByRole('button', { name: '添加母版' })
+    const style = screen.getByRole('button', { name: '选择画风，当前不指定' })
+    const send = screen.getByRole('button', { name: '生成角色' })
+
+    expect(template.querySelector('svg')).toBeTruthy()
+    expect(template.querySelector('svg')?.getAttribute('data-icon')).toBe('master-frame')
+    expect(template.querySelector('svg')?.getAttribute('width')).toBe('24')
+    expect(style.querySelector('svg')?.getAttribute('data-icon')).toBe('style-tile')
+    expect(screen.getByTestId('quick-start-selected-style').textContent).toBe('不指定')
+    expect(send.querySelector('svg')).toBeTruthy()
+    expect(template.textContent).toBe('添加母版')
+    expect(style.getAttribute('aria-expanded')).toBe('false')
+    expect(send.className).toContain('rounded-full')
+  })
+
+  it('opens generation direction as an animated slider control below the composer', () => {
+    renderAt('/quick-start', serviceFor(null))
+
+    const direction = screen.getByRole('button', { name: '生成方向，当前单向' })
+    expect(direction.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(direction)
+
+    const panel = screen.getByRole('group', { name: '生成方向设置' })
+    const slider = screen.getByRole('slider', { name: '生成方向' }) as HTMLInputElement
+    expect(direction.getAttribute('aria-expanded')).toBe('true')
+    expect(panel.className).toContain('z-30')
+    expect(panel.querySelector('canvas')).toBeNull()
+    expect(panel.querySelector('[data-direction-shader]')).toBeNull()
+    expect(panel.querySelector('.quick-start-direction-ticks')).toBeNull()
+    expect(slider.value).toBe('0')
+    fireEvent.change(slider, { target: { value: '0.6' } })
+    expect(slider.value).toBe('0.6')
+    expect(screen.getByRole('button', { name: '生成方向，当前四向' })).toBeTruthy()
+    fireEvent.pointerUp(slider, { target: { value: '0.6' } })
+    expect(slider.value).toBe('1')
   })
 
   it('keeps browser form history out of the creation composer', () => {
@@ -832,7 +995,8 @@ describe('QuickStartPage', () => {
     window.history.replaceState(null, '', '/quick-start')
     const firstView = renderInBrowserHistory(service, agent)
 
-    fireEvent.change(screen.getByLabelText('画风'), { target: { value: 'pixel' } })
+    fireEvent.click(screen.getByRole('button', { name: '选择画风，当前不指定' }))
+    fireEvent.click(screen.getByRole('menuitemradio', { name: '像素' }))
     fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
       target: { value: '一个住在云端的机械师。' },
     })
@@ -1075,6 +1239,8 @@ describe('QuickStartPage', () => {
     expect(scrollRegion?.contains(composer)).toBe(false)
     expect(composer.getAttribute('data-position')).toBe('floating')
     expect(composer.className).toContain('absolute')
+    expect(composer.className).toContain('sm:bottom-4')
+    expect(composer.querySelector('form')?.className).toContain('rounded-[18px]')
     expect(agentTurns.length).toBeGreaterThanOrEqual(2)
     expect(userTurns.length).toBeGreaterThanOrEqual(2)
     expect(userTurns.every((turn) => turn.className.includes('w-fit'))).toBe(true)
@@ -1090,6 +1256,7 @@ describe('QuickStartPage', () => {
     expect(composer).toBeTruthy()
     expect(interrupt.querySelector('svg')).toBeTruthy()
     expect(interrupt.hasAttribute('disabled')).toBe(false)
+    expect(interrupt.className).toContain('rounded-full')
   })
 
   it('scrolls only the transcript region when new Agent output arrives', async () => {
@@ -1654,7 +1821,10 @@ describe('QuickStartPage', () => {
     const agent = agentFor({ startCharacterGeneration })
     const view = renderAt('/quick-start', service, agent)
 
-    expect(screen.queryByRole('radio', { name: '单向' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: '生成方向，当前单向' }))
+    fireEvent.change(screen.getByRole('slider', { name: '生成方向' }), {
+      target: { value: '1' },
+    })
     fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
       target: { value: '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色' },
     })
@@ -1673,9 +1843,12 @@ describe('QuickStartPage', () => {
     view.unmount()
     renderAt('/quick-start', service)
     const file = new File(['pixels'], 'hero.png', { type: 'image/png' })
+    fireEvent.click(screen.getByRole('button', { name: '生成方向，当前单向' }))
+    fireEvent.change(screen.getByRole('slider', { name: '生成方向' }), {
+      target: { value: '2' },
+    })
     fireEvent.click(screen.getByRole('button', { name: '添加母版' }))
     fireEvent.change(screen.getByLabelText('上传角色母版'), { target: { files: [file] } })
-    fireEvent.click(screen.getByRole('radio', { name: '八向' }))
     expect(screen.getByText('hero.png')).toBeTruthy()
     fireEvent.change(screen.getByLabelText('创作指令'), { target: { value: '挥手' } })
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -15,8 +15,8 @@ import {
   ArrowBendDownLeft,
   ArrowClockwise,
   ArrowUp,
+  CaretDown,
   CopySimple,
-  ImageSquare,
   PlusCircle,
   Stop,
   X,
@@ -441,6 +441,7 @@ function IconActionButton({
   onClick,
   type = 'button',
   className = '',
+  expanded,
   children,
 }: {
   label: string
@@ -449,6 +450,7 @@ function IconActionButton({
   onClick?: () => void
   type?: 'button' | 'submit'
   className?: string
+  expanded?: boolean
   children: ReactNode
 }) {
   const tooltipId = useId()
@@ -458,6 +460,7 @@ function IconActionButton({
       type={type}
       aria-label={label}
       aria-describedby={tooltipId}
+      aria-expanded={expanded}
       disabled={disabled}
       onClick={onClick}
       data-icon-action
@@ -476,6 +479,52 @@ function IconActionButton({
         {label}
       </span>
     </button>
+  )
+}
+
+function MasterFrameIcon() {
+  return (
+    <svg
+      data-icon="master-frame"
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M7.25 5.5h10.5a1.75 1.75 0 0 1 1.75 1.75v9.5a1.75 1.75 0 0 1-1.75 1.75H7.25a1.75 1.75 0 0 1-1.75-1.75v-9.5A1.75 1.75 0 0 1 7.25 5.5Z" />
+      <path
+        d="M5.5 8H4.75A1.75 1.75 0 0 0 3 9.75v8.5A1.75 1.75 0 0 0 4.75 20h10.5A1.75 1.75 0 0 0 17 18.5"
+        opacity="0.58"
+      />
+      <path d="m8.25 15.5 2.45-2.65a.75.75 0 0 1 1.1-.02l1.45 1.45 1.2-1.2a.75.75 0 0 1 1.08.02l1.97 2.4" />
+      <circle cx="15.75" cy="9.25" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
+function StyleTileIcon() {
+  return (
+    <svg
+      data-icon="style-tile"
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width="22"
+      height="22"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="4.25" y="4.25" width="15.5" height="15.5" rx="3.25" />
+      <path d="M12 7.75c.38 2.42 1.83 3.87 4.25 4.25-2.42.38-3.87 1.83-4.25 4.25-.38-2.42-1.83-3.87-4.25-4.25 2.42-.38 3.87-1.83 4.25-4.25Z" />
+      <circle cx="17.25" cy="6.75" r=".75" fill="currentColor" stroke="none" />
+    </svg>
   )
 }
 
@@ -575,6 +624,7 @@ function QuickStartInput({
   const fileInput = useRef<HTMLInputElement>(null)
   const promptInput = useRef<HTMLTextAreaElement>(null)
   const submitAbortController = useRef<AbortController | null>(null)
+  const pendingPrompt = useRef<string | null>(null)
   const handoffTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const rewriteTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const conversationTurnsRef = useRef(conversationTurns)
@@ -596,6 +646,7 @@ function QuickStartInput({
     promptState === 'rewriting' ||
     promptState === 'direction' ||
     generationStarting
+  const entryCanInterrupt = submitting || agentPlanning
   const hasPrompt = Boolean(prompt.trim())
   const hasConversation = conversationTurns.length > 0
   const showConversation = hasConversation || agentThinking || agentSession.state.status === 'error'
@@ -752,6 +803,43 @@ function QuickStartInput({
     if (fileInput.current) fileInput.current.value = ''
   }
 
+  function chooseGameStyle(next: ArtStyle) {
+    setGameStyle(next)
+    setStyleMenuOpen(false)
+    const draftId = draftIdRef.current
+    if (draftId) {
+      writeAgentConversation(
+        'sessionStorage',
+        agentDraftConversationStorageKey(activeRunUserId, draftId),
+        { turns: conversationTurnsRef.current, gameStyle: next },
+      )
+    }
+  }
+
+  function stopEntryWork() {
+    agentSession.cancel()
+    submitAbortController.current?.abort()
+    submitAbortController.current = null
+    if (handoffTimer.current) clearTimeout(handoffTimer.current)
+    handoffTimer.current = null
+    if (pendingPrompt.current) {
+      const restoredPrompt = pendingPrompt.current
+      setPrompt(restoredPrompt)
+      const turns = conversationTurnsRef.current
+      const lastTurn = turns.at(-1)
+      if (lastTurn?.role === 'user' && lastTurn.content === restoredPrompt) {
+        const nextTurns = turns.slice(0, -1)
+        conversationTurnsRef.current = nextTurns
+        setConversationTurns(nextTurns)
+        persistDraftConversation(nextTurns)
+      }
+    }
+    pendingPrompt.current = null
+    setSubmitting(false)
+    setRevealingFirstAgentTurn(false)
+    setEntryTransition('idle')
+  }
+
   async function handoffGenerated(
     result: Extract<QuickStartAgentResult, { kind: 'generated' }>,
   ): Promise<void> {
@@ -798,9 +886,11 @@ function QuickStartInput({
       const userTurn: AgentConversationTurn = { role: 'user', content: normalizedPrompt }
       if (hasConversation) appendConversationTurn(userTurn)
       else await revealFirstAgentTurn(userTurn)
+      pendingPrompt.current = normalizedPrompt
       setPrompt('')
       try {
         const result = await agentSession.submit(normalizedPrompt)
+        pendingPrompt.current = null
         setRevealingFirstAgentTurn(false)
         if (result.kind === 'message') {
           appendConversationTurn({
@@ -905,6 +995,13 @@ function QuickStartInput({
   const canSubmit = awaitingGenerationConfirmation
     ? Boolean(prompt.trim())
     : Boolean(prompt.trim()) || Boolean(templateFile)
+  const [styleMenuOpen, setStyleMenuOpen] = useState(false)
+  const [directionMenuOpen, setDirectionMenuOpen] = useState(false)
+  const [directionDragging, setDirectionDragging] = useState(false)
+  const [directionSliderValue, setDirectionSliderValue] = useState(() =>
+    QUICK_START_DIRECTIONAL_MOVEMENTS.indexOf(directionalMovement),
+  )
+  const directionalMovementIndex = QUICK_START_DIRECTIONAL_MOVEMENTS.indexOf(directionalMovement)
 
   return (
     <section
@@ -916,7 +1013,7 @@ function QuickStartInput({
       <div
         data-layout="quick-start-entry"
         data-transition={entryTransition}
-        className="relative z-10 grid min-h-[calc(100dvh-3.5rem)] grid-rows-[1fr_auto] gap-6 px-5 py-6 sm:px-8 sm:pb-8 sm:pt-10"
+        className="relative z-10 grid h-[calc(100dvh-3.5rem)] grid-rows-[1fr_auto] gap-6 px-5 py-6 sm:px-8 sm:pb-4 sm:pt-10"
       >
         <div
           data-layout="quick-start-entry-stage"
@@ -1025,7 +1122,7 @@ function QuickStartInput({
         <div
           data-testid="quick-start-composer"
           data-layout="quick-start-composer"
-          data-position="floating"
+          data-position="bottom"
           data-prompt-state={promptState}
           className={`mx-auto w-full max-w-3xl self-end transition-[opacity,transform,filter] duration-[460ms] ease-[cubic-bezier(0.55,0,1,0.45)] motion-reduce:transition-none ${
             entryTransition === 'leaving'
@@ -1033,45 +1130,14 @@ function QuickStartInput({
               : 'translate-y-0 opacity-100 blur-0'
           }`}
         >
-          {templateFile ? (
-            <fieldset
-              aria-label="角色方向"
-              disabled={entryBusy}
-              className="mb-2 flex items-center justify-end gap-1.5 text-xs"
-            >
-              <legend className="mr-1 text-app-muted">生成方向</legend>
-              {QUICK_START_DIRECTIONAL_MOVEMENTS.map((movement) => (
-                <label
-                  key={movement}
-                  className={`relative cursor-pointer rounded-full border px-3 py-1.5 font-semibold transition focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-app-accent ${
-                    directionalMovement === movement
-                      ? 'border-app-accent bg-app-accent-soft text-app-accent'
-                      : 'border-app-line bg-app-surface/70 text-app-muted hover:border-app-line-strong hover:text-app-ink'
-                  } ${entryBusy ? 'cursor-not-allowed opacity-50' : ''}`}
-                >
-                  <input
-                    type="radio"
-                    name="quick-start-directional-movement"
-                    value={movement}
-                    checked={directionalMovement === movement}
-                    onChange={() => setDirectionalMovement(movement)}
-                    className="sr-only"
-                  />
-                  {DIRECTIONAL_MOVEMENT[movement]}
-                </label>
-              ))}
-            </fieldset>
-          ) : null}
           <form
             onSubmit={(event) => void submit(event)}
             autoComplete="off"
             data-prompt-state={promptState}
-            className={`quick-start-agent-composer grid items-center gap-1.5 overflow-hidden rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)] ${
-              hasConversation ? 'sm:grid-cols-[1fr_auto]' : 'sm:grid-cols-[1fr_auto_auto]'
-            }`}
+            className="quick-start-agent-composer relative flex flex-col"
           >
             <label
-              className="relative ml-2 min-w-0 overflow-hidden rounded-lg"
+              className="relative block min-h-[52px] min-w-0 overflow-hidden rounded-[18px] border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]"
               htmlFor="quick-start-prompt"
             >
               <span className="sr-only">创作指令</span>
@@ -1083,6 +1149,13 @@ function QuickStartInput({
                 aria-label="创作指令"
                 value={prompt}
                 onChange={(event) => setPrompt(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key !== 'Enter' || event.metaKey || event.nativeEvent.isComposing) {
+                    return
+                  }
+                  event.preventDefault()
+                  event.currentTarget.form?.requestSubmit()
+                }}
                 disabled={inputLocked}
                 placeholder={
                   agentPlanning
@@ -1093,7 +1166,7 @@ function QuickStartInput({
                         ? '描述动作，可留空生成待机动作…'
                         : '描述角色的外形、身份和气质…'
                 }
-                className={`block min-h-10 max-h-40 w-full min-w-0 resize-none overflow-y-auto border-0 bg-transparent px-4 py-2.5 text-[15px] leading-5 text-app-ink outline-none [field-sizing:content] placeholder:text-app-faint ${
+                className={`block min-h-[52px] max-h-40 w-full min-w-0 resize-none overflow-y-auto border-0 bg-transparent py-[14px] pr-14 pl-4 text-[15px] leading-6 text-app-ink outline-none [field-sizing:content] placeholder:text-app-faint ${
                   promptState === 'rewriting' ? 'text-transparent caret-transparent' : ''
                 }`}
               />
@@ -1101,7 +1174,7 @@ function QuickStartInput({
                 <span
                   data-prompt-rewrite
                   aria-hidden="true"
-                  className="quick-start-prompt-rewrite absolute inset-0 flex min-h-10 max-h-40 items-start overflow-y-auto px-4 py-2.5 text-[15px] leading-5 text-app-ink"
+                  className="quick-start-prompt-rewrite absolute inset-0 flex min-h-[52px] max-h-40 items-start overflow-y-auto py-[14px] pr-14 pl-4 text-[15px] leading-6 text-app-ink"
                 >
                   <KineticCopyCycle
                     active
@@ -1113,7 +1186,24 @@ function QuickStartInput({
                 </span>
               ) : null}
             </label>
-
+            <button
+              type={entryCanInterrupt ? 'button' : 'submit'}
+              aria-label={entryCanInterrupt ? '停止生成' : buttonLabel}
+              title={entryCanInterrupt ? '停止生成' : buttonLabel}
+              onClick={entryCanInterrupt ? stopEntryWork : undefined}
+              disabled={
+                entryCanInterrupt ? false : !canSubmit || entryBusy || Boolean(unavailableReason)
+              }
+              className={`absolute right-[6px] bottom-[6px] z-10 grid size-10 place-items-center rounded-full border-0 text-app-canvas transition-[opacity,transform,background] duration-150 hover:-translate-y-px active:scale-95 disabled:cursor-default disabled:opacity-25 ${
+                entryCanInterrupt ? 'bg-app-ink' : 'bg-app-accent hover:bg-app-accent-hover'
+              }`}
+            >
+              {entryCanInterrupt ? (
+                <Stop aria-hidden="true" size={16} weight="fill" />
+              ) : (
+                <ArrowUp aria-hidden="true" size={19} weight="bold" />
+              )}
+            </button>
             <input
               ref={fileInput}
               type="file"
@@ -1123,76 +1213,171 @@ function QuickStartInput({
               className="sr-only"
               onChange={selectTemplateFile}
             />
-            {templateFile ? (
-              <span className="flex h-10 min-w-0 max-w-56 items-center rounded-lg bg-app-surface-muted text-xs text-app-ink-soft">
-                <button
-                  type="button"
-                  aria-label={`更换母版 ${templateFile.name}`}
-                  disabled={entryBusy}
-                  onClick={() => fileInput.current?.click()}
-                  className="inline-flex h-full min-w-0 items-center gap-2 rounded-l-lg px-2.5 font-semibold transition hover:bg-app-surface hover:text-app-accent focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
-                >
-                  <ImageSquare aria-hidden="true" size={16} weight="duotone" />
-                  <span className="max-w-32 truncate">{templateFile.name}</span>
-                </button>
-                <button
-                  type="button"
-                  aria-label="移除图片"
-                  disabled={entryBusy}
-                  onClick={removeTemplateFile}
-                  className="grid size-8 shrink-0 place-items-center rounded-md text-app-muted transition hover:bg-app-surface hover:text-app-accent focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
-                >
-                  <X aria-hidden="true" size={14} weight="bold" />
-                </button>
-              </span>
-            ) : !hasConversation ? (
-              <button
-                type="button"
-                disabled={entryBusy}
-                onClick={() => fileInput.current?.click()}
-                className="inline-flex h-10 items-center gap-2 rounded-lg px-3 text-xs font-semibold whitespace-nowrap text-app-muted transition hover:bg-app-surface-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
-              >
-                <ImageSquare aria-hidden="true" size={17} weight="duotone" />
-                添加母版
-              </button>
-            ) : null}
-            {!hasConversation ? (
-              <label className="inline-flex h-10 items-center gap-1.5 rounded-lg px-2 text-xs font-semibold whitespace-nowrap text-app-muted">
-                画风
-                <select
-                  value={gameStyle}
-                  disabled={entryBusy}
-                  aria-label="画风"
-                  onChange={(event) => {
-                    const next = event.target.value as ArtStyle
-                    setGameStyle(next)
-                    const draftId = draftIdRef.current
-                    if (draftId) {
-                      writeAgentConversation(
-                        'sessionStorage',
-                        agentDraftConversationStorageKey(activeRunUserId, draftId),
-                        { turns: conversationTurnsRef.current, gameStyle: next },
-                      )
-                    }
-                  }}
-                  className="rounded-md border border-app-line bg-app-surface px-2 py-1 text-xs text-app-ink-soft outline-none focus-visible:border-app-accent"
-                >
-                  {ART_STYLE_OPTIONS.map((value) => (
-                    <option key={value} value={value}>
-                      {ART_STYLE[value]}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            ) : null}
-            <button
-              type="submit"
-              disabled={!canSubmit || entryBusy || Boolean(unavailableReason)}
-              className="inline-flex h-10 self-end items-center gap-2 rounded-lg bg-app-accent px-4 text-sm font-bold whitespace-nowrap text-app-on-accent transition hover:bg-app-accent-hover active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-45"
+            <div
+              data-layout="quick-start-composer-controls"
+              className="order-first mb-2 flex min-h-10 items-center justify-between gap-3 px-1"
             >
-              {buttonLabel}
-              {!entryBusy ? <ArrowUp aria-hidden="true" size={16} weight="bold" /> : null}
-            </button>
+              {!hasConversation ? (
+                <div className="flex items-center gap-1">
+                  <IconActionButton
+                    label={templateFile ? `更换母版 ${templateFile.name}` : '添加母版'}
+                    disabled={entryBusy}
+                    onClick={() => fileInput.current?.click()}
+                    className={templateFile ? 'text-app-accent' : ''}
+                  >
+                    <MasterFrameIcon />
+                  </IconActionButton>
+                  <div className="relative">
+                    <IconActionButton
+                      label={`选择画风，当前${ART_STYLE[gameStyle]}`}
+                      disabled={entryBusy}
+                      onClick={() => {
+                        setDirectionMenuOpen(false)
+                        setStyleMenuOpen((open) => !open)
+                      }}
+                      expanded={styleMenuOpen}
+                    >
+                      <StyleTileIcon />
+                    </IconActionButton>
+                    {styleMenuOpen ? (
+                      <div
+                        role="menu"
+                        aria-label="选择画风"
+                        className="quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-32 gap-1 rounded-[14px] border border-app-line bg-[var(--color-app-surface-raised)] p-1.5 opacity-100 shadow-app-panel"
+                      >
+                        {ART_STYLE_OPTIONS.map((value) => (
+                          <button
+                            key={value}
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={gameStyle === value}
+                            onClick={() => chooseGameStyle(value)}
+                            className={`rounded-lg px-3 py-2 text-left text-xs transition ${
+                              gameStyle === value
+                                ? 'bg-app-accent-soft text-app-accent'
+                                : 'text-app-ink-soft hover:bg-app-surface-muted'
+                            }`}
+                          >
+                            {ART_STYLE[value]}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+              {templateFile && !hasConversation ? (
+                <span className="absolute bottom-full left-3 mb-2 inline-flex max-w-56 items-center gap-1 rounded-lg bg-app-surface-raised px-2 py-1 text-xs text-app-ink-soft shadow-app-card">
+                  <span className="truncate">{templateFile.name}</span>
+                  <button
+                    type="button"
+                    aria-label="移除图片"
+                    disabled={entryBusy}
+                    onClick={removeTemplateFile}
+                    className="grid size-6 shrink-0 place-items-center rounded-md text-app-muted hover:text-app-accent"
+                  >
+                    <X aria-hidden="true" size={13} weight="bold" />
+                  </button>
+                </span>
+              ) : null}
+              <div className="flex items-center gap-1">
+                {!hasConversation ? (
+                  <>
+                    <span
+                      data-testid="quick-start-selected-style"
+                      className="max-w-28 truncate px-2 text-sm font-medium text-app-muted"
+                    >
+                      {ART_STYLE[gameStyle]}
+                    </span>
+                    <div className="relative">
+                      <button
+                        type="button"
+                        aria-label={`生成方向，当前${DIRECTIONAL_MOVEMENT[directionalMovement]}`}
+                        aria-expanded={directionMenuOpen}
+                        disabled={entryBusy}
+                        onClick={() => {
+                          setStyleMenuOpen(false)
+                          setDirectionSliderValue(directionalMovementIndex)
+                          setDirectionMenuOpen((open) => !open)
+                        }}
+                        className="inline-flex h-10 items-center gap-1 rounded-lg px-3 text-sm font-medium text-app-ink-soft transition hover:bg-app-surface-muted hover:text-app-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-45"
+                      >
+                        {DIRECTIONAL_MOVEMENT[directionalMovement]}
+                        <CaretDown
+                          aria-hidden="true"
+                          size={14}
+                          weight="bold"
+                          className={`transition-transform duration-200 motion-reduce:transition-none ${directionMenuOpen ? 'rotate-180' : ''}`}
+                        />
+                      </button>
+                      {directionMenuOpen ? (
+                        <div
+                          role="group"
+                          aria-label="生成方向设置"
+                          className="quick-start-control-popover absolute right-0 bottom-full z-30 mb-3 w-72 rounded-[18px] border border-app-line-strong bg-[var(--color-app-surface-raised)] p-5 opacity-100 shadow-app-panel"
+                        >
+                          <div className="mb-4 flex items-center justify-between">
+                            <span className="text-sm text-app-muted">生成方向</span>
+                            <strong
+                              key={directionalMovement}
+                              className="quick-start-direction-value text-sm font-semibold text-app-ink"
+                            >
+                              {DIRECTIONAL_MOVEMENT[directionalMovement]}
+                            </strong>
+                          </div>
+                          <div className="mb-2 flex justify-between text-xs text-app-muted">
+                            <span>单向</span>
+                            <span>八向</span>
+                          </div>
+                          <div
+                            data-dragging={directionDragging ? 'true' : 'false'}
+                            className="quick-start-direction-slider-wrap"
+                            style={
+                              {
+                                '--quick-start-direction-progress': `${directionSliderValue * 50}%`,
+                              } as CSSProperties
+                            }
+                          >
+                            <input
+                              type="range"
+                              min="0"
+                              max="2"
+                              step="0.01"
+                              value={directionSliderValue}
+                              aria-label="生成方向"
+                              aria-valuetext={DIRECTIONAL_MOVEMENT[directionalMovement]}
+                              onPointerDown={() => setDirectionDragging(true)}
+                              onPointerUp={(event) => {
+                                const index = Math.round(Number(event.currentTarget.value))
+                                setDirectionDragging(false)
+                                setDirectionSliderValue(index)
+                                setDirectionalMovement(
+                                  QUICK_START_DIRECTIONAL_MOVEMENTS[index] ?? 'single',
+                                )
+                              }}
+                              onPointerCancel={() => setDirectionDragging(false)}
+                              onBlur={(event) => {
+                                const index = Math.round(Number(event.currentTarget.value))
+                                setDirectionDragging(false)
+                                setDirectionSliderValue(index)
+                              }}
+                              onChange={(event) => {
+                                const value = Number(event.target.value)
+                                setDirectionSliderValue(value)
+                                setDirectionalMovement(
+                                  QUICK_START_DIRECTIONAL_MOVEMENTS[Math.round(value)] ?? 'single',
+                                )
+                              }}
+                              className="quick-start-direction-slider"
+                            />
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  </>
+                ) : null}
+              </div>
+            </div>
           </form>
 
           {unavailableReason ? (
@@ -2563,11 +2748,11 @@ function QuickStartRun({
         <footer
           data-testid="quick-start-composer"
           data-position="floating"
-          className="absolute right-5 bottom-4 left-5 z-10 mx-auto w-auto max-w-3xl sm:right-8 sm:bottom-6 sm:left-8"
+          className="absolute right-5 bottom-4 left-5 z-10 mx-auto w-auto max-w-3xl sm:right-8 sm:bottom-4 sm:left-8"
         >
           <form
             onSubmit={continueConversation}
-            className="grid grid-cols-[1fr_auto] items-center gap-1.5 rounded-2xl border border-app-line-strong bg-app-surface-raised/96 p-1.5 shadow-app-panel backdrop-blur-xl transition focus-within:border-app-accent"
+            className="grid grid-cols-[1fr_auto] items-center gap-1.5 rounded-[18px] border border-app-line-strong bg-app-surface-raised/96 p-1.5 shadow-app-panel backdrop-blur-xl transition focus-within:border-app-accent"
           >
             <label htmlFor="quick-start-continuation" className="min-w-0">
               <span className="sr-only">继续描述你的想法</span>
@@ -2601,7 +2786,7 @@ function QuickStartRun({
                     (workflowAgentMode && workflowAgentSession.busy)
               }
               accent
-              className="active:scale-[0.98] disabled:opacity-35"
+              className="!rounded-full active:scale-[0.98] disabled:opacity-35"
             >
               {composerCanInterrupt ? (
                 <Stop aria-hidden="true" size={18} weight="bold" />

--- a/frontend/src/pages/quick-start/quick-start-motion.css
+++ b/frontend/src/pages/quick-start/quick-start-motion.css
@@ -262,6 +262,114 @@
   place-items: start;
 }
 
+.quick-start-control-popover {
+  transform-origin: 84% 100%;
+  animation: quick-start-control-popover-in 260ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.quick-start-direction-value {
+  animation: quick-start-direction-value-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.quick-start-direction-slider-wrap {
+  position: relative;
+  height: 2.25rem;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-app-accent) 30%, var(--color-app-surface-muted)) 0
+      var(--quick-start-direction-progress),
+    var(--color-app-surface-muted) var(--quick-start-direction-progress) 100%
+  );
+  transition: transform 180ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.quick-start-direction-slider-wrap[data-dragging='true'] {
+  transform: translateY(-2px) scale(1.012);
+}
+
+.quick-start-direction-slider-wrap[data-dragging='true']
+  .quick-start-direction-slider::-webkit-slider-runnable-track {
+  transition: none;
+}
+
+.quick-start-direction-slider {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  margin: 0;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.quick-start-direction-slider::-webkit-slider-runnable-track {
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  background: transparent;
+}
+
+.quick-start-direction-slider::-webkit-slider-thumb {
+  width: 2rem;
+  height: 2rem;
+  margin-top: 0.125rem;
+  appearance: none;
+  border: 1px solid var(--color-app-line);
+  border-radius: 0.7rem;
+  background: var(--color-app-surface-raised);
+  box-shadow:
+    0 1px 2px rgb(29 37 31 / 12%),
+    0 6px 18px rgb(29 37 31 / 14%);
+  transition:
+    transform 150ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 150ms ease-out;
+}
+
+.quick-start-direction-slider:hover::-webkit-slider-thumb {
+  transform: scale(1.04);
+}
+
+.quick-start-direction-slider:active::-webkit-slider-thumb {
+  transform: scale(1.12);
+  box-shadow:
+    0 2px 4px rgb(29 37 31 / 12%),
+    0 12px 28px rgb(29 37 31 / 20%);
+}
+
+.quick-start-direction-slider:focus-visible {
+  outline: 2px solid var(--color-app-accent);
+  outline-offset: 3px;
+  border-radius: 0.75rem;
+}
+
+@keyframes quick-start-control-popover-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.94);
+    filter: blur(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+}
+
+@keyframes quick-start-direction-value-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+    filter: blur(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
 .quick-start-reveal-card {
   opacity: 0;
   filter: blur(7px);
@@ -372,5 +480,12 @@
     filter: none;
     transform: none;
     animation: none;
+  }
+
+  .quick-start-control-popover,
+  .quick-start-direction-value,
+  .quick-start-direction-slider-wrap,
+  .quick-start-direction-slider::-webkit-slider-thumb {
+    transition: none;
   }
 }


### PR DESCRIPTION
## Summary

- keep the Quick Start composer compact and anchored at the bottom, with template/style controls above the input and selected style/direction on the right
- send with Enter, preserve Command+Enter for newlines, and ignore Enter during IME composition
- allow planning and uploaded-template startup to be interrupted, restore the editable prompt, and ignore stale planner completion
- keep the active-run composer and interrupt action aligned with the entry composer geometry

## Checks

- `npm test -- src/features/quick-start-agent/react.test.tsx src/pages/quick-start/index.test.tsx`
- `npm run typecheck`
- `npm run lint -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx src/features/quick-start-agent/react.ts src/features/quick-start-agent/react.test.tsx`
- `npm run format:check -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx src/features/quick-start-agent/react.ts src/features/quick-start-agent/react.test.tsx src/pages/quick-start/quick-start-motion.css`
- `npm run build`

Closes #672