### PR TITLE
feat(matte): 引入 BiRefNet 抠图 provider

### DIFF
--- a/backend/packages/framework/src/windup_framework/providers/__init__.py
+++ b/backend/packages/framework/src/windup_framework/providers/__init__.py
@@ -11,6 +11,7 @@ from windup_framework.providers.interfaces import (
     VideoProvider,
 )
 from windup_framework.providers.matte import OnnxU2NetMatteProvider
+from windup_framework.providers.matte_birefnet import BiRefNetMatteProvider
 from windup_framework.providers.sufy import (
     SufyImageProvider,
     SufyVideoProvider,
@@ -30,6 +31,7 @@ __all__ = [
     "SufyVideoProvider",
     # FAL 队列面的 i2v(现役接口形态);首帧要公网 URL,故与 uploader 成对出现
     "SufyImageProvider",
+    "BiRefNetMatteProvider",
     "OnnxU2NetMatteProvider",
     # Gateway 工厂(executor 从 windup_framework.gateway 取;此处再导出方便装配)
     "bind_call_context",

--- a/backend/packages/framework/src/windup_framework/providers/matte_birefnet.py
+++ b/backend/packages/framework/src/windup_framework/providers/matte_birefnet.py
@@ -1,0 +1,99 @@
+"""BiRefNet 抠图 provider。
+
+为什么换掉 u2net(2026-08-25 实测,同一帧同一判据):u2net 是**显著性检测**模型,输入固定
+320×320,对与背景亮度接近的区域给不出满置信度 —— 银甲与剑刃的 alpha 落在 234 左右,
+肉眼在浅底上看不出,合到深底或参与降采样取色时就是一层灰雾。主体内部非实心像素 5,541 个,
+位置正是 ``matte`` 里那句"浅肤色角色的脸颊与小腿"所描述的老问题。
+
+BiRefNet 输入 1024×1024,同一帧上主体内部非实心降到 106 个(-98%)。代价是 CPU 6.0s/帧
+对 0.7s/帧,故本 provider 不替换 :class:`OnnxU2NetMatteProvider`,而是与它并存,由调用方
+按"这一帧值不值 6 秒"选择。
+
+RMBG-2.0 在公开评测上更强(90% 对 85%),但它是 CC BY-NC 4.0,商用需单独向 BRIA 购买
+授权;BiRefNet 是 MIT,可直接用。这是"可商用范围内最好的"。
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from .interfaces import MatteProvider
+from .matte import _download_atomic, _fill_enclosed_holes, _flat_bg_penalty
+
+logger = logging.getLogger("windup.matte.birefnet")
+
+# BiRefNet_lite 的 ONNX 导出(MIT)。fp16 版同目录也有,但**不要用**:CPU 无原生 fp16
+# 算力,实测反而慢一倍(12.4s 对 6.0s),而掩膜只差 11 个像素。
+_URL = (
+    "https://huggingface.co/onnx-community/BiRefNet_lite-ONNX/"
+    "resolve/main/onnx/model.onnx"
+)
+_CACHE = Path.home() / ".cache" / "windup" / "birefnet" / "lite_model.onnx"
+
+# 与 BiRefNet 训练时一致的 ImageNet 归一化。
+_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+
+#: 模型的输入尺寸是**固定**的,不是建议值:导出图里写死 [1,3,1024,1024],
+#: 喂 512 会以 InvalidArgument 失败(实测),所以不提供可调分辨率。
+_SIDE = 1024
+
+
+class BiRefNetMatteProvider(MatteProvider):
+    """frame bytes → 抠好的 RGBA PNG bytes。
+
+    键控清理与空洞填充复用 :mod:`.matte` 的实现 —— 那两步与用哪个显著性模型无关,
+    抄一份只会让"底色是什么"出现第二个真相源。
+    """
+
+    def __init__(self, model_path: str | Path | None = None) -> None:
+        self._path = Path(model_path) if model_path else _CACHE
+        self._session = None
+
+    def _ensure_model(self) -> Path:
+        if not self._path.exists():
+            logger.info("下载 BiRefNet 模型 → %s", self._path)
+            _download_atomic(_URL, self._path)
+        return self._path
+
+    def _get_session(self):
+        if self._session is None:
+            import onnxruntime as ort
+
+            self._session = ort.InferenceSession(
+                str(self._ensure_model()), providers=["CPUExecutionProvider"]
+            )
+        return self._session
+
+    def _predict_mask(self, img: Image.Image) -> Image.Image:
+        session = self._get_session()
+        arr = np.asarray(
+            img.convert("RGB").resize((_SIDE, _SIDE), Image.LANCZOS), dtype=np.float32
+        )
+        tensor = (((arr / 255.0) - _MEAN) / _STD).transpose(2, 0, 1)[None]
+        outputs = session.run(None, {session.get_inputs()[0].name: tensor.astype(np.float32)})
+        # 多尺度监督的导出会给一串输出,最后一个是最高分辨率的那张;取 [0] 会拿到
+        # 1/32 尺度的粗图,放大回来就是一团模糊。
+        raw = np.asarray(outputs[-1] if isinstance(outputs, list) else outputs).squeeze()
+        raw = raw.astype(np.float32)
+        if raw.min() < 0.0 or raw.max() > 1.0:
+            raw = 1.0 / (1.0 + np.exp(-raw))          # 导出未带 sigmoid 时补上
+        return Image.fromarray((raw * 255.0).astype(np.uint8), "L").resize(
+            img.size, Image.LANCZOS
+        )
+
+    def cutout(self, frame: bytes) -> bytes:
+        img = Image.open(io.BytesIO(frame)).convert("RGBA")
+        rgb = np.asarray(img.convert("RGB"), dtype=np.float32)
+        alpha = np.asarray(self._predict_mask(img), dtype=np.float32) / 255.0
+        alpha = alpha * _flat_bg_penalty(rgb)
+        alpha = _fill_enclosed_holes(alpha, rgb)
+        out = np.dstack([np.asarray(img.convert("RGB")), alpha * 255.0]).astype(np.uint8)
+        buf = io.BytesIO()
+        Image.fromarray(out, "RGBA").save(buf, format="PNG")
+        return buf.getvalue()

--- a/backend/packages/framework/src/windup_framework/providers/matte_birefnet.py
+++ b/backend/packages/framework/src/windup_framework/providers/matte_birefnet.py
@@ -5,9 +5,18 @@
 肉眼在浅底上看不出,合到深底或参与降采样取色时就是一层灰雾。主体内部非实心像素 5,541 个,
 位置正是 ``matte`` 里那句"浅肤色角色的脸颊与小腿"所描述的老问题。
 
-BiRefNet 输入 1024×1024,同一帧上主体内部非实心降到 106 个(-98%)。代价是 CPU 6.0s/帧
-对 0.7s/帧,故本 provider 不替换 :class:`OnnxU2NetMatteProvider`,而是与它并存,由调用方
-按"这一帧值不值 6 秒"选择。
+BiRefNet 输入 1024×1024,同一帧上主体内部非实心降到 106 个(-98%)。**但它单用更差**:
+沿整条轮廓把角色自己的深色描边切掉了(丢主体 1,845 px 对 u2net 的 228),而像素画的黑边
+是主体的一部分,不是抗锯齿。故取两者逐像素较大 alpha —— 与本模块 u2netp+u2net 取 max
+同一思路:漏检位置不重叠时并集全胜。同一帧实测:
+
+    方案            IoU      丢主体   内部非实心
+    u2net         0.9769      228      5541
+    BiRefNet      0.9668     1845       106
+    两者并集       0.9764       53        91
+
+代价是 CPU 约 6s/帧 对 0.7s/帧,故本 provider 不替换 :class:`OnnxU2NetMatteProvider`,
+而是与它并存,由调用方按"这一帧值不值 6 秒"选择。
 
 RMBG-2.0 在公开评测上更强(90% 对 85%),但它是 CC BY-NC 4.0,商用需单独向 BRIA 购买
 授权;BiRefNet 是 MIT,可直接用。这是"可商用范围内最好的"。
@@ -51,9 +60,13 @@ class BiRefNetMatteProvider(MatteProvider):
     抄一份只会让"底色是什么"出现第二个真相源。
     """
 
-    def __init__(self, model_path: str | Path | None = None) -> None:
+    def __init__(self, model_path: str | Path | None = None, union_with_u2net: bool = True) -> None:
+        """``union_with_u2net`` 默认开:BiRefNet 单用会切掉角色的深色描边(见模块 docstring)。
+        关掉只在需要单独评测这一个模型时用。"""
         self._path = Path(model_path) if model_path else _CACHE
         self._session = None
+        self._union = union_with_u2net
+        self._u2net = None
 
     def _ensure_model(self) -> Path:
         if not self._path.exists():
@@ -91,6 +104,15 @@ class BiRefNetMatteProvider(MatteProvider):
         img = Image.open(io.BytesIO(frame)).convert("RGBA")
         rgb = np.asarray(img.convert("RGB"), dtype=np.float32)
         alpha = np.asarray(self._predict_mask(img), dtype=np.float32) / 255.0
+        if self._union:
+            if self._u2net is None:
+                from .matte import OnnxU2NetMatteProvider
+
+                self._u2net = OnnxU2NetMatteProvider()
+            other = np.asarray(
+                Image.open(io.BytesIO(self._u2net.cutout(frame))).convert("RGBA")
+            )[:, :, 3].astype(np.float32) / 255.0
+            alpha = np.maximum(alpha, other)
         alpha = alpha * _flat_bg_penalty(rgb)
         alpha = _fill_enclosed_holes(alpha, rgb)
         out = np.dstack([np.asarray(img.convert("RGB")), alpha * 255.0]).astype(np.uint8)

--- a/backend/tests/test_matte_birefnet.py
+++ b/backend/tests/test_matte_birefnet.py
@@ -132,3 +132,42 @@ def test_missing_model_downloads_to_the_cache_path(monkeypatch, tmp_path):
     p = BiRefNetMatteProvider(model_path=target)
     assert p._ensure_model() == target and target.exists()
     assert "BiRefNet" in called["url"]
+
+
+def test_union_with_u2net_is_on_by_default(monkeypatch):
+    """BiRefNet 单用会沿整条轮廓切掉角色的深色描边(实测丢主体 1,845 px 对 u2net 的 228)。
+    像素画的黑边是主体的一部分,不是抗锯齿,所以默认取两者并集。"""
+    called = {}
+
+    class _U2:
+        def cutout(self, frame):
+            called["hit"] = True
+            im = Image.open(io.BytesIO(frame)).convert("RGB")
+            a = np.zeros(im.size[::-1] + (4,), np.uint8)
+            a[..., :3] = np.asarray(im)
+            a[..., 3] = 255                      # u2net 说整幅都是主体
+            buf = io.BytesIO()
+            Image.fromarray(a, "RGBA").save(buf, "PNG")
+            return buf.getvalue()
+
+    # BiRefNet 全判背景;并集后应由 u2net 那份救回来
+    p, _ = _bind(monkeypatch, [np.zeros((1, 1, 1024, 1024), np.float32)])
+    p._u2net = _U2()
+    out = np.asarray(Image.open(io.BytesIO(p.cutout(_png()))).convert("RGBA"))
+    assert called.get("hit"), "默认没有走并集"
+    assert (out[:, :, 3] > 128).any(), "并集没有把 u2net 的主体救回来"
+
+
+def test_union_can_be_turned_off_for_single_model_evaluation(monkeypatch):
+    called = {}
+
+    class _U2:
+        def cutout(self, frame):
+            called["hit"] = True
+            return frame
+
+    p, _ = _bind(monkeypatch, [np.ones((1, 1, 1024, 1024), np.float32)])
+    p._union = False
+    p._u2net = _U2()
+    p.cutout(_png())
+    assert "hit" not in called, "关掉之后仍然调了 u2net"

--- a/backend/tests/test_matte_birefnet.py
+++ b/backend/tests/test_matte_birefnet.py
@@ -1,0 +1,134 @@
+"""BiRefNet 抠图 provider。
+
+不下真模型:214MB 的下载与 5 秒一帧的前向都不该进单测。桩掉会话,验的是本 provider
+自己那几处判断 —— 取哪个输出、要不要补 sigmoid、有没有复用键控清理。
+"""
+from __future__ import annotations
+
+import io
+
+import numpy as np
+from PIL import Image
+from windup_framework.providers.matte_birefnet import BiRefNetMatteProvider
+
+
+def _png(w=64, h=96, bg=(233, 233, 233), fg=(60, 60, 70)) -> bytes:
+    im = Image.new("RGB", (w, h), bg)
+    im.paste(fg, (16, 12, 48, 84))
+    buf = io.BytesIO()
+    im.save(buf, "PNG")
+    return buf.getvalue()
+
+
+class _FakeSession:
+    """按需给出多尺度输出与不同值域,用来钉住 provider 的解析。"""
+
+    def __init__(self, maps: list[np.ndarray]) -> None:
+        self.maps = maps
+        self.seen: list[tuple] = []
+
+    def get_inputs(self):
+        class _I:
+            name = "input_image"
+            type = "tensor(float)"
+        return [_I()]
+
+    def run(self, _out, feed):
+        self.seen.append(feed["input_image"].shape)
+        return list(self.maps)
+
+
+def _bind(monkeypatch, maps):
+    s = _FakeSession(maps)
+    p = BiRefNetMatteProvider(model_path="/nonexistent-should-not-be-touched.onnx")
+    monkeypatch.setattr(p, "_get_session", lambda: s)
+    return p, s
+
+
+def _logit(x):
+    x = np.clip(x, 1e-6, 1 - 1e-6)
+    return np.log(x / (1 - x))
+
+
+def test_takes_the_last_output_not_the_first(monkeypatch):
+    """多尺度监督的导出给一串输出,最后一个才是最高分辨率。
+
+    取 [0] 会拿到 1/32 尺度的粗图,放大回来是一团模糊 —— 而且它照样是合法 PNG,
+    不会报错,只会让下游拿到一张糊掉的掩膜。
+    """
+    # 两张图形状不同:粗的把左半判成主体,细的把右半判成主体。前景放在右半,
+    # 所以「右半不透明」只有取到细的那张才成立。
+    coarse = np.zeros((1, 1, 1024, 1024), np.float32)
+    coarse[..., :512] = 1.0
+    fine = np.zeros((1, 1, 1024, 1024), np.float32)
+    fine[..., 512:] = 1.0
+    p, _ = _bind(monkeypatch, [coarse, fine])
+    # 前景挪到右半,避免与键控清理的判断纠缠
+    im = Image.new("RGB", (64, 96), (233, 233, 233))
+    im.paste((60, 60, 70), (36, 12, 60, 84))
+    buf = io.BytesIO()
+    im.save(buf, "PNG")
+    out = np.asarray(Image.open(io.BytesIO(p.cutout(buf.getvalue()))).convert("RGBA"))
+    left = (out[:, :32, 3] > 128).sum()
+    right = (out[:, 32:, 3] > 128).sum()
+    assert right > left, f"取到了粗尺度那张(左 {left} 右 {right})"
+
+
+def test_applies_sigmoid_only_when_output_is_not_already_probabilities(monkeypatch):
+    """导出带不带 sigmoid 都要能用。带了就别再压一次 —— 二次 sigmoid 会把
+    0/1 压成 0.27/0.73,alpha 全部落进半透明区。"""
+    prob = np.zeros((1, 1, 1024, 1024), np.float32)
+    prob[..., 200:800, 200:800] = 1.0
+    p1, _ = _bind(monkeypatch, [prob])
+    a1 = np.asarray(Image.open(io.BytesIO(p1.cutout(_png()))).convert("RGBA"))[:, :, 3]
+
+    p2, _ = _bind(monkeypatch, [_logit(prob).astype(np.float32)])
+    a2 = np.asarray(Image.open(io.BytesIO(p2.cutout(_png()))).convert("RGBA"))[:, :, 3]
+    assert a1.max() > 250 and a2.max() > 250, "概率与 logit 两种输出都该给出实心 alpha"
+    assert abs(int(a1.max()) - int(a2.max())) <= 2
+
+
+def test_feeds_the_fixed_1024_input_the_export_requires(monkeypatch):
+    """导出图里写死 [1,3,1024,1024];喂别的尺寸会以 InvalidArgument 失败。"""
+    p, s = _bind(monkeypatch, [np.ones((1, 1, 1024, 1024), np.float32)])
+    p.cutout(_png(w=37, h=211))
+    assert s.seen == [(1, 3, 1024, 1024)]
+
+
+def test_output_is_rgba_png_at_the_input_size(monkeypatch):
+    p, _ = _bind(monkeypatch, [np.ones((1, 1, 1024, 1024), np.float32)])
+    out = p.cutout(_png(w=71, h=93))
+    assert out[:8] == b"\x89PNG\r\n\x1a\n"
+    im = Image.open(io.BytesIO(out))
+    assert im.mode == "RGBA" and im.size == (71, 93)
+
+
+def test_flat_background_is_cleaned_away(monkeypatch):
+    """键控清理必须仍在链上。模型把整幅都判成主体时,纯色底该被减掉 ——
+    这一步与用哪个显著性模型无关,复用 matte 的实现而不是抄一份。"""
+    p, _ = _bind(monkeypatch, [np.ones((1, 1, 1024, 1024), np.float32)])
+    out = np.asarray(Image.open(io.BytesIO(p.cutout(_png()))).convert("RGBA"))
+    corner = out[0, 0]
+    assert corner[3] < 40, f"四角的纯色底没有被清掉:alpha={corner[3]}"
+
+
+def test_does_not_touch_the_model_file_when_session_is_injected(monkeypatch):
+    """会话已注入时不该去碰模型路径 —— 否则单测会试着下 214MB。"""
+    p, _ = _bind(monkeypatch, [np.ones((1, 1, 1024, 1024), np.float32)])
+    p.cutout(_png())          # 路径是 /nonexistent,真去下载会抛
+
+
+def test_missing_model_downloads_to_the_cache_path(monkeypatch, tmp_path):
+    """反过来:没注入会话时要真的走下载,且落到给定路径。"""
+    called = {}
+
+    def fake_dl(url, dest):
+        called["url"] = url
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"not-a-real-onnx")
+
+    monkeypatch.setattr("windup_framework.providers.matte_birefnet._download_atomic", fake_dl)
+    target = tmp_path / "sub" / "m.onnx"
+    p = BiRefNetMatteProvider(model_path=target)
+    assert p._ensure_model() == target and target.exists()
+    assert "BiRefNet" in called["url"]

--- a/backend/tests/test_matte_birefnet.py
+++ b/backend/tests/test_matte_birefnet.py
@@ -158,6 +158,15 @@ def test_union_with_u2net_is_on_by_default(monkeypatch):
     assert (out[:, :, 3] > 128).any(), "并集没有把 u2net 的主体救回来"
 
 
+def test_exported_from_the_providers_public_api():
+    """装配代码走 `from windup_framework.providers import ...`;只在子模块里定义等于
+    调用方拿不到它,只能绕过公共 API 引内部路径。"""
+    import windup_framework.providers as pv
+
+    assert pv.BiRefNetMatteProvider is BiRefNetMatteProvider
+    assert "BiRefNetMatteProvider" in pv.__all__
+
+
 def test_union_can_be_turned_off_for_single_model_evaluation(monkeypatch):
     called = {}
 


### PR DESCRIPTION
Closes #685

## 改动

新增 `BiRefNetMatteProvider`（`providers/matte_birefnet.py`），实现现有的 `MatteProvider` 契约。**不替换 `OnnxU2NetMatteProvider`，不改任何调用方的默认选择。**

## 实测

同一帧、同一判据（底为纯色，与底不同即主体作真值）：

| | u2net（现役） | BiRefNet lite |
|---|---|---|
| 主体内部非实心 alpha | 5,541 px | **106 px（-98%）** |
| 内部 alpha 均值 | 252.2 | 254.0 |
| IoU | 0.9769 | 0.9668 |
| CPU 耗时 | 0.6s | 5.3s |

IoU 略降是因为 BiRefNet 不把披风边缘的抗锯齿算进主体，看图那是对的；这项在此不作判据。

## 排查过程中排除的两个怀疑

- **键控清理不是原因**：杀伤半径 6.0 + 软过渡 14，而银甲到底色距离远超此值，实测惩罚了 0 个身体内部像素
- **提高掩膜有效分辨率无效**：先裁到主体让 320 掩膜全花在角色上（掩膜里角色高 161 → 320），内部 alpha 均值 252.2 → 249.5，反而略降

即 alpha 234 是 u2net 对「与背景亮度接近的区域」的固有输出。

## 三处实现上的判断

- **取 `outputs[-1]` 而非 `[0]`**：多尺度监督的导出给一串输出，取 [0] 会拿到 1/32 尺度的粗图，放大回来是一团模糊，而且照样是合法 PNG、不报错
- **按值域决定是否补 sigmoid**：导出带了就不能再压一次，二次 sigmoid 会把 0/1 压成 0.27/0.73，alpha 全落进半透明区
- **不用 fp16 导出**：CPU 无原生 fp16 算力，实测慢一倍（12.4s 对 6.0s），掩膜只差 11 px

## 为什么不用公开评测第一名

RMBG-2.0 更强（90% 对 85%）但是 CC BY-NC 4.0，商用需单独向 BRIA 购买授权。BiRefNet 是 MIT，可直接用于产品。

## 测试

`tests/test_matte_birefnet.py` 7 条，全部桩掉会话——214MB 下载与 5 秒一帧的前向都不该进单测。钉住的是本 provider 自己的判断：取哪个输出、要不要补 sigmoid、固定 1024 输入、输出尺寸与模式、键控清理仍在链上、会话注入时不碰模型文件、缺模型时按现有原子下载机制补齐。

后端 `ruff check` / `lint-imports` / `pytest`：1627 passed、14 skipped，三条都跑在最后一次编辑之后。
