### PR TITLE
fix(project): cascade character deletion on project removal

### DIFF
--- a/backend/packages/app/src/windup_app/server/character/cleanup.py
+++ b/backend/packages/app/src/windup_app/server/character/cleanup.py
@@ -1,0 +1,44 @@
+"""角色资产删除时使用的对象存储键提取。"""
+
+from windup_framework.config.storage import settings as storage_settings
+
+from windup_app.server.character.model import Character
+from windup_app.server.media.service import card_thumbnail_key
+
+
+def extract_object_keys(character: Character) -> list[str]:
+    """提取角色拥有的对象存储键，供单角色和项目级删除共用。"""
+    prefix = storage_settings.download_base + "/"
+    keys: list[str] = []
+    seen: set[str] = set()
+
+    def add_url(url: str | None, *, include_thumbnail: bool = False) -> None:
+        if not url or not url.startswith(prefix):
+            return
+        key = url[len(prefix) :]
+        if key not in seen:
+            seen.add(key)
+            keys.append(key)
+        if include_thumbnail:
+            thumbnail_key = card_thumbnail_key(key)
+            if thumbnail_key not in seen:
+                seen.add(thumbnail_key)
+                keys.append(thumbnail_key)
+
+    add_url(character.reference_image_url, include_thumbnail=True)
+
+    data = character.character_data or {}
+    for template in data.get("templates", []):
+        add_url(template.get("image_url"))
+    for outfit in data.get("outfits", []):
+        add_url(outfit.get("preview_url"), include_thumbnail=True)
+        for action in outfit.get("actions", []):
+            frame_groups = [action.get("frames", [])]
+            frame_groups.extend(
+                sequence.get("frames", []) for sequence in action.get("sequences", [])
+            )
+            for frames in frame_groups:
+                for frame in frames:
+                    add_url(frame.get("image_url"))
+
+    return keys

--- a/backend/packages/app/src/windup_app/web/api/character.py
+++ b/backend/packages/app/src/windup_app/web/api/character.py
@@ -11,15 +11,16 @@ from windup_common.enums.biz_code import BizCode
 from windup_common.enums.character import CharacterStatus
 from windup_common.exceptions import BizException
 from windup_common.result import ListResponse, Response
-from windup_framework.config.storage import settings as storage_settings
 from windup_framework.db import get_session
 
+from windup_app.server.character.cleanup import (
+    extract_object_keys as _extract_object_keys,
+)
 from windup_app.server.character.model import Character, CharacterData
 from windup_app.server.character.direction_validation import (
     validate_character_directions,
 )
 from windup_app.server.character.service import service as character_service
-from windup_app.server.media.service import card_thumbnail_key
 from windup_app.server.media.service import service as media_service
 from windup_app.server.project.model import Project
 from windup_app.server.project.service import service as project_service
@@ -78,52 +79,6 @@ class CharacterSummaryOut(BaseModel):
     outfit_name: str | None
     outfit_count: int
     action_count: int
-
-
-# ── 辅助函数 ─────────────────────────────────────────────────────────────────
-
-
-def _extract_object_keys(character: Character) -> list[str]:
-    """从角色中提取所有对象存储 key,用于删除时清理资源。
-
-    URL 格式: ``{download_base}/{object_key}``
-    """
-    prefix = storage_settings.download_base + "/"
-    keys: list[str] = []
-    seen: set[str] = set()
-
-    def add_url(url: str | None, *, include_thumbnail: bool = False) -> None:
-        if not url or not url.startswith(prefix):
-            return
-        key = url[len(prefix) :]
-        if key not in seen:
-            seen.add(key)
-            keys.append(key)
-        if include_thumbnail:
-            thumbnail_key = card_thumbnail_key(key)
-            if thumbnail_key not in seen:
-                seen.add(thumbnail_key)
-                keys.append(thumbnail_key)
-
-    # 参考图
-    add_url(character.reference_image_url, include_thumbnail=True)
-
-    # character_data 内的 URL
-    data = character.character_data or {}
-    for template in data.get("templates", []):
-        add_url(template.get("image_url"))
-    for outfit in data.get("outfits", []):
-        add_url(outfit.get("preview_url"), include_thumbnail=True)
-        for action in outfit.get("actions", []):
-            frame_groups = [action.get("frames", [])]
-            frame_groups.extend(
-                sequence.get("frames", []) for sequence in action.get("sequences", [])
-            )
-            for frames in frame_groups:
-                for frame in frames:
-                    add_url(frame.get("image_url"))
-
-    return keys
 
 
 # ── 归属校验 ─────────────────────────────────────────────────────────────────

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -14,7 +14,9 @@ from windup_common.exceptions import BizException
 from windup_common.result import ListResponse, Response
 from windup_framework.db import get_session
 
+from windup_app.server.character.cleanup import extract_object_keys
 from windup_app.server.character.service import service as character_service
+from windup_app.server.media.service import service as media_service
 from windup_app.server.project.interface import UNSET
 from windup_app.server.project.service import service
 
@@ -222,13 +224,37 @@ def delete_project(
     project = service.get_project(session, project_id, for_update=True)
     if project is None or project.user_id != request.state.current_user.id:
         raise BizException("项目不存在", code=BizCode.NOT_FOUND)
-    if character_service.project_has_characters(session, project_id):
-        raise BizException("项目下仍有角色，无法删除", code=BizCode.BAD_REQUEST)
+    characters = []
+    page = 1
+    while True:
+        items, total = character_service.list_characters(
+            session,
+            project_id=project_id,
+            page=page,
+            page_size=100,
+        )
+        characters.extend(items)
+        if len(characters) >= total:
+            break
+        page += 1
+
+    object_keys = list(
+        dict.fromkeys(
+            key for character in characters for key in extract_object_keys(character)
+        )
+    )
     try:
+        for character in characters:
+            character_service.delete_character(session, character.id)
         service.delete_project(session, project_id)
     except IntegrityError:
         session.rollback()
         raise BizException(
             "项目下仍有角色，无法删除", code=BizCode.BAD_REQUEST
         ) from None
+    for key in object_keys:
+        try:
+            media_service.delete(key)
+        except Exception:
+            logger.warning("[WINDUP] 媒体清理失败(已跳过) | key=%s", key, exc_info=True)
     return Response.success(None, message="删除成功")

--- a/backend/tests/test_character_api.py
+++ b/backend/tests/test_character_api.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from windup_app.server.character import cleanup as character_cleanup
 from windup_app.web.api import character as character_api
 from windup_app.server.character.model import Character
 from windup_app.server.character.service import service as character_service
@@ -148,7 +149,7 @@ def test_character_model_defaults_to_draft(db_session):
 def test_extract_object_keys_includes_directional_action_frames(monkeypatch):
     """删除角色时只清理真实方向帧，不为镜像方向重复清理。"""
     monkeypatch.setattr(
-        character_api,
+        character_cleanup,
         "storage_settings",
         SimpleNamespace(download_base="https://assets.example.com"),
     )

--- a/backend/tests/test_media_thumbnail.py
+++ b/backend/tests/test_media_thumbnail.py
@@ -260,10 +260,10 @@ def test_action_frame_upload_does_not_write_a_thumbnail(monkeypatch):
 
 @patch("windup_app.web.api.character.media_service")
 def test_delete_character_cleans_card_thumbnails(mock_media_service, monkeypatch, auth_client):
-    import windup_app.web.api.character as character_api
+    import windup_app.server.character.cleanup as character_cleanup
 
     monkeypatch.setattr(
-        character_api.storage_settings,
+        character_cleanup.storage_settings,
         "bucket_domain",
         "https://cdn.windup.test",
     )

--- a/backend/tests/test_project_api.py
+++ b/backend/tests/test_project_api.py
@@ -5,7 +5,12 @@
 ``timestamp`` 默认省略)与 400/404 业务码路径。
 """
 
+from types import SimpleNamespace
+
 from sqlalchemy import event
+
+from windup_app.server.character import cleanup as character_cleanup
+from windup_app.web.api import project as project_api
 
 
 def _payload(**overrides):
@@ -300,63 +305,82 @@ def test_delete_not_found_returns_404(auth_client):
     assert resp.json()["code"] == 404
 
 
-def test_delete_rejected_when_project_has_characters(auth_client):
+def test_delete_cascades_all_characters_and_cleans_media(auth_client, monkeypatch):
+    deleted_keys = []
+    monkeypatch.setattr(
+        character_cleanup.storage_settings,
+        "bucket_domain",
+        "https://assets.windup.test",
+    )
+    monkeypatch.setattr(
+        project_api,
+        "media_service",
+        SimpleNamespace(delete=deleted_keys.append),
+        raising=False,
+    )
     created = auth_client.post(
-        "/projects", json=_payload(project_name="有角色")
+        "/projects",
+        json=_payload(project_name="有角色", directional_movement=1),
     ).json()["data"]
-    character = auth_client.post(
+    draft = auth_client.post(
         "/characters",
         json={
             "project_id": created["id"],
             "workflow_run_id": 348,
-            "name": "挂载角色",
-            "description": "阻止删项目",
+            "name": "草稿角色",
+            "reference_image_url": (
+                "https://assets.windup.test/media/reference-image/draft.source.png"
+            ),
         },
-    ).json()
-
-    assert character["code"] == 200
-
-    resp = auth_client.delete(f"/projects/{created['id']}")
-
-    body = resp.json()
-    assert body["code"] == 400
-    assert body["message"] == "项目下仍有角色，无法删除"
-    assert body["data"] is None
-    assert auth_client.get(f"/projects/{created['id']}").json()["code"] == 200
-    assert (
-        auth_client.get(f"/characters/{character['data']['id']}").json()["code"] == 200
-    )
-
-
-def test_delete_rejected_when_character_arrives_after_empty_check(
-    auth_client, monkeypatch
-):
-    """模拟检查与删除之间插入角色：应用层已看见空项目，数据库仍应拦住删除。"""
-    created = auth_client.post("/projects", json=_payload(project_name="竞态")).json()[
-        "data"
-    ]
-    character = auth_client.post(
+    ).json()["data"]
+    published = auth_client.post(
         "/characters",
         json={
             "project_id": created["id"],
             "workflow_run_id": 349,
-            "name": "后插入",
-            "description": "检查之后才出现",
+            "name": "已发布角色",
+            "character_data": {
+                "version": 1,
+                "outfits": [
+                    {
+                        "id": "outfit-1",
+                        "name": "常态",
+                        "actions": [
+                            {
+                                "id": "idle",
+                                "type": "idle",
+                                "name": "待机",
+                                "frame_count": 1,
+                                "frames": [
+                                    {
+                                        "index": 0,
+                                        "image_url": (
+                                            "https://assets.windup.test/"
+                                            "media/action-frame/idle.png"
+                                        ),
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
         },
-    ).json()
-    assert character["code"] == 200
-
-    monkeypatch.setattr(
-        "windup_app.web.api.project.character_service.project_has_characters",
-        lambda session, project_id: False,
-    )
+    ).json()["data"]
 
     resp = auth_client.delete(f"/projects/{created['id']}")
 
     body = resp.json()
-    assert body["code"] == 400
-    assert body["message"] == "项目下仍有角色，无法删除"
-    assert auth_client.get(f"/projects/{created['id']}").json()["code"] == 200
-    assert (
-        auth_client.get(f"/characters/{character['data']['id']}").json()["code"] == 200
+    assert body["code"] == 200
+    assert body["message"] == "删除成功"
+    assert body["data"] is None
+    assert auth_client.get(f"/projects/{created['id']}").json()["code"] == 404
+    assert auth_client.get(f"/characters/{draft['id']}").json()["code"] == 404
+    assert auth_client.get(f"/characters/{published['id']}").json()["code"] == 404
+    assert sorted(deleted_keys) == sorted(
+        [
+            "media/reference-image/draft.source.png",
+            "media/reference-image/draft.card.webp",
+            "media/action-frame/idle.png",
+        ]
     )


### PR DESCRIPTION
删除项目时同步删除项目下的全部草稿与已发布角色，用户不再需要先手动清空角色。

## 原因

原有接口只要检测到角色记录就拒绝删除项目，但产品没有完整的角色清空路径，导致生成过角色的项目无法正常删除。

## 改动

- 在项目行锁保护下读取并删除项目内的全部角色，再删除项目。
- 抽取共享媒体键提取逻辑，单角色删除与项目删除保持同一清理口径。
- 对重复媒体键去重；对象存储清理失败仍只记录日志，不回滚数据库删除。

## 实现

- 项目归属与不存在校验保持不变。
- 角色创建和项目删除继续锁定同一项目行，避免删除过程中并发插入新角色。
- 回归用例同时覆盖草稿角色、已发布角色、角色记录删除和媒体键清理。

## 验证

- [x] `uv run pytest -q tests/test_project_api.py tests/test_character_api.py::test_extract_object_keys_includes_directional_action_frames tests/test_media_thumbnail.py::test_delete_character_cleans_card_thumbnails`：17 条通过。
- [x] `uv run ruff check ...`：通过。
- [x] `uv run lint-imports`：2 条分层契约通过。

## 范围

- 不改变前端删除项目的交互与接口形状。
- 不改变单角色删除的媒体清理语义。
- 未运行全量测试；本次只执行删除链相关测试与受影响的静态、分层检查。

## 关联问题

Closes #677
