### PR TITLE
fix(slicing): i2v 抽帧两遍解码,避免 720p 帧常驻 (#690)

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/slicing/__init__.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/slicing/__init__.py
@@ -10,13 +10,19 @@ loop),一次性动作裁动作区间。像素化 / 对齐 / 打包在 :mod:`..po
 注意它**仍然不参与选帧** —— 那条消融结论没变,见 :func:`.loop.pick_cycle`。
 """
 
-from .extract import extract_all_frames_bytes, extract_frames_bytes
-from .loop import find_period, pick_cycle
+from .extract import (
+    extract_all_frames_bytes,
+    extract_frames_at,
+    extract_frames_bytes,
+    extract_preview_frames,
+)
+from .loop import find_period, pick_cycle, pick_cycle_indices
 from .oneshot import (
     find_motion_span,
     first_action_end,
     foot_line_series,
     pick_oneshot,
+    pick_oneshot_indices,
     split_jump_phases,
 )
 from .quality import (
@@ -30,8 +36,11 @@ from .quality import (
 __all__ = [
     "extract_frames_bytes",
     "extract_all_frames_bytes",
+    "extract_preview_frames",
+    "extract_frames_at",
     "find_period",
     "pick_cycle",
+    "pick_cycle_indices",
     # 交付成色的四个读数(汇成 ports.ActionQuality;其余 quality.* 仍是内部诊断)
     "dead_frame_indices",
     "limb_motion",
@@ -42,5 +51,6 @@ __all__ = [
     "first_action_end",
     "foot_line_series",
     "pick_oneshot",
+    "pick_oneshot_indices",
     "split_jump_phases",
 ]

--- a/backend/packages/ai_engine/src/windup_ai_engine/slicing/extract.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/slicing/extract.py
@@ -8,17 +8,25 @@
 
 from __future__ import annotations
 
+import glob
 import io
 import logging
 import os
+import re
 import tempfile
+from collections.abc import Sequence
 from pathlib import Path
 
 from PIL import Image
 
 logger = logging.getLogger("windup.ai_engine.extract")
 
-__all__ = ["extract_frames_bytes", "extract_all_frames_bytes"]
+__all__ = [
+    "extract_frames_bytes",
+    "extract_all_frames_bytes",
+    "extract_preview_frames",
+    "extract_frames_at",
+]
 
 _PYAV = {"plugin": "pyav"}
 _PYAV_BYTES = {"plugin": "pyav", "extension": ".mp4"}
@@ -30,8 +38,24 @@ def extract_frames_bytes(video: bytes, n: int) -> list[Image.Image]:
 
 
 def extract_all_frames_bytes(video: bytes, cap: int = 150) -> list[Image.Image]:
-    """抽视频全部帧（至多 ``cap``，均匀降采样），供周期检测用。"""
+    """抽视频全部帧（至多 ``cap``，均匀降采样）。测试 / 冷路径;生产走两遍解码。"""
     return _extract_frames(video, cap)
+
+
+def extract_preview_frames(
+    video: bytes, cap: int = 150, size: int = 48
+) -> tuple[list[Image.Image], list[int]]:
+    """Pass A:流式解码后立刻缩到 ``size``×``size`` RGB,丢掉全分辨率。
+
+    返回 ``(previews, src_idx)``:预览帧与各自在源视频里的下标。均匀取样口径与
+    :func:`extract_all_frames_bytes` 相同。选帧算法吃这批小图即可,不必常驻 150 张 720p。
+    """
+    return _extract_preview(video, cap, size)
+
+
+def extract_frames_at(video: bytes, indices: Sequence[int]) -> list[Image.Image]:
+    """Pass B:只把指定源下标解成全分辨率 RGBA。返回顺序与 ``indices`` 一致。"""
+    return _extract_at(video, list(indices))
 
 
 def _uniform_indices(total: int, n: int) -> list[int]:
@@ -74,6 +98,64 @@ def _frame_count(source, kw: dict | None = None) -> int:
     return total
 
 
+def _as_pil(frame, *, preview: bool, size: int) -> Image.Image:
+    im = Image.fromarray(frame)
+    if preview:
+        return im.convert("RGB").resize((size, size))
+    return im.convert("RGBA")
+
+
+def _pyav_take(
+    handle, kw: dict, indices: Sequence[int], *, preview: bool, size: int = 48
+) -> dict[int, Image.Image] | None:
+    """按源下标从已打开的 pyav 流取帧。缺帧返回 None,让调用方回退 ffmpeg。"""
+    import imageio.v3 as iio
+
+    wanted = set(indices)
+    if not wanted:
+        return {}
+    found: dict[int, Image.Image] = {}
+    for i, frame in enumerate(iio.imiter(handle, **kw)):
+        if i in wanted:
+            found[i] = _as_pil(frame, preview=preview, size=size)
+            if len(found) == len(wanted):
+                break
+    if len(found) != len(wanted):
+        return None
+    return found
+
+
+def _extract_preview(
+    source: str | bytes, cap: int, size: int
+) -> tuple[list[Image.Image], list[int]]:
+    handle, kw = _pyav_source(source)
+    try:
+        total = _frame_count(handle, kw)
+        if total <= 0:
+            raise RuntimeError("视频无可解码帧")
+        src_idx = _uniform_indices(total, cap)
+        _rewind(handle)
+        found = _pyav_take(handle, kw, src_idx, preview=True, size=size)
+        if found is not None:
+            return [found[i] for i in src_idx], src_idx
+    except Exception:                                   # noqa: BLE001 - 兜底到 ffmpeg
+        logger.warning("imageio 预览抽帧失败,回退系统 ffmpeg", exc_info=True)
+    return _ffmpeg_preview(source, cap, size)
+
+
+def _extract_at(source: str | bytes, indices: list[int]) -> list[Image.Image]:
+    if not indices:
+        return []
+    handle, kw = _pyav_source(source)
+    try:
+        found = _pyav_take(handle, kw, indices, preview=False)
+        if found is not None:
+            return [found[i] for i in indices]
+    except Exception:                                   # noqa: BLE001 - 兜底到 ffmpeg
+        logger.warning("imageio 定点抽帧失败,回退系统 ffmpeg", exc_info=True)
+    return _ffmpeg_at(source, indices)
+
+
 def _extract_frames(source: str | bytes, n: int) -> list[Image.Image]:
     """从视频均匀抽 ``n`` 帧。优先 imageio(流式),回退系统 ffmpeg。
 
@@ -86,22 +168,14 @@ def _extract_frames(source: str | bytes, n: int) -> list[Image.Image]:
     """
     handle, kw = _pyav_source(source)
     try:
-        import imageio.v3 as iio
-
         total = _frame_count(handle, kw)
         if total <= 0:
             raise RuntimeError("视频无可解码帧")
+        idx = _uniform_indices(total, n)
         _rewind(handle)
-        wanted = set(_uniform_indices(total, n))
-        out: list[Image.Image] = []
-        for i, frame in enumerate(iio.imiter(handle, **kw)):
-            if i in wanted:
-                # convert 之后原始 ndarray 就可以被回收;不持有 frame 本身。
-                out.append(Image.fromarray(frame).convert("RGBA"))
-                if len(out) == len(wanted):
-                    break
-        if out:
-            return out
+        found = _pyav_take(handle, kw, idx, preview=False)
+        if found is not None:
+            return [found[i] for i in idx]
     except Exception:                                   # noqa: BLE001 - 兜底到 ffmpeg
         # 不静默:这个 except 曾把"我们自己算错下标"和"环境里没装 imageio"混为一谈,
         # 两者都表现为悄悄换用 ffmpeg 分支、产出看着正常的帧。至少留一条日志。
@@ -110,27 +184,98 @@ def _extract_frames(source: str | bytes, n: int) -> list[Image.Image]:
     return _ffmpeg_extract(source, n)
 
 
-def _ffmpeg_extract(source: str | bytes, n: int) -> list[Image.Image]:
-    """仅 pyav 失败时走。会把整段导出成 PNG,只应是冷路径。"""
-    import glob
-    import subprocess
+def _video_path(source: str | bytes, tmp: str) -> str:
+    if isinstance(source, str):
+        return source
+    path = str(Path(tmp) / "source.mp4")
+    Path(path).write_bytes(source)
+    return path
+
+
+def _ffmpeg_exe() -> str:
     from imageio_ffmpeg import get_ffmpeg_exe
 
+    return get_ffmpeg_exe()
+
+
+def _ffmpeg_run(args: list[str]) -> None:
+    import subprocess
+
+    subprocess.run(args, capture_output=True, check=True)
+
+
+def _ffmpeg_count(video_path: str) -> int:
+    """解码计数,不落 PNG。比把整段导出成全分辨率 PNG 再 len(files) 便宜。"""
+    import subprocess
+
+    proc = subprocess.run(
+        [_ffmpeg_exe(), "-i", video_path, "-vsync", "0", "-f", "null", "-"],
+        capture_output=True,
+    )
+    text = (proc.stderr or b"").decode("utf-8", errors="replace")
+    hits = re.findall(r"frame=\s*(\d+)", text)
+    if not hits or int(hits[-1]) <= 0:
+        raise RuntimeError("抽帧失败:视频无可解码帧")
+    return int(hits[-1])
+
+
+def _select_filter(indices: Sequence[int]) -> str:
+    """只留下这些源下标。逗号按 ffmpeg filtergraph 规则转义。"""
+    uniq = sorted(set(indices))
+    select = "+".join(f"eq(n\\,{i})" for i in uniq)
+    return f"select={select},setpts=N/TB"
+
+
+def _load_pngs(files: list[str]) -> list[Image.Image]:
+    return [Image.open(p).convert("RGBA").copy() for p in files]
+
+
+def _ffmpeg_at_path(video_path: str, tmp: str, indices: list[int]) -> list[Image.Image]:
+    uniq = sorted(set(indices))
+    if not uniq:
+        return []
+    pattern = os.path.join(tmp, "f_%04d.png")
+    _ffmpeg_run(
+        [_ffmpeg_exe(), "-y", "-i", video_path, "-vf", _select_filter(uniq),
+         "-vsync", "vfr", pattern],
+    )
+    files = sorted(glob.glob(os.path.join(tmp, "f_*.png")))
+    if len(files) != len(uniq):
+        raise RuntimeError(
+            f"抽帧失败:要 {len(uniq)} 帧,ffmpeg 交出 {len(files)} 帧"
+        )
+    by_n = {n: im for n, im in zip(uniq, _load_pngs(files))}
+    return [by_n[i] for i in indices]
+
+
+def _ffmpeg_at(source: str | bytes, indices: list[int]) -> list[Image.Image]:
     with tempfile.TemporaryDirectory() as tmp:
-        if isinstance(source, str):
-            video_path = source
-        else:
-            video_path = str(Path(tmp) / "source.mp4")
-            Path(video_path).write_bytes(source)
-        subprocess.run(
-            [get_ffmpeg_exe(), "-y", "-i", video_path, "-vsync", "0",
-             os.path.join(tmp, "f_%04d.png")],
-            capture_output=True,
-            check=True,
+        return _ffmpeg_at_path(_video_path(source, tmp), tmp, indices)
+
+
+def _ffmpeg_preview(
+    source: str | bytes, cap: int, size: int
+) -> tuple[list[Image.Image], list[int]]:
+    """冷路径:整段缩到小图再均匀取。小 PNG 常驻可接受,禁止落全分辨率。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        video_path = _video_path(source, tmp)
+        pattern = os.path.join(tmp, "f_%04d.png")
+        _ffmpeg_run(
+            [_ffmpeg_exe(), "-y", "-i", video_path,
+             "-vf", f"scale={size}:{size}", "-vsync", "0", pattern],
         )
         files = sorted(glob.glob(os.path.join(tmp, "f_*.png")))
         if not files:
             raise RuntimeError("抽帧失败:视频无可解码帧")
-        m = min(n, len(files))
-        idx = [round(i * (len(files) - 1) / max(1, m - 1)) for i in range(m)]
-        return [Image.open(files[i]).convert("RGBA").copy() for i in idx]
+        src_idx = _uniform_indices(len(files), cap)
+        previews = [Image.open(files[i]).convert("RGB").copy() for i in src_idx]
+        return previews, src_idx
+
+
+def _ffmpeg_extract(source: str | bytes, n: int) -> list[Image.Image]:
+    """仅 pyav 失败时走。按均匀下标 ``select``,不把整段导出成全分辨率 PNG。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        video_path = _video_path(source, tmp)
+        total = _ffmpeg_count(video_path)
+        idx = _uniform_indices(total, n)
+        return _ffmpeg_at_path(video_path, tmp, idx)

--- a/backend/packages/ai_engine/src/windup_ai_engine/slicing/loop.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/slicing/loop.py
@@ -13,7 +13,7 @@ from PIL import Image
 from ._frames import SMALL as _SMALL
 from ._frames import gray as _gray
 
-__all__ = ["find_period", "pick_cycle"]
+__all__ = ["find_period", "pick_cycle", "pick_cycle_indices"]
 
 
 def _deskew(gs: list[np.ndarray]) -> list[np.ndarray]:
@@ -80,6 +80,64 @@ def _offsets(P: int, n: int) -> list[int]:
     return [round(k * P / n) for k in range(n)]
 
 
+def pick_cycle_indices(frames: list[Image.Image], n: int) -> list[int]:
+    """与 :func:`pick_cycle` 同一套周期/接缝判据,只返回源下标。
+
+    生产路径用下标再解一遍全分辨率帧,避免把 150 张 720p 常驻到选完。
+    """
+    if n <= 0:
+        # n<=0 没有合法语义。检出周期时 `_offsets(P, 0)` 会走到空 idx 再 IndexError;
+        # 测不到周期时旧实现静默返回 [] —— 后者更危险,入口显式拒绝。
+        raise ValueError(f"n 必须 >= 1,收到 {n}")
+    total = len(frames)
+    if total < n:
+        # 源帧不够就报错,不再原样返回:长度不足且不报错,下游 frame_durations 按实际长度现算,
+        # 帧数与时长表自洽,server 看不出异常,用户拿到的是一段没走完的循环。
+        raise ValueError(f"源帧不足:请求 {n} 帧,只有 {total} 帧")
+    if total == n:
+        return list(range(total))
+    M = _dmat(_deskew(_gray(frames)))
+    if n == 1:
+        # 单帧"循环"没有接缝也没有相位,整套周期/接缝机制全部失效。显式取 medoid:
+        # 与全片平均姿态最近的一帧 = 循环停留最久的相位,比 frames[0](i2v 首帧是母版静立姿)
+        # 更能代表这个循环。
+        return [int(np.argmin(M.mean(1)))]
+    adj = np.array([M[i, i + 1] for i in range(total - 1)])
+    scale = float(np.median(adj))
+
+    pmin = max(6, min(n, total // 6))
+    pmax = min(total - 3, max(pmin + 2, int(total * 0.6)))
+    got = _prominent_period(_curve(M, pmin, pmax), scale)
+    if got is None or got[1] < 0.25:
+        return [round(k * (total - 1) / n) for k in range(n)]
+
+    p = got[0]
+    cands = []
+    for k in range(1, 4):
+        P = k * p
+        if P > total - 2:
+            break
+        offs = _offsets(P, n)
+        if len(set(offs)) < n:
+            continue
+        best = None
+        for i0 in range(total - P):
+            idx = [i0 + o for o in offs]
+            a = float(np.mean([M[idx[j], idx[j + 1]] for j in range(n - 1)]))
+            if a < 0.5 * scale:
+                continue
+            score = M[idx[-1], idx[0]] / max(a, 1e-6)
+            if best is None or score < best[0]:
+                best = (score, idx)
+        if best:
+            cands.append((k, best[0], best[1]))
+    if not cands:
+        return [round(k * (total - 1) / n) for k in range(n)]
+    ok = [c for c in cands if c[1] <= 1.2]
+    pick = ok[0] if ok else min(cands, key=lambda c: c[1])
+    return list(pick[2])
+
+
 def pick_cycle(frames: list[Image.Image], n: int) -> list[Image.Image]:
     """从密集帧里抽正好一个步态周期的 N 帧(无缝 loop)。返回长度恒等于 ``n``。
 
@@ -113,62 +171,7 @@ def pick_cycle(frames: list[Image.Image], n: int) -> list[Image.Image]:
     形状、波及所有调用方,而今天还没有任何调用方会依据"原因"改变行为。等真有调用方要按
     原因给不同提示时,再让本函数返回 ``(frames, reason)``。
     """
-    # n<=0 没有合法语义(要 0 帧的动画不存在),且两条出路都是坏的(2026-08-10 实测):
-    # 检出周期时 `_offsets(P, 0)` 交出空 offsets,一路走到 `M[idx[-1], idx[0]]` 抛 IndexError;
-    # 测不到周期时(单调曲线)直接静默返回 [] —— 后者更危险,故在入口显式拒绝。
-    # (机器审说这里除零并不准确:`range(n)` 为空,`k*P/n` 根本没被求值。)
-    if n <= 0:
-        raise ValueError(f"n 必须 >= 1,收到 {n}")
-    total = len(frames)
-    if total < n:
-        # 源帧不够就报错,不再原样返回:长度不足且不报错,下游 frame_durations 按实际长度现算,
-        # 帧数与时长表自洽,server 看不出异常,用户拿到的是一段没走完的循环。
-        raise ValueError(f"源帧不足:请求 {n} 帧,只有 {total} 帧")
-    if total == n:
+    idx = pick_cycle_indices(frames, n)
+    if n == len(frames):
         return frames
-    M = _dmat(_deskew(_gray(frames)))
-    if n == 1:
-        # 单帧"循环"没有接缝也没有相位,下面整套周期/接缝机制全部失效(实测 n=1 时窗口内相邻差
-        # 是空均值 = nan,`a < 0.5*scale` 与接缝评分双双被 nan 短路,靠比较运算的意外结果才
-        # 返回 frames[0])。显式取 medoid:与全片平均姿态最近的一帧 = 循环停留最久的相位,
-        # 比 frames[0](i2v 的首帧是母版静立姿,单看读不出"在走")更能代表这个循环。
-        return [frames[int(np.argmin(M.mean(1)))]]
-    adj = np.array([M[i, i + 1] for i in range(total - 1)])
-    scale = float(np.median(adj))
-
-    pmin = max(6, min(n, total // 6))
-    pmax = min(total - 3, max(pmin + 2, int(total * 0.6)))
-    got = _prominent_period(_curve(M, pmin, pmax), scale)
-    if got is None or got[1] < 0.25:                       # 测不到可信周期 → 不硬闭环
-        idx = [round(k * (total - 1) / n) for k in range(n)]
-        return [frames[i] for i in idx]
-
-    p = got[0]
-    cands = []
-    for k in range(1, 4):                                  # 在基周期的整数倍里复选
-        P = k * p
-        if P > total - 2:
-            break
-        offs = _offsets(P, n)
-        if len(set(offs)) < n:                             # 该倍数取不出 n 个不同相位
-            continue
-        best = None
-        for i0 in range(total - P):
-            idx = [i0 + o for o in offs]
-            a = float(np.mean([M[idx[j], idx[j + 1]] for j in range(n - 1)]))
-            if a < 0.5 * scale:                            # 窗口几乎不动(i2v 尾部常停顿)→ 弃
-                continue
-            score = M[idx[-1], idx[0]] / max(a, 1e-6)      # 归一化接缝
-            if best is None or score < best[0]:
-                best = (score, idx)
-        if best:
-            cands.append((k, best[0], best[1]))
-    if not cands:
-        idx = [round(k * (total - 1) / n) for k in range(n)]
-        return [frames[i] for i in idx]
-    # 倍数越大 = 一个 loop 里塞进越多周期 = 每周期帧数越少(动作变糙),故**优先最小倍数**:
-    # 取第一个"已经闭合"的倍数(归一化接缝 <= 1.2,即末→首的跳幅不超过一个正常帧间步长),
-    # 都不闭合才退而取最优 —— 这一条专治"取到半周期 → 接缝处左右腿瞬间互换"。
-    ok = [c for c in cands if c[1] <= 1.2]
-    pick = ok[0] if ok else min(cands, key=lambda c: c[1])
-    return [frames[i] for i in pick[2]]
+    return [frames[i] for i in idx]

--- a/backend/packages/ai_engine/src/windup_ai_engine/slicing/oneshot.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/slicing/oneshot.py
@@ -22,6 +22,7 @@ __all__ = [
     "find_motion_span",
     "first_action_end",
     "pick_oneshot",
+    "pick_oneshot_indices",
     "split_jump_phases",
     "foot_line_series",
 ]
@@ -163,6 +164,28 @@ def _widen_span(start: int, end: int, n: int, total: int) -> tuple[int, int]:
     return max(0, end - n + 1), end                # 右边撞到尾部时把缺口退回左边
 
 
+def pick_oneshot_indices(
+    frames: list[Image.Image], n: int, first_only: bool = True, kind: str = "swing"
+) -> list[int]:
+    """与 :func:`pick_oneshot` 同一套裁区间 / 关键姿势判据,只返回源下标。"""
+    _check_kind(kind)                              # first_only=False 时不走 first_action_end,这里兜住
+    if n <= 0:
+        # 2026-08-10 实测:n<=0 原本静默返回 [](range(n) 为空,连除零都不报),"成功"地交出零帧。
+        raise ValueError(f"n 必须 >= 1,收到 {n}")
+    if len(frames) < n:
+        raise ValueError(f"源帧不足:请求 {n} 帧,只有 {len(frames)} 帧")
+    if len(frames) == n:
+        return list(range(n))
+    start, end = find_motion_span(frames)
+    if first_only:
+        end = max(start + 1, first_action_end(frames, start, end, kind=kind))
+    start, end = _widen_span(start, end, n, len(frames))
+    span = frames[start : end + 1]
+    if n == 1:                                     # n=1 撞下面的 /(n-1) 除零(机器审 P1,2026-08-10 复现)
+        return [start + _key_pose(span, kind)]
+    return [start + round(i * (len(span) - 1) / (n - 1)) for i in range(n)]
+
+
 def pick_oneshot(
     frames: list[Image.Image], n: int, first_only: bool = True, kind: str = "swing"
 ) -> list[Image.Image]:
@@ -173,23 +196,10 @@ def pick_oneshot(
 
     返回长度**恒等于** ``n``;源帧不够 n 帧则报错,不静默少给。
     """
-    _check_kind(kind)                              # first_only=False 时不走 first_action_end,这里兜住
-    if n <= 0:
-        # 2026-08-10 实测:n<=0 原本静默返回 [](range(n) 为空,连除零都不报),"成功"地交出零帧。
-        raise ValueError(f"n 必须 >= 1,收到 {n}")
-    if len(frames) < n:
-        raise ValueError(f"源帧不足:请求 {n} 帧,只有 {len(frames)} 帧")
-    if len(frames) == n:
+    idx = pick_oneshot_indices(frames, n, first_only=first_only, kind=kind)
+    if n == len(frames):
         return frames
-    start, end = find_motion_span(frames)
-    if first_only:
-        end = max(start + 1, first_action_end(frames, start, end, kind=kind))
-    start, end = _widen_span(start, end, n, len(frames))
-    span = frames[start : end + 1]
-    if n == 1:                                     # n=1 撞下面的 /(n-1) 除零(机器审 P1,2026-08-10 复现)
-        return [span[_key_pose(span, kind)]]
-    idx = [round(i * (len(span) - 1) / (n - 1)) for i in range(n)]
-    return [span[i] for i in idx]
+    return [frames[i] for i in idx]
 
 
 def _subject_rows(frame: Image.Image, alpha_thr: int = 128, bg_tol: int = 60) -> np.ndarray:

--- a/backend/packages/ai_engine/src/windup_ai_engine/slicing/oneshot.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/slicing/oneshot.py
@@ -30,6 +30,10 @@ __all__ = [
 
 _KINDS = ("swing", "airborne")
 
+# 脚线回地容差按画高归一。6px 是 720p i2v 上的轻微抖动;48×48 预览若仍用 6px,
+# 等于约 12.5% 画高,下降段会提前被当成落地。
+_AIRBORNE_LAND_REL = 6.0 / 720.0
+
 
 def _check_kind(kind: str) -> None:
     """未知 ``kind`` 直接报错,不静默回落到 ``swing``。
@@ -68,17 +72,23 @@ def find_motion_span(frames: list[Image.Image], rel_thr: float = 0.25) -> tuple[
     return start, end
 
 
-def _airborne_end(frames: list[Image.Image], start: int, end: int, tol: float = 6.0) -> int:
+def _land_tol_px(frame: Image.Image) -> float:
+    """回地容差(像素)= 720p 上 6px 所占画高比例 × 当前帧高。"""
+    return _AIRBORNE_LAND_REL * max(frame.size[1], 1)
+
+
+def _airborne_end(frames: list[Image.Image], start: int, end: int) -> int:
     """腾空类(jump)的结束:脚线越过最高点后**首次回到地面**。
 
     几何信号,明确无歧义 —— 比任何"能量安静"判据都稳。
+    容差随画高缩放,选帧吃 48×48 预览时仍等价于源分辨率上约 6px。
     """
     y = foot_line_series(frames[start : end + 1])
     if len(y) < 4:
         return end
     apex = int(np.argmin(y))
     ground = float(np.median([y[0], y[-1]]))
-    back = np.flatnonzero(y[apex:] >= ground - tol)
+    back = np.flatnonzero(y[apex:] >= ground - _land_tol_px(frames[start]))
     return min(end, start + apex + int(back[0]) + 2) if len(back) else end
 
 

--- a/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
@@ -33,7 +33,12 @@ from windup_ai_engine._imgio import to_png as _png
 from windup_ai_engine.master_prep import prepare_master
 from windup_ai_engine.ports import ProgressPort, PromptAdapterPort, PromptRejected
 from windup_ai_engine.postprocess import master_pixel_spec, pixelate_frames
-from windup_ai_engine.slicing import extract_all_frames_bytes, pick_cycle, pick_oneshot
+from windup_ai_engine.slicing import (
+    extract_frames_at,
+    extract_preview_frames,
+    pick_cycle_indices,
+    pick_oneshot_indices,
+)
 from windup_ai_engine.prompt import (
     build_attack_prompt,
     build_custom_prompt,
@@ -181,29 +186,62 @@ class VideoFrameStrategy(DerivationStrategy):
     ) -> list[bytes]:
         del card
         n = action.n_frames
-        dense = extract_all_frames_bytes(video)
-        # 跨动作一致性:用视频首帧(=母版姿态)的角色高当共同定标基准。各动作都从同一母版
-        # 起手,故此值一致 —— 否则各动作按自己最高帧定标,切状态时角色会忽大忽小。
-        ref_h = None
-        if dense:
-            _first = _img(self._matte.cutout(_png(dense[0])))
-            _ys, _ = np.where(np.asarray(_first)[:, :, 3] > 128)
-            ref_h = float(_ys.max() - _ys.min()) if len(_ys) else None
+        previews, src_idx = extract_preview_frames(video)
         if is_cyclic(action):
             progress.step("derive", 1, 3, f"步态周期取 {n} 帧(无缝 loop)+ 抠图")
-            picked = pick_cycle(dense, n)  # 单周期闭环(#21)
+            local = pick_cycle_indices(previews, n)
         else:
             progress.step("derive", 1, 3, f"裁动作区间取 {n} 帧(不闭环)+ 抠图")
             kind = "airborne" if action.action is ActionType.JUMP else "swing"
-            picked = pick_oneshot(dense, n, kind=kind)  # 一次性动作:裁起止
-        cut = [_img(self._matte.cutout(_png(im))) for im in picked]
+            local = pick_oneshot_indices(previews, n, kind=kind)
+        del previews
+        wanted = [src_idx[i] for i in local]
+        need_ref = action.stylize is not Stylize.NONE
+        order = list(dict.fromkeys(([0] if need_ref else []) + wanted))
+        full = extract_frames_at(video, order)
+        by_src = dict(zip(order, full, strict=True))
+        del full
+
+        # 跨动作一致性:用视频首帧(=母版姿态)的角色高当共同定标基准。各动作都从同一母版
+        # 起手,故此值一致 —— 否则各动作按自己最高帧定标,切状态时角色会忽大忽小。
+        ref_h = None
+        matted0 = None
+        if need_ref:
+            raw0 = by_src.pop(0)
+            png0 = self._matte.cutout(_png(raw0))
+            del raw0
+            cut0 = _img(png0)
+            del png0
+            _ys, _ = np.where(np.asarray(cut0)[:, :, 3] > 128)
+            ref_h = float(_ys.max() - _ys.min()) if len(_ys) else None
+            if 0 in wanted:
+                matted0 = cut0
+            else:
+                del cut0
+
+        none = action.stylize is Stylize.NONE
+        cut_png: list[bytes] = []
+        cut: list = []
+        for src in wanted:
+            if src == 0 and matted0 is not None:
+                cut.append(matted0)
+                matted0 = None
+                continue
+            raw = by_src.pop(src)
+            png = self._matte.cutout(_png(raw))
+            del raw
+            if none:
+                cut_png.append(png)
+            else:
+                cut.append(_img(png))
+        by_src.clear()
 
         # 风格化按需(见 ActionSpec.stylize):none=保留 i2v 画风(插画/伪 3D 角色);
         # pixel=像素化。原生像素角色**按母版规格**做:吸附母版像素网格 + 锁母版色板,
         # 顺带消掉首帧 JPG / H.264 在硬边留下的灰颗粒(实测:通用降采样+量化反而更糊)。
-        if action.stylize is Stylize.NONE:
+        if none:
             progress.step("derive", 2, 3, "保留 i2v 画风(不像素化)")
-            return [_png(im) for im in cut]
+            return cut_png
 
         target_h, palette = action.pixel_h, None
         try:

--- a/backend/tests/test_ai_engine_skeleton.py
+++ b/backend/tests/test_ai_engine_skeleton.py
@@ -94,8 +94,12 @@ def _offline_video_strategy(monkeypatch, video=None) -> VideoFrameStrategy:
     """离线版 VideoFrameStrategy:抽帧被顶替,不解码 mp4 / 不联网 / 不花钱。"""
     dense = [Image.open(io.BytesIO(_tiny_png(shift=i % 6))).convert("RGBA") for i in range(24)]
     monkeypatch.setattr(
-        "windup_ai_engine.strategy.concrete.extract_all_frames_bytes",
-        lambda video, cap=150: dense,
+        "windup_ai_engine.strategy.concrete.extract_preview_frames",
+        lambda video, cap=150, size=48: (dense, list(range(len(dense)))),
+    )
+    monkeypatch.setattr(
+        "windup_ai_engine.strategy.concrete.extract_frames_at",
+        lambda video, indices: [dense[i] for i in indices],
     )
 
     class _StubVideo:

--- a/backend/tests/test_custom_action.py
+++ b/backend/tests/test_custom_action.py
@@ -105,8 +105,12 @@ def _offline_strategy(monkeypatch, spy: list[str]):
     """离线 VideoFrameStrategy:抽帧被顶替,不联网不花钱;记下送进 i2v 的提示词。"""
     dense = [Image.open(io.BytesIO(_png(i % 6))).convert("RGBA") for i in range(24)]
     monkeypatch.setattr(
-        "windup_ai_engine.strategy.concrete.extract_all_frames_bytes",
-        lambda video, cap=150: dense,
+        "windup_ai_engine.strategy.concrete.extract_preview_frames",
+        lambda video, cap=150, size=48: (dense, list(range(len(dense)))),
+    )
+    monkeypatch.setattr(
+        "windup_ai_engine.strategy.concrete.extract_frames_at",
+        lambda video, indices: [dense[i] for i in indices],
     )
 
     class _SpyVideo:

--- a/backend/tests/test_extract_streaming.py
+++ b/backend/tests/test_extract_streaming.py
@@ -17,7 +17,9 @@ from windup_ai_engine.slicing.extract import (
     _extract_frames,
     _frame_count,
     _uniform_indices,
+    extract_frames_at,
     extract_frames_bytes,
+    extract_preview_frames,
 )
 
 
@@ -112,6 +114,85 @@ def test_bytes_entry_point_streams_too(video, monkeypatch):
     monkeypatch.setattr(extract_mod.tempfile, "TemporaryDirectory", _forbidden)
     with open(video, "rb") as f:
         assert len(extract_frames_bytes(f.read(), 4)) == 4
+
+
+def test_preview_frames_are_48px_and_keep_source_indices(video):
+    """Pass A 只留 48×48,下标仍指向源视频,不能先解成 720p 再缩。"""
+    with open(video, "rb") as f:
+        previews, src_idx = extract_preview_frames(f.read(), cap=150, size=48)
+    assert src_idx == list(range(20))
+    assert len(previews) == 20
+    assert all(p.size == (48, 48) and p.mode == "RGB" for p in previews)
+
+
+def test_extract_frames_at_returns_the_requested_ramp_frames(video):
+    """Pass B 按下标取全分辨率帧,不是前 n 帧。"""
+    with open(video, "rb") as f:
+        frames = extract_frames_at(f.read(), [0, 10, 19])
+    assert len(frames) == 3
+    assert all(f.size == (64, 64) and f.mode == "RGBA" for f in frames)
+    greys = [int(np.asarray(f.convert("L")).mean()) for f in frames]
+    assert greys[0] < greys[1] < greys[2], greys
+    assert greys[0] < 30, greys[0]
+    assert greys[-1] > 200, greys[-1]
+
+
+def test_preview_and_at_do_not_materialise_via_imread(video, monkeypatch):
+    import imageio.v3 as iio
+
+    monkeypatch.setattr(iio, "imread", _forbidden)
+    with open(video, "rb") as f:
+        data = f.read()
+    previews, src_idx = extract_preview_frames(data, size=48)
+    assert len(previews) == len(src_idx) == 20
+    assert extract_frames_at(data, [0, 19])[0].mode == "RGBA"
+
+
+def test_ffmpeg_fallback_selects_only_needed_frames(video, monkeypatch):
+    """冷路径禁止把整段导出成全分辨率 PNG;只 select 要的下标。"""
+    import imageio.v3 as iio
+    import subprocess
+
+    monkeypatch.setattr(iio, "improps", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no pyav")))
+    monkeypatch.setattr(iio, "imiter", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no pyav")))
+
+    seen: list[list[str]] = []
+    real = subprocess.run
+
+    def spy(args, **kw):
+        seen.append(list(args))
+        return real(args, **kw)
+
+    monkeypatch.setattr(subprocess, "run", spy)
+    frames = _extract_frames(video, 4)
+    assert len(frames) == 4
+    png_cmds = [c for c in seen if any(str(a).endswith(".png") for a in c)]
+    assert png_cmds, seen
+    assert all("-vf" in c for c in png_cmds), png_cmds
+    assert any(any("select=" in str(a) for a in c) for c in png_cmds), png_cmds
+
+
+def test_ffmpeg_preview_fallback_stays_small(video, monkeypatch):
+    """预览冷路径可以落小 PNG,但不能解成全分辨率。"""
+    import imageio.v3 as iio
+
+    monkeypatch.setattr(iio, "improps", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no pyav")))
+    monkeypatch.setattr(iio, "imiter", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no pyav")))
+    with open(video, "rb") as f:
+        previews, src_idx = extract_preview_frames(f.read(), size=48)
+    assert src_idx == list(range(20))
+    assert all(p.size == (48, 48) and p.mode == "RGB" for p in previews)
+
+
+def test_ffmpeg_frames_at_fallback_keeps_requested_order(video, monkeypatch):
+    import imageio.v3 as iio
+
+    monkeypatch.setattr(iio, "improps", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no pyav")))
+    monkeypatch.setattr(iio, "imiter", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no pyav")))
+    with open(video, "rb") as f:
+        frames = extract_frames_at(f.read(), [19, 0])
+    greys = [int(np.asarray(f.convert("L")).mean()) for f in frames]
+    assert greys[0] > 200 and greys[1] < 30, greys
 
 
 def test_bundled_ffmpeg_is_used_when_pyav_cannot_decode(video, monkeypatch):

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -88,8 +88,12 @@ def _real_offline_generator(monkeypatch) -> CharacterGenerator:
         for i in range(24)
     ]
     monkeypatch.setattr(
-        "windup_ai_engine.strategy.concrete.extract_all_frames_bytes",
-        lambda video, cap=150: dense,
+        "windup_ai_engine.strategy.concrete.extract_preview_frames",
+        lambda video, cap=150, size=48: (dense, list(range(len(dense)))),
+    )
+    monkeypatch.setattr(
+        "windup_ai_engine.strategy.concrete.extract_frames_at",
+        lambda video, indices: [dense[i] for i in indices],
     )
     return CharacterGenerator(
         {GenRoute.VIDEO_I2V: VideoFrameStrategy(_StubVideo(), _StubMatte())}
@@ -876,8 +880,15 @@ def _pixel_master() -> bytes:
 def _delivered_colors(game_style: str | None, session_factory, monkeypatch) -> int:
     """建一个该画风的项目,跑完一条动作任务,数交付帧的色数。"""
     monkeypatch.setattr(
-        "windup_ai_engine.strategy.concrete.extract_all_frames_bytes",
-        lambda video, cap=150: [_gradient_frame(i % 6) for i in range(24)],
+        "windup_ai_engine.strategy.concrete.extract_preview_frames",
+        lambda video, cap=150, size=48: (
+            [_gradient_frame(i % 6) for i in range(24)],
+            list(range(24)),
+        ),
+    )
+    monkeypatch.setattr(
+        "windup_ai_engine.strategy.concrete.extract_frames_at",
+        lambda video, indices: [_gradient_frame(i % 6) for i in indices],
     )
     with session_factory() as s:
         project = Project(

--- a/backend/tests/test_loop.py
+++ b/backend/tests/test_loop.py
@@ -3,7 +3,7 @@
 import pytest
 from PIL import Image
 
-from windup_ai_engine.slicing import find_period, pick_cycle
+from windup_ai_engine.slicing import find_period, pick_cycle, pick_cycle_indices
 
 
 def _periodic_frames(period: int, cycles: int) -> list[Image.Image]:
@@ -79,6 +79,16 @@ def test_pick_cycle_returns_exactly_n_distinct_frames_for_every_legal_n():
             assert len(out) == n, n
             pos = [next(i for i, f in enumerate(frames) if f is o) for o in out]
             assert len(set(pos)) == n, (n, pos)
+
+
+def test_pick_cycle_indices_match_pick_cycle_identities():
+    """下标 API 与旧的帧列表 API 指向同一组源帧对象。"""
+    for frames in (_periodic_frames(period=8, cycles=5), _ramp_frames()):
+        for n in (1, 8, len(frames)):
+            out = pick_cycle(frames, n)
+            idx = pick_cycle_indices(frames, n)
+            assert len(idx) == n
+            assert all(out[j] is frames[i] for j, i in enumerate(idx))
 
 
 def test_pick_cycle_closes_the_loop():

--- a/backend/tests/test_oneshot.py
+++ b/backend/tests/test_oneshot.py
@@ -12,6 +12,7 @@ from windup_ai_engine.slicing import (
     pick_oneshot_indices,
     split_jump_phases,
 )
+from windup_ai_engine.slicing._frames import SMALL
 
 
 def _figure_at(y_bottom: int, size: int = 64, h: int = 20) -> Image.Image:
@@ -173,6 +174,38 @@ def test_pick_oneshot_frames_are_distinct_source_frames_in_order():
             pos = [next(i for i, f in enumerate(frames) if f is o) for o in out]
             assert pos == sorted(pos), (n, pos)
             assert len(set(pos)) == n, (n, pos)         # 无重复帧
+
+
+def _long_descent_jump(size: int) -> list[Image.Image]:
+    """长下降 + 落地后再起跳:固定 6px 容差在小图上会提前截断,按画高缩放则不应。"""
+    ground = round(size * 0.78)
+    apex = round(size * 0.22)
+    crouch = min(size - 1, ground + max(1, size // 32))
+    fig_h = max(6, size // 5)
+    n_fall = 12
+    fall = [round(apex + (ground - apex) * i / n_fall) for i in range(1, n_fall)]
+    ys = (
+        [ground] * 4
+        + [crouch, crouch]
+        + [round(apex + (ground - apex) * 0.35), round(apex + (ground - apex) * 0.12), apex, apex]
+        + fall
+        + [ground] * 3
+        + [crouch, round((apex + ground) / 2), apex]
+    )
+    return [_figure_at(y, size=size, h=fig_h) for y in ys]
+
+
+def test_airborne_pick_indices_match_fullres_and_48_preview():
+    """生产路径 Pass A 是 48×48;jump 下标必须与全分辨率选帧一致,不能提前截下降段。"""
+    src = _long_descent_jump(192)
+    preview = [f.resize((SMALL, SMALL), Image.NEAREST) for f in src]
+    assert first_action_end(src, *find_motion_span(src), kind="airborne") == first_action_end(
+        preview, *find_motion_span(preview), kind="airborne"
+    )
+    for n in (6, 8, 12):
+        assert pick_oneshot_indices(src, n, kind="airborne") == pick_oneshot_indices(
+            preview, n, kind="airborne"
+        )
 
 
 def test_unknown_kind_is_rejected():

--- a/backend/tests/test_oneshot.py
+++ b/backend/tests/test_oneshot.py
@@ -9,6 +9,7 @@ from windup_ai_engine.slicing import (
     first_action_end,
     foot_line_series,
     pick_oneshot,
+    pick_oneshot_indices,
     split_jump_phases,
 )
 
@@ -149,6 +150,15 @@ def test_pick_oneshot_returns_exactly_n_for_every_legal_n():
 def test_pick_oneshot_passthrough_when_n_equals_len():
     frames = _jump_sequence()
     assert pick_oneshot(frames, len(frames)) is frames
+
+
+def test_pick_oneshot_indices_match_pick_oneshot_identities():
+    frames = _jump_sequence()
+    for n in (1, 6, len(frames)):
+        out = pick_oneshot(frames, n, kind="airborne")
+        idx = pick_oneshot_indices(frames, n, kind="airborne")
+        assert len(idx) == n
+        assert all(out[j] is frames[i] for j, i in enumerate(idx))
 
 
 def test_pick_oneshot_frames_are_distinct_source_frames_in_order():

--- a/backend/tests/test_prompt_adapter.py
+++ b/backend/tests/test_prompt_adapter.py
@@ -270,8 +270,12 @@ def _spec(action: str, *, cyclic: bool = False) -> ActionSpec:
 def _offline(monkeypatch, adapter=None) -> tuple[VideoFrameStrategy, _SpyVideo]:
     dense = [Image.open(io.BytesIO(_png())).convert("RGBA") for _ in range(24)]
     monkeypatch.setattr(
-        "windup_ai_engine.strategy.concrete.extract_all_frames_bytes",
-        lambda video, cap=150: dense,
+        "windup_ai_engine.strategy.concrete.extract_preview_frames",
+        lambda video, cap=150, size=48: (dense, list(range(len(dense)))),
+    )
+    monkeypatch.setattr(
+        "windup_ai_engine.strategy.concrete.extract_frames_at",
+        lambda video, indices: [dense[i] for i in indices],
     )
     video = _SpyVideo()
     return VideoFrameStrategy(video, _Matte(), adapter), video


### PR DESCRIPTION
## Summary
- 一期落地 [#690](https://github.com/1024XEngineer/Windup/issues/690)：选帧不再常驻最多 150 张全分辨率 RGBA。Pass A 流式解码后立刻缩到 48×48 RGB（jump 脚线仍要颜色），`pick_cycle` / `pick_oneshot` 新增下标 API；Pass B 只解选中的 12/32 张。
- `frames_from_video` 抠完即丢源帧；`Stylize.NONE` 直接用 cutout 返回的 PNG，去掉多余 PIL↔PNG 往返。
- ffmpeg 冷路径改为 `select` 只要的下标，不再把整段导出成全分辨率 PNG。

本 PR **不含二期**（ORT arena / matte 单例 / 可选跳过全量 u2net）。不改 i2v 提交/轮询/扣费、选帧判定、交付帧数与画质闸。

## Test plan
- [x] `uv run pytest tests/test_extract_streaming.py tests/test_loop.py tests/test_oneshot.py tests/test_ai_engine_skeleton.py tests/test_custom_action.py tests/test_prompt_adapter.py tests/test_generation_orchestration.py --no-cov`（192 passed）
- [x] 同一夹具视频：下标 API 与旧帧列表 API 指向同一组源帧（单测已锁）
- [x] 部署到 4C8G 后，POLL=2 跑 32 帧 custom，worker RSS 峰值 < 2GB（一期允许 ORT 地板仍在）
Res #690 