### PR TITLE
fix(quick-start-agent): respect selected art style

### DIFF
--- a/frontend/src/features/quick-start-agent/planner.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.test.ts
@@ -27,6 +27,32 @@ describe('quickStartPlannerInstructions', () => {
 })
 
 describe('createAiSdkQuickStartPlanner', () => {
+  it('treats the selected art style as fixed context when drafting prompts', async () => {
+    const generate = vi.fn<QuickStartGenerateText>(async () => ({
+      text: '可以继续。',
+      finishReason: 'stop',
+      toolCalls: [],
+    }))
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      generateText: generate,
+    })
+
+    await planner({
+      messages: [{ role: 'user', content: '一个住在云端的机械师' }],
+      clarificationUsed: false,
+      artStyle: '像素',
+    })
+
+    expect(generate.mock.calls[0]?.[0].instructions).toContain('用户当前选择的画风是「像素」')
+
+    await planner({
+      messages: [{ role: 'user', content: '一个住在云端的机械师' }],
+      clarificationUsed: false,
+    })
+    expect(generate.mock.calls[1]?.[0].instructions).not.toContain('用户当前选择的画风')
+  })
+
   it('uses one schema-only Tool, non-streaming generateText, and no SDK retries', async () => {
     const signal = new AbortController().signal
     const generate = vi.fn<QuickStartGenerateText>(async () => ({

--- a/frontend/src/features/quick-start-agent/planner.ts
+++ b/frontend/src/features/quick-start-agent/planner.ts
@@ -226,11 +226,19 @@ function fallbackPlannerResult(
   }
 }
 
-export function quickStartPlannerInstructions(clarificationUsed: boolean): string {
+export function quickStartPlannerInstructions(
+  clarificationUsed: boolean,
+  artStyle?: string,
+): string {
   const clarificationRule = clarificationUsed
     ? '本草稿已经问过一次必要澄清，不得因为轮数强制生成，也不得再问第二个澄清问题；信息不足时用 reply 说明可继续补充，存在硬冲突时用 blocked。'
     : '本草稿尚未问过必要澄清。只有缺少会实质改变角色母版的关键信息时，才可以用 clarification 问一个最关键的问题。'
+  const artStyleContext = artStyle
+    ? `用户当前选择的画风是「${artStyle}」。这是宿主已经确定的生成约束；拟写提示词时不得使用与它冲突的画风描述，也不要修改或重新选择画风。`
+    : ''
   return `你是 Windup Quick Start 的轻量 Planner。你只理解当前草稿、回复用户，并在合适时给出角色母版提示词提案；你不执行生成，也不参与生成后的流程。
+
+${artStyleContext}
 
 每轮必须调用一次 ${QUICK_START_DECISION_TOOL}，并只返回一个决策：
 - reply：闲聊、回顾历史、评价、比较方案、解释或继续讨论。reply 不消耗澄清额度。
@@ -276,7 +284,13 @@ export function createAiSdkQuickStartPlanner({
   })
   const model = provider.chatModel(modelId)
 
-  return async ({ messages, clarificationUsed, workflow, signal }): Promise<PlannerResult> => {
+  return async ({
+    messages,
+    clarificationUsed,
+    artStyle,
+    workflow,
+    signal,
+  }): Promise<PlannerResult> => {
     const tools = workflow
       ? Object.fromEntries(
           workflow.availableTools.map((name: WorkflowAgentToolName) => [name, workflowTools[name]]),
@@ -284,7 +298,7 @@ export function createAiSdkQuickStartPlanner({
       : { [QUICK_START_DECISION_TOOL]: quickStartDecisionTool }
     const instructions = workflow
       ? quickStartWorkflowInstructions(workflow)
-      : quickStartPlannerInstructions(clarificationUsed)
+      : quickStartPlannerInstructions(clarificationUsed, artStyle)
     const history = messages.slice(-MAX_PLANNER_HISTORY_MESSAGES)
     const result = await generateText({
       model,

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -68,6 +68,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
   const {
     planner,
     startCharacterGeneration,
+    artStyle,
     initialMessages,
     initialClarificationUsed,
     initialProposal,
@@ -88,18 +89,20 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
       agent.current?.revoke()
       agent.current = null
     }
-  }, [initialMessages, planner, startCharacterGeneration])
+  }, [artStyle, initialMessages, planner, startCharacterGeneration])
 
   const ensureAgent = useCallback(() => {
     agent.current ??= createQuickStartAgent({
       planner,
       startCharacterGeneration,
+      artStyle,
       initialMessages,
       initialClarificationUsed,
       initialProposal,
     })
     return agent.current
   }, [
+    artStyle,
     initialClarificationUsed,
     initialMessages,
     initialProposal,

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -38,6 +38,8 @@ export interface PlannerResult {
 export interface PlannerInput {
   messages: readonly PlannerMessage[]
   clarificationUsed: boolean
+  /** 用户在宿主中选择的画风；Planner 只把它当作拟写提示词时的既定约束。 */
+  artStyle?: string
   workflow?: WorkflowAgentContext
   signal?: AbortSignal
 }
@@ -100,6 +102,7 @@ export type StartCharacterGenerationAction = (input: {
 export interface CreateQuickStartAgentOptions {
   planner: QuickStartPlanner
   startCharacterGeneration: StartCharacterGenerationAction
+  artStyle?: string
   initialMessages?: readonly PlannerMessage[]
   initialClarificationUsed?: boolean
   initialProposal?: CharacterGenerationProposal | null
@@ -238,6 +241,7 @@ function proposalMessage(plan: CharacterGenerationPlan): string {
 export function createQuickStartAgent({
   planner,
   startCharacterGeneration,
+  artStyle,
   initialMessages = [],
   initialClarificationUsed = false,
   initialProposal = null,
@@ -279,7 +283,7 @@ export function createQuickStartAgent({
       // runtime 也必须保留同一历史，避免刷新前后得到不同上下文。
       messages = nextMessages
       const decision = validatePlannerTerminal(
-        await planner({ messages: nextMessages, clarificationUsed, signal }),
+        await planner({ messages: nextMessages, clarificationUsed, artStyle, signal }),
       )
       if (signal?.aborted) {
         revoked = true

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1026,6 +1026,25 @@ describe('QuickStartPage', () => {
     expect(window.sessionStorage.getItem(key)).toContain('"gameStyle":"pixel"')
   })
 
+  it('passes the chosen art style into every Agent planning turn', async () => {
+    const planner = vi.fn(async (_input: PlannerInput) => ({
+      text: '想保留哪个特征？',
+      finishReason: 'stop',
+      toolCalls: [],
+    }))
+    renderAt('/quick-start', serviceFor(null), agentFor({ planner }))
+
+    fireEvent.click(screen.getByRole('button', { name: '选择画风，当前不指定' }))
+    fireEvent.click(screen.getByRole('menuitemradio', { name: '像素' }))
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '一个住在云端的机械师。' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+
+    await waitFor(() => expect(planner).toHaveBeenCalledTimes(1))
+    expect(planner.mock.calls[0]?.[0]).toMatchObject({ artStyle: '像素' })
+  })
+
   it('moves the Agent draft into a run-scoped sidecar when generation starts', async () => {
     vi.useFakeTimers()
     const createdRun = workflow(setupAndTemplate({ phase: 'generating' }), 'run-created')

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -660,6 +660,7 @@ function QuickStartInput({
   const initialAgentSeed = useRef(createAgentSeed(conversationTurns)).current
   const agentSession = useQuickStartAgent({
     ...agent,
+    ...(gameStyle === 'unspecified' ? {} : { artStyle: ART_STYLE[gameStyle] }),
     initialMessages: initialAgentSeed.messages,
     initialClarificationUsed: initialAgentSeed.clarificationUsed,
     initialProposal: initialAgentSeed.pendingProposal,


### PR DESCRIPTION
让 Quick Start Agent 在拟写角色母版提示词时读取用户当前选择的画风，使 Agent 提案与既有生成约束保持一致。

## Why

Quick Start 原先只在确认生成时把画风交给生成管线，Planner 看到的只有对话历史。因此用户已经选择像素等具体画风后，Agent 仍可能拟写与该画风冲突的提示词。

## Changes

- 将 Quick Start 当前选择的具体画风传入 Agent Planner。
- 在 system instructions 中把该画风声明为宿主已经确定的只读生成约束。
- 选择“不指定”时不向 Agent 注入具体画风。

## Implementation

- `PlannerInput` 增加可选 `artStyle`，由现有 Quick Start hook 和 runtime 原样传递。
- Planner 仅使用画风显示名约束提示词拟写；生成仍由现有项目字段和生成管线负责。

## Verification

- [x] `npm test -- src/features/quick-start-agent/planner.test.ts src/pages/quick-start/index.test.tsx`：104 tests passed。
- [x] `npm run typecheck`：通过。
- [x] `npx oxlint src/features/quick-start-agent/planner.test.ts src/features/quick-start-agent/planner.ts src/features/quick-start-agent/react.ts src/features/quick-start-agent/runtime.ts src/pages/quick-start/index.test.tsx src/pages/quick-start/index.tsx`：通过。
- [x] `npx oxfmt --check src/features/quick-start-agent/planner.test.ts src/features/quick-start-agent/planner.ts src/features/quick-start-agent/react.ts src/features/quick-start-agent/runtime.ts src/pages/quick-start/index.test.tsx src/pages/quick-start/index.tsx`：通过。

## Scope

- 本 PR 不包含：画风选择器、画风预设集合、项目字段或生成执行器修改。
- 后续事项：无。

## Related Issues

Closes #701
