### PR TITLE
feat(quick-start): add automatic asset delivery

### DIFF
--- a/frontend/src/entities/workflow-run/api.test.ts
+++ b/frontend/src/entities/workflow-run/api.test.ts
@@ -205,6 +205,18 @@ describe('workflowRunApis', () => {
     expect(requestUrl).toBe('https://api.windup.test/workflow-runs/17')
   })
 
+  it('hydrates the persisted automatic delivery intent from the setup node', async () => {
+    const automaticNodes = structuredClone(nodes)
+    const setup = automaticNodes.find((node) => node.type === 'character-setup')
+    if (!setup || setup.type !== 'character-setup') throw new Error('测试缺少角色设定节点')
+    setup.automation = { mode: 'automatic', actionPrompt: '开心地左右摇摆跳舞' }
+    const apis = await loadWorkflowRunApis(async () =>
+      jsonResponse({ ...workflowRunDto, nodes: automaticNodes }),
+    )
+
+    await expect(apis.get('17')).resolves.toMatchObject({ nodes: automaticNodes })
+  })
+
   it('patches the complete node graph and uses the returned version', async () => {
     let request: Request | undefined
     const apis = await loadWorkflowRunApis(async (input, init) => {

--- a/frontend/src/entities/workflow-run/api.ts
+++ b/frontend/src/entities/workflow-run/api.ts
@@ -121,6 +121,16 @@ function hasValidCharacterInput(value: unknown): boolean {
   )
 }
 
+function hasValidAutomationIntent(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (isRecord(value) &&
+      value.mode === 'automatic' &&
+      isNullableString(value.actionPrompt) &&
+      (value.actionPrompt === null || value.actionPrompt.trim().length > 0))
+  )
+}
+
 function hasValidActionInput(value: unknown): boolean {
   if (!isRecord(value)) return false
   return (
@@ -144,6 +154,7 @@ function isCharacterSetupNode(value: unknown): value is CharacterSetupWorkflowNo
     hasValidCommonNodeFields(value) &&
     ['configuring', 'completed'].includes(String(value.phase)) &&
     hasValidCharacterInput(value.input) &&
+    hasValidAutomationIntent(value.automation) &&
     hasOnlyGenerationRole(value, null)
   )
 }

--- a/frontend/src/entities/workflow-run/index.ts
+++ b/frontend/src/entities/workflow-run/index.ts
@@ -61,11 +61,19 @@ export interface WorkflowCharacterInput {
   referenceMedia: readonly MediaReference[]
 }
 
+/** Quick Start 已获一次性授权后需要恢复的自动交付目标；流程状态仍以节点图为准。 */
+export interface WorkflowAutomationIntent {
+  mode: 'automatic'
+  /** 没有动作时只交付角色母版；有动作时继续推进到完整动画。 */
+  actionPrompt: string | null
+}
+
 /** 角色资料卡片；只保存用户输入，不承担图片生成。 */
 export interface CharacterSetupWorkflowNode extends WorkflowNodeBase {
   type: 'character-setup'
   phase: 'configuring' | 'completed'
   input: WorkflowCharacterInput
+  automation?: WorkflowAutomationIntent
 }
 
 /** 角色母版卡片；生成候选图并保存用户最终确认的母版。 */

--- a/frontend/src/features/quick-start-agent/planner.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.test.ts
@@ -14,6 +14,8 @@ describe('quickStartPlannerInstructions', () => {
     expect(firstTurn).toContain('最多问一个')
     expect(firstTurn).toContain('直接生成')
     expect(firstTurn).toContain('proposal 只是提案，不代表用户授权生成')
+    expect(firstTurn).toContain('角色和动作')
+    expect(firstTurn).toContain('actionPrompt')
     expect(firstTurn).toContain('不得只靠关键词')
     expect(firstTurn).toContain('对话轮数永远不是 proposal 的触发条件')
     expect(firstTurn).toContain('咨询或元对话必须用 reply')

--- a/frontend/src/features/quick-start-agent/planner.ts
+++ b/frontend/src/features/quick-start-agent/planner.ts
@@ -61,6 +61,7 @@ const quickStartDecisionTool = tool({
         },
         message: { type: 'string', minLength: 1, maxLength: 2_000 },
         optimizedPrompt: { type: 'string', minLength: 1, maxLength: 4_000 },
+        actionPrompt: { type: 'string', minLength: 1, maxLength: 4_000 },
         optimizationSummary: { type: 'string', minLength: 1, maxLength: 600 },
       },
       required: ['kind'],
@@ -131,13 +132,13 @@ export function quickStartPlannerInstructions(clarificationUsed: boolean): strin
 - blocked：存在安全问题、明显自相矛盾或超出单角色母版能力，说明需要修改的内容。
 - proposal：已有足够角色设定，或用户明确要求整理最终提示词、直接生成时，给出可选择采用的完整提案。proposal 只是提案，不代表用户授权生成。
 
-当前能力只面向一个角色的角色母版：单角色、完整身体、清楚轮廓，适合后续动作生成。保留用户明确给出的身份、外观、服装、气质和美术风格；动态动作留到角色母版确认后处理。
+当前能力面向一个角色及其可选动作。optimizedPrompt 只描述稳定的单角色母版：完整身体、清楚轮廓，保留身份、外观、服装、气质和美术风格。用户明确给出动作时，必须把动作单独写入 actionPrompt；没有动作时省略 actionPrompt，不得替用户补动作。
 
 决策规则：
 1. 对话轮数永远不是 proposal 的触发条件。不得在澄清额度用完后用默认值强制补齐并提案。
 2. “你觉得怎么样”“怎么优化好”“还有什么方案”“刚才我说了什么”等咨询或元对话必须用 reply；不得只靠关键词，要理解最新消息在完整上下文中的意图。
-3. 用户明确要求形成最终版本或直接生成时，可以返回 proposal，但宿主仍会要求用户主动填入、编辑并确认后才生成。
-4. proposal 的 optimizedPrompt 是完整单角色全身提示词；optimizationSummary 用一到两句正常对话说明保留、补充或移除了什么。
+3. 用户明确要求形成最终版本或直接生成时，可以返回 proposal，但宿主仍会要求用户确认一次；确认前不得生成。
+4. proposal 的 optimizedPrompt 是完整单角色全身提示词；actionPrompt 只保存用户明确给出的动作；optimizationSummary 用一到两句正常对话确认你理解的角色和动作，并请用户确认一次。
 5. 不得输出思维过程、逐步推理、默认假设清单、Tool 名称、调用计划或内部状态。
 
 ${clarificationRule}`

--- a/frontend/src/features/quick-start-agent/production.test.ts
+++ b/frontend/src/features/quick-start-agent/production.test.ts
@@ -219,7 +219,12 @@ describe('Quick Start Agent composition', () => {
     })
 
     await expect(
-      dependencies.startCharacterGeneration({ prompt: '银发像素骑士' }),
+      dependencies.startCharacterGeneration({
+        prompt: '银发像素骑士',
+        actionPrompt: '挥剑',
+        directionalMovement: 'single',
+        automaticDelivery: true,
+      }),
     ).resolves.toEqual({ runId: 'run-agent' })
 
     expect(createController).toHaveBeenCalledWith(
@@ -229,7 +234,12 @@ describe('Quick Start Agent composition', () => {
         generationApis: expect.anything(),
       }),
     )
-    expect(startCharacterGeneration).toHaveBeenCalledWith({ prompt: '银发像素骑士' })
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: '银发像素骑士',
+      directionalMovement: 'single',
+      gameStyle: undefined,
+      automaticDelivery: { actionPrompt: '挥剑' },
+    })
     expect(dispose).toHaveBeenCalledTimes(1)
   })
 

--- a/frontend/src/features/quick-start-agent/production.ts
+++ b/frontend/src/features/quick-start-agent/production.ts
@@ -143,7 +143,18 @@ export function createProductionQuickStartAgentDependencies(
         onAsyncError: reportError,
       })
       try {
-        return await controller.startCharacterGeneration({ prompt: input.prompt, gameStyle })
+        return await controller.startCharacterGeneration({
+          prompt: input.prompt,
+          directionalMovement: input.directionalMovement,
+          gameStyle,
+          ...(input.automaticDelivery
+            ? {
+                automaticDelivery: {
+                  ...(input.actionPrompt ? { actionPrompt: input.actionPrompt } : {}),
+                },
+              }
+            : {}),
+        })
       } finally {
         controller.dispose()
       }

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -128,8 +128,14 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
               messageKind: result.messageKind,
             })
           } else if (result.kind === 'proposal') {
-            const { proposalId, optimizedPrompt, optimizationSummary } = result
-            setState({ status: 'proposal', proposalId, optimizedPrompt, optimizationSummary })
+            const { proposalId, optimizedPrompt, actionPrompt, optimizationSummary } = result
+            setState({
+              status: 'proposal',
+              proposalId,
+              optimizedPrompt,
+              ...(actionPrompt ? { actionPrompt } : {}),
+              optimizationSummary,
+            })
           }
         }
         return result
@@ -159,17 +165,18 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
     async (
       prompt: string,
       directionalMovement: QuickStartDirectionalMovement = 'single',
-      options?: { gameStyle?: string },
+      options?: { gameStyle?: string; automaticDelivery?: boolean },
     ): Promise<QuickStartAgentResult> => {
       if (running.current) throw new Error('Planner 正在处理上一条输入')
       if (state.status !== 'proposal') throw new Error('提示词提案已失效')
       running.current = true
-      const { proposalId, optimizedPrompt, optimizationSummary } = state
+      const { proposalId, optimizedPrompt, actionPrompt, optimizationSummary } = state
       if (mounted.current) {
         setState({
           status: 'dispatching',
           proposalId,
           optimizedPrompt,
+          ...(actionPrompt ? { actionPrompt } : {}),
           optimizationSummary,
         })
       }

--- a/frontend/src/features/quick-start-agent/runtime.test.ts
+++ b/frontend/src/features/quick-start-agent/runtime.test.ts
@@ -238,6 +238,30 @@ describe('createQuickStartAgent', () => {
     })
   })
 
+  it('carries the interpreted action into automatic delivery after one confirmation', async () => {
+    const { agent, startCharacterGeneration } = fixture(
+      decisionResult({
+        kind: 'proposal',
+        optimizedPrompt: '圆润可爱的卡皮巴拉，全身像',
+        actionPrompt: '开心地左右摇摆跳舞',
+        optimizationSummary: '我理解为一只正在开心跳舞的卡皮巴拉。',
+      }),
+    )
+    const proposal = await agent.start('生成一只跳舞的卡皮巴拉')
+    if (proposal.kind !== 'proposal') throw new Error('测试缺少提案')
+
+    await agent.confirmProposal(proposal.proposalId, proposal.optimizedPrompt, 'single', {
+      automaticDelivery: true,
+    })
+
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: '圆润可爱的卡皮巴拉，全身像',
+      actionPrompt: '开心地左右摇摆跳舞',
+      directionalMovement: 'single',
+      automaticDelivery: true,
+    })
+  })
+
   it('restores a pending proposal without dispatching it', async () => {
     const planner = vi.fn<QuickStartPlanner>()
     const startCharacterGeneration = vi.fn<StartCharacterGenerationAction>(async () => ({

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -13,6 +13,7 @@ const QUICK_START_DECISION_FIELDS = new Set([
   'kind',
   'message',
   'optimizedPrompt',
+  'actionPrompt',
   'optimizationSummary',
 ])
 
@@ -45,6 +46,7 @@ export type QuickStartPlanner = (input: PlannerInput) => Promise<PlannerResult>
 
 export interface CharacterGenerationPlan {
   optimizedPrompt: string
+  actionPrompt?: string
   optimizationSummary: string
 }
 
@@ -70,6 +72,8 @@ export interface QuickStartAgentTurnOptions {
 export interface ConfirmProposalOptions {
   /** 画风原样透传给宿主；取值范围由宿主定义，本模块不认识业务对象。 */
   gameStyle?: string
+  /** 用户选择确认后由 Controller 自动交付，不再暴露中间候选选择。 */
+  automaticDelivery?: boolean
 }
 
 export interface QuickStartAgent {
@@ -87,8 +91,10 @@ export interface QuickStartAgent {
 /** 宿主从现有 WorkflowController 绑定出的单次生成动作；本 Feature 不拥有业务对象。 */
 export type StartCharacterGenerationAction = (input: {
   prompt: string
+  actionPrompt?: string
   directionalMovement?: QuickStartDirectionalMovement
   gameStyle?: string
+  automaticDelivery?: boolean
 }) => Promise<{ runId: string }>
 
 export interface CreateQuickStartAgentOptions {
@@ -169,7 +175,19 @@ export function parseCharacterGenerationPlan(value: unknown): CharacterGeneratio
   if (!optimizationSummary || optimizationSummary.length > MAX_OPTIMIZATION_SUMMARY_LENGTH) {
     throw new Error('生成提案的 optimizationSummary 无效')
   }
-  return { optimizedPrompt, optimizationSummary }
+  const actionPrompt =
+    typeof value.actionPrompt === 'string' ? value.actionPrompt.trim() : undefined
+  if (
+    value.actionPrompt !== undefined &&
+    (!actionPrompt || actionPrompt.length > MAX_PROMPT_LENGTH)
+  ) {
+    throw new Error('生成提案的 actionPrompt 无效')
+  }
+  return {
+    optimizedPrompt,
+    ...(actionPrompt ? { actionPrompt } : {}),
+    optimizationSummary,
+  }
 }
 
 export function parseQuickStartDecision(value: unknown): QuickStartDecision {
@@ -213,7 +231,8 @@ function abortError(): DOMException {
 }
 
 function proposalMessage(plan: CharacterGenerationPlan): string {
-  return `${plan.optimizationSummary}\n\n提示词提案：${plan.optimizedPrompt}`
+  const action = plan.actionPrompt ? `\n动作：${plan.actionPrompt}` : ''
+  return `${plan.optimizationSummary}\n\n角色：${plan.optimizedPrompt}${action}`
 }
 
 export function createQuickStartAgent({
@@ -276,6 +295,7 @@ export function createQuickStartAgent({
       const proposal: CharacterGenerationProposal = {
         proposalId: `proposal-${nextMessages.length}`,
         optimizedPrompt: decision.optimizedPrompt,
+        ...(decision.actionPrompt ? { actionPrompt: decision.actionPrompt } : {}),
         optimizationSummary: decision.optimizationSummary,
       }
       currentProposal = proposal
@@ -290,7 +310,7 @@ export function createQuickStartAgent({
     proposalId: string,
     prompt: string,
     directionalMovement: QuickStartDirectionalMovement = 'single',
-    { gameStyle }: ConfirmProposalOptions = {},
+    { gameStyle, automaticDelivery }: ConfirmProposalOptions = {},
   ): Promise<QuickStartAgentResult> {
     assertAuthorized()
     if (running) throw new Error('Planner 正在处理上一条输入')
@@ -309,8 +329,10 @@ export function createQuickStartAgent({
     try {
       const { runId } = await startCharacterGeneration({
         prompt: effectivePrompt,
+        ...(proposal.actionPrompt ? { actionPrompt: proposal.actionPrompt } : {}),
         directionalMovement,
         gameStyle,
+        ...(automaticDelivery ? { automaticDelivery: true } : {}),
       })
       return { kind: 'generated', runId, ...proposal, optimizedPrompt: effectivePrompt }
     } finally {

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -309,6 +309,42 @@ describe('WorkflowController', () => {
     })
   })
 
+  it('为 Agent 自动交付持久化动作意图并只生成一个母版候选', async () => {
+    const workflow = createWorkflowApis()
+    const generation = createGenerationHarness()
+    const controller = createWorkflowController({
+      workflowRunApis: workflow.apis,
+      generationApis: generation.apis,
+      prepareProject: vi.fn(async () => ({
+        id: 'project-agent',
+        spriteSize: { width: 256, height: 256 },
+      })),
+      onAsyncError: () => undefined,
+    })
+
+    await controller.startCharacterGeneration({
+      prompt: '圆润可爱的卡皮巴拉，全身像',
+      automaticDelivery: { actionPrompt: '开心地左右摇摆跳舞' },
+    })
+
+    expect(workflow.apis.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodes: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'character-setup',
+            automation: {
+              mode: 'automatic',
+              actionPrompt: '开心地左右摇摆跳舞',
+            },
+          }),
+        ]),
+      }),
+    )
+    expect(generation.apis.create).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'character_template', candidateCount: 1 }),
+    )
+  })
+
   it('按 Quick Start 选择四向项目时仍只提交三张东向母版候选', async () => {
     const workflow = createWorkflowApis()
     const generation = createGenerationHarness()

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -82,6 +82,8 @@ export interface GenerateFirstFrameOptions {
   sourceImageUrls?: Partial<Record<ActionDirection, GeneratedImage['url']>>
   /** 只影响本次请求的 prompt 覆盖值；不改写动作节点的原始输入。 */
   prompt?: string
+  /** 本阶段每个方向的候选数；自动交付固定为一张。 */
+  candidateCount?: ImageCandidateCount
 }
 
 export type RegenerationMode = 'regenerate' | 'refine'
@@ -121,6 +123,7 @@ export interface StartCharacterGenerationInput {
   prompt: string
   directionalMovement?: DirectionalMovement
   gameStyle?: ArtStyle
+  automaticDelivery?: { actionPrompt?: string }
 }
 
 export interface StartCharacterGenerationResult {
@@ -404,12 +407,14 @@ export function createWorkflowController({
     prompt,
     directionalMovement: selectedDirectionalMovement = 'single',
     gameStyle,
+    automaticDelivery,
   }: StartCharacterGenerationInput): Promise<StartCharacterGenerationResult> {
     ensureRunning()
     if (!prepareProject) {
       throw new Error('WorkflowController 未配置 Quick Start 项目准备能力')
     }
     const normalizedPrompt = nonEmpty(prompt, '角色描述')
+    const actionPrompt = automaticDelivery?.actionPrompt?.trim() || null
     const project = await prepareProject(normalizedPrompt, selectedDirectionalMovement, {
       gameStyle,
     })
@@ -428,6 +433,9 @@ export function createWorkflowController({
           generations: [],
           error: null,
           input: { prompt: normalizedPrompt, referenceMedia: [] },
+          ...(automaticDelivery
+            ? { automation: { mode: 'automatic' as const, actionPrompt } }
+            : {}),
         },
         {
           id: 'character-template',
@@ -445,6 +453,7 @@ export function createWorkflowController({
       spriteWidth: project.spriteSize.width,
       spriteHeight: project.spriteSize.height,
       directions: ['east'],
+      ...(automaticDelivery ? { candidateCount: 1 as const } : {}),
     })
     return { runId: requireWorkflow().id }
   }
@@ -834,6 +843,9 @@ export function createWorkflowController({
           spriteHeight: options.spriteHeight,
           referenceMedia: [sourceImage ?? (characterTemplateReference as MediaReference)],
           direction,
+          ...(options.candidateCount === undefined
+            ? {}
+            : { candidateCount: options.candidateCount }),
         }
         return input
       },

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1158,7 +1158,7 @@ describe('QuickStartPage', () => {
     expect(optimizedCopy?.className).not.toContain('pl-4')
     const fill = screen.getByRole('button', { name: '填入输入框' })
     expect(fill.className).not.toContain('border')
-    expect(fill.textContent).toContain('填入输入框后，还可以继续修改')
+    expect(fill.textContent).toContain('编辑后逐步确认')
     fireEvent.click(fill)
 
     expect(composer.dataset.promptState).toBe('rewriting')
@@ -1191,6 +1191,45 @@ describe('QuickStartPage', () => {
       directionalMovement: 'eight-way',
       gameStyle: 'unspecified',
     })
+  })
+
+  it('confirms a character action once and starts automatic delivery without direction confirmation', async () => {
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-created' }))
+    const planner = vi.fn(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'quick_start_decision',
+          input: {
+            kind: 'proposal',
+            optimizedPrompt: '圆润可爱的卡皮巴拉，全身像',
+            actionPrompt: '开心地左右摇摆跳舞',
+            optimizationSummary: '我理解为一只正在开心跳舞的卡皮巴拉。',
+          },
+        },
+      ],
+    }))
+    renderAt('/quick-start', serviceFor(null), { planner, startCharacterGeneration })
+
+    fireEvent.change(screen.getByLabelText('创作指令'), {
+      target: { value: '生成一只跳舞的卡皮巴拉' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+
+    expect(await screen.findByText('动作：开心地左右摇摆跳舞')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: '确认并生成' }))
+
+    await vi.waitFor(() =>
+      expect(startCharacterGeneration).toHaveBeenCalledWith({
+        prompt: '圆润可爱的卡皮巴拉，全身像',
+        actionPrompt: '开心地左右摇摆跳舞',
+        directionalMovement: 'single',
+        gameStyle: 'unspecified',
+        automaticDelivery: true,
+      }),
+    )
+    expect(screen.queryByText('最后确认一下：需要单向、四向还是八向？')).toBeNull()
   })
 
   it('keeps a proposal optional when the user continues the conversation', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -162,6 +162,7 @@ type AgentConversationTurn =
       kind: 'proposal'
       proposalId: string
       optimizedPrompt: string
+      actionPrompt?: string
       optimizationSummary: string
       proposalStatus: 'pending' | 'superseded' | 'adopted' | 'confirmed'
       scope?: 'workflow'
@@ -275,6 +276,9 @@ function readAgentConversation(
             kind: 'proposal',
             proposalId: turn.proposalId,
             optimizedPrompt: turn.optimizedPrompt,
+            ...('actionPrompt' in turn && typeof turn.actionPrompt === 'string'
+              ? { actionPrompt: turn.actionPrompt }
+              : {}),
             optimizationSummary: turn.optimizationSummary,
             proposalStatus: turn.proposalStatus,
             ...(scope ? { scope } : {}),
@@ -313,6 +317,7 @@ function createAgentSeed(turns: readonly AgentConversationTurn[]): {
         ? {
             proposalId: pending.proposalId,
             optimizedPrompt: pending.optimizedPrompt,
+            ...(pending.actionPrompt ? { actionPrompt: pending.actionPrompt } : {}),
             optimizationSummary: pending.optimizationSummary,
           }
         : null,
@@ -756,7 +761,7 @@ function QuickStartInput({
         ? {
             ...turn,
             content: confirmedPrompt
-              ? `${turn.optimizationSummary}\n\n提示词提案：${confirmedPrompt}`
+              ? `${turn.optimizationSummary}\n\n角色：${confirmedPrompt}${turn.actionPrompt ? `\n动作：${turn.actionPrompt}` : ''}`
               : turn.content,
             optimizedPrompt: confirmedPrompt ?? turn.optimizedPrompt,
             proposalStatus,
@@ -789,6 +794,24 @@ function QuickStartInput({
       setPromptState('ready')
       promptInput.current?.focus()
     }, PROMPT_REWRITE_MS)
+  }
+
+  async function confirmAutomaticProposal(proposalId: string) {
+    const state = agentSession.state
+    if (state.status !== 'proposal' || state.proposalId !== proposalId || generationStarting) {
+      return
+    }
+    setPromptState('confirmed')
+    try {
+      const result = await agentSession.confirmProposal(
+        state.optimizedPrompt,
+        directionalMovement,
+        { gameStyle, automaticDelivery: true },
+      )
+      if (result.kind === 'generated') await handoffGenerated(result)
+    } catch {
+      setPromptState('collecting')
+    }
   }
 
   function selectTemplateFile(event: ChangeEvent<HTMLInputElement>) {
@@ -903,10 +926,11 @@ function QuickStartInput({
         if (result.kind === 'proposal') {
           appendConversationTurn({
             role: 'assistant',
-            content: `${result.optimizationSummary}\n\n提示词提案：${result.optimizedPrompt}`,
+            content: `${result.optimizationSummary}\n\n角色：${result.optimizedPrompt}${result.actionPrompt ? `\n动作：${result.actionPrompt}` : ''}`,
             kind: 'proposal',
             proposalId: result.proposalId,
             optimizedPrompt: result.optimizedPrompt,
+            ...(result.actionPrompt ? { actionPrompt: result.actionPrompt } : {}),
             optimizationSummary: result.optimizationSummary,
             proposalStatus: 'pending',
           })
@@ -1042,6 +1066,7 @@ function QuickStartInput({
                     <PromptProposal
                       summary={turn.optimizationSummary}
                       prompt={turn.optimizedPrompt}
+                      actionPrompt={turn.actionPrompt}
                       status={turn.proposalStatus}
                       disabled={
                         turn.proposalStatus !== 'pending' ||
@@ -1050,6 +1075,7 @@ function QuickStartInput({
                         promptState === 'rewriting' ||
                         generationStarting
                       }
+                      onConfirm={() => void confirmAutomaticProposal(turn.proposalId)}
                       onFill={() => fillOptimizedPrompt(turn.proposalId)}
                     />
                   ) : (
@@ -1402,14 +1428,18 @@ function QuickStartInput({
 function PromptProposal({
   summary,
   prompt,
+  actionPrompt,
   status,
   disabled,
+  onConfirm,
   onFill,
 }: {
   summary: string
   prompt: string
+  actionPrompt?: string
   status: Extract<AgentConversationTurn, { kind: 'proposal' }>['proposalStatus']
   disabled: boolean
+  onConfirm: () => void
   onFill: () => void
 }) {
   return (
@@ -1418,19 +1448,31 @@ function PromptProposal({
       <blockquote className="max-w-2xl font-serif text-base leading-7 text-app-ink">
         {prompt}
       </blockquote>
+      {actionPrompt ? <p className="text-sm text-app-muted">动作：{actionPrompt}</p> : null}
       {status === 'pending' ? (
-        <button
-          type="button"
-          aria-label="填入输入框"
-          disabled={disabled}
-          onClick={onFill}
-          className="group inline-flex min-h-8 items-center gap-2 rounded-full pr-2 text-xs text-app-muted transition hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-45"
-        >
-          <span className="grid size-8 shrink-0 place-items-center rounded-full transition group-hover:bg-app-surface-muted">
-            <ArrowBendDownLeft aria-hidden="true" size={17} weight="bold" />
-          </span>
-          <span>填入输入框后，还可以继续修改</span>
-        </button>
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            aria-label="确认并生成"
+            disabled={disabled}
+            onClick={onConfirm}
+            className="min-h-9 rounded-full bg-app-accent px-4 text-xs font-semibold text-app-canvas transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:opacity-45"
+          >
+            确认并生成
+          </button>
+          <button
+            type="button"
+            aria-label="填入输入框"
+            disabled={disabled}
+            onClick={onFill}
+            className="group inline-flex min-h-8 items-center gap-2 rounded-full pr-2 text-xs text-app-muted transition hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-45"
+          >
+            <span className="grid size-8 shrink-0 place-items-center rounded-full transition group-hover:bg-app-surface-muted">
+              <ArrowBendDownLeft aria-hidden="true" size={17} weight="bold" />
+            </span>
+            <span>编辑后逐步确认</span>
+          </button>
+        </div>
       ) : status === 'superseded' ? (
         <p className="text-xs text-app-faint">已继续讨论</p>
       ) : status === 'adopted' ? (

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -83,6 +83,71 @@ function pendingGenerationApis(): GenerationApis {
   }
 }
 
+function automaticDeliveryGenerationApis(): GenerationApis {
+  const tasks = new Map<string, Awaited<ReturnType<GenerationApis['create']>>>()
+  tasks.set('task-template', {
+    id: 'task-template',
+    projectId: 'project-1',
+    type: 'character_template',
+    status: 'completed',
+    result: {
+      type: 'character_template',
+      images: [{ url: 'template.png' }],
+    },
+    error: null,
+  })
+  let sequence = 0
+  return {
+    create: vi.fn(async (input) => {
+      const id = `task-auto-${++sequence}`
+      const task =
+        input.type === 'complete_animation'
+          ? {
+              id,
+              projectId: input.projectId,
+              type: input.type,
+              status: 'completed' as const,
+              result: {
+                type: input.type,
+                frames: [{ index: 0, url: 'dance-1.png', durationMs: 80 }],
+              },
+              error: null,
+            }
+          : {
+              id,
+              projectId: input.projectId,
+              type: input.type,
+              status: 'completed' as const,
+              result: {
+                type: input.type,
+                images: [{ url: input.type === 'first_frame' ? 'first.png' : 'template.png' }],
+              },
+              error: null,
+            }
+      tasks.set(id, task)
+      return structuredClone(task)
+    }) as GenerationApis['create'],
+    get: vi.fn(async (_projectId, id) => structuredClone(tasks.get(id)!)),
+    subscribe: vi.fn((...args: unknown[]) => {
+      const id = String(args[1])
+      const listener = (typeof args[2] === 'function' ? args[2] : args[3]) as (
+        event: unknown,
+      ) => void
+      const task = tasks.get(id)!
+      queueMicrotask(() =>
+        listener({
+          taskId: id,
+          type: task.type,
+          status: task.status,
+          result: task.result,
+          error: task.error,
+        }),
+      )
+      return () => undefined
+    }) as GenerationApis['subscribe'],
+  }
+}
+
 function completedAnimationGenerationApis(): GenerationApis {
   return {
     create: vi.fn(),
@@ -266,6 +331,139 @@ function actionRun(firstFramePending = false): WorkflowRun {
 }
 
 describe('createQuickStartService', () => {
+  it('恢复自动交付 Run 后用唯一母版和唯一首帧推进到完整动画', async () => {
+    const run: WorkflowRun = {
+      id: 'run-auto',
+      projectId: 'project-1',
+      version: 1,
+      storageStatus: 'active',
+      nodes: [
+        {
+          id: 'character-setup',
+          type: 'character-setup',
+          status: 'passed',
+          phase: 'completed',
+          dependsOnNodeIds: [],
+          generations: [],
+          error: null,
+          input: { prompt: '圆润可爱的卡皮巴拉，全身像', referenceMedia: [] },
+          automation: { mode: 'automatic', actionPrompt: '开心地左右摇摆跳舞' },
+        },
+        {
+          id: 'character-template',
+          type: 'character-template',
+          status: 'active',
+          phase: 'selecting',
+          dependsOnNodeIds: ['character-setup'],
+          generations: [{ taskId: 'task-template', role: 'character_template' }],
+          error: null,
+          selectedImageUrl: null,
+        },
+      ],
+    }
+    const workflowRunApis = createWorkflowRunApis([run])
+    const generationApis = automaticDeliveryGenerationApis()
+    const onAsyncError = vi.fn()
+    let character = characterFixture({
+      workflowRunId: run.id,
+      name: '卡皮巴拉',
+      referenceImageUrl: null,
+    })
+    const service = createQuickStartService({
+      workflowRunApis,
+      generationApis,
+      prepareProject: vi.fn(),
+      projectApis: projectReader(),
+      characterApis: mutableCharacterApis(
+        () => character,
+        (value) => (character = value),
+      ),
+      onAsyncError,
+    })
+
+    const session = await service.open(run.id)
+    await session.resume()
+
+    await vi.waitFor(() => {
+      expect(
+        session.getWorkflow().nodes.find((node) => node.type === 'action-full-frame')?.status,
+      ).toBe('passed')
+    })
+    expect(generationApis.create).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'first_frame', candidateCount: 1 }),
+    )
+    expect(generationApis.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'complete_animation',
+        prompt: '开心地左右摇摆跳舞',
+      }),
+    )
+    expect(session.getWorkflow().nodes.find((node) => node.type === 'review')).toMatchObject({
+      status: 'active',
+      phase: 'reviewing',
+    })
+  })
+
+  it('自动交付没有动作时确认唯一母版后停止', async () => {
+    const run: WorkflowRun = {
+      id: 'run-character-auto',
+      projectId: 'project-1',
+      version: 1,
+      storageStatus: 'active',
+      nodes: [
+        {
+          id: 'character-setup',
+          type: 'character-setup',
+          status: 'passed',
+          phase: 'completed',
+          dependsOnNodeIds: [],
+          generations: [],
+          error: null,
+          input: { prompt: '圆润可爱的卡皮巴拉，全身像', referenceMedia: [] },
+          automation: { mode: 'automatic', actionPrompt: null },
+        },
+        {
+          id: 'character-template',
+          type: 'character-template',
+          status: 'active',
+          phase: 'selecting',
+          dependsOnNodeIds: ['character-setup'],
+          generations: [{ taskId: 'task-template', role: 'character_template' }],
+          error: null,
+          selectedImageUrl: null,
+        },
+      ],
+    }
+    const generationApis = automaticDeliveryGenerationApis()
+    const onAsyncError = vi.fn()
+    let character = characterFixture({ workflowRunId: run.id, referenceImageUrl: null })
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis([run]),
+      generationApis,
+      prepareProject: vi.fn(),
+      projectApis: projectReader(),
+      characterApis: mutableCharacterApis(
+        () => character,
+        (value) => (character = value),
+      ),
+      onAsyncError,
+    })
+
+    const session = await service.open(run.id)
+    await session.resume()
+
+    await vi.waitFor(() =>
+      expect(
+        session.getWorkflow().nodes.find((node) => node.type === 'character-template'),
+      ).toMatchObject({ status: 'passed', phase: 'completed', selectedImageUrl: 'template.png' }),
+    )
+    expect(session.getWorkflow().nodes.some((node) => node.type === 'action-first-frame')).toBe(
+      false,
+    )
+    expect(generationApis.create).not.toHaveBeenCalled()
+    expect(onAsyncError).not.toHaveBeenCalled()
+  })
+
   it('四向 Quick Start 在用户选定母版前只创建东向三候选任务', async () => {
     const generationApis = pendingGenerationApis()
     const service = createQuickStartService({

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -428,6 +428,7 @@ export function createQuickStartService({
     outfitId: string,
     actionDescription: string,
     spriteSize: Project['spriteSize'],
+    candidateCount?: 1,
   ) {
     const prompt = actionDescription.trim()
     const name = boundedDisplayName(prompt, ACTION_DISPLAY_NAME_MAX_LENGTH) || '待机'
@@ -441,6 +442,7 @@ export function createQuickStartService({
     await controller.generateFirstFrame(firstFrame.id, {
       spriteWidth: spriteSize.width,
       spriteHeight: spriteSize.height,
+      ...(candidateCount ? { candidateCount } : {}),
     })
   }
 
@@ -622,11 +624,127 @@ export function createQuickStartService({
     }
   }
 
+  function startAutomaticDelivery(controller: WorkflowController): () => void {
+    let advancing = false
+    let stopped = false
+
+    const advance = (run: WorkflowRun) => {
+      if (advancing || stopped) return
+      const setup = setupNode(run)
+      const automation = setup.automation
+      if (automation?.mode !== 'automatic') return
+
+      const template = templateNode(run)
+      const firstFrame = latestActionFirstFrame(run)
+      const shouldConfirmTemplate = template.status === 'active' && template.phase === 'selecting'
+      const shouldConfirmFirstFrame =
+        firstFrame?.type === 'action-first-frame' &&
+        firstFrame.status === 'active' &&
+        firstFrame.phase === 'selecting'
+      if (!shouldConfirmTemplate && !shouldConfirmFirstFrame) return
+
+      advancing = true
+      void (async (): Promise<boolean> => {
+        if (shouldConfirmTemplate) {
+          const candidates = await candidatesByDirection(
+            controller,
+            template.id,
+            'character_template',
+          )
+          const selections = Object.fromEntries(
+            candidates.map((candidate) => [candidate.direction, candidate.imageUrl]),
+          ) as QuickStartDirectionSelections
+          const east = selections.east
+          if (!east) return false
+
+          let characterId = setup.input.characterId ?? null
+          let outfitId: string | null = null
+          if (!template.selectedImageUrl || !characterId) {
+            const target = await persistCharacterTemplate(
+              controller,
+              east,
+              (_setupId, selectedCharacterId) =>
+                controller.confirmCharacterTemplate(template.id, east, selectedCharacterId),
+            )
+            characterId = target.characterId
+            outfitId = target.outfitId
+            const directions = generationDirectionsFor(controller)
+            if (directions.length > 1) {
+              const spriteSize = await resolveProjectSpriteSize(run.projectId)
+              await controller.generateCharacterTemplate(setup.id, {
+                spriteWidth: spriteSize.width,
+                spriteHeight: spriteSize.height,
+                sourceImageUrl: east,
+                directions: directions.slice(1),
+                candidateCount: 1,
+              })
+              return true
+            }
+          } else if (generationDirectionsFor(controller).length > 1) {
+            const selectedImages = selectedDirections(controller, selections, {
+              east: template.selectedImageUrl,
+              ...(template.selectedImages ?? {}),
+            })
+            await confirmRemainingTemplateDirections(controller, characterId, selectedImages)
+          }
+
+          const actionPrompt = automation.actionPrompt?.trim()
+          if (!actionPrompt) return true
+          if (latestActionFirstFrame(controller.getWorkflow())) return true
+          if (!outfitId) {
+            if (!characterApis || !characterId) throw new Error('角色服务尚未配置，不能自动交付')
+            const character = await characterApis.get(characterId)
+            outfitId =
+              character.outfits.find((item) => item.previewUrl === east)?.id ??
+              character.outfits.find((item) => item.id === 'outfit-default')?.id ??
+              null
+          }
+          if (!outfitId) throw new Error('自动交付没有找到角色造型')
+          const spriteSize = await resolveProjectSpriteSize(run.projectId)
+          await prepareAction(controller, outfitId, actionPrompt, spriteSize, 1)
+          return true
+        }
+
+        if (shouldConfirmFirstFrame && firstFrame) {
+          const candidates = await candidatesByDirection(controller, firstFrame.id, 'first_frame')
+          const selections = Object.fromEntries(
+            candidates.map((candidate) => [candidate.direction, candidate.imageUrl]),
+          ) as QuickStartDirectionSelections
+          await confirmAllFirstFrameDirections(controller, firstFrame.id, selections)
+          return true
+        }
+        return false
+      })().then(
+        (changed) => {
+          advancing = false
+          if (!stopped && changed) advance(controller.getWorkflow())
+        },
+        (cause: unknown) => {
+          advancing = false
+          if (stopped) return
+          stopped = true
+          reportControllerError(
+            controller,
+            cause instanceof Error ? cause : new Error('Quick Start 自动交付失败'),
+          )
+        },
+      )
+    }
+
+    const stop = controller.subscribe(advance)
+    advance(controller.getWorkflow())
+    return () => {
+      stopped = true
+      stop()
+    }
+  }
+
   function createSession(
     controller: WorkflowController,
     knownSpriteSize?: Project['spriteSize'],
   ): QuickStartSession {
     let stopAutomaticAdvance: (() => void) | null = null
+    let stopAutomaticDelivery: (() => void) | null = null
     let candidateCommand: Promise<WorkflowRun> | null = null
     let disposed = false
 
@@ -647,19 +765,26 @@ export function createQuickStartService({
       async resume({ automaticActionAdvance = true } = {}) {
         disposed = false
         await controller.resume()
-        if (!disposed && automaticActionAdvance) ensureAutomaticAdvance()
+        if (!disposed && automaticActionAdvance) {
+          ensureAutomaticAdvance()
+          stopAutomaticDelivery ??= startAutomaticDelivery(controller)
+        }
         return controller.getWorkflow()
       },
       async interrupt() {
         await controller.interrupt()
         stopAutomaticAdvance?.()
         stopAutomaticAdvance = null
+        stopAutomaticDelivery?.()
+        stopAutomaticDelivery = null
         return controller.getWorkflow()
       },
       dispose() {
         disposed = true
         stopAutomaticAdvance?.()
         stopAutomaticAdvance = null
+        stopAutomaticDelivery?.()
+        stopAutomaticDelivery = null
         controllerErrorChannels.get(controller)?.listeners.clear()
         controller.dispose()
       },


### PR DESCRIPTION
## Overview

Quick Start Agent 在识别出角色与动作后提供一次生成确认；确认后由 WorkflowController 自动推进至目标素材。

## Why

明确的角色与动作请求仍会暴露角色候选和动作首帧的中间确认，增加用户操作与无效候选成本。

## Changes

- 扩展 `quick_start_decision` 提案，携带可选 `actionPrompt`。
- 提案提供“确认并生成”和“编辑后逐步确认”两条入口。
- 自动交付模式下，角色母版与动作首帧均只请求一个候选并自动确认。
- 仅包含角色的请求在角色母版确认后停止；包含动作的请求继续生成完整动画。

## Implementation

自动交付意图持久化在 WorkflowRun 的 `character-setup` 节点中。Quick Start 服务只读取 WorkflowRun 状态并调用 WorkflowController 命令推进，业务写操作不绕过 Controller。现有逐步确认流程保持不变。

## Verification

- `npm test -- src/entities/workflow-run/api.test.ts src/features/quick-start-agent/runtime.test.ts src/features/quick-start-agent/planner.test.ts src/features/quick-start-agent/production.test.ts src/features/workflow-controller/controller.test.ts src/pages/quick-start/service.test.ts src/pages/quick-start/index.test.tsx`（316 tests）
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run build`

## Scope

仅修改 frontend 的 Quick Start Agent、WorkflowController 接口与 WorkflowRun 状态校验；不修改后端 API、审核自动通过策略或现有 guided flow。

## Related Issues

Closes #697