### PR TITLE
fix(quick-start): unify completion action icons

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -2545,8 +2545,22 @@ describe('QuickStartPage', () => {
   it('saves a completed animation without navigating and exposes both explicit destinations', async () => {
     const run = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'active' })
     const approved = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'passed' })
+    const exportModel: ExportPackageModel = {
+      stage: 'action-assets',
+      characterId: 'character-1',
+      characterName: '像素骑士',
+      characterImageUrl: '/master.png',
+      outfitId: 'outfit-1',
+      outfitName: '默认造型',
+      canvas: { width: 32, height: 40 },
+      source: { workflowRunId: run.id, generationIds: [] },
+      firstFrames: [],
+      actions: [],
+      playtest: null,
+    }
     const service = serviceFor(run, {
       approveReview: vi.fn(async () => approved),
+      getExportModel: vi.fn(async () => exportModel),
       getActionFrames: vi.fn(async () => [
         { index: 0, imageUrl: 'https://example.test/frame-0.png', durationMs: 80 },
         { index: 1, imageUrl: 'https://example.test/frame-1.png', durationMs: 80 },
@@ -2555,10 +2569,28 @@ describe('QuickStartPage', () => {
     const view = renderAt('/quick-start/run-1', service)
     await waitFor(() => expect(service.approveReview).toHaveBeenCalledWith())
     expect(screen.getByTestId('quick-start-run')).toBeTruthy()
-    expect(screen.getByRole('button', { name: '跳转到资产工作台' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: '跳转到 Play Test' })).toBeTruthy()
+    const assetWorkspaceAction = screen.getByRole('button', { name: '跳转到资产工作台' })
+    const playtestAction = screen.getByRole('button', { name: '跳转到 Play Test' })
+    const downloadAction = screen.getByRole('button', { name: '导出完整动作资产' })
+    const actionGroup = assetWorkspaceAction.closest('[data-agent-actions]')
 
-    fireEvent.click(screen.getByRole('button', { name: '跳转到资产工作台' }))
+    expect(
+      Array.from(actionGroup?.querySelectorAll('button') ?? []).map((button) =>
+        button.getAttribute('aria-label'),
+      ),
+    ).toEqual(['导出完整动作资产', '跳转到资产工作台', '跳转到 Play Test', '新建一次创作'])
+
+    for (const action of [assetWorkspaceAction, playtestAction]) {
+      expect(action.querySelector('svg')).toBeTruthy()
+      expect(action.querySelector('[role="tooltip"]')).toBeTruthy()
+      expect(action.className).not.toMatch(/\bborder(?:-\S+)?\b/)
+    }
+    expect(assetWorkspaceAction.querySelector('svg')?.getAttribute('data-icon')).toBe('asset-stack')
+    expect(playtestAction.querySelector('svg')?.getAttribute('data-icon')).toBe('playtest-play')
+    expect(downloadAction.className).not.toMatch(/\bbg-app-accent\b/)
+    expect(downloadAction.className).toContain('text-app-muted')
+
+    fireEvent.click(assetWorkspaceAction)
     expect(await screen.findByRole('heading', { name: '/projects/project-1/assets' })).toBeTruthy()
 
     view.unmount()

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -17,7 +17,9 @@ import {
   ArrowUp,
   CaretDown,
   CopySimple,
+  Play,
   PlusCircle,
+  Stack,
   Stop,
   X,
 } from '@phosphor-icons/react'
@@ -532,6 +534,9 @@ function AgentActions({
   copyLabel,
   onCopy,
   exportModel,
+  onOpenAssetWorkspace,
+  onOpenPlaytest,
+  playtestDisabled = false,
   onNewCreation,
   onRegenerate,
   regenerateDisabled = false,
@@ -540,6 +545,9 @@ function AgentActions({
   copyLabel?: string
   onCopy?: () => void
   exportModel?: ExportPackageModel | null
+  onOpenAssetWorkspace?: () => void
+  onOpenPlaytest?: () => void
+  playtestDisabled?: boolean
   onNewCreation: () => void
   onRegenerate?: () => void
   regenerateDisabled?: boolean
@@ -566,8 +574,22 @@ function AgentActions({
         <ExportButton
           model={exportModel}
           iconOnly
-          className="bg-app-accent text-app-on-accent hover:bg-app-accent-hover"
+          className="text-app-muted hover:bg-app-surface-muted hover:text-app-accent"
         />
+      ) : null}
+      {onOpenAssetWorkspace ? (
+        <IconActionButton label="跳转到资产工作台" onClick={onOpenAssetWorkspace}>
+          <Stack data-icon="asset-stack" aria-hidden="true" size={18} weight="bold" />
+        </IconActionButton>
+      ) : null}
+      {onOpenPlaytest ? (
+        <IconActionButton
+          label="跳转到 Play Test"
+          onClick={onOpenPlaytest}
+          disabled={playtestDisabled}
+        >
+          <Play data-icon="playtest-play" aria-hidden="true" size={18} weight="fill" />
+        </IconActionButton>
       ) : null}
       {showNewCreation ? (
         <IconActionButton label="新建一次创作" onClick={onNewCreation}>
@@ -2617,27 +2639,6 @@ function QuickStartRun({
                           className="quick-start-generated-image aspect-square w-full rounded-2xl border border-app-line bg-app-surface-muted object-contain [image-rendering:pixelated]"
                         />
                       </div>
-                      {reviewStep?.status === 'passed' ? (
-                        <div className="flex flex-wrap gap-2">
-                          <button
-                            type="button"
-                            onClick={() =>
-                              navigate(`/projects/${encodeURIComponent(revision.projectId)}/assets`)
-                            }
-                            className="rounded-lg border border-app-line-strong px-3 py-1.5 text-xs font-semibold text-app-ink-soft transition hover:border-app-accent hover:text-app-accent"
-                          >
-                            跳转到资产工作台
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => void openPlaytest()}
-                            disabled={workflowConflict}
-                            className="rounded-lg border border-app-line-strong px-3 py-1.5 text-xs font-semibold text-app-ink-soft transition hover:border-app-accent hover:text-app-accent"
-                          >
-                            跳转到 Play Test
-                          </button>
-                        </div>
-                      ) : null}
                       <div className="flex max-w-full gap-1.5 overflow-x-auto pb-1">
                         {actionFrames.map((frame, index) => (
                           <AssetVisual
@@ -2682,9 +2683,19 @@ function QuickStartRun({
                       </div>
                     </>
                   )}
-                  {isActionFailed || actionExportModel ? (
+                  {isActionFailed || actionExportModel || reviewStep?.status === 'passed' ? (
                     <AgentActions
                       exportModel={actionExportModel}
+                      onOpenAssetWorkspace={
+                        reviewStep?.status === 'passed'
+                          ? () =>
+                              navigate(`/projects/${encodeURIComponent(revision.projectId)}/assets`)
+                          : undefined
+                      }
+                      onOpenPlaytest={
+                        reviewStep?.status === 'passed' ? () => void openPlaytest() : undefined
+                      }
+                      playtestDisabled={workflowConflict}
                       onNewCreation={() => navigate('/quick-start')}
                       showNewCreation={actionTurnIsCurrent}
                     />


### PR DESCRIPTION
统一 Quick Start 动作完成态的四个操作入口，消除文字描边按钮、实心下载按钮和裸图标按钮混用造成的视觉割裂。

## Why

动作完成态原先把资产工作台和 Play Test 放在预览图下方，并使用带文字描边按钮；下载和新建则位于另一排，且下载使用独立实心底色。同一组操作缺少一致的布局和图形语言。

## Changes

- 将下载、资产工作台、Play Test、新建收拢到同一排。
- 四个入口统一为无边框 SVG 图标按钮，下载不再使用实心背景。
- 资产工作台复用 `Stack`，Play Test 复用产品现有的实心 `Play` 图标。
- 保留 tooltip、可访问名称、禁用状态和原有业务行为。

## Implementation

- 扩展 `AgentActions` 的可选目的地操作，由完成态传入现有导航回调。
- 回归测试约束按钮顺序、图标标识、无边框样式和原有跳转结果。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx`：96 个测试通过。
- [x] `npx oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run typecheck`：通过。

## Scope

- 本 PR 不包含：导出协议、资产保存、Play Test 运行逻辑或其他页面样式调整。
- 后续事项：无。

## Related Issues

Closes #698
