### PR TITLE
fix(quick-start): gate automatic delivery on actions

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1156,6 +1156,7 @@ describe('QuickStartPage', () => {
     const optimizedCopy = proposal?.querySelector('blockquote')
     expect(optimizedCopy?.className).not.toContain('border-l')
     expect(optimizedCopy?.className).not.toContain('pl-4')
+    expect(screen.queryByRole('button', { name: '确认并生成' })).toBeNull()
     const fill = screen.getByRole('button', { name: '填入输入框' })
     expect(fill.className).not.toContain('border')
     expect(fill.textContent).toContain('编辑后逐步确认')

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1474,15 +1474,17 @@ function PromptProposal({
       {actionPrompt ? <p className="text-sm text-app-muted">动作：{actionPrompt}</p> : null}
       {status === 'pending' ? (
         <div className="flex flex-wrap items-center gap-3">
-          <button
-            type="button"
-            aria-label="确认并生成"
-            disabled={disabled}
-            onClick={onConfirm}
-            className="min-h-9 rounded-full bg-app-accent px-4 text-xs font-semibold text-app-canvas transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:opacity-45"
-          >
-            确认并生成
-          </button>
+          {actionPrompt ? (
+            <button
+              type="button"
+              aria-label="确认并生成"
+              disabled={disabled}
+              onClick={onConfirm}
+              className="min-h-9 rounded-full bg-app-accent px-4 text-xs font-semibold text-app-canvas transition hover:bg-app-accent-hover disabled:cursor-not-allowed disabled:opacity-45"
+            >
+              确认并生成
+            </button>
+          ) : null}
           <button
             type="button"
             aria-label="填入输入框"


### PR DESCRIPTION
Quick Start 现在只在 Agent 提案包含动作时提供自动交付入口；纯角色提案继续复用原有逐步确认流程。

## Why

Agent 已能通过 `actionPrompt` 表达提案是否包含动作，但页面此前无条件显示“确认并生成”，使纯角色提案也能进入不适用的自动交付流程。

## Changes

- 无 `actionPrompt` 时隐藏“确认并生成”。
- 保留“编辑后逐步确认”，且不留下按钮占位。
- 有动作提案的自动交付行为保持不变。

## Implementation

由 `PromptProposal` 直接根据现有 `actionPrompt` 条件渲染主按钮，不新增 Agent 判断、协议或业务状态。

## Verification

- `npm test -- src/pages/quick-start/index.test.tsx`：98 tests passed。
- `npm run typecheck`：通过。
- `npx oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。

## Scope

- 不修改 Planner、WorkflowController 或自动交付执行器。
- 不改变有动作提案和现有逐步确认流程。

## Related Issues

Closes #709
