### PR TITLE
fix(quick-start): restore composer cohesion and reply reveal

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -971,7 +971,7 @@ describe('QuickStartPage', () => {
 
   it('renders Markdown emphasis and lists in a Planner reply', async () => {
     const planner = vi.fn(async (_input: PlannerInput) => ({
-      text: '**建议先定住轮廓：**\n\n- 银色面具\n- 深色披风',
+      text: '**建议先定住轮廓：**\n\n- 银色面具\n- 深色披风\n\n[查看角色规范](https://example.com/guide)',
       finishReason: 'stop',
       toolCalls: [],
     }))
@@ -994,6 +994,7 @@ describe('QuickStartPage', () => {
     expect(reply.className).toContain('quick-start-agent-markdown--entering')
     expect(reply.querySelectorAll('.kinetic-copy-character').length).toBeGreaterThan(0)
     expect(bot?.querySelector('.kinetic-copy-character')).toBeNull()
+    expect(screen.getByRole('link', { name: '查看角色规范' })).toBeTruthy()
   })
 
   it('keeps the chosen art style across a page refresh', async () => {
@@ -1494,11 +1495,11 @@ describe('QuickStartPage', () => {
     renderAt('/quick-start', serviceFor(null))
 
     const prompt = await screen.findByRole('textbox', { name: '创作指令' })
-    const editingSurface = prompt.closest('label')
+    const composerSurface = prompt.closest('form')
     const uploadButton = screen.getByRole('button', { name: '添加母版' })
     const directionButton = screen.getByRole('button', { name: '生成方向，当前单向' })
 
-    expect(editingSurface?.className).toContain('rounded-app-surface')
+    expect(composerSurface?.className).toContain('rounded-app-surface')
     expect(uploadButton.className).toContain('rounded-app-compact')
     expect(directionButton.className).toContain('rounded-app-control')
 

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -674,19 +674,16 @@ describe('QuickStartPage', () => {
     expect(composer.className).toContain('block')
     expect(composer.className).toContain('pl-4')
     expect(composer.className).toContain('pr-14')
-    expect(form?.className).toContain('rounded-app-surface')
-    expect(form?.className).toContain('border-app-line-strong')
-    expect(form?.className).toContain('bg-app-surface-raised')
-    expect(form?.className).toContain('shadow-app-panel')
-    expect(editingSurface?.className).not.toContain('border-app-line-strong')
-    expect(editingSurface?.className).not.toContain('bg-app-surface-raised')
-    expect(editingSurface?.className).not.toContain('shadow-app-panel')
+    expect(editingSurface?.className).toContain('rounded-app-surface')
+    expect(editingSurface?.className).toContain('bg-app-surface-raised')
     expect(screen.getByRole('button', { name: '生成角色' }).className).toContain('rounded-full')
     expect(form?.className).toContain('flex-col')
     expect(controls?.className).toContain('order-first')
-    expect(controls?.className).not.toContain('mb-2')
+    expect(controls?.className).toContain('mb-2')
     expect(screen.getByRole('button', { name: '生成角色' }).className).toContain('bottom-[6px]')
-    expect(form?.className).toContain('focus-within:shadow-[var(--shadow-app-composer-focus)]')
+    expect(editingSurface?.className).toContain(
+      'focus-within:shadow-[var(--shadow-app-composer-focus)]',
+    )
   })
 
   it('submits the entry with Enter', async () => {
@@ -1148,6 +1145,16 @@ describe('QuickStartPage', () => {
 
     const composer = screen.getByTestId('quick-start-composer')
     const input = screen.getByRole('textbox', { name: '创作指令' }) as HTMLTextAreaElement
+    const conversationForm = input.closest('form')
+    const conversationSurface = input.closest('label')
+    const conversationControls = composer.querySelector(
+      '[data-layout="quick-start-composer-controls"]',
+    )
+    expect(conversationForm?.className).toContain('grid-cols-[1fr_auto]')
+    expect(conversationSurface?.className).not.toContain('border-app-line-strong')
+    expect(conversationSurface?.className).not.toContain('shadow-app-panel')
+    expect(conversationControls?.className).toContain('hidden')
+    expect(conversationForm?.querySelector('button')?.className).not.toContain('absolute')
     expect(input.tagName).toBe('TEXTAREA')
     expect(input.rows).toBe(1)
     expect(input.className).toContain('[field-sizing:content]')
@@ -1495,11 +1502,11 @@ describe('QuickStartPage', () => {
     renderAt('/quick-start', serviceFor(null))
 
     const prompt = await screen.findByRole('textbox', { name: '创作指令' })
-    const composerSurface = prompt.closest('form')
+    const editingSurface = prompt.closest('label')
     const uploadButton = screen.getByRole('button', { name: '添加母版' })
     const directionButton = screen.getByRole('button', { name: '生成方向，当前单向' })
 
-    expect(composerSurface?.className).toContain('rounded-app-surface')
+    expect(editingSurface?.className).toContain('rounded-app-surface')
     expect(uploadButton.className).toContain('rounded-app-compact')
     expect(directionButton.className).toContain('rounded-app-control')
 

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -674,16 +674,19 @@ describe('QuickStartPage', () => {
     expect(composer.className).toContain('block')
     expect(composer.className).toContain('pl-4')
     expect(composer.className).toContain('pr-14')
-    expect(editingSurface?.className).toContain('rounded-app-surface')
-    expect(editingSurface?.className).toContain('bg-app-surface-raised')
+    expect(form?.className).toContain('rounded-app-surface')
+    expect(form?.className).toContain('border-app-line-strong')
+    expect(form?.className).toContain('bg-app-surface-raised')
+    expect(form?.className).toContain('shadow-app-panel')
+    expect(editingSurface?.className).not.toContain('border-app-line-strong')
+    expect(editingSurface?.className).not.toContain('bg-app-surface-raised')
+    expect(editingSurface?.className).not.toContain('shadow-app-panel')
     expect(screen.getByRole('button', { name: '生成角色' }).className).toContain('rounded-full')
     expect(form?.className).toContain('flex-col')
     expect(controls?.className).toContain('order-first')
-    expect(controls?.className).toContain('mb-2')
+    expect(controls?.className).not.toContain('mb-2')
     expect(screen.getByRole('button', { name: '生成角色' }).className).toContain('bottom-[6px]')
-    expect(editingSurface?.className).toContain(
-      'focus-within:shadow-[var(--shadow-app-composer-focus)]',
-    )
+    expect(form?.className).toContain('focus-within:shadow-[var(--shadow-app-composer-focus)]')
   })
 
   it('submits the entry with Enter', async () => {
@@ -980,11 +983,17 @@ describe('QuickStartPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
 
     const reply = await screen.findByLabelText('Agent 回答')
+    const agentCopy = reply.closest('[data-agent-copy]')
+    const bot = agentCopy?.querySelector('[data-quick-start-agent-bot]')
     expect(reply.querySelector('strong')?.textContent).toBe('建议先定住轮廓：')
     expect(Array.from(reply.querySelectorAll('li')).map((item) => item.textContent)).toEqual([
       '银色面具',
       '深色披风',
     ])
+    expect(agentCopy?.className).not.toContain('quick-start-agent-copy--entering')
+    expect(reply.className).toContain('quick-start-agent-markdown--entering')
+    expect(reply.querySelectorAll('.kinetic-copy-character').length).toBeGreaterThan(0)
+    expect(bot?.querySelector('.kinetic-copy-character')).toBeNull()
   })
 
   it('keeps the chosen art style across a page refresh', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1574,14 +1574,28 @@ function animateMarkdownCharacters(
   if (Array.isArray(node)) {
     return node.map((child) => animateMarkdownCharacters(child, counter))
   }
-  if (!isValidElement<{ children?: ReactNode }>(node)) return node
+  if (!isValidElement<AnimatedMarkdownElementProps>(node)) return node
 
-  const element = node as ReactElement<{ children?: ReactNode }>
+  const element = node as ReactElement<AnimatedMarkdownElementProps>
+  const accessibleProps =
+    element.type === 'a' ? { 'aria-label': markdownTextContent(element.props.children) } : undefined
   return cloneElement(
     element,
-    undefined,
+    accessibleProps,
     animateMarkdownCharacters(element.props.children, counter),
   )
+}
+
+type AnimatedMarkdownElementProps = {
+  children?: ReactNode
+  'aria-label'?: string
+}
+
+function markdownTextContent(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(markdownTextContent).join('')
+  if (!isValidElement<AnimatedMarkdownElementProps>(node)) return ''
+  return markdownTextContent(node.props.children)
 }
 
 function QuickStartAgentBot({ placement }: { placement: 'title' | 'thinking' | 'answer' }) {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1186,10 +1186,18 @@ function QuickStartInput({
             onSubmit={(event) => void submit(event)}
             autoComplete="off"
             data-prompt-state={promptState}
-            className="quick-start-agent-composer relative flex flex-col rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]"
+            className={
+              hasConversation
+                ? 'quick-start-agent-composer grid grid-cols-[1fr_auto] items-center gap-1.5 overflow-hidden rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
+                : 'quick-start-agent-composer relative flex flex-col'
+            }
           >
             <label
-              className="relative block min-h-[52px] min-w-0 overflow-hidden"
+              className={
+                hasConversation
+                  ? 'relative ml-2 min-w-0 overflow-hidden rounded-lg'
+                  : 'relative block min-h-[52px] min-w-0 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
+              }
               htmlFor="quick-start-prompt"
             >
               <span className="sr-only">创作指令</span>
@@ -1218,15 +1226,21 @@ function QuickStartInput({
                         ? '描述动作，可留空生成待机动作…'
                         : '描述角色的外形、身份和气质…'
                 }
-                className={`block min-h-[52px] max-h-40 w-full min-w-0 resize-none overflow-y-auto border-0 bg-transparent py-[14px] pr-14 pl-4 text-[15px] leading-6 text-app-ink outline-none [field-sizing:content] placeholder:text-app-faint ${
-                  promptState === 'rewriting' ? 'text-transparent caret-transparent' : ''
-                }`}
+                className={`block max-h-40 w-full min-w-0 resize-none overflow-y-auto border-0 bg-transparent text-[15px] text-app-ink outline-none [field-sizing:content] placeholder:text-app-faint ${
+                  hasConversation
+                    ? 'min-h-10 px-4 py-2.5 leading-5'
+                    : 'min-h-[52px] py-[14px] pr-14 pl-4 leading-6'
+                } ${promptState === 'rewriting' ? 'text-transparent caret-transparent' : ''}`}
               />
               {promptState === 'rewriting' ? (
                 <span
                   data-prompt-rewrite
                   aria-hidden="true"
-                  className="quick-start-prompt-rewrite absolute inset-0 flex min-h-[52px] max-h-40 items-start overflow-y-auto py-[14px] pr-14 pl-4 text-[15px] leading-6 text-app-ink"
+                  className={`quick-start-prompt-rewrite absolute inset-0 flex max-h-40 items-start overflow-y-auto text-[15px] text-app-ink ${
+                    hasConversation
+                      ? 'min-h-10 px-4 py-2.5 leading-5'
+                      : 'min-h-[52px] py-[14px] pr-14 pl-4 leading-6'
+                  }`}
                 >
                   <KineticCopyCycle
                     active
@@ -1246,14 +1260,21 @@ function QuickStartInput({
               disabled={
                 entryCanInterrupt ? false : !canSubmit || entryBusy || Boolean(unavailableReason)
               }
-              className={`absolute right-[6px] bottom-[6px] z-10 grid size-10 place-items-center rounded-full border-0 text-app-canvas transition-[opacity,transform,background] duration-150 hover:-translate-y-px active:scale-95 disabled:cursor-default disabled:opacity-25 ${
-                entryCanInterrupt ? 'bg-app-ink' : 'bg-app-accent hover:bg-app-accent-hover'
-              }`}
+              className={`z-10 grid place-items-center border-0 text-app-canvas transition-[opacity,transform,background] duration-150 hover:-translate-y-px active:scale-95 disabled:cursor-default disabled:opacity-25 ${
+                hasConversation
+                  ? 'h-10 min-w-10 rounded-lg px-3'
+                  : 'absolute right-[6px] bottom-[6px] size-10 rounded-full'
+              } ${entryCanInterrupt ? 'bg-app-ink' : 'bg-app-accent hover:bg-app-accent-hover'}`}
             >
               {entryCanInterrupt ? (
                 <Stop aria-hidden="true" size={16} weight="fill" />
               ) : (
-                <ArrowUp aria-hidden="true" size={19} weight="bold" />
+                <span className="inline-flex items-center gap-2">
+                  {hasConversation ? (
+                    <span className="text-sm font-bold">{buttonLabel}</span>
+                  ) : null}
+                  <ArrowUp aria-hidden="true" size={hasConversation ? 16 : 19} weight="bold" />
+                </span>
               )}
             </button>
             <input
@@ -1267,7 +1288,9 @@ function QuickStartInput({
             />
             <div
               data-layout="quick-start-composer-controls"
-              className="order-first flex min-h-10 items-center justify-between gap-3 px-2 pt-1"
+              className={`order-first mb-2 min-h-10 items-center justify-between gap-3 px-1 ${
+                hasConversation ? 'hidden' : 'flex'
+              }`}
             >
               {!hasConversation ? (
                 <div className="flex items-center gap-1">

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1,4 +1,6 @@
 import {
+  cloneElement,
+  isValidElement,
   useCallback,
   useEffect,
   useMemo,
@@ -8,6 +10,7 @@ import {
   type CSSProperties,
   type ChangeEvent,
   type FormEvent,
+  type ReactElement,
   type ReactNode,
 } from 'react'
 import { flushSync } from 'react-dom'
@@ -23,7 +26,7 @@ import {
   Stop,
   X,
 } from '@phosphor-icons/react'
-import Markdown from 'markdown-to-jsx'
+import Markdown, { compiler } from 'markdown-to-jsx'
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router'
 
 import {
@@ -1183,10 +1186,10 @@ function QuickStartInput({
             onSubmit={(event) => void submit(event)}
             autoComplete="off"
             data-prompt-state={promptState}
-            className="quick-start-agent-composer relative flex flex-col"
+            className="quick-start-agent-composer relative flex flex-col rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]"
           >
             <label
-              className="relative block min-h-[52px] min-w-0 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]"
+              className="relative block min-h-[52px] min-w-0 overflow-hidden"
               htmlFor="quick-start-prompt"
             >
               <span className="sr-only">创作指令</span>
@@ -1264,7 +1267,7 @@ function QuickStartInput({
             />
             <div
               data-layout="quick-start-composer-controls"
-              className="order-first mb-2 flex min-h-10 items-center justify-between gap-3 px-1"
+              className="order-first flex min-h-10 items-center justify-between gap-3 px-2 pt-1"
             >
               {!hasConversation ? (
                 <div className="flex items-center gap-1">
@@ -1515,6 +1518,7 @@ function AgentCopy({
   animate?: boolean
 }) {
   const copy = lines.join('\n')
+  const animatedCopy = animateMarkdownCharacters(compiler(copy))
 
   return (
     <div
@@ -1522,17 +1526,61 @@ function AgentCopy({
       aria-label={lines.join(' ')}
       className={`quick-start-agent-copy grid grid-cols-[2rem_minmax(0,1fr)] items-start gap-3 font-serif ${
         tone === 'danger' ? 'text-app-danger' : 'text-app-ink-soft'
-      } ${animate ? 'quick-start-agent-copy--entering' : ''}`}
+      }`}
     >
       <QuickStartAgentBot placement="answer" />
       <div
         aria-label="Agent 回答"
         data-agent-markdown
-        className="quick-start-agent-markdown min-w-0"
+        className={`quick-start-agent-markdown min-w-0 ${
+          animate ? 'quick-start-agent-markdown--entering' : ''
+        }`}
       >
-        <Markdown>{copy}</Markdown>
+        {animate ? (
+          <>
+            <span className="sr-only" data-agent-copy-text>
+              {copy}
+            </span>
+            {animatedCopy}
+          </>
+        ) : (
+          <Markdown>{copy}</Markdown>
+        )}
       </div>
     </div>
+  )
+}
+
+function animateMarkdownCharacters(
+  node: ReactNode,
+  counter: { value: number } = { value: 0 },
+): ReactNode {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return Array.from(String(node)).map((character) => {
+      const characterIndex = counter.value
+      counter.value += 1
+      return (
+        <span
+          key={characterIndex}
+          aria-hidden="true"
+          className="kinetic-copy-character"
+          style={{ '--kinetic-copy-character-index': characterIndex } as CSSProperties}
+        >
+          {character === ' ' ? '\u00a0' : character}
+        </span>
+      )
+    })
+  }
+  if (Array.isArray(node)) {
+    return node.map((child) => animateMarkdownCharacters(child, counter))
+  }
+  if (!isValidElement<{ children?: ReactNode }>(node)) return node
+
+  const element = node as ReactElement<{ children?: ReactNode }>
+  return cloneElement(
+    element,
+    undefined,
+    animateMarkdownCharacters(element.props.children, counter),
   )
 }
 

--- a/frontend/src/pages/quick-start/quick-start-motion.css
+++ b/frontend/src/pages/quick-start/quick-start-motion.css
@@ -67,8 +67,13 @@
   animation: quick-start-agent-bot-blink 4.3s cubic-bezier(0.4, 0, 0.55, 1) infinite;
 }
 
-.quick-start-agent-copy--entering {
-  animation: quick-start-agent-answer-enter 680ms cubic-bezier(0.16, 1, 0.3, 1) both;
+.quick-start-agent-markdown--entering .kinetic-copy-character {
+  opacity: 0;
+  filter: blur(4px);
+  transform: translate3d(0, 0.42em, 0);
+  animation: kinetic-copy-character-enter 520ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation-delay: calc(90ms + min(var(--kinetic-copy-character-index) * 18ms, 420ms));
+  will-change: opacity, transform, filter;
 }
 
 .quick-start-agent-markdown {
@@ -195,19 +200,6 @@
   }
   95% {
     transform: scaleY(0.12);
-  }
-}
-
-@keyframes quick-start-agent-answer-enter {
-  from {
-    opacity: 0;
-    filter: blur(7px);
-    transform: translate3d(-12px, 10px, 0) scale(0.985);
-  }
-  to {
-    opacity: 1;
-    filter: blur(0);
-    transform: translate3d(0, 0, 0) scale(1);
   }
 }
 
@@ -463,8 +455,14 @@
   .quick-start-agent-bot__face,
   .quick-start-agent-bot__gaze,
   .quick-start-agent-bot__frame,
-  .quick-start-agent-bot__blink,
-  .quick-start-agent-copy--entering {
+  .quick-start-agent-bot__blink {
+    animation: none;
+    filter: none;
+    transform: none;
+  }
+
+  .quick-start-agent-markdown--entering .kinetic-copy-character {
+    opacity: 1;
     animation: none;
     filter: none;
     transform: none;


### PR DESCRIPTION
## 改动

- 将边框、背景、阴影和聚焦态移到完整 composer 外层，使配置控件与输入框保持为同一视觉表面。
- Agent 生成阶段继续显示三点加载，机器人进入回复列后保持稳定，不随答案再次淡入。
- 仅对 Markdown 正文复用现有逐字浮现动效，保留标题、强调、列表结构，并为完整文本保留无障碍读取节点。
- `prefers-reduced-motion` 下直接显示完整正文，不执行字符动画。

## 边界

- 仅修改 Quick Start UI 和对应测试。
- 不修改 API、Planner、知识库、生成流程、字段语义或后端逻辑。
- 未增加依赖。

## 验证

- `npm test -- --run src/pages/quick-start/index.test.tsx`（96 passed）
- `npm run typecheck`
- `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`
- `npm run format:check -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx src/pages/quick-start/quick-start-motion.css`
- `npm run build`
- `git diff --check upstream/main...HEAD`

Closes #692
