### PR TITLE
fix(projects): remove duplicate card entrance motion

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -332,16 +332,16 @@ body,
 }
 
 .project-preview-image {
-  opacity: 0;
-  transform: scale(0.985);
+  opacity: 0.35;
+  filter: blur(12px);
   transition:
     opacity 320ms cubic-bezier(0.16, 1, 0.3, 1),
-    transform 560ms cubic-bezier(0.16, 1, 0.3, 1);
+    filter 420ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .project-preview-image-ready {
   opacity: 1;
-  transform: scale(1);
+  filter: blur(0);
 }
 
 .project-preview-message span {

--- a/frontend/src/pages/projects/index.test.tsx
+++ b/frontend/src/pages/projects/index.test.tsx
@@ -171,6 +171,7 @@ describe('ProjectsPage', () => {
     expect(await screen.findAllByRole('link', { name: /打开项目/ })).toHaveLength(2)
     const previewProject = screen.getByRole('link', { name: '打开项目 点灯人 · MVP' })
     expect(previewProject.getAttribute('href')).toBe('/projects/42/assets')
+    expect(previewProject.closest('article')?.classList.contains('projects-card-enter')).toBe(false)
     expect(screen.getByRole('heading', { name: '最近项目 · 02' })).toBeTruthy()
     const emptyProject = screen.getByRole('link', { name: '打开项目 空白海岸' })
     await waitFor(() => {

--- a/frontend/src/pages/projects/index.tsx
+++ b/frontend/src/pages/projects/index.tsx
@@ -294,7 +294,7 @@ function ProjectGalleryTile({
   return (
     <article
       style={{ '--project-card-order': motionOrder } as CSSProperties}
-      className="projects-card-enter group/tile relative min-w-0"
+      className="group/tile relative min-w-0"
     >
       <Link
         to={`/projects/${project.id}/assets`}


### PR DESCRIPTION
移除项目列表真实卡片的强制弹出动画，并把图片已有的加载过渡改为原位模糊渐清；项目数据与图片加载逻辑保持不变。

## Why

项目占位结束后，真实卡片仍会固定执行一次位移缩放入场，造成重复加载感。

## Changes

- 移除项目卡片上的 `projects-card-enter` 类。
- 将预览图片已有的缩放过渡替换为透明度与模糊过渡。
- 增加回归断言，防止强制入场动画被恢复。

## Verification

- [x] `npm test -- src/pages/projects/index.test.tsx`：10 项通过。
- [x] `npm run typecheck`：通过。
- [x] `npx oxfmt --check src/pages/projects/index.tsx src/pages/projects/index.test.tsx`：通过。
- [x] 本地 `/projects`：真实卡片不再执行固定弹出动画。

## Scope

- 本 PR 不修改接口请求、加载占位、图片 `onLoad`、缓存或等待逻辑，也不增加最低动画时长。

## Related Issues

Closes #705
