### PR TITLE
fix(quick-start-agent): harden planner proposal contract

### DIFF
--- a/frontend/src/features/quick-start-agent/planner.protocol.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.protocol.test.ts
@@ -44,7 +44,16 @@ describe('AI SDK OpenAI-compatible protocol fixture', () => {
       tool_choice: 'required',
     })
     expect(captured.stream).toBeUndefined()
-    expect((captured.tools as unknown[] | undefined)?.length).toBe(1)
+    const tools = captured.tools as
+      | Array<{ function?: { parameters?: { oneOf?: Array<{ required?: string[] }> } } }>
+      | undefined
+    expect(tools).toHaveLength(1)
+    expect(tools?.[0]?.function?.parameters?.oneOf).toEqual([
+      expect.objectContaining({
+        required: ['kind', 'optimizedPrompt', 'optimizationSummary'],
+      }),
+      expect.objectContaining({ required: ['kind', 'message'] }),
+    ])
   })
 
   it('parses one standard Tool Call and normalizes its finish reason', async () => {
@@ -92,7 +101,7 @@ describe('AI SDK OpenAI-compatible protocol fixture', () => {
     })
   })
 
-  it('rejects a Tool Call whose arguments fail the declared schema', async () => {
+  it('repairs the production proposal shape when the summary is returned as message', async () => {
     const planner = createAiSdkQuickStartPlanner({
       baseURL: 'https://api.windup.test/ai/v1',
       fetch: vi.fn(async () =>
@@ -102,11 +111,12 @@ describe('AI SDK OpenAI-compatible protocol fixture', () => {
             content: null,
             tool_calls: [
               {
-                id: 'call-invalid',
+                id: 'call-production-shape',
                 type: 'function',
                 function: {
-                  name: 'start_character_generation',
-                  arguments: '{"optimizedPrompt":"","optimizationSummary":"我会整理角色描述。"}',
+                  name: 'quick_start_decision',
+                  arguments:
+                    '{"kind":"proposal","message":"我保留了斗篷骑士的核心特征。","optimizedPrompt":"披着深色斗篷的全身骑士"}',
                 },
               },
             ],
@@ -116,12 +126,123 @@ describe('AI SDK OpenAI-compatible protocol fixture', () => {
       ),
     })
 
+    await expect(
+      planner({
+        messages: [{ role: 'user', content: '生成一个披着斗篷的骑士' }],
+        clarificationUsed: false,
+      }),
+    ).resolves.toEqual({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'quick_start_decision',
+          input: {
+            kind: 'proposal',
+            optimizedPrompt: '披着深色斗篷的全身骑士',
+            optimizationSummary: '我保留了斗篷骑士的核心特征。',
+          },
+        },
+      ],
+    })
+  })
+
+  it('re-asks once for an irreparable Tool Call and returns the repaired proposal', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        completion({
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call-invalid',
+                type: 'function',
+                function: {
+                  name: 'quick_start_decision',
+                  arguments: '{"kind":"proposal","message":"已经整理好了。"}',
+                },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        }),
+      )
+      .mockResolvedValueOnce(
+        completion({
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call-repaired',
+                type: 'function',
+                function: {
+                  name: 'quick_start_decision',
+                  arguments:
+                    '{"kind":"proposal","optimizedPrompt":"披着斗篷的全身骑士","optimizationSummary":"补齐了完整的角色母版描述。"}',
+                },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        }),
+      )
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      fetch,
+    })
+
     const result = await planner({
-      messages: [{ role: 'user', content: '直接生成' }],
+      messages: [{ role: 'user', content: '生成一个披着斗篷的骑士' }],
       clarificationUsed: false,
     })
 
-    expect(() => validatePlannerTerminal(result)).toThrow('生成提案的 optimizedPrompt 无效')
+    expect(validatePlannerTerminal(result)).toEqual({
+      kind: 'proposal',
+      optimizedPrompt: '披着斗篷的全身骑士',
+      optimizationSummary: '补齐了完整的角色母版描述。',
+    })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to a confirmable original prompt after one failed repair', async () => {
+    const invalid = () =>
+      completion({
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'call-still-invalid',
+              type: 'function',
+              function: {
+                name: 'quick_start_decision',
+                arguments: '{"kind":"proposal"}',
+              },
+            },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      })
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => invalid())
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      fetch,
+    })
+
+    const result = await planner({
+      messages: [{ role: 'user', content: '生成一个披着斗篷的骑士' }],
+      clarificationUsed: false,
+    })
+
+    expect(validatePlannerTerminal(result)).toEqual({
+      kind: 'proposal',
+      optimizedPrompt: '生成一个披着斗篷的骑士',
+      optimizationSummary: '我先完整保留了你的原始描述，你可以直接采用或继续补充细节。',
+    })
+    expect(fetch).toHaveBeenCalledTimes(2)
   })
 
   it('surfaces a standard 401 and honors cancellation', async () => {

--- a/frontend/src/features/quick-start-agent/planner.ts
+++ b/frontend/src/features/quick-start-agent/planner.ts
@@ -8,6 +8,7 @@ import {
   REGENERATE_FIRST_FRAME_TOOL,
   parseQuickStartDecision,
   QUICK_START_DECISION_TOOL,
+  validatePlannerTerminal,
   type PlannerInput,
   type PlannerResult,
   type QuickStartDecision,
@@ -30,6 +31,15 @@ interface GenerateTextOptionsLike {
   toolChoice: 'auto' | 'required'
   maxRetries: 0
   abortSignal?: AbortSignal
+  repairToolCall?: (options: {
+    toolCall: { toolCallId: string; toolName: string; input: string; [key: string]: unknown }
+    error: Error
+  }) => Promise<{
+    toolCallId: string
+    toolName: string
+    input: string
+    [key: string]: unknown
+  } | null>
 }
 
 export type QuickStartGenerateText = (
@@ -63,7 +73,18 @@ const quickStartDecisionTool = tool({
         optimizedPrompt: { type: 'string', minLength: 1, maxLength: 4_000 },
         optimizationSummary: { type: 'string', minLength: 1, maxLength: 600 },
       },
-      required: ['kind'],
+      oneOf: [
+        {
+          properties: { kind: { type: 'string', enum: ['proposal'] } },
+          required: ['kind', 'optimizedPrompt', 'optimizationSummary'],
+        },
+        {
+          properties: {
+            kind: { type: 'string', enum: ['reply', 'clarification', 'blocked'] },
+          },
+          required: ['kind', 'message'],
+        },
+      ],
     },
     {
       validate(value) {
@@ -117,6 +138,91 @@ const workflowTools = {
     description: '用户要求基于已确认的动作首帧修改姿态、朝向或动作起始细节时使用。',
     inputSchema: refinementToolSchema,
   }),
+}
+
+function recordInput(value: unknown): Record<string, unknown> | null {
+  if (typeof value === 'string') {
+    try {
+      const parsed: unknown = JSON.parse(value)
+      return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null
+    } catch {
+      return null
+    }
+  }
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function deterministicDecisionRepair(value: unknown): Record<string, unknown> | null {
+  const input = recordInput(value)
+  if (!input) return null
+  const message = typeof input.message === 'string' ? input.message.trim() : ''
+  const candidate =
+    input.kind === 'proposal' && !input.optimizationSummary && message
+      ? { ...input, optimizationSummary: message }
+      : input
+  try {
+    parseQuickStartDecision(candidate)
+    return candidate
+  } catch {
+    return null
+  }
+}
+
+function fallbackPlannerResult(
+  result: PlannerResult,
+  messages: PlannerInput['messages'],
+): PlannerResult {
+  try {
+    validatePlannerTerminal(result)
+    return result
+  } catch {
+    const call = result.toolCalls[0]
+    const input = recordInput(call?.input)
+    if (call?.toolName === QUICK_START_DECISION_TOOL && input?.kind === 'proposal') {
+      const latestUserInput = messages
+        .findLast((message) => message.role === 'user')
+        ?.content.trim()
+      const optimizedPrompt =
+        typeof input.optimizedPrompt === 'string' && input.optimizedPrompt.trim()
+          ? input.optimizedPrompt.trim().slice(0, 4_000)
+          : latestUserInput?.slice(0, 4_000)
+      if (optimizedPrompt) {
+        const suppliedSummary =
+          typeof input.optimizationSummary === 'string' && input.optimizationSummary.trim()
+            ? input.optimizationSummary.trim()
+            : typeof input.message === 'string' && input.message.trim()
+              ? input.message.trim()
+              : ''
+        return {
+          text: '',
+          finishReason: 'tool-calls',
+          toolCalls: [
+            {
+              toolName: QUICK_START_DECISION_TOOL,
+              input: {
+                kind: 'proposal',
+                optimizedPrompt,
+                optimizationSummary:
+                  suppliedSummary.slice(0, 600) ||
+                  '我先完整保留了你的原始描述，你可以直接采用或继续补充细节。',
+              },
+            },
+          ],
+        }
+      }
+    }
+
+    const message = typeof input?.message === 'string' ? input.message.trim() : ''
+    return {
+      text: message.slice(0, 2_000) || '请再补充一个最想保留的角色特征，我会继续整理。',
+      finishReason: 'stop',
+      toolCalls: [],
+    }
+  }
 }
 
 export function quickStartPlannerInstructions(clarificationUsed: boolean): string {
@@ -175,18 +281,49 @@ export function createAiSdkQuickStartPlanner({
           workflow.availableTools.map((name: WorkflowAgentToolName) => [name, workflowTools[name]]),
         )
       : { [QUICK_START_DECISION_TOOL]: quickStartDecisionTool }
+    const instructions = workflow
+      ? quickStartWorkflowInstructions(workflow)
+      : quickStartPlannerInstructions(clarificationUsed)
+    const history = messages.slice(-MAX_PLANNER_HISTORY_MESSAGES)
     const result = await generateText({
       model,
-      instructions: workflow
-        ? quickStartWorkflowInstructions(workflow)
-        : quickStartPlannerInstructions(clarificationUsed),
-      messages: messages.slice(-MAX_PLANNER_HISTORY_MESSAGES),
+      instructions,
+      messages: history,
       tools,
       toolChoice: workflow ? 'auto' : 'required',
       maxRetries: 0,
       abortSignal: signal,
+      repairToolCall: workflow
+        ? undefined
+        : async ({ toolCall, error }) => {
+            if (toolCall.toolName !== QUICK_START_DECISION_TOOL) return null
+            const repairedInput = deterministicDecisionRepair(toolCall.input)
+            if (repairedInput) {
+              return { ...toolCall, input: JSON.stringify(repairedInput) }
+            }
+
+            const repairResult = await generateText({
+              model,
+              instructions: `${instructions}\n\n上一份 Tool 参数没有通过合同校验。只修复参数结构，不改变用户意图。`,
+              messages: [
+                ...history.slice(-(MAX_PLANNER_HISTORY_MESSAGES - 1)),
+                {
+                  role: 'user',
+                  content: `请重新返回合法的 ${QUICK_START_DECISION_TOOL} 参数。上一份参数：${String(toolCall.input).slice(0, 6_000)}。校验错误：${error.message}`,
+                },
+              ],
+              tools,
+              toolChoice: 'required',
+              maxRetries: 0,
+              abortSignal: signal,
+            })
+            const repairedCall = repairResult.toolCalls.find(
+              (call) => call.toolName === QUICK_START_DECISION_TOOL,
+            )
+            return repairedCall ? { ...toolCall, input: JSON.stringify(repairedCall.input) } : null
+          },
     })
-    return {
+    const plannerResult: PlannerResult = {
       text: result.text,
       finishReason: result.finishReason,
       toolCalls: result.toolCalls.map((call) => ({
@@ -194,5 +331,6 @@ export function createAiSdkQuickStartPlanner({
         input: call.input,
       })),
     }
+    return workflow ? plannerResult : fallbackPlannerResult(plannerResult, messages)
   }
 }


### PR DESCRIPTION
修复 Quick Start Agent 提案 Tool 参数高频失配：让 provider、SDK 校验和运行时使用同一份分支合同，并在模型仍返回畸形参数时完成有界修复与安全降级。

## Why

生产请求 `e15be25c-8662-4d17-9c8a-bbbd606521c7` 的上游调用成功且返回一个 Tool Call，但 `proposal` 高频缺少 `optimizationSummary`。原 Schema 只要求 `kind`，分支必填字段直到浏览器运行时才被拒绝，最终显示“Agent 没有完成这次回复”。同一生产模型对同一输入复现 6 次，其中 4 次返回该畸形结构。

## Changes

- `quick_start_decision` 改用判别联合 Schema：proposal 明确要求提示词与优化摘要，文字分支明确要求 message。
- 将生产中“摘要写入 message”的等价结构确定性归一化，避免无意义的第二次模型调用。
- 其余畸形 Tool Call 最多重问一次；仍不合法时使用原始用户描述形成可确认提案，或降级为普通回复。
- 保持 proposal 校验和用户确认边界，任何降级路径都不直接触发生成。

## Implementation

- 使用 AI SDK `repairToolCall` 处理 Tool 输入校验失败；修复调用仍使用同一模型、同一 Tool 集合和 `maxRetries: 0`。
- 修复消息保留最近 14 条历史并追加一条校验反馈，连同 system message 不超过后端 16 条限制。
- 终态再次经过 `validatePlannerTerminal`；只有完整 proposal 才进入原有确认流程。

## Verification

- [x] `npm test -- src/features/quick-start-agent --configLoader runner`：6 files / 57 tests passed。
- [x] `npx oxfmt --check src/features/quick-start-agent/planner.ts src/features/quick-start-agent/planner.protocol.test.ts`：通过。
- [x] `npx oxlint src/features/quick-start-agent/planner.ts src/features/quick-start-agent/planner.protocol.test.ts`：通过。
- [x] `npm run build`：TypeScript 与 Vite 构建通过。
- [x] 生产有效模型使用判别联合 Schema 重放 6 次：6 次均返回分支必填字段。

## Scope

- 本 PR 不改变后端 `/ai/chat`、Gateway 路由、模型配置、生成授权、方向、画风或 Workflow 写入流程。
- 合并后需在预发用生产模型完成一次真实 Quick Start 对话，再同步生产。

## Related Issues

Closes #691
Refs #642
