### PR TITLE
feat(landing): expand hero window on scroll

### DIFF
--- a/frontend/src/pages/landing/index.test.tsx
+++ b/frontend/src/pages/landing/index.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, within } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router'
 
 import expectedBirdLeft from '@/assets/landing/illustrations/gongbi-tit-flight-up.webp'
@@ -11,6 +11,7 @@ import { LandingPage } from './index'
 afterEach(() => {
   cleanup()
   window.localStorage.clear()
+  vi.unstubAllGlobals()
 })
 
 describe('LandingPage', () => {
@@ -36,6 +37,60 @@ describe('LandingPage', () => {
       expect(image.getAttribute('fetchpriority')).toBe('high')
     }
     expect(within(hero).queryByTestId('landing-brand-bird')).toBeNull()
+  })
+
+  it('只在滚动后接管原始产品卡片，并在回到顶部时完整交还原样式', async () => {
+    const animationFrames: FrameRequestCallback[] = []
+    const requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      animationFrames.push(callback)
+      return animationFrames.length
+    })
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrame)
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1_200 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 1_000 })
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0, writable: true })
+
+    const { unmount } = render(
+      <GuestAuthSession>
+        <MemoryRouter>
+          <LandingPage />
+        </MemoryRouter>
+      </GuestAuthSession>,
+    )
+
+    const surface = await screen
+      .findAllByTestId('workflow-editor-placeholder')
+      .then(([first]) => first)
+    const productWindow = surface.parentElement as HTMLElement
+
+    expect(productWindow.style.width).toBe('')
+    expect(productWindow.style.height).toBe('')
+    expect(productWindow.dataset.expanding).toBeUndefined()
+    expect(surface.className).toContain('rounded-2xl')
+    expect(surface.className).toContain('shadow-[0_30px_80px_rgba(53,58,49,0.18)]')
+
+    window.scrollY = 400
+    fireEvent.scroll(window)
+    act(() => animationFrames.splice(0).forEach((callback) => callback(0)))
+
+    expect(productWindow.style.getPropertyValue('--hero-window-progress')).toBe('0.5000')
+    expect(productWindow.style.width).toBe('1080px')
+    expect(productWindow.style.height).toBe('740px')
+    expect(productWindow.dataset.expanding).toBe('true')
+
+    window.scrollY = 0
+    fireEvent.scroll(window)
+    act(() => animationFrames.splice(0).forEach((callback) => callback(0)))
+
+    expect(productWindow.style.width).toBe('')
+    expect(productWindow.style.height).toBe('')
+    expect(productWindow.dataset.expanding).toBeUndefined()
+
+    unmount()
+    const frameCountAfterUnmount = requestAnimationFrame.mock.calls.length
+    fireEvent.scroll(window)
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(frameCountAfterUnmount)
   })
 
   it('让访客先理解产品，再通过明确的登录与创作入口进入产品', async () => {

--- a/frontend/src/pages/landing/index.tsx
+++ b/frontend/src/pages/landing/index.tsx
@@ -506,6 +506,72 @@ function GenerationPipeline() {
 export function LandingPage() {
   const session = useAuthSession()
   const startPath = session.state.status === 'guest' ? creationEntry : '/workspace'
+  const heroProductWindowRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const root = heroProductWindowRef.current
+    if (!root) return
+
+    let animationFrame = 0
+
+    const restoreOriginalCard = () => {
+      delete root.dataset.expanding
+      root.style.removeProperty('--hero-window-progress')
+      root.style.removeProperty('--hero-window-radius')
+      root.style.removeProperty('--hero-window-shadow-alpha')
+      root.style.removeProperty('height')
+      root.style.removeProperty('max-width')
+      root.style.removeProperty('width')
+    }
+
+    const updateProgress = () => {
+      animationFrame = 0
+
+      if (
+        window.innerWidth < 640 ||
+        (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false)
+      ) {
+        restoreOriginalCard()
+        return
+      }
+
+      const distance = Math.max(window.innerHeight * 0.8, 1)
+      const progress = clampProgress(window.scrollY / distance)
+      if (progress <= 0) {
+        restoreOriginalCard()
+        return
+      }
+
+      const collapsedWidth = Math.min(window.innerWidth * 0.8, 72 * 16)
+      const collapsedHeight = collapsedWidth / 2
+      const width = collapsedWidth + (window.innerWidth - collapsedWidth) * progress
+      const height = collapsedHeight + (window.innerHeight - collapsedHeight) * progress
+
+      root.dataset.expanding = 'true'
+      root.style.setProperty('--hero-window-progress', progress.toFixed(4))
+      root.style.setProperty('--hero-window-radius', `${16 * (1 - progress)}px`)
+      root.style.setProperty('--hero-window-shadow-alpha', `${0.18 * (1 - progress)}`)
+      root.style.width = `${width}px`
+      root.style.height = `${height}px`
+      root.style.maxWidth = 'none'
+    }
+
+    const scheduleProgressUpdate = () => {
+      if (animationFrame) return
+      animationFrame = window.requestAnimationFrame(updateProgress)
+    }
+
+    updateProgress()
+    window.addEventListener('scroll', scheduleProgressUpdate, { passive: true })
+    window.addEventListener('resize', scheduleProgressUpdate)
+
+    return () => {
+      window.removeEventListener('scroll', scheduleProgressUpdate)
+      window.removeEventListener('resize', scheduleProgressUpdate)
+      if (animationFrame) window.cancelAnimationFrame(animationFrame)
+      restoreOriginalCard()
+    }
+  }, [])
 
   return (
     <div className="landing-page min-h-[100dvh] bg-paper text-ink">
@@ -514,7 +580,7 @@ export function LandingPage() {
       <main>
         <section
           aria-label="Windup 首屏"
-          className="relative isolate min-h-[100svh] overflow-hidden text-[#252520] [background:linear-gradient(180deg,rgb(247_246_240/0.82),rgb(237_239_231/0.92)),#f2f1ea] sm:min-h-[calc(80dvh_+_min(40vw,_36rem))]"
+          className="relative isolate min-h-[100svh] overflow-hidden text-[#252520] [background:linear-gradient(180deg,rgb(247_246_240/0.82),rgb(237_239_231/0.92)),#f2f1ea] sm:min-h-[180svh]"
         >
           <div
             aria-hidden="true"
@@ -570,10 +636,13 @@ export function LandingPage() {
             </Link>
           </div>
 
-          <figure className="relative z-20 mx-auto mt-16 w-[calc(100%_-_2rem)] max-w-[72rem] transform-gpu sm:absolute sm:top-[80dvh] sm:left-1/2 sm:mx-0 sm:mt-0 sm:w-[80%] sm:-translate-x-1/2">
+          <figure
+            ref={heroProductWindowRef}
+            className="landing-hero-product-window relative z-20 mx-auto mt-16 w-[calc(100%_-_2rem)] max-w-[72rem] transform-gpu sm:absolute sm:top-[80dvh] sm:left-1/2 sm:mx-0 sm:mt-0 sm:w-[80%] sm:-translate-x-1/2"
+          >
             <div
               data-testid="workflow-editor-placeholder"
-              className="aspect-[2/1] overflow-hidden rounded-2xl border border-[#c9c8c0] bg-[#f9f8f3] shadow-[0_30px_80px_rgba(53,58,49,0.18)]"
+              className="landing-hero-product-window__surface aspect-[2/1] overflow-hidden rounded-2xl border border-[#c9c8c0] bg-[#f9f8f3] shadow-[0_30px_80px_rgba(53,58,49,0.18)]"
             />
           </figure>
         </section>

--- a/frontend/src/pages/landing/landing-motion.css
+++ b/frontend/src/pages/landing/landing-motion.css
@@ -35,6 +35,14 @@ html:has(.landing-page) {
   }
 }
 
+.landing-hero-product-window[data-expanding='true'] .landing-hero-product-window__surface {
+  width: 100%;
+  height: 100%;
+  aspect-ratio: auto;
+  border-radius: var(--hero-window-radius);
+  box-shadow: 0 30px 80px rgb(53 58 49 / var(--hero-window-shadow-alpha));
+}
+
 @media (prefers-reduced-motion: reduce) {
   html:has(.landing-page) {
     scroll-behavior: auto;


### PR DESCRIPTION
首屏产品窗现在会在向下滚动时连续展开到完整视口，同时严格保留页面顶部的原始位置、尺寸、圆角和阴影，回滚到顶部后也会完整恢复。

## Why

原有产品窗保持静态，首屏与后续产品叙事之间缺少连续过渡；首次迁移还改变了卡片的初始视觉，因此本次实现将顶部原样作为硬边界。

## Changes

- 迁移滚动进度驱动的产品窗展开效果。
- 保持顶部原始卡片样式，并支持反向滚动恢复。
- 为展开、回退和监听清理补充局部回归测试。

## Implementation

- 使用 `requestAnimationFrame` 合并滚动更新。
- 仅在桌面端且非 reduced-motion 环境接管尺寸；顶部与不适用环境清除全部内联状态。

## Verification

- [x] `npm test -- src/pages/landing/index.test.tsx`：6/6 通过。
- [x] `npx oxfmt --check src/pages/landing/index.tsx src/pages/landing/index.test.tsx src/pages/landing/landing-motion.css`：通过。
- [x] `npx oxlint src/pages/landing/index.tsx src/pages/landing/index.test.tsx`：通过。
- [x] `npm run build`：通过。
- [x] 本地浏览器检查顶部、半程展开、全屏展开与回顶恢复。

## Scope

- 本 PR 不包含：首屏文案、导航、素材、路由、认证与后续页面调整。
- 后续事项：产品窗真实内容另行处理。

## Related Issues

Closes #654
