### PR TITLE
fix(quick-start): remove generation action borders

### DIFF
--- a/frontend/src/features/export-package/export-panel.tsx
+++ b/frontend/src/features/export-package/export-panel.tsx
@@ -176,7 +176,7 @@ export function ExportButton({
         onClick={() => void startExport()}
         className={
           iconOnly
-            ? `group/export-action relative grid size-10 shrink-0 place-items-center rounded-lg border border-current transition focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-50 ${className}`
+            ? `group/export-action relative grid size-10 shrink-0 place-items-center rounded-lg transition focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-50 ${className}`
             : `${pill ? 'rounded-full' : 'rounded-lg'} inline-flex min-h-10 items-center justify-center gap-2 border border-current px-3 py-2 text-xs font-semibold disabled:opacity-50 ${className}`
         }
       >

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -483,6 +483,12 @@ describe('QuickStartPage', () => {
     expect(actions.every((button) => button.querySelector('svg'))).toBe(true)
     expect(actions.every((button) => button.querySelector('[role="tooltip"]'))).toBe(true)
 
+    const relatedActions = actions[0]?.closest<HTMLElement>('[data-agent-actions]')
+    expect(relatedActions?.className).not.toMatch(/\b(border|bg-app-surface\/80|p-1)\b/)
+    expect(
+      actions.slice(0, 3).every((button) => !button.className.match(/\bborder(?:-\S+)?\b/)),
+    ).toBe(true)
+
     fireEvent.click(actions[0]!)
     await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith('像素骑士'))
   })

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -501,7 +501,7 @@ function AgentActions({
       data-agent-actions
       role="group"
       aria-label="相关操作"
-      className="flex w-fit max-w-full flex-wrap items-center gap-1 rounded-xl border border-app-line bg-app-surface/80 p-1"
+      className="flex w-fit max-w-full flex-wrap items-center gap-1"
     >
       {copyLabel && onCopy ? (
         <IconActionButton label={copyLabel} onClick={onCopy}>
@@ -517,7 +517,7 @@ function AgentActions({
         <ExportButton
           model={exportModel}
           iconOnly
-          className="border-transparent bg-app-accent text-app-on-accent hover:bg-app-accent-hover"
+          className="bg-app-accent text-app-on-accent hover:bg-app-accent-hover"
         />
       ) : null}
       {showNewCreation ? (


### PR DESCRIPTION
Quick Start 生成结果区改为轻量无边框图标操作，移除额外容器底板，同时保持原有交互与状态语义。

## Why

复制、下载等上下文操作此前带有额外边框和操作组底板，在生成结果之间形成不必要的视觉块，且同一组按钮的表现不一致。

## Changes

- 移除生成结果相关操作组的边框、底色和额外内边距。
- 移除 `iconOnly` 导出按钮的边框，保留强调色、图标、工具提示和状态反馈。
- 增加回归断言，覆盖操作组与图标按钮的无边框约束。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx -t 'renders real Chat History actions as SVG controls with accessible tooltips'`：1 passed。
- [x] `npm test -- src/features/export-package/export-panel.test.tsx`：9 passed。
- [x] `npx oxfmt --check src/features/export-package/export-panel.tsx src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxlint src/features/export-package/export-panel.tsx src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。

## Scope

- 本 PR 不修改生成流程、下载逻辑、数据契约或普通文字导出按钮。
- 本 PR 不包含其他 Quick Start 视觉调整。

## Related Issues

Closes #682
