### PR TITLE
feat(ui): unify product radius and surface styles

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -141,6 +141,10 @@ describe('AppHeader 进行中任务入口', () => {
     const entry = await screen.findByRole('button', { name: '创作，有任务进行中' })
     expect(entry.getAttribute('aria-expanded')).toBe('false')
     expect(screen.queryByRole('link', { name: '创作' })).toBeNull()
+
+    fireEvent.click(entry)
+    expect(screen.getByTestId('active-run-menu').className).toContain('rounded-app-surface')
+    expect(screen.getByTestId('active-run-menu').className).toContain('border-app-line-strong')
   })
 
   it('任务在同一标签页开始后，入口无需刷新就出现', async () => {
@@ -524,6 +528,12 @@ describe('AppHeader', () => {
     renderHeader('/workspace', createApis(), undefined, quota)
 
     fireEvent.click(await screen.findByRole('button', { name: '打开账号菜单' }))
+
+    expect(screen.getByRole('button', { name: '打开账号菜单' }).className).toContain(
+      'rounded-app-control',
+    )
+    expect(screen.getByTestId('account-menu').className).toContain('rounded-app-surface')
+    expect(screen.getByTestId('account-menu').className).toContain('border-app-line-strong')
 
     await waitFor(() => expect(quota.getBalance).toHaveBeenCalledTimes(1))
     expect(screen.getByText('可用积分')).toBeTruthy()

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -6,6 +6,7 @@ import type { QuotaApis } from '@/entities'
 import { readActiveRun, subscribeActiveRun } from '@/features/active-run'
 import { AUTH_SESSION_STORAGE_PREFIX, useAuthSession } from '@/features/auth-session'
 import { useQuotaBalance } from '@/features/quota'
+import { productControlClass, productMenuItemClass, productPopoverClass } from '@/shared/ui'
 import { PageBackButton } from './page-back-button'
 
 interface ProductNavigationItem {
@@ -295,7 +296,7 @@ export function AppHeader({
                     aria-hidden={activeRunMenuOpen ? undefined : true}
                     inert={!activeRunMenuOpen}
                     onAnimationEnd={finishActiveRunMenuMotion}
-                    className={`absolute top-[calc(100%+0.5rem)] left-1/2 grid min-w-44 origin-top -translate-x-1/2 overflow-hidden rounded-lg border border-app-ink/12 bg-app-surface-raised p-1.5 shadow-app-menu ${
+                    className={`${productPopoverClass} absolute top-[calc(100%+0.5rem)] left-1/2 grid min-w-44 origin-top -translate-x-1/2 overflow-hidden p-1.5 ${
                       activeRunMenuState === 'open'
                         ? 'visible app-header-account-menu-in'
                         : activeRunMenuState === 'closing'
@@ -306,7 +307,7 @@ export function AppHeader({
                     <Link
                       to={`/quick-start/${encodeURIComponent(activeRunId)}`}
                       onClick={closeActiveRunMenu}
-                      className="flex min-h-11 items-center gap-2 rounded-md px-3 text-[13px] text-app-ink-soft transition-colors hover:bg-app-accent-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                      className={`${productMenuItemClass} min-h-11 gap-2 text-app-ink-soft hover:text-app-accent`}
                     >
                       <span
                         aria-hidden="true"
@@ -317,7 +318,7 @@ export function AppHeader({
                     <Link
                       to={item.to}
                       onClick={closeActiveRunMenu}
-                      className="flex min-h-11 items-center rounded-md px-3 text-[13px] text-app-ink-soft transition-colors hover:bg-app-accent-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                      className={`${productMenuItemClass} min-h-11 text-app-ink-soft hover:text-app-accent`}
                     >
                       开始新的创作
                     </Link>
@@ -400,7 +401,7 @@ export function AppHeader({
                 aria-expanded={accountMenuOpen}
                 title={session.state.user.email}
                 onClick={toggleAccountMenu}
-                className={`inline-flex min-h-10 max-w-24 items-center gap-2 rounded-lg px-2.5 text-xs font-medium text-app-ink-soft transition-[color,background-color,transform] duration-150 ease-out hover:bg-app-accent-muted hover:text-app-accent active:translate-y-px active:scale-[0.97] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent motion-reduce:transform-none sm:max-w-36 ${
+                className={`${productControlClass('chrome', 'max-w-24 gap-2 px-2.5 font-medium active:translate-y-px active:scale-[0.97] motion-reduce:transform-none sm:max-w-36')} ${
                   accountMenuOpen ? 'bg-app-accent-muted text-app-accent' : ''
                 }`}
               >
@@ -423,7 +424,7 @@ export function AppHeader({
                 aria-hidden={accountMenuOpen ? undefined : true}
                 inert={!accountMenuOpen}
                 onAnimationEnd={finishAccountMenuMotion}
-                className={`absolute top-[calc(100%+0.5rem)] right-0 grid min-w-44 origin-top-right overflow-hidden rounded-lg border border-app-ink/12 bg-app-surface-raised p-1.5 shadow-app-menu ${
+                className={`${productPopoverClass} absolute top-[calc(100%+0.5rem)] right-0 grid min-w-44 origin-top-right overflow-hidden p-1.5 ${
                   accountMenuState === 'open'
                     ? 'visible app-header-account-menu-in'
                     : accountMenuState === 'closing'
@@ -460,7 +461,7 @@ export function AppHeader({
                   aria-label="打开账号中心"
                   aria-current={pathname.startsWith('/account') ? 'page' : undefined}
                   onClick={() => setAccountMenuState('closing')}
-                  className="flex min-h-10 items-center rounded-md px-3 text-[13px] text-app-ink-soft transition-colors hover:bg-app-accent-muted focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-app-accent"
+                  className={`${productMenuItemClass} text-app-ink-soft`}
                 >
                   账号中心
                 </Link>
@@ -468,7 +469,7 @@ export function AppHeader({
                   type="button"
                   onClick={signOut}
                   aria-label="退出登录"
-                  className="flex min-h-10 items-center rounded-md px-3 text-left text-[13px] text-app-muted transition-colors hover:bg-app-accent-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-app-accent"
+                  className={`${productMenuItemClass} text-left text-app-muted hover:text-app-accent`}
                 >
                   退出登录
                 </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -182,6 +182,14 @@ body,
 @theme {
   --font-serif: 'Noto Serif SC Variable', serif;
 
+  /*
+   * 登录后产品界面的圆角只保留三层。紧凑元素、交互控件和内容表面逐级增加，
+   * 胶囊与正圆仍使用 rounded-full；宣传页不复用这些语义令牌。
+   */
+  --radius-app-compact: 0.5rem;
+  --radius-app-control: 0.75rem;
+  --radius-app-surface: 1rem;
+
   --color-paper: #f5f5f2;
   --color-paper-raised: #fbfbfa;
   --color-paper-sunken: #e9eae4;

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -674,7 +674,7 @@ describe('QuickStartPage', () => {
     expect(composer.className).toContain('block')
     expect(composer.className).toContain('pl-4')
     expect(composer.className).toContain('pr-14')
-    expect(editingSurface?.className).toContain('rounded-[18px]')
+    expect(editingSurface?.className).toContain('rounded-app-surface')
     expect(editingSurface?.className).toContain('bg-app-surface-raised')
     expect(screen.getByRole('button', { name: '生成角色' }).className).toContain('rounded-full')
     expect(form?.className).toContain('flex-col')
@@ -1246,7 +1246,7 @@ describe('QuickStartPage', () => {
     expect(composer.getAttribute('data-position')).toBe('floating')
     expect(composer.className).toContain('absolute')
     expect(composer.className).toContain('sm:bottom-4')
-    expect(composer.querySelector('form')?.className).toContain('rounded-[18px]')
+    expect(composer.querySelector('form')?.className).toContain('rounded-app-surface')
     expect(agentTurns.length).toBeGreaterThanOrEqual(2)
     expect(userTurns.length).toBeGreaterThanOrEqual(2)
     expect(userTurns.every((turn) => turn.className.includes('w-fit'))).toBe(true)
@@ -1433,13 +1433,31 @@ describe('QuickStartPage', () => {
     expect(cards.every((card) => card.querySelector('img'))).toBeTruthy()
   })
 
-  it('matches generated cards to the composer radius and keeps image surfaces free of labels', async () => {
+  it('uses the shared surface radius for generated cards and keeps image surfaces free of labels', async () => {
     renderStateFixture('template-selecting')
 
     const cards = await screen.findAllByRole('button', { name: /选择角色方案/u })
 
-    expect(cards.every((card) => card.className.includes('rounded-2xl'))).toBe(true)
+    expect(cards.every((card) => card.className.includes('rounded-app-surface'))).toBe(true)
     expect(cards.every((card) => card.textContent === '')).toBe(true)
+  })
+
+  it('uses shared control and surface radii in the entry composer', async () => {
+    renderAt('/quick-start', serviceFor(null))
+
+    const prompt = await screen.findByRole('textbox', { name: '创作指令' })
+    const editingSurface = prompt.closest('label')
+    const uploadButton = screen.getByRole('button', { name: '添加母版' })
+    const directionButton = screen.getByRole('button', { name: '生成方向，当前单向' })
+
+    expect(editingSurface?.className).toContain('rounded-app-surface')
+    expect(uploadButton.className).toContain('rounded-app-compact')
+    expect(directionButton.className).toContain('rounded-app-control')
+
+    fireEvent.click(directionButton)
+    expect(screen.getByRole('group', { name: '生成方向设置' }).className).toContain(
+      'rounded-app-surface',
+    )
   })
 
   it('keeps equal candidate frames at the same size as confirmed assets', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -52,6 +52,7 @@ import {
   GenerationPreviewCard,
   GenerationProgressCopy,
   KineticCopyCycle,
+  productPopoverClass,
   type KineticCopyMessage,
 } from '@/shared/ui'
 import {
@@ -464,7 +465,7 @@ function IconActionButton({
       disabled={disabled}
       onClick={onClick}
       data-icon-action
-      className={`group/action relative grid size-10 shrink-0 place-items-center rounded-lg transition focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-45 ${
+      className={`group/action relative grid size-10 shrink-0 place-items-center rounded-app-compact transition focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-45 ${
         accent
           ? 'bg-app-accent text-app-on-accent hover:bg-app-accent-hover'
           : 'text-app-muted hover:bg-app-surface-muted hover:text-app-accent'
@@ -474,7 +475,7 @@ function IconActionButton({
       <span
         id={tooltipId}
         role="tooltip"
-        className="pointer-events-none absolute top-full left-1/2 z-20 mt-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-app-ink px-2 py-1 text-[11px] font-medium text-app-canvas opacity-0 shadow-app-card transition group-hover/action:visible group-hover/action:opacity-100 group-focus-within/action:visible group-focus-within/action:opacity-100 invisible"
+        className="pointer-events-none absolute top-full left-1/2 z-20 mt-2 -translate-x-1/2 whitespace-nowrap rounded-app-compact bg-app-ink px-2 py-1 text-[11px] font-medium text-app-canvas opacity-0 shadow-app-card transition group-hover/action:visible group-hover/action:opacity-100 group-focus-within/action:visible group-focus-within/action:opacity-100 invisible"
       >
         {label}
       </span>
@@ -1137,7 +1138,7 @@ function QuickStartInput({
             className="quick-start-agent-composer relative flex flex-col"
           >
             <label
-              className="relative block min-h-[52px] min-w-0 overflow-hidden rounded-[18px] border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]"
+              className="relative block min-h-[52px] min-w-0 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]"
               htmlFor="quick-start-prompt"
             >
               <span className="sr-only">创作指令</span>
@@ -1243,7 +1244,7 @@ function QuickStartInput({
                       <div
                         role="menu"
                         aria-label="选择画风"
-                        className="quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-32 gap-1 rounded-[14px] border border-app-line bg-[var(--color-app-surface-raised)] p-1.5 opacity-100 shadow-app-panel"
+                        className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-32 gap-1 p-1.5 opacity-100`}
                       >
                         {ART_STYLE_OPTIONS.map((value) => (
                           <button
@@ -1252,7 +1253,7 @@ function QuickStartInput({
                             role="menuitemradio"
                             aria-checked={gameStyle === value}
                             onClick={() => chooseGameStyle(value)}
-                            className={`rounded-lg px-3 py-2 text-left text-xs transition ${
+                            className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${
                               gameStyle === value
                                 ? 'bg-app-accent-soft text-app-accent'
                                 : 'text-app-ink-soft hover:bg-app-surface-muted'
@@ -1267,14 +1268,14 @@ function QuickStartInput({
                 </div>
               ) : null}
               {templateFile && !hasConversation ? (
-                <span className="absolute bottom-full left-3 mb-2 inline-flex max-w-56 items-center gap-1 rounded-lg bg-app-surface-raised px-2 py-1 text-xs text-app-ink-soft shadow-app-card">
+                <span className="absolute bottom-full left-3 mb-2 inline-flex max-w-56 items-center gap-1 rounded-app-compact bg-app-surface-raised px-2 py-1 text-xs text-app-ink-soft shadow-app-card">
                   <span className="truncate">{templateFile.name}</span>
                   <button
                     type="button"
                     aria-label="移除图片"
                     disabled={entryBusy}
                     onClick={removeTemplateFile}
-                    className="grid size-6 shrink-0 place-items-center rounded-md text-app-muted hover:text-app-accent"
+                    className="grid size-6 shrink-0 place-items-center rounded-app-compact text-app-muted hover:text-app-accent"
                   >
                     <X aria-hidden="true" size={13} weight="bold" />
                   </button>
@@ -1300,7 +1301,7 @@ function QuickStartInput({
                           setDirectionSliderValue(directionalMovementIndex)
                           setDirectionMenuOpen((open) => !open)
                         }}
-                        className="inline-flex h-10 items-center gap-1 rounded-lg px-3 text-sm font-medium text-app-ink-soft transition hover:bg-app-surface-muted hover:text-app-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-45"
+                        className="inline-flex h-10 items-center gap-1 rounded-app-control px-3 text-sm font-medium text-app-ink-soft transition hover:bg-app-surface-muted hover:text-app-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-45"
                       >
                         {DIRECTIONAL_MOVEMENT[directionalMovement]}
                         <CaretDown
@@ -1314,7 +1315,7 @@ function QuickStartInput({
                         <div
                           role="group"
                           aria-label="生成方向设置"
-                          className="quick-start-control-popover absolute right-0 bottom-full z-30 mb-3 w-72 rounded-[18px] border border-app-line-strong bg-[var(--color-app-surface-raised)] p-5 opacity-100 shadow-app-panel"
+                          className={`${productPopoverClass} quick-start-control-popover absolute right-0 bottom-full z-30 mb-3 w-72 p-5 opacity-100`}
                         >
                           <div className="mb-4 flex items-center justify-between">
                             <span className="text-sm text-app-muted">生成方向</span>
@@ -1381,14 +1382,14 @@ function QuickStartInput({
           </form>
 
           {unavailableReason ? (
-            <p className="mt-3 rounded-xl border border-app-warning-line bg-app-warning-soft px-4 py-3 text-sm text-app-warning">
+            <p className="mt-3 rounded-app-surface border border-app-warning-line bg-app-warning-soft px-4 py-3 text-sm text-app-warning">
               {unavailableReason}
             </p>
           ) : null}
           {error ? (
             <p
               role="alert"
-              className="mt-3 rounded-xl bg-app-danger px-4 py-3 text-sm text-app-danger-soft"
+              className="mt-3 rounded-app-surface bg-app-danger px-4 py-3 text-sm text-app-danger-soft"
             >
               {error}
             </p>
@@ -1510,7 +1511,7 @@ function UserTurn({ children }: { children: ReactNode }) {
   return (
     <div
       data-user-turn
-      className="ml-auto w-fit max-w-[78%] rounded-[1.15rem] rounded-br-md bg-app-surface-muted px-4 py-2.5 text-left text-sm leading-6 text-app-ink-soft"
+      className="ml-auto w-fit max-w-[78%] rounded-app-surface rounded-br-app-compact bg-app-surface-muted px-4 py-2.5 text-left text-sm leading-6 text-app-ink-soft"
     >
       <span>{children}</span>
     </div>
@@ -1619,7 +1620,7 @@ function DirectionCandidatePicker({
                   }
                   data-reveal="card"
                   style={{ '--reveal-index': displayIndex } as CSSProperties}
-                  className={`quick-start-reveal-card relative aspect-square overflow-hidden rounded-2xl border bg-app-surface-raised text-left transition duration-200 ${
+                  className={`quick-start-reveal-card relative aspect-square overflow-hidden rounded-app-surface border bg-app-surface-raised text-left transition duration-200 ${
                     chosen
                       ? 'border-app-accent ring-1 ring-app-accent'
                       : 'border-app-line hover:border-app-line-strong'
@@ -1657,14 +1658,14 @@ function DirectionFirstFrameStack({
       role="group"
       aria-label={`${directionCountLabel}首帧集合`}
       data-layout="direction-first-frame-stack"
-      className="grid aspect-square w-full max-w-xl grid-cols-2 gap-3 overflow-hidden rounded-[2rem] border border-app-line-strong bg-app-surface-muted p-4 shadow-app-card sm:p-5"
+      className="grid aspect-square w-full max-w-xl grid-cols-2 gap-3 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-muted p-4 shadow-app-card sm:p-5"
     >
       {directions.map((direction) => {
         const imageUrl = selections[direction]
         return imageUrl ? (
           <figure
             key={direction}
-            className="relative min-h-0 overflow-hidden rounded-2xl border border-app-line bg-app-surface-raised"
+            className="relative min-h-0 overflow-hidden rounded-app-control border border-app-line bg-app-surface-raised"
           >
             <AssetVisual
               src={imageUrl}
@@ -1680,7 +1681,7 @@ function DirectionFirstFrameStack({
             key={direction}
             role="status"
             aria-label={`${DIRECTION_LABELS[direction]}方向首帧生成中`}
-            className="grid min-h-0 place-items-center rounded-2xl border border-dashed border-app-line bg-app-surface-raised text-xs font-semibold text-app-muted"
+            className="grid min-h-0 place-items-center rounded-app-control border border-dashed border-app-line bg-app-surface-raised text-xs font-semibold text-app-muted"
           >
             {DIRECTION_LABELS[direction]}方向生成中
           </div>
@@ -2752,7 +2753,7 @@ function QuickStartRun({
         >
           <form
             onSubmit={continueConversation}
-            className="grid grid-cols-[1fr_auto] items-center gap-1.5 rounded-[18px] border border-app-line-strong bg-app-surface-raised/96 p-1.5 shadow-app-panel backdrop-blur-xl transition focus-within:border-app-accent"
+            className="grid grid-cols-[1fr_auto] items-center gap-1.5 rounded-app-surface border border-app-line-strong bg-app-surface-raised/96 p-1.5 shadow-app-panel backdrop-blur-xl transition focus-within:border-app-accent"
           >
             <label htmlFor="quick-start-continuation" className="min-w-0">
               <span className="sr-only">继续描述你的想法</span>

--- a/frontend/src/pages/workspace/index.test.tsx
+++ b/frontend/src/pages/workspace/index.test.tsx
@@ -255,6 +255,24 @@ describe('WorkspacePage', () => {
     expect(screen.getByRole('link', { name: '新建项目' }).getAttribute('href')).toBe(
       '/projects/new',
     )
+    expect(screen.getByRole('link', { name: '查看全部项目' }).className).toContain(
+      'rounded-app-control',
+    )
+    expect(screen.getByRole('link', { name: '查看全部项目' }).className).not.toContain(
+      'rounded-full',
+    )
+    expect(screen.getByRole('link', { name: '新建项目' }).className).toContain(
+      'rounded-app-control',
+    )
+    expect(screen.getByRole('link', { name: '查看全部项目' }).className.split(' ')).not.toContain(
+      'border',
+    )
+    expect(screen.getByRole('link', { name: '新建项目' }).className.split(' ')).not.toContain(
+      'border',
+    )
+    expect(screen.getByRole('link', { name: '查看全部项目' }).querySelector('svg')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '新建项目' }).querySelector('svg')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '查看全部项目' }).textContent).toBe('全部项目')
   })
 
   it('announces project loading before the first page resolves', async () => {

--- a/frontend/src/pages/workspace/index.tsx
+++ b/frontend/src/pages/workspace/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react'
+import { FolderOpen, Plus } from '@phosphor-icons/react'
 import { Link } from 'react-router'
 
 import {
@@ -11,7 +12,7 @@ import {
   type WorkflowRun,
 } from '@/entities'
 import type { Paged } from '@/shared/pagination'
-import { Pagination } from '@/shared/ui'
+import { Pagination, productControlClass } from '@/shared/ui'
 
 import { WorkspaceEntranceVisual } from './visuals'
 import './workspace.css'
@@ -419,9 +420,11 @@ export function WorkspacePage() {
             {mode === 'projects' && projects !== null && projects.total > 0 ? (
               <ContextFooter className="shrink-0 pt-3">
                 <ContextLink to="/projects" aria-label="查看全部项目">
-                  查看全部项目
+                  <FolderOpen aria-hidden="true" size={16} weight="regular" />
+                  全部项目
                 </ContextLink>
                 <PrimaryContextLink to="/projects/new" aria-label="新建项目">
+                  <Plus aria-hidden="true" size={16} weight="bold" />
                   新建项目
                 </PrimaryContextLink>
               </ContextFooter>
@@ -974,10 +977,7 @@ function ContextFooter({ children, className = '' }: { children: ReactNode; clas
 
 function ContextLink({ children, ...props }: Omit<React.ComponentProps<typeof Link>, 'className'>) {
   return (
-    <Link
-      {...props}
-      className="inline-flex min-h-10 items-center rounded-full border border-app-line bg-app-surface-raised px-4 text-xs font-semibold text-app-ink-soft transition hover:border-app-line-strong hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-    >
+    <Link {...props} className={productControlClass('chrome')}>
       {children}
     </Link>
   )
@@ -988,10 +988,7 @@ function PrimaryContextLink({
   ...props
 }: Omit<React.ComponentProps<typeof Link>, 'className'>) {
   return (
-    <Link
-      {...props}
-      className="inline-flex min-h-10 items-center rounded-full bg-app-accent px-4 text-xs font-semibold text-app-on-accent transition hover:bg-app-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-    >
+    <Link {...props} className={productControlClass('accent')}>
       {children}
     </Link>
   )

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -18,3 +18,5 @@ export type { KineticCopyCycleProps, KineticCopyMessage } from './kinetic-copy-c
 export { PixelMatrix } from './pixel-matrix'
 export { FrameAnimationPlayer } from './frame-animation-player'
 export type { FrameAnimationFrame, FrameAnimationPlayerProps } from './frame-animation-player'
+export { productControlClass, productMenuItemClass, productPopoverClass } from './product-control'
+export type { ProductControlVariant } from './product-control'

--- a/frontend/src/shared/ui/product-control.test.ts
+++ b/frontend/src/shared/ui/product-control.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { productControlClass, productMenuItemClass, productPopoverClass } from './product-control'
+
+describe('product control styles', () => {
+  it('keeps primary and secondary actions on the same control geometry', () => {
+    const primary = productControlClass('primary')
+    const secondary = productControlClass('secondary')
+
+    for (const className of [primary, secondary]) {
+      expect(className).toContain('rounded-app-control')
+      expect(className).toContain('border')
+      expect(className).not.toContain('rounded-full')
+    }
+    expect(primary.split(' ')).toContain('bg-app-accent-muted')
+    expect(secondary).toContain('bg-app-surface-raised')
+  })
+
+  it('keeps chrome controls borderless and reserves the outlined surface for popovers', () => {
+    expect(productControlClass('chrome').split(' ')).not.toContain('border')
+    expect(productControlClass('chrome')).toContain('bg-transparent')
+    expect(productControlClass('accent').split(' ')).not.toContain('border')
+    expect(productControlClass('accent')).toContain('bg-app-accent-muted')
+    expect(productPopoverClass).toContain('rounded-app-surface')
+    expect(productPopoverClass).toContain('border-app-line-strong')
+    expect(productMenuItemClass).toContain('rounded-app-compact')
+  })
+})

--- a/frontend/src/shared/ui/product-control.ts
+++ b/frontend/src/shared/ui/product-control.ts
@@ -1,0 +1,23 @@
+export type ProductControlVariant = 'accent' | 'chrome' | 'primary' | 'secondary'
+
+const productControlBaseClass =
+  'inline-flex min-h-10 items-center gap-2 rounded-app-control px-4 text-xs font-semibold transition-[color,background-color,border-color,transform] duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent'
+
+const productControlVariantClass: Record<ProductControlVariant, string> = {
+  accent: 'bg-app-accent-muted text-app-accent hover:bg-app-accent-soft',
+  chrome: 'bg-transparent text-app-ink-soft hover:bg-app-accent-muted hover:text-app-accent',
+  primary: 'border border-app-accent bg-app-accent-muted text-app-accent hover:bg-app-accent-soft',
+  secondary:
+    'border border-app-line-strong bg-app-surface-raised text-app-ink-soft hover:border-app-accent hover:bg-app-accent-muted hover:text-app-accent',
+}
+
+export function productControlClass(variant: ProductControlVariant, className = ''): string {
+  return `${productControlBaseClass} ${productControlVariantClass[variant]} ${className}`.trim()
+}
+
+/** 与 Quick Start 方向面板共用的产品浮层表面。 */
+export const productPopoverClass =
+  'rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel'
+
+export const productMenuItemClass =
+  'flex min-h-10 items-center rounded-app-compact px-3 text-[13px] transition-colors hover:bg-app-accent-muted focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-app-accent'


### PR DESCRIPTION
本 PR 为产品界面建立统一的 8/12/16px 圆角层级，并将 Quick Start、顶部菜单与工作台项目操作收敛到共享视觉样式，保持现有流程和交互语义不变。

## Why

产品界面此前混用了 Tailwind 默认圆角与多组任意值，相同层级的控件、菜单和浮层呈现不同曲率与边界处理，削弱了界面的一致性。

## Changes

- 建立 8px 紧凑元素、12px 控件、16px 面板的产品圆角令牌。
- 统一共享控件、菜单和浮层的白底、灰绿描边与克制阴影。
- 迁移 Quick Start 关键控件以及方向、画风面板。
- 统一 Header 账号菜单和进行中任务菜单的表面样式。
- 将工作台“全部项目 / 新建项目”调整为保留 SVG 的无边框按钮样式。

## Implementation

- 在 `frontend/src/index.css` 定义语义化圆角变量。
- 在 `frontend/src/shared/ui/product-control.ts` 提供共享 control、menu 与 popover 样式入口。
- 头像、状态点、标签和正圆按钮继续保留 `rounded-full`，不被矩形控件令牌覆盖。

## Verification

- [x] 相关 4 个测试文件：163/163 通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run format:check`：通过。
- [x] `npm run lint`：通过。
- [x] `npm run build`：通过。
- [x] `npm run test:coverage`：75 个测试文件、1104 个测试通过；Statements 90.51%。

## Scope

- 本 PR 不包含宣传页、后端与 API 契约、字体或 Logo 尺寸调整。
- 本 PR 不包含尚未确认迁移的其他遗留浮层。

## Related Issues

Closes #674
