### PR TITLE
fix(matte): 关 mem_pattern,generation 结束后 trim glibc 堆 (#690)

### DIFF
--- a/backend/packages/app/src/windup_app/worker/consumer.py
+++ b/backend/packages/app/src/windup_app/worker/consumer.py
@@ -29,8 +29,16 @@ from windup_framework.mq import client as mq_client
 from windup_framework.mq.config import MAX_CONSUME_ATTEMPTS, PEL_CLAIM_INTERVAL_SECONDS
 from windup_framework.mq import repository as mq_repo
 from windup_framework.mq.repository import ConsumeClaimResult
+from windup_framework.providers.matte import release_inference_scratch
 
 logger = logging.getLogger("windup.worker.consumer")
+
+# 抠图/抽帧走这些类型。结束后 trim glibc 堆,会话留着给下一单。
+_TRIM_AFTER = frozenset({
+    MSG_TYPE_CHARACTER_IMAGE,
+    MSG_TYPE_CHARACTER_ACTION,
+    MSG_TYPE_CHARACTER_ACTION_POLL,
+})
 
 
 @dataclass(frozen=True)
@@ -164,6 +172,7 @@ class StreamConsumer:
         redis_client = get_redis()
         semaphores: list[threading.Semaphore] = []
         message_id: uuid.UUID | None = None
+        msg_type: str | None = None
         try:
             envelope = mq_client.parse_envelope(fields)
             message_id = uuid.UUID(str(envelope["id"]))
@@ -236,6 +245,8 @@ class StreamConsumer:
             )
             self._handle_failure(stream_id, fields, exc, message_id)
         finally:
+            if msg_type in _TRIM_AFTER:
+                release_inference_scratch()
             for sem in semaphores:
                 sem.release()
 

--- a/backend/packages/framework/src/windup_framework/providers/matte.py
+++ b/backend/packages/framework/src/windup_framework/providers/matte.py
@@ -81,15 +81,29 @@ def _refine_enabled() -> bool:
 
 
 def _ort_session(path: Path):
-    """CPU 会话:关 arena、intra_op=1,避免 4C8G 上预分配后 RSS 不回落。"""
+    """CPU 会话:关 arena 与 mem_pattern、intra_op=1,避免预分配后 RSS 不回落。"""
     import onnxruntime as ort
 
     opt = ort.SessionOptions()
     opt.enable_cpu_mem_arena = False
+    opt.enable_mem_pattern = False
     opt.intra_op_num_threads = 1
     return ort.InferenceSession(
         str(path), sess_options=opt, providers=["CPUExecutionProvider"]
     )
+
+
+def release_inference_scratch() -> None:
+    """任务结束后把 glibc 空闲页还给 OS。不卸载 ONNX 会话。"""
+    import gc
+
+    gc.collect()
+    try:
+        import ctypes
+
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except (OSError, AttributeError):
+        pass
 
 
 def _download_atomic(url: str, dest: Path) -> None:

--- a/backend/tests/test_matte_provider.py
+++ b/backend/tests/test_matte_provider.py
@@ -620,7 +620,7 @@ def test_an_unusable_cached_model_is_removed_so_the_next_run_can_redownload(
 
 
 def test_ort_session_disables_cpu_arena_and_limits_intra_op(monkeypatch, tmp_path):
-    """4C8G:关 CPU arena、intra_op=1,否则预分配后 RSS 不回落。"""
+    """4C8G:关 CPU arena / mem_pattern、intra_op=1,否则预分配后 RSS 不回落。"""
     import sys
     import types
 
@@ -629,10 +629,12 @@ def test_ort_session_disables_cpu_arena_and_limits_intra_op(monkeypatch, tmp_pat
     class _Opt:
         def __init__(self):
             self.enable_cpu_mem_arena = True
+            self.enable_mem_pattern = True
             self.intra_op_num_threads = 0
 
     def _session(path, sess_options=None, providers=None):
         captured["arena"] = sess_options.enable_cpu_mem_arena
+        captured["pattern"] = sess_options.enable_mem_pattern
         captured["threads"] = sess_options.intra_op_num_threads
         captured["providers"] = providers
         return _FakeSession()
@@ -645,6 +647,7 @@ def test_ort_session_disables_cpu_arena_and_limits_intra_op(monkeypatch, tmp_pat
     model.write_bytes(b"x")
     OnnxU2NetMatteProvider(model_path=model, refine_model_url=None)._get_session()
     assert captured["arena"] is False
+    assert captured["pattern"] is False
     assert captured["threads"] == 1
     assert captured["providers"] == ["CPUExecutionProvider"]
 
@@ -692,3 +695,32 @@ def test_cutout_serializes_ort_run_across_threads(monkeypatch):
     for t in threads:
         t.join(timeout=5)
     assert max_running == 1, f"ORT Run 叠了 {max_running} 路"
+
+
+def test_release_inference_scratch_trims_glibc_heap(monkeypatch):
+    import ctypes
+
+    from windup_framework.providers.matte import release_inference_scratch
+
+    calls: list[int] = []
+
+    class _Lib:
+        @staticmethod
+        def malloc_trim(pad):
+            calls.append(pad)
+
+    monkeypatch.setattr(ctypes, "CDLL", lambda _name: _Lib())
+    release_inference_scratch()
+    assert calls == [0]
+
+
+def test_release_inference_scratch_ignores_missing_glibc(monkeypatch):
+    import ctypes
+
+    from windup_framework.providers.matte import release_inference_scratch
+
+    def _boom(_name):
+        raise OSError("no libc.so.6")
+
+    monkeypatch.setattr(ctypes, "CDLL", _boom)
+    release_inference_scratch()

--- a/backend/tests/test_mq_worker.py
+++ b/backend/tests/test_mq_worker.py
@@ -1154,3 +1154,55 @@ def test_warmup_injects_one_matte_into_both_executors(monkeypatch):
     finally:
         ex.executor._matte = prev_a
         ex.image_executor._matte = prev_i
+
+
+def test_consumer_trims_heap_after_image_not_email(engine, worker_session, monkeypatch):
+    """出图结束 trim 堆;邮件路径不碰 malloc_trim。"""
+    _patch_worker_session_local(monkeypatch, engine)
+    trimmed: list[int] = []
+    monkeypatch.setattr(
+        "windup_app.worker.consumer.release_inference_scratch",
+        lambda: trimmed.append(1),
+    )
+    monkeypatch.setattr("windup_app.worker.consumer.get_redis", lambda: MagicMock())
+    monkeypatch.setattr("windup_app.worker.consumer.dispatch_handler", lambda *_a, **_k: None)
+
+    email_id = _published_message(worker_session)
+    email = StreamConsumer(
+        ConsumerConfig(stream="windup:stream:email", group="email", concurrency=1),
+        run_image_task=MagicMock(),
+        run_action_task=MagicMock(),
+        stop_event=threading.Event(),
+    )
+    email._process_message("1-0", {"data": json.dumps({
+        "v": 1,
+        "id": str(email_id),
+        "type": MSG_TYPE_VERIFICATION_CODE,
+        "payload": {"email": "a@x.com", "purpose": "login"},
+    })})
+    assert trimmed == []
+
+    image_id = uuid.uuid4()
+    mq_repo.insert_pending(
+        worker_session,
+        message_id=image_id,
+        dedupe_key=f"generation:image:{image_id}",
+        stream="windup:stream:generation",
+        msg_type=MSG_TYPE_CHARACTER_IMAGE,
+        payload={"task_id": 1, "task_type": "character_image"},
+    )
+    mq_repo.mark_published(worker_session, image_id, "i-0")
+    worker_session.commit()
+    gen = StreamConsumer(
+        ConsumerConfig(stream="windup:stream:generation", group="generation", concurrency=1),
+        run_image_task=MagicMock(),
+        run_action_task=MagicMock(),
+        stop_event=threading.Event(),
+    )
+    gen._process_message("i-0", {"data": json.dumps({
+        "v": 1,
+        "id": str(image_id),
+        "type": MSG_TYPE_CHARACTER_IMAGE,
+        "payload": {"task_id": 1, "task_type": "character_image"},
+    })})
+    assert trimmed == [1]


### PR DESCRIPTION
## Summary
- i2v 抠图三期第一刀（#690）：`SessionOptions.enable_mem_pattern=False`，减少 ORT 规划器预分配。
- 出图 / 动作 / i2v poll 消息处理完 `gc.collect()` + `malloc_trim(0)`，把本单 scratch 还给内核。**不卸载**预热的 ONNX 会话。
- 邮件消息不 trim。非 glibc 环境静默跳过。

不关 #690：队列 UI / 拆机 / RVM 仍后置。

## Test plan
- [x] `uv run pytest tests/test_matte_provider.py tests/test_mq_worker.py --no-cov`（81 passed）
- [x] 4C8G 重建 worker 后跑一单 32 帧，结束后看 `/proc/1/smaps_rollup` 的 `Anonymous` 是否低于现在的 ~981MiB
- [x] 日志仍有 `ONNX 抠图会话已预热`，下一单不再冷加载 u2net