### PR TITLE
feat(render3d): 出帧交给用户浏览器，worker 不再装 Chromium

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,7 +132,17 @@ POSTGRES_MAX_OVERFLOW=10
 
 # ── 三渲二（可选）─────────────────────────────────────────────────────
 # 出模型与自动绑骨走腾讯云 ai3d，按量计费；不填则该路线在运行时报缺凭证，
-# 其余功能不受影响。worker 镜像还需 target=runtime-render3d（node/playwright/three）。
+# 其余功能不受影响。
 TENCENT_SECRET_ID=
 TENCENT_SECRET_KEY=
 TENCENT_REGION=ap-guangzhou
+
+# 出帧由用户浏览器承担（#714）。设成 0 回退到 worker 内 Playwright，
+# 此时 WINDUP_WORKER_TARGET 必须同时改成 runtime-render3d——只关开关不换镜像
+# 会一直跑到出帧那一步才报缺 node/playwright/three。
+WINDUP_RENDER3D_CLIENT_BAKE=1
+# 浏览器多久没交帧就判失败。比 i2v 的 30 分钟短：那边等的是上游算力，
+# 这边等的是一个开着的页面，关了标签就永远不会有回报。
+WINDUP_RENDER3D_CLIENT_BAKE_DEADLINE_S=900
+# worker 镜像构建目标。runtime 不含浏览器（820MB）；runtime-render3d 含（2.53GB）。
+WINDUP_WORKER_TARGET=runtime

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -59,9 +59,13 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
 # 启动命令
 CMD ["uvicorn", "windup_app.bootstrap.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]
 
-# ── 阶段 2b: 出帧运行时（三渲二，只有 worker 需要）──
+# ── 阶段 2b: 出帧运行时（三渲二的服务端渲，回退路径）──
 # 出帧段是「起本地 HTTP 服务 → node + playwright 驱动出帧台 → 读回 PNG」，
 # 所以 node / playwright / three 是硬依赖，缺任何一个该路线在运行时才报错。
+#
+# 默认已不再构建它：应用机 4 核无 GPU，只能走 SwiftShader 软件光栅（实测峰值想吃 7.6
+# 个核），而这一层让 worker 镜像从 820MB 涨到 2.53GB（其中 /ms-playwright 656MB）。
+# 出帧改由用户浏览器承担（#714）；本阶段留给 WINDUP_RENDER3D_CLIENT_BAKE=0 的回退。
 FROM runtime-base AS runtime-render3d
 
 ARG PLAYWRIGHT_VERSION=1.62.1

--- a/backend/packages/ai_engine/src/windup_ai_engine/impl/character_generator.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/impl/character_generator.py
@@ -25,6 +25,7 @@ from windup_ai_engine.ports import (
     CharacterGeneratorPort,
     GeneratedAction,
     ProgressPort,
+    RenderPlan,
     SequenceGeometry,
 )
 from windup_ai_engine.postprocess import FOOT_LINE, align_bottom_center, frame_durations
@@ -206,6 +207,34 @@ class CharacterGenerator(CharacterGeneratorPort):
             card, action, rigged_model, _BandProgress(progress, _DERIVE_FROM, _DERIVE_TO)
         )
         return self._finish(frames, action, route, progress, canvas)
+
+    def plan_rendered(self, action: ActionSpec) -> RenderPlan:
+        """三渲二该渲什么。出帧交给浏览器时,server 把这份参数原样发给它。"""
+        strategy = self._pick(GenRoute.RENDER_3D, action)
+        plan = getattr(strategy, "plan", None)
+        if plan is None:
+            raise TypeError("RENDER_3D 路线不支持出帧计划")
+        return plan(action)
+
+    def finish_rendered(
+        self,
+        frames: list[bytes],
+        card: CharacterCard,
+        action: ActionSpec,
+        progress: ProgressPort,
+        canvas: tuple[int, int] | None = None,
+    ) -> GeneratedAction:
+        """浏览器渲好的帧到位后续跑像素化与最后一公里。"""
+        route = GenRoute.RENDER_3D
+        progress.step("route", _TICK_ROUTE, _TOTAL, f"{action.action.value} → {route.value}")
+        strategy = self._pick(route, action)
+        frames_from = getattr(strategy, "frames_from_client", None)
+        if frames_from is None:
+            raise TypeError(f"{route.value} 不支持从客户端帧续跑")
+        produced = frames_from(
+            frames, card, action, _BandProgress(progress, _DERIVE_FROM, _DERIVE_TO)
+        )
+        return self._finish(produced, action, route, progress, canvas)
 
     # ── 两个入口共用的部分 ────────────────────────────────────────────────
     def _pick(self, route: GenRoute, action: ActionSpec) -> DerivationStrategy:

--- a/backend/packages/ai_engine/src/windup_ai_engine/ports/__init__.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/ports/__init__.py
@@ -276,6 +276,25 @@ class GeneratedAction:
     prompt_version: str = field(kw_only=True)
 
 
+@dataclass(frozen=True)
+class RenderPlan:
+    """三渲二出帧的全部参数 —— 无论谁来渲,都按这一份。
+
+    出帧那一段可以在 worker 里跑(Playwright),也可以交给用户浏览器跑(#714)。
+    参数在两处各写一份的话,同一个动作在两条路上会渲出不同的东西,而帧数、时长、
+    成色全都正常,没有任何一道会红。
+    """
+
+    clip: str
+    direction: str
+    camera_yaw: float
+    frames: int
+    width: int
+    height: int
+    material: str
+    min_coverage: float
+
+
 # ---- 出门那道闸的仪器:判官(server 注入实现,framework 层有一个)----
 # 与 ``ActionQuality`` 分工不同:那三个数由本地像素算出来,零成本、量的是帧**之间**的
 # 关系;判官量的是一帧画面**里**有什么,要花一次付费调用,且本地算不出来 —— 像素统计
@@ -358,6 +377,33 @@ class CharacterGeneratorPort(Protocol):
         Raises:
             NotImplementedError: 没注入 ``GenRoute.RENDER_3D`` 的 strategy。
             ValueError: 模型渲不出请求朝向 / 产出帧数对不上契约。
+        """
+        ...
+
+    def plan_rendered(self, action: ActionSpec) -> RenderPlan:
+        """三渲二出帧参数。**不渲,只回答"该渲什么"**。
+
+        出帧交给浏览器时,server 要先把这份参数发给它;交给 worker 时,同一份参数由
+        :meth:`generate_rendered` 内部消费。两条路共用一份,是因为朝向、材质、画布、
+        帧数任何一项分叉都不会报错,只会安静地渲出另一个东西。
+        """
+        ...
+
+    def finish_rendered(
+        self,
+        frames: list[bytes],
+        card: CharacterCard,
+        action: ActionSpec,
+        progress: ProgressPort,
+        canvas: tuple[int, int] | None = None,
+    ) -> GeneratedAction:
+        """吃已渲好的序列帧(浏览器交回的),续跑像素化与最后一公里。
+
+        与 :meth:`generate_rendered` 的区别只在谁渲的;**闸口一道不减** —— 帧数对账、
+        空帧自检、脚线对齐、成色测量仍在服务端做,不因为帧来自客户端就放行。
+
+        Raises:
+            ValueError: 帧数对不上契约 / 几乎全透明 / 不是 PNG。
         """
         ...
 

--- a/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
@@ -31,7 +31,7 @@ from windup_framework.providers import ImageProvider, MatteProvider, VideoProvid
 from windup_ai_engine._imgio import from_png as _img
 from windup_ai_engine._imgio import to_png as _png
 from windup_ai_engine.master_prep import prepare_master
-from windup_ai_engine.ports import ProgressPort, PromptAdapterPort, PromptRejected
+from windup_ai_engine.ports import ProgressPort, PromptAdapterPort, PromptRejected, RenderPlan
 from windup_ai_engine.postprocess import master_pixel_spec, pixelate_frames
 from windup_ai_engine.slicing import (
     extract_frames_at,
@@ -302,6 +302,19 @@ class PerFrameStrategy(DerivationStrategy):
 # 才是正面(奶白胸腹与口鼻可见,浅色像素占比 21.0%),s 是背面(8.5%)。两者主体像素数
 # 几乎相同,靠轮廓分不出正反,而单元测试也逮不到 —— 朝向错了但帧数、时长、成色全部正常。
 # 改这张表之前先渲一遍再量。
+def _coverage(png: bytes) -> float:
+    """一帧的非透明像素占比。**与出帧台 ``__coverage`` 同一口径**:先缩到 128 宽再数
+    ``alpha > 8`` —— 两边算法不同的话,客户端自检过了服务端再判一次会无故打回。
+    """
+    image = _img(png)
+    if image.mode != "RGBA":
+        return 1.0
+    width = 128
+    height = max(1, round(image.height / image.width * width))
+    alpha = np.asarray(image.resize((width, height)).getchannel("A"))
+    return float((alpha > 8).sum()) / float(width * height)
+
+
 _FACING_TO_DIRECTION: dict[Facing, str] = {
     Facing.SIDE: "e",  # yaw=0°,角色朝画面右(与出帧台 faces="right" 同口径)
     Facing.FRONT: "n",  # yaw=90°,身体正对观者
@@ -331,20 +344,25 @@ class RenderFrameStrategy(DerivationStrategy):
 
     def __init__(
         self,
-        renderer: SpriteRenderProvider,
+        renderer: SpriteRenderProvider | None = None,
         *,
         directions: int = 4,
         material: str = "cel",
         size: tuple[int, int] | None = None,
+        min_coverage: float = 0.005,
     ) -> None:
         # 出帧台的 provider 包只在这条路线上用得着(它连着 node + 浏览器)。在模块顶层
         # import 会让走 i2v / 逐帧的部署也必须装齐它,而这两条路线一行都用不到。
         from windup_framework.providers.render3d import RENDER_SIZE
 
+        # 出帧交给浏览器时这里恒为 None:worker 不装 node / Chromium,只做后处理。
+        # 缺省不报错,是因为 plan / frames_from_client 两条路都用不到渲染器;真去
+        # derive 才炸,那时候的报错才指得准。
         self._renderer = renderer
         self._directions = directions
         self._material = material
         self._size = size or RENDER_SIZE
+        self._min_coverage = min_coverage
 
     def derive(
         self,
@@ -361,12 +379,13 @@ class RenderFrameStrategy(DerivationStrategy):
                 "server 侧应在调用前确认该造型的 3D 资产可读。"
             )
 
-        # 新请求按真实源方向取序列；旧的三渲二调用没有 direction 时，继续按
-        # facing 选择序列，不能把缺省值误当成 east。
-        if action.direction is None:
-            want = _FACING_TO_DIRECTION.get(action.facing, "e")
-        else:
-            want = _ACTION_DIRECTION_TO_RENDERER[action.direction.value]
+        if self._renderer is None:
+            raise RuntimeError(
+                "三渲二没有注入出帧台。出帧已交给浏览器时不该走到这里(见 "
+                "WINDUP_RENDER3D_CLIENT_BAKE);要在服务端渲就注入 SpriteRenderProvider。"
+            )
+        plan = self.plan(action)
+        want = plan.direction
         progress.step(
             "derive",
             0,
@@ -404,6 +423,71 @@ class RenderFrameStrategy(DerivationStrategy):
         # 那条分支在生产里无条件不成立。留着会让人以为多朝向已经算好了只是没带出来。
         progress.step("derive", 1, 3, f"朝向 {chosen.direction} 共 {len(frames)} 帧")
 
+        return self._stylize(frames, action, progress)
+
+    def plan(self, action: ActionSpec) -> RenderPlan:
+        """这个动作该渲什么 —— 朝向、材质、画布、帧数、空帧阈值。
+
+        朝向解析留在 strategy 里而不是让调用方各算各的:新请求按真实源方向取序列,
+        旧的三渲二调用没有 ``direction`` 时继续按 ``facing`` 选,把缺省值误当成 east
+        的后果是角色朝反方向走,而帧数、时长、成色全都正常。
+        """
+        from windup_framework.providers.render3d import DIRECTIONS_4, DIRECTIONS_8
+
+        if action.direction is None:
+            want = _FACING_TO_DIRECTION.get(action.facing, "e")
+        else:
+            want = _ACTION_DIRECTION_TO_RENDERER[action.direction.value]
+        table = DIRECTIONS_8 if self._directions == 8 else DIRECTIONS_4
+        if want not in table:
+            raise ValueError(f"朝向 {want!r} 不属于当前 {self._directions} 向项目")
+        return RenderPlan(
+            clip=action.action.value,
+            direction=want,
+            camera_yaw=float(table[want]),
+            frames=action.n_frames,
+            width=self._size[0],
+            height=self._size[1],
+            material=self._material,
+            min_coverage=self._min_coverage,
+        )
+
+    def frames_from_client(
+        self,
+        frames: list[bytes],
+        card: CharacterCard,
+        action: ActionSpec,
+        progress: ProgressPort,
+    ) -> list[bytes]:
+        """浏览器渲好的序列帧 → 像素化。**闸口与服务端渲一模一样,一道不减。**
+
+        空帧自检必须在服务端再做一次:客户端自报的覆盖率只是它的说法,而出帧台在
+        角色出画 / 片段选错时会安静地产出全透明帧,外面照样以为成功了。
+        """
+        plan = self.plan(action)
+        if len(frames) != plan.frames:
+            raise ValueError(
+                f"浏览器交回 {len(frames)} 帧,契约要 {plan.frames} 帧"
+                f"(动作 {action.action.value}、朝向 {plan.direction})。"
+            )
+        progress.step("derive", 0, 3, f"浏览器交回 {len(frames)} 帧({plan.direction} 朝向)")
+        empty = [
+            f"第 {i} 帧覆盖率 {cov:.5f}"
+            for i, cov in enumerate(_coverage(f) for f in frames)
+            if cov < plan.min_coverage
+        ]
+        if empty:
+            raise ValueError(
+                f"浏览器交回的帧几乎全透明({len(empty)}/{len(frames)}):{'; '.join(empty[:4])}。"
+                "角色出画或片段选错都会产出这种帧,不能当成功交付。"
+            )
+        progress.step("derive", 1, 3, f"空帧自检通过(阈值 {plan.min_coverage})")
+        return self._stylize(frames, action, progress)
+
+    def _stylize(
+        self, frames: list[bytes], action: ActionSpec, progress: ProgressPort
+    ) -> list[bytes]:
+        """出帧之后的画风处理。服务端渲与浏览器渲共用同一份,不复制。"""
         # 3D 帧本来就是透明底,**不套抠图**:去白边那一步会把浅灰甲当漏白吃掉。
         # 像素化仍按 ActionSpec 走。
         if action.stylize is Stylize.NONE:

--- a/backend/packages/app/src/windup_app/bootstrap/worker.py
+++ b/backend/packages/app/src/windup_app/bootstrap/worker.py
@@ -11,6 +11,7 @@ from windup_app.server.mq.catalog import all_stream_specs, email_stream_spec, ge
 from windup_app.server.orchestrator import task_repo
 from windup_app.server.orchestrator.executor import (
     bind_matte,
+    resume_action_client_bake,
     resume_action_poll,
     run_action_task,
     run_image_task,
@@ -80,6 +81,7 @@ def main() -> None:
             run_direction_set_task=run_direction_set_task,
             stop_event=stop_event,
             resume_action_poll=resume_action_poll,
+            resume_action_client_bake=resume_action_client_bake,
         ),
     ]
     threads = [consumer.start() for consumer in consumers]

--- a/backend/packages/app/src/windup_app/server/mq/catalog.py
+++ b/backend/packages/app/src/windup_app/server/mq/catalog.py
@@ -39,6 +39,7 @@ MSG_TYPE_VERIFICATION_CODE = "verification_code"
 MSG_TYPE_CHARACTER_IMAGE = "character_image"
 MSG_TYPE_CHARACTER_ACTION = "character_action"
 MSG_TYPE_CHARACTER_ACTION_POLL = "character_action_poll"
+MSG_TYPE_CHARACTER_ACTION_CLIENT_BAKE = "character_action_client_bake"
 
 POOL_SHARED = "shared"
 POOL_POLL = "poll"
@@ -111,6 +112,13 @@ def type_specs() -> tuple[TypeSpec, ...]:
         ),
         TypeSpec(
             msg_type=MSG_TYPE_CHARACTER_ACTION_POLL,
+            stream=GENERATION_STREAM,
+            pool=POOL_POLL,
+            concurrency=generation_poll_concurrency(),
+            limit=True,
+        ),
+        TypeSpec(
+            msg_type=MSG_TYPE_CHARACTER_ACTION_CLIENT_BAKE,
             stream=GENERATION_STREAM,
             pool=POOL_POLL,
             concurrency=generation_poll_concurrency(),

--- a/backend/packages/app/src/windup_app/server/orchestrator/_fetch.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/_fetch.py
@@ -24,7 +24,7 @@ import httpx
 
 from windup_framework.config.storage import settings as storage_settings
 
-__all__ = ["MAX_FETCH_BYTES", "FetchNotAllowed", "fetch_own_media"]
+__all__ = ["MAX_FETCH_BYTES", "FetchNotAllowed", "fetch_own_media", "is_own_media"]
 
 # 单张图的上限。母版是 1024² 级的 PNG（实测 860~970 KB），16 MiB 留了足够余量，
 # 又不至于让一个恶意 URL 拖垮 worker 内存。
@@ -69,3 +69,13 @@ def fetch_own_media(url: str, *, timeout: float = 30.0) -> bytes:
                     )
                 chunks.append(chunk)
     return b"".join(chunks)
+
+
+def is_own_media(url: str) -> bool:
+    """URL 是否落在自家对象存储上 —— 与 :func:`fetch_own_media` 同一条白名单,不取内容。
+
+    出帧交给浏览器后,模型由**浏览器**去拉;服务端仍要在把地址发出去之前校验它,
+    否则等于让任意 URL 借用户的浏览器和登录态发一次请求。
+    """
+    base = storage_settings.download_base
+    return bool(base) and url.startswith(f"{base}/")

--- a/backend/packages/app/src/windup_app/server/orchestrator/client_bake.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/client_bake.py
@@ -1,0 +1,189 @@
+"""动作任务等浏览器出帧时的 Redis 状态。
+
+任务行保持 RUNNING,worker 立刻让出:出帧那一段在用户浏览器里跑,应用机既不起
+Chromium 也不吃软件光栅那 7.6 个核(Refs #714)。
+
+帧走 Redis 而不是对象存储:API 与 worker 在不同容器里,交接必须过共享存储;
+实测单帧 1536×2560 的 PNG 是 178–209KB(透明底 + 平涂压得住),一个 32 帧动作
+约 6–7MB,放 Redis 短时中转比多两跳对象存储上下行便宜。base64 是因为全站
+Redis 连接池开着 ``decode_responses=True``。
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+
+from windup_app.server.mq.catalog import (
+    GENERATION_STREAM,
+    MSG_TYPE_CHARACTER_ACTION_CLIENT_BAKE,
+)
+from windup_framework.db.redis import get_redis
+from windup_framework.mq.delayed import schedule_delayed
+
+KEY_PREFIX = "windup:clientbake:"
+STATE_TTL_S = 2 * 3600
+# 浏览器没交帧就判失败的期限。比 i2v 的 30 分钟短:那边等的是上游算力,这边等的是
+# 一个开着的页面 —— 关标签 / 切后台 / 手机 WebGL 起不来都不会有任何回报,拖着只是
+# 占着一笔冻结积分。
+DEADLINE_S = float(os.getenv("WINDUP_RENDER3D_CLIENT_BAKE_DEADLINE_S", "900"))
+# 单帧上限。实测 178–209KB,给到 2MB 是 10 倍余量;超过它一定不是本管线的帧。
+MAX_FRAME_BYTES = 2 * 1024 * 1024
+
+REASON_FRAMES = "frames"
+REASON_TIMEOUT = "timeout"
+REASON_CLIENT_FAILED = "client_failed"
+
+
+class ActionAwaitingClientBake(Exception):
+    """出帧任务已挂给浏览器,任务保持 RUNNING,不占 action worker。"""
+
+
+class ClientBakeError(RuntimeError):
+    """浏览器交回的帧不满足契约。零成本段,失败可重试。"""
+
+
+@dataclass(frozen=True)
+class ClientBakeSpec:
+    """浏览器出帧要的全部参数。字段名与出帧台钩子的入参一一对应。"""
+
+    model_url: str
+    clip: str
+    direction: str
+    camera_yaw: float
+    frames: int
+    width: int
+    height: int
+    material: str
+    min_coverage: float
+
+    def to_payload(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def enabled() -> bool:
+    """出帧是否交给浏览器。关掉即回到 worker 内 Playwright(过渡机仍需 render3d 镜像)。"""
+    return os.getenv("WINDUP_RENDER3D_CLIENT_BAKE", "1").strip().lower() not in {
+        "0", "false", "off", "no",
+    }
+
+
+def _key(task_id: int) -> str:
+    return f"{KEY_PREFIX}{task_id}"
+
+
+def _frames_key(task_id: int) -> str:
+    return f"{KEY_PREFIX}{task_id}:frames"
+
+
+def open_job(task_id: int, spec: ClientBakeSpec) -> float:
+    """挂出一个待浏览器认领的出帧任务,返回过期时刻(epoch 秒)。"""
+    deadline = time.time() + DEADLINE_S
+    redis_client = get_redis()
+    mapping = {k: str(v) for k, v in spec.to_payload().items()}
+    mapping["deadline_at"] = str(deadline)
+    pipe = redis_client.pipeline()
+    pipe.delete(_frames_key(task_id))
+    pipe.hset(_key(task_id), mapping=mapping)
+    pipe.expire(_key(task_id), STATE_TTL_S)
+    pipe.execute()
+    schedule_delayed(
+        delay_s=DEADLINE_S,
+        stream=GENERATION_STREAM,
+        msg_type=MSG_TYPE_CHARACTER_ACTION_CLIENT_BAKE,
+        payload={"task_id": task_id, "reason": REASON_TIMEOUT},
+        dedupe_key=f"generation:{task_id}:clientbake:timeout",
+    )
+    return deadline
+
+
+def load_spec(task_id: int) -> tuple[ClientBakeSpec, float] | None:
+    raw = get_redis().hgetall(_key(task_id))
+    if not raw:
+        return None
+    spec = ClientBakeSpec(
+        model_url=str(raw.get("model_url") or ""),
+        clip=str(raw.get("clip") or ""),
+        direction=str(raw.get("direction") or ""),
+        camera_yaw=float(raw.get("camera_yaw") or 0.0),
+        frames=int(raw.get("frames") or 0),
+        width=int(raw.get("width") or 0),
+        height=int(raw.get("height") or 0),
+        material=str(raw.get("material") or ""),
+        min_coverage=float(raw.get("min_coverage") or 0.0),
+    )
+    return spec, float(raw.get("deadline_at") or 0.0)
+
+
+def put_frame(task_id: int, index: int, png: bytes) -> int:
+    """收一帧,返回已收帧数。**只判形状,不判画得对不对** —— 后者在 worker 侧统一做。"""
+    spec_and_deadline = load_spec(task_id)
+    if spec_and_deadline is None:
+        raise ClientBakeError(f"任务 {task_id} 没有待出帧的登记(可能已超时或已交付)")
+    spec, _deadline = spec_and_deadline
+    if not 0 <= index < spec.frames:
+        raise ClientBakeError(f"帧下标 {index} 不在 0..{spec.frames - 1}")
+    if len(png) > MAX_FRAME_BYTES:
+        raise ClientBakeError(
+            f"单帧 {len(png) / 1024:.0f}KB 超过上限 {MAX_FRAME_BYTES // 1024}KB"
+        )
+    if not png.startswith(b"\x89PNG\r\n\x1a\n"):
+        # 形状守卫:空画布时 toDataURL 会给出没有 base64 段的串,切出来是空字符串。
+        # 让它写进来的话,坏帧会一路当成正常产物走到交付。
+        raise ClientBakeError(f"第 {index} 帧不是 PNG")
+    redis_client = get_redis()
+    pipe = redis_client.pipeline()
+    pipe.hset(_frames_key(task_id), str(index), base64.b64encode(png).decode("ascii"))
+    pipe.expire(_frames_key(task_id), STATE_TTL_S)
+    pipe.hlen(_frames_key(task_id))
+    return int(pipe.execute()[-1])
+
+
+def collect_frames(task_id: int, expected: int) -> list[bytes]:
+    """按下标取回全部帧。缺一帧就抛 —— 少给的后果是一段步子没走完的动作,不是崩溃。"""
+    raw = get_redis().hgetall(_frames_key(task_id))
+    frames: list[bytes] = []
+    for i in range(expected):
+        value = raw.get(str(i))
+        if not value:
+            raise ClientBakeError(f"缺第 {i} 帧(已收 {len(raw)}/{expected})")
+        try:
+            frames.append(base64.b64decode(value, validate=True))
+        except (binascii.Error, ValueError) as exc:
+            raise ClientBakeError(f"第 {i} 帧不是合法 base64") from exc
+    return frames
+
+
+def clear(task_id: int) -> None:
+    get_redis().delete(_key(task_id), _frames_key(task_id))
+
+
+def schedule_resume(task_id: int, reason: str = REASON_FRAMES, detail: str = "") -> None:
+    """帧齐了(或浏览器自报失败)→ 交回 worker 续跑后处理。"""
+    payload: dict[str, object] = {"task_id": task_id, "reason": reason}
+    if detail:
+        payload["detail"] = detail[:200]
+    schedule_delayed(
+        delay_s=0,
+        stream=GENERATION_STREAM,
+        msg_type=MSG_TYPE_CHARACTER_ACTION_CLIENT_BAKE,
+        payload=payload,
+        dedupe_key=f"generation:{task_id}:clientbake:{reason}",
+    )
+
+
+def public_view(task_id: int) -> dict[str, object] | None:
+    """给前端的形状。``json.dumps`` 前先过一遍,免得 float 精度在两处各写一份。"""
+    loaded = load_spec(task_id)
+    if loaded is None:
+        return None
+    spec, deadline = loaded
+    view = spec.to_payload()
+    view["task_id"] = task_id
+    view["deadline_at"] = deadline
+    view["received"] = int(get_redis().hlen(_frames_key(task_id)))
+    return json.loads(json.dumps(view))

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -33,10 +34,18 @@ from windup_framework.gateway.registry import ModelRegistry
 from windup_framework.gateway.types import Scene
 from windup_framework.config.quality_gate import settings as gate_settings
 
-from windup_app.server.orchestrator import billing, generation_io, i2v_poll, quality_gate, task_repo
+from windup_app.server.orchestrator import (
+    billing,
+    client_bake,
+    generation_io,
+    i2v_poll,
+    quality_gate,
+    task_repo,
+)
 from windup_app.server.orchestrator._failure import user_message
 from windup_app.server.orchestrator.i2v_poll import ActionAwaitingVideo
-from windup_app.server.orchestrator._fetch import fetch_own_media
+from windup_app.server.orchestrator._fetch import FetchNotAllowed, fetch_own_media, is_own_media
+from windup_app.server.orchestrator.client_bake import ActionAwaitingClientBake
 from windup_app.server.orchestrator.model import (
     ActionType,
     CharacterActionInput,
@@ -304,6 +313,8 @@ class ActionTaskExecutor:
             generation_io.using_session(session, self._make_session, _complete)
         except ActionAwaitingVideo:
             logger.info("动作任务 %s 已提交 i2v,等待延迟轮询", task_id)
+        except ActionAwaitingClientBake:
+            logger.info("动作任务 %s 已把出帧挂给浏览器,等它交帧", task_id)
         except PromptRejected as exc:
             # 单独捕获而不是落进下面那个兜底:兜底只存 str(exc),``code`` 就丢了,server
             # 于是分不出"用户改一句话就能过的输入错"和"引擎故障",只能去解析异常文本。
@@ -411,6 +422,39 @@ class ActionTaskExecutor:
             # 三渲二那支不取母版,而出口的判官闸口要拿它当参照 —— 不先置 None 的话那支会
             # 撞 UnboundLocalError,而它只在有 3D 资产的造型上触发。
             master: bytes | None = None
+            if model_url and client_bake.enabled():
+                # 出帧交给浏览器:**模型一个字节都不经过应用机**。原路径要
+                # fetch_own_media 把整份 GLB 拉进 worker 内存(还卡在 16MiB 上限上),
+                # 再起 node + Chromium 软件光栅渲一遍 —— 那两样在这条分支上都不发生。
+                if not is_own_media(model_url):
+                    raise FetchNotAllowed(
+                        f"3D 模型地址不在自家对象存储上:{model_url[:80]!r}"
+                    )
+                plan = self._get_generator(
+                    _resolve_video_model(input.video_model), cons.directions
+                ).plan_rendered(action)
+                deadline = client_bake.open_job(
+                    task_id,
+                    client_bake.ClientBakeSpec(
+                        model_url=model_url,
+                        clip=plan.clip,
+                        direction=plan.direction,
+                        camera_yaw=plan.camera_yaw,
+                        frames=plan.frames,
+                        width=plan.width,
+                        height=plan.height,
+                        material=plan.material,
+                        min_coverage=plan.min_coverage,
+                    ),
+                )
+                logger.info(
+                    "[gen] 造型 %s 走三渲二,出帧挂给浏览器(%s 朝向 × %d 帧,%.0fs 内交)",
+                    input.outfit_id or "?",
+                    plan.direction,
+                    plan.frames,
+                    deadline - time.time(),
+                )
+                raise ActionAwaitingClientBake
             if model_url:
                 rigged = (self._fetch_model3d or self._download_model3d)(model_url)
                 logger.info(
@@ -506,6 +550,91 @@ class ActionTaskExecutor:
             logger.exception("动作任务 %s 轮询失败", task_id)
             if session is not None:
                 session.rollback()
+            error_message = user_message(exc)
+
+            def _fail(s: Session) -> None:
+                _close_failed(s, task_id, error_message)
+
+            generation_io.using_session(session, self._make_session, _fail)
+        finally:
+            if reset is not None:
+                reset()
+
+    def resume_action_client_bake(
+        self,
+        task_id: int,
+        input: CharacterActionInput,
+        project_id: int | None = None,
+        *,
+        reason: str = client_bake.REASON_FRAMES,
+        detail: str = "",
+        session: Session | None = None,
+    ) -> None:
+        """浏览器那一侧有结果了:交回帧、自报失败,或到期未交。
+
+        三种入口收在同一个方法里,是因为它们改的是同一条任务的同一个终态;分开写会
+        让"超时"这一支漏掉解冻(积分冻着、任务永远 RUNNING)。
+        """
+        reset = None
+        try:
+            def _mark_running(s: Session) -> ProjectConstraints:
+                task = task_repo.get_task(s, task_id)
+                if task is None:
+                    raise RuntimeError(f"任务 {task_id} 不存在")
+                if task.status in (TaskStatus.COMPLETED, TaskStatus.FAILED):
+                    raise _PollSkip(f"任务 {task_id} 已终态")
+                return (self._fetch_constraints or _load_constraints)(s, project_id)
+
+            try:
+                cons = generation_io.using_session(session, self._make_session, _mark_running)
+            except _PollSkip:
+                client_bake.clear(task_id)
+                return
+
+            loaded = client_bake.load_spec(task_id)
+            if loaded is None:
+                # 登记已经不在了:要么另一条消息已经收口,要么状态过期。不重复判失败。
+                logger.info("动作任务 %s 没有待出帧登记,跳过", task_id)
+                return
+            spec, _deadline = loaded
+
+            if reason != client_bake.REASON_FRAMES:
+                message = (
+                    f"浏览器出帧超时({client_bake.DEADLINE_S:.0f}s 未交帧)"
+                    if reason == client_bake.REASON_TIMEOUT
+                    else f"浏览器出帧失败:{detail or '未给出原因'}"
+                )
+                client_bake.clear(task_id)
+
+                def _fail_client(s: Session) -> None:
+                    _close_failed(s, task_id, message)
+
+                generation_io.using_session(session, self._make_session, _fail_client)
+                return
+
+            frames = client_bake.collect_frames(task_id, spec.frames)
+            reset = bind_call_context(
+                task_id=str(task_id),
+                start_from_model=_resolve_video_model(input.video_model),
+            )
+            card, action, canvas = self._action_spec(input, cons)
+            progress: ProgressPort = _LogProgress()
+            generated = self._get_generator(
+                _resolve_video_model(input.video_model), cons.directions
+            ).finish_rendered(frames, card, action, progress, canvas=canvas)
+            result = self._deliver_generated(generated, input, cons, None)
+            client_bake.clear(task_id)
+
+            def _complete(s: Session) -> None:
+                task_repo.update_result(s, task_id, _ACTION_RESULT, result)
+                _settle_credit(s, task_id, success=True)
+
+            generation_io.using_session(session, self._make_session, _complete)
+        except Exception as exc:  # noqa: BLE001 —— 兜底后处理/上传/网络异常
+            logger.exception("动作任务 %s 的浏览器出帧收口失败", task_id)
+            if session is not None:
+                session.rollback()
+            client_bake.clear(task_id)
             error_message = user_message(exc)
 
             def _fail(s: Session) -> None:
@@ -688,20 +817,36 @@ class ActionTaskExecutor:
             route = GenRoute.RENDER_3D
 
             def __init__(self) -> None:
-                self._inner: DerivationStrategy | None = None
+                self._plain: DerivationStrategy | None = None
+                self._with_stage: DerivationStrategy | None = None
+
+            def _build(self, renderer):
+                from windup_ai_engine.strategy.concrete import RenderFrameStrategy
+
+                return RenderFrameStrategy(renderer, directions=renderer_directions)
+
+            def _no_stage(self):
+                """出帧参数与后处理两条路都用不到出帧台,**不要**顺手把它 import 进来:
+                worker 镜像里没有 node / Chromium 时,那一行 import 本身还能过,真正的
+                代价是把 700MB 量级的运行时依赖重新变成部署前提。"""
+                if self._plain is None:
+                    self._plain = self._build(None)
+                return self._plain
+
+            def plan(self, action):
+                return self._no_stage().plan(action)
+
+            def frames_from_client(self, frames, card, action, progress):
+                return self._no_stage().frames_from_client(frames, card, action, progress)
 
             def derive(self, card, action, source, progress):
-                if self._inner is None:
-                    from windup_ai_engine.strategy.concrete import RenderFrameStrategy
+                if self._with_stage is None:
                     from windup_framework.providers.render3d import (
                         LocalSpriteRenderProvider,
                     )
 
-                    self._inner = RenderFrameStrategy(
-                        LocalSpriteRenderProvider(),
-                        directions=renderer_directions,
-                    )
-                return self._inner.derive(card, action, source, progress)
+                    self._with_stage = self._build(LocalSpriteRenderProvider())
+                return self._with_stage.derive(card, action, source, progress)
 
         return _LazyRenderStrategy()
 
@@ -1184,6 +1329,7 @@ class DirectionSetTaskExecutor:
 executor = ActionTaskExecutor()
 run_action_task = executor.run_action_task
 resume_action_poll = executor.resume_action_poll
+resume_action_client_bake = executor.resume_action_client_bake
 image_executor = ImageTaskExecutor()
 run_image_task = image_executor.run_image_task
 direction_set_executor = DirectionSetTaskExecutor(image_executor=image_executor)

--- a/backend/packages/app/src/windup_app/web/api/render3d.py
+++ b/backend/packages/app/src/windup_app/web/api/render3d.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, File, Request, UploadFile
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -21,6 +21,7 @@ from windup_common.result import Response
 from windup_framework.db import get_session
 
 from windup_app.server.character.model import Character, CharacterData
+from windup_app.server.orchestrator import client_bake, task_repo
 from windup_app.server.orchestrator._failure import user_message
 from windup_app.server.character.service import service as character_service
 from windup_app.web.api.character import get_character_with_auth
@@ -195,3 +196,119 @@ def discard_outfit_asset(
     except ValueError as exc:
         raise BizException(user_message(exc), code=BizCode.BAD_REQUEST) from exc
     return Response.success(view, message="已丢弃待审模型")
+
+
+# ── 浏览器出帧(#714)────────────────────────────────────────────────────────
+# 出帧那一段在用户浏览器里跑:应用机不起 Chromium、不做软件光栅、模型一个字节都不经过它。
+# 本段四个端点只搬运与校验,渲染参数由 ai_engine 的 RenderPlan 定,这里不重写一份。
+
+
+class BakeCompleteRequest(BaseModel):
+    """浏览器自报交齐了。帧本身已逐帧 POST 上来,这里只带回可对账的采样信息。"""
+
+    clip: str = Field(..., min_length=1)
+    sample_times: list[float] = Field(default_factory=list)
+
+
+class BakeFailRequest(BaseModel):
+    """浏览器自报渲不出来(WebGL 起不来 / 模型加载失败 / 用户关了页面前的兜底)。"""
+
+    reason: str = Field(default="", max_length=200)
+
+
+def _own_task_or_raise(session: Session, request: Request, task_id: int):
+    """出帧任务必须属于当前用户 —— 帧是产物,谁都能往里塞就等于谁都能改别人的交付。"""
+    task = task_repo.get_task_by_user(session, request.state.current_user.id, task_id)
+    if task is None:
+        raise BizException("任务不存在", code=BizCode.NOT_FOUND)
+    return task
+
+
+@router.get("/bake/{task_id}", response_model=Response[dict])
+def get_bake_job(
+    task_id: int,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> Response[dict]:
+    """取这个任务的出帧参数。没有登记就是不需要浏览器出帧(或已收口)。"""
+    _own_task_or_raise(session, request, task_id)
+    view = client_bake.public_view(task_id)
+    if view is None:
+        raise BizException("该任务没有待浏览器出帧的登记", code=BizCode.NOT_FOUND)
+    return Response.success(view)
+
+
+@router.post("/bake/{task_id}/frames/{index}", response_model=Response[dict])
+async def put_bake_frame(
+    task_id: int,
+    index: int,
+    request: Request,
+    file: UploadFile = File(...),
+    session: Session = Depends(get_session),
+) -> Response[dict]:
+    """收一帧 PNG。逐帧收而不是一次收一整包:32 帧一起传要几十 MB 的请求体常驻内存。"""
+    _own_task_or_raise(session, request, task_id)
+    data = bytearray()
+    while True:
+        chunk = await file.read(64 * 1024)
+        if not chunk:
+            break
+        if len(data) + len(chunk) > client_bake.MAX_FRAME_BYTES:
+            raise BizException(
+                f"单帧超过上限 {client_bake.MAX_FRAME_BYTES // 1024} KB",
+                code=BizCode.BAD_REQUEST,
+            )
+        data.extend(chunk)
+    try:
+        received = client_bake.put_frame(task_id, index, bytes(data))
+    except client_bake.ClientBakeError as exc:
+        raise BizException(str(exc), code=BizCode.BAD_REQUEST) from exc
+    return Response.success({"task_id": task_id, "index": index, "received": received})
+
+
+@router.post("/bake/{task_id}/complete", response_model=Response[dict])
+def complete_bake(
+    task_id: int,
+    body: BakeCompleteRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> Response[dict]:
+    """帧交齐 → 交回 worker 续跑后处理。
+
+    **不信前端说交齐了**:这里按登记的帧数点数,少一帧就不放行 —— 少给的后果是一段
+    步子没走完的动作,而帧数、时长、成色在下游全都自洽,没有一道会红。
+    """
+    _own_task_or_raise(session, request, task_id)
+    loaded = client_bake.load_spec(task_id)
+    if loaded is None:
+        raise BizException("该任务没有待浏览器出帧的登记", code=BizCode.NOT_FOUND)
+    spec, _deadline = loaded
+    if body.clip != spec.clip:
+        raise BizException(
+            f"交回的片段是 {body.clip!r},登记的是 {spec.clip!r}", code=BizCode.BAD_REQUEST
+        )
+    try:
+        client_bake.collect_frames(task_id, spec.frames)
+    except client_bake.ClientBakeError as exc:
+        raise BizException(str(exc), code=BizCode.BAD_REQUEST) from exc
+    client_bake.schedule_resume(task_id)
+    return Response.success(
+        {"task_id": task_id, "frames": spec.frames}, message="帧已交齐,继续后处理"
+    )
+
+
+@router.post("/bake/{task_id}/fail", response_model=Response[dict])
+def fail_bake(
+    task_id: int,
+    body: BakeFailRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> Response[dict]:
+    """浏览器自报渲不出来。早报早失败、早解冻,不必等到期限耗完。"""
+    _own_task_or_raise(session, request, task_id)
+    if client_bake.load_spec(task_id) is None:
+        raise BizException("该任务没有待浏览器出帧的登记", code=BizCode.NOT_FOUND)
+    client_bake.schedule_resume(
+        task_id, reason=client_bake.REASON_CLIENT_FAILED, detail=body.reason
+    )
+    return Response.success({"task_id": task_id}, message="已记为出帧失败")

--- a/backend/packages/app/src/windup_app/worker/consumer.py
+++ b/backend/packages/app/src/windup_app/worker/consumer.py
@@ -51,12 +51,14 @@ class StreamConsumer:
         run_action_task: Callable[..., Any],
         stop_event: threading.Event,
         resume_action_poll: Callable[..., Any] | None = None,
+        resume_action_client_bake: Callable[..., Any] | None = None,
         run_direction_set_task: Callable[..., Any] | None = None,
     ) -> None:
         self._config = config
         self._run_image_task = run_image_task
         self._run_action_task = run_action_task
         self._resume_action_poll = resume_action_poll
+        self._resume_action_client_bake = resume_action_client_bake
         self._run_direction_set_task = run_direction_set_task
         self._stop = stop_event
         self._consumer_name = f"{socket.gethostname()}-{threading.get_ident()}"
@@ -205,6 +207,7 @@ class StreamConsumer:
                 run_image_task=self._run_image_task,
                 run_action_task=self._run_action_task,
                 resume_action_poll=self._resume_action_poll,
+                resume_action_client_bake=self._resume_action_client_bake,
                 run_direction_set_task=self._run_direction_set_task,
             )
 

--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -10,6 +10,7 @@ from typing import Any
 from windup_app.server.mq.catalog import (
     EMAIL_HANDLER_RETRIES,
     MSG_TYPE_CHARACTER_ACTION,
+    MSG_TYPE_CHARACTER_ACTION_CLIENT_BAKE,
     MSG_TYPE_CHARACTER_ACTION_POLL,
     MSG_TYPE_CHARACTER_IMAGE,
     MSG_TYPE_VERIFICATION_CODE,
@@ -199,6 +200,39 @@ def handle_action_poll(
     resume_action_poll(task_id, _action_input(input_payload), project_id)
 
 
+def handle_action_client_bake(
+    payload: dict[str, Any],
+    *,
+    resume_action_client_bake: Callable[..., Any],
+) -> None:
+    """浏览器交回帧 / 自报失败 / 到期未交,三种都从这里回到 worker。
+
+    RUNNING 是预期态:建单 worker 早就 ACK 让出了,出帧那一段在用户浏览器里跑。
+    """
+    task_id = int(payload["task_id"])
+    reason = str(payload.get("reason") or "frames")
+    detail = str(payload.get("detail") or "")
+    session = SessionLocal()
+    try:
+        task = task_repo.get_task(session, task_id)
+        if task is None:
+            logger.warning("出帧任务不存在 | task_id=%d", task_id)
+            return
+        if task.status in (TaskStatus.COMPLETED, TaskStatus.FAILED):
+            logger.info("出帧任务已终态，跳过 | task_id=%d status=%s", task_id, task.status)
+            return
+        if not billing.has_open_freeze(session, task_id):
+            logger.warning("出帧任务无开放冻结，跳过 | task_id=%d", task_id)
+            return
+        input_payload = task.input_payload or {}
+        project_id = task.project_id
+    finally:
+        session.close()
+    resume_action_client_bake(
+        task_id, _action_input(input_payload), project_id, reason=reason, detail=detail
+    )
+
+
 def dispatch_handler(
     msg_type: str,
     payload: dict[str, Any],
@@ -206,6 +240,7 @@ def dispatch_handler(
     run_image_task: Callable[..., Any],
     run_action_task: Callable[..., Any],
     resume_action_poll: Callable[..., Any] | None = None,
+    resume_action_client_bake: Callable[..., Any] | None = None,
     run_direction_set_task: Callable[..., Any] | None = None,
 ) -> None:
     handler = HANDLERS.get(msg_type)
@@ -216,6 +251,7 @@ def dispatch_handler(
         run_image_task=run_image_task,
         run_action_task=run_action_task,
         resume_action_poll=resume_action_poll,
+        resume_action_client_bake=resume_action_client_bake,
         run_direction_set_task=run_direction_set_task,
     )
 
@@ -251,9 +287,21 @@ def _dispatch_action_poll(
     handle_action_poll(payload, resume_action_poll=resume_action_poll)
 
 
+def _dispatch_action_client_bake(
+    payload: dict[str, Any],
+    *,
+    resume_action_client_bake: Callable[..., Any] | None = None,
+    **_deps: Any,
+) -> None:
+    if resume_action_client_bake is None:
+        raise RuntimeError("未注入 resume_action_client_bake")
+    handle_action_client_bake(payload, resume_action_client_bake=resume_action_client_bake)
+
+
 HANDLERS: dict[str, Callable[..., None]] = {
     MSG_TYPE_VERIFICATION_CODE: _dispatch_verification_code,
     MSG_TYPE_CHARACTER_IMAGE: _dispatch_generation,
     MSG_TYPE_CHARACTER_ACTION: _dispatch_generation,
     MSG_TYPE_CHARACTER_ACTION_POLL: _dispatch_action_poll,
+    MSG_TYPE_CHARACTER_ACTION_CLIENT_BAKE: _dispatch_action_client_bake,
 }

--- a/backend/tests/test_env_example_keys_are_live.py
+++ b/backend/tests/test_env_example_keys_are_live.py
@@ -35,6 +35,9 @@ _INFRA_KEYS = frozenset({
     "WINDUP_MATTE_REFINE",
     # render3d._tc3.TencentCredentials.resolve:环境变量 → 加锁文件,不走 BaseSettings
     "TENCENT_SECRET_ID", "TENCENT_SECRET_KEY", "TENCENT_REGION",
+    # orchestrator.client_bake / docker-compose 的构建目标,都是 os.getenv
+    "WINDUP_RENDER3D_CLIENT_BAKE", "WINDUP_RENDER3D_CLIENT_BAKE_DEADLINE_S",
+    "WINDUP_WORKER_TARGET",
 })
 
 

--- a/backend/tests/test_render3d_bake_endpoints.py
+++ b/backend/tests/test_render3d_bake_endpoints.py
@@ -1,0 +1,216 @@
+"""浏览器出帧的四个端点:取参数 / 交帧 / 报交齐 / 报失败(#714)。
+
+从 HTTP 入口发起,不直接调 service —— 加在编排层的字段没贯通到端点是这条线上反复出现
+的缺陷形态(直接构造对象的单测会全绿)。
+
+锁的是**归属与对账**:帧是交付产物,谁都能往里塞就等于谁都能改别人的交付;而"交齐了"
+必须由服务端点数,不能信前端的说法。
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+from sqlalchemy.orm import sessionmaker
+
+from windup_app.server.orchestrator import client_bake
+from windup_app.server.orchestrator.client_bake import ClientBakeSpec
+from windup_app.server.orchestrator.model import GenerationTaskRecord, GenerationType, TaskStatus
+from windup_app.server.project.model import Project
+
+TASK_ID = 41
+SPEC = ClientBakeSpec(
+    model_url="https://cdn.test/media/model-3d/rigged.glb",
+    clip="walk",
+    direction="e",
+    camera_yaw=0.0,
+    frames=2,
+    width=1536,
+    height=2560,
+    material="cel",
+    min_coverage=0.005,
+)
+
+
+def _png() -> bytes:
+    image = Image.new("RGBA", (8, 8), (200, 60, 60, 255))
+    buffer = io.BytesIO()
+    image.save(buffer, "PNG")
+    return buffer.getvalue()
+
+
+class _MemStore:
+    """把 client_bake 的 Redis 面换成进程内字典;延迟队列只记有没有被投过。"""
+
+    def __init__(self) -> None:
+        self.specs: dict[int, ClientBakeSpec] = {}
+        self.frames: dict[int, dict[int, bytes]] = {}
+        self.resumed: list[tuple[int, str]] = []
+
+
+@pytest.fixture()
+def store(monkeypatch):
+    mem = _MemStore()
+
+    def load_spec(task_id):
+        spec = mem.specs.get(task_id)
+        return (spec, 0.0) if spec else None
+
+    def put_frame(task_id, index, png):
+        spec = mem.specs.get(task_id)
+        if spec is None:
+            raise client_bake.ClientBakeError(f"任务 {task_id} 没有待出帧的登记")
+        if not 0 <= index < spec.frames:
+            raise client_bake.ClientBakeError(f"帧下标 {index} 不在 0..{spec.frames - 1}")
+        if not png.startswith(b"\x89PNG\r\n\x1a\n"):
+            raise client_bake.ClientBakeError(f"第 {index} 帧不是 PNG")
+        mem.frames.setdefault(task_id, {})[index] = png
+        return len(mem.frames[task_id])
+
+    def collect_frames(task_id, expected):
+        got = mem.frames.get(task_id, {})
+        for i in range(expected):
+            if i not in got:
+                raise client_bake.ClientBakeError(f"缺第 {i} 帧(已收 {len(got)}/{expected})")
+        return [got[i] for i in range(expected)]
+
+    def public_view(task_id):
+        spec = mem.specs.get(task_id)
+        if spec is None:
+            return None
+        view = spec.to_payload()
+        view["task_id"] = task_id
+        view["deadline_at"] = 0.0
+        view["received"] = len(mem.frames.get(task_id, {}))
+        return view
+
+    monkeypatch.setattr(client_bake, "load_spec", load_spec)
+    monkeypatch.setattr(client_bake, "put_frame", put_frame)
+    monkeypatch.setattr(client_bake, "collect_frames", collect_frames)
+    monkeypatch.setattr(client_bake, "public_view", public_view)
+    monkeypatch.setattr(
+        client_bake,
+        "schedule_resume",
+        lambda task_id, reason=client_bake.REASON_FRAMES, detail="": mem.resumed.append(
+            (task_id, reason)
+        ),
+    )
+    return mem
+
+
+@pytest.fixture()
+def api(auth_client, engine, store):
+    """一个属于 user 1 的 RUNNING 动作任务,外加一条属于别人的同类任务。"""
+    session = sessionmaker(bind=engine)()
+    session.add(Project(id=1, user_id=1, project_name="p", character_perspective=1,
+                        directional_movement=1, sprite_width=64, sprite_height=64))
+    session.flush()
+    for task_id, user_id in ((TASK_ID, 1), (TASK_ID + 1, 2)):
+        session.add(GenerationTaskRecord(
+            id=task_id, user_id=user_id, project_id=1,
+            task_type=GenerationType.CHARACTER_ACTION.value,
+            status=TaskStatus.RUNNING.value, input_payload={},
+        ))
+    session.commit()
+    session.close()
+    store.specs[TASK_ID] = SPEC
+    store.specs[TASK_ID + 1] = SPEC
+    return auth_client
+
+
+def _data(response) -> dict:
+    body = response.json()
+    assert body["code"] == 200, body
+    return body["data"]
+
+
+def _refused(response) -> dict:
+    """断言被拒。**要具体码,不能只断言"不是成功"** —— 那样 500 也算过,
+    于是"闸拦住了"与"代码崩了"在用例里长得一模一样。"""
+    body = response.json()
+    assert body["code"] in (400, 404), body
+    return body
+
+
+def test_get_bake_job_returns_the_render_plan(api):
+    data = _data(api.get(f"/render3d/bake/{TASK_ID}"))
+    assert data["model_url"] == SPEC.model_url
+    assert (data["clip"], data["direction"], data["frames"]) == ("walk", "e", 2)
+    assert data["width"] == 1536 and data["height"] == 2560
+    assert data["min_coverage"] == 0.005
+
+
+def test_get_bake_job_without_registration_is_404(api, store):
+    store.specs.pop(TASK_ID)
+    _refused(api.get(f"/render3d/bake/{TASK_ID}"))
+
+
+def test_another_users_task_is_not_reachable(api):
+    """帧是交付产物 —— 归属校验不做,谁都能改别人的交付而没有任何一处会红。"""
+    _refused(api.get(f"/render3d/bake/{TASK_ID + 1}"))
+    _refused(
+        api.post(
+            f"/render3d/bake/{TASK_ID + 1}/frames/0",
+            files={"file": ("f00.png", _png(), "image/png")},
+        )
+    )
+
+
+def test_put_frames_then_complete_hands_back_to_the_worker(api, store):
+    for index in range(2):
+        data = _data(
+            api.post(
+                f"/render3d/bake/{TASK_ID}/frames/{index}",
+                files={"file": (f"f{index:02d}.png", _png(), "image/png")},
+            )
+        )
+        assert data["received"] == index + 1
+    _data(
+        api.post(
+            f"/render3d/bake/{TASK_ID}/complete",
+            json={"clip": "walk", "sample_times": [0.0, 0.5]},
+        )
+    )
+    assert store.resumed == [(TASK_ID, client_bake.REASON_FRAMES)]
+
+
+def test_complete_with_missing_frames_is_refused(api, store):
+    """不信前端说交齐了 —— 少一帧的序列在下游帧数、时长、成色全都自洽。"""
+    api.post(
+        f"/render3d/bake/{TASK_ID}/frames/0",
+        files={"file": ("f00.png", _png(), "image/png")},
+    )
+    _refused(
+        api.post(f"/render3d/bake/{TASK_ID}/complete", json={"clip": "walk", "sample_times": []})
+    )
+    assert store.resumed == [], "帧不齐却已经交回 worker 续跑"
+
+
+def test_complete_with_a_different_clip_is_refused(api, store):
+    """片段对不上等于渲的是另一个动作,而帧数与成色照样正常。"""
+    for index in range(2):
+        api.post(
+            f"/render3d/bake/{TASK_ID}/frames/{index}",
+            files={"file": (f"f{index:02d}.png", _png(), "image/png")},
+        )
+    _refused(
+        api.post(f"/render3d/bake/{TASK_ID}/complete", json={"clip": "run", "sample_times": []})
+    )
+    assert store.resumed == []
+
+
+def test_non_png_frame_is_refused(api):
+    """空画布时 toDataURL 会给出没有 base64 段的串,切出来就是这种东西。"""
+    _refused(
+        api.post(
+            f"/render3d/bake/{TASK_ID}/frames/0",
+            files={"file": ("f00.png", b"data:,", "image/png")},
+        )
+    )
+
+
+def test_fail_reports_client_side_failure(api, store):
+    _data(api.post(f"/render3d/bake/{TASK_ID}/fail", json={"reason": "WebGL 上下文创建失败"}))
+    assert store.resumed == [(TASK_ID, client_bake.REASON_CLIENT_FAILED)]

--- a/backend/tests/test_render3d_client_bake.py
+++ b/backend/tests/test_render3d_client_bake.py
@@ -1,0 +1,204 @@
+"""出帧交给用户浏览器(#714):登记、收帧、收口,以及闸口一道不减。
+
+**这条线最容易出的错不是崩溃,而是安静地交付坏产物** —— 帧少一张、朝向反了、全透明帧
+冒充成功,而帧数、时长、成色在下游全都自洽。所以本文件的用例大半在验"该拒的拒了"。
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+import pytest
+
+from windup_app.server.orchestrator import client_bake
+from windup_app.server.orchestrator.client_bake import ClientBakeError, ClientBakeSpec
+
+
+class _MemPipeline:
+    def __init__(self, mem: "_MemRedis") -> None:
+        self._mem = mem
+        self._steps: list = []
+
+    def delete(self, *keys):
+        self._steps.append(lambda: self._mem.delete(*keys))
+        return self
+
+    def hset(self, name, key=None, value=None, mapping=None):
+        self._steps.append(lambda: self._mem.hset(name, key, value, mapping))
+        return self
+
+    def expire(self, name, ttl):
+        self._steps.append(lambda: 1)
+        return self
+
+    def hlen(self, name):
+        self._steps.append(lambda: self._mem.hlen(name))
+        return self
+
+    def execute(self):
+        return [step() for step in self._steps]
+
+
+class _MemRedis:
+    """够跑本模块用到的那几个 hash 命令;签名照 redis-py,免得桩比被测代码更宽松。"""
+
+    def __init__(self) -> None:
+        self.hashes: dict[str, dict[str, str]] = {}
+
+    def pipeline(self):
+        return _MemPipeline(self)
+
+    def delete(self, *keys):
+        for key in keys:
+            self.hashes.pop(key, None)
+        return len(keys)
+
+    def hset(self, name, key=None, value=None, mapping=None):
+        bucket = self.hashes.setdefault(name, {})
+        if key is not None:
+            bucket[str(key)] = str(value)
+        if mapping:
+            bucket.update({str(k): str(v) for k, v in mapping.items()})
+        return 1
+
+    def hlen(self, name):
+        return len(self.hashes.get(name, {}))
+
+    def hgetall(self, name):
+        return dict(self.hashes.get(name, {}))
+
+
+def _png(width: int = 4, height: int = 4) -> bytes:
+    """一张真 PNG。用真的而不是 b"\\x89PNG..." 前缀串,是因为守卫只认前缀就等于没验。"""
+    raw = b"".join(b"\x00" + b"\xff\x00\x00\xff" * width for _ in range(height))
+
+    def chunk(tag: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(payload))
+            + tag
+            + payload
+            + struct.pack(">I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+        )
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(raw))
+        + chunk(b"IEND", b"")
+    )
+
+
+SPEC = ClientBakeSpec(
+    model_url="https://cdn.test/media/model-3d/rigged.glb",
+    clip="walk",
+    direction="e",
+    camera_yaw=0.0,
+    frames=3,
+    width=1536,
+    height=2560,
+    material="cel",
+    min_coverage=0.005,
+)
+
+
+@pytest.fixture
+def redis_mem(monkeypatch):
+    mem = _MemRedis()
+    monkeypatch.setattr("windup_app.server.orchestrator.client_bake.get_redis", lambda: mem)
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.client_bake.schedule_delayed",
+        lambda **kwargs: kwargs.get("dedupe_key", ""),
+    )
+    return mem
+
+
+def test_open_job_then_load_spec_roundtrips(redis_mem):
+    deadline = client_bake.open_job(7, SPEC)
+    loaded, stored_deadline = client_bake.load_spec(7)
+    assert loaded == SPEC
+    assert stored_deadline == pytest.approx(deadline)
+
+
+def test_load_spec_absent_is_none_not_error(redis_mem):
+    assert client_bake.load_spec(404) is None
+
+
+def test_put_frame_counts_and_collect_orders_by_index(redis_mem):
+    client_bake.open_job(7, SPEC)
+    for index in (2, 0, 1):
+        client_bake.put_frame(7, index, _png(width=index + 1))
+    frames = client_bake.collect_frames(7, 3)
+    assert [len(f) for f in frames] == [
+        len(_png(width=1)),
+        len(_png(width=2)),
+        len(_png(width=3)),
+    ]
+
+
+def test_collect_rejects_missing_frame(redis_mem):
+    """少给一帧的后果是"步子没走完的动作",下游全部自洽 —— 只能在这里拦。"""
+    client_bake.open_job(7, SPEC)
+    client_bake.put_frame(7, 0, _png())
+    client_bake.put_frame(7, 2, _png())
+    with pytest.raises(ClientBakeError, match="缺第 1 帧"):
+        client_bake.collect_frames(7, 3)
+
+
+def test_put_frame_rejects_non_png(redis_mem):
+    client_bake.open_job(7, SPEC)
+    with pytest.raises(ClientBakeError, match="不是 PNG"):
+        client_bake.put_frame(7, 0, b"data:,")
+
+
+def test_put_frame_rejects_index_out_of_range(redis_mem):
+    client_bake.open_job(7, SPEC)
+    with pytest.raises(ClientBakeError, match="不在 0\\.\\.2"):
+        client_bake.put_frame(7, 3, _png())
+
+
+def test_put_frame_rejects_oversized(redis_mem):
+    client_bake.open_job(7, SPEC)
+    huge = _png() + b"\x00" * client_bake.MAX_FRAME_BYTES
+    with pytest.raises(ClientBakeError, match="超过上限"):
+        client_bake.put_frame(7, 0, huge)
+
+
+def test_put_frame_without_open_job_is_refused(redis_mem):
+    with pytest.raises(ClientBakeError, match="没有待出帧的登记"):
+        client_bake.put_frame(7, 0, _png())
+
+
+def test_open_job_clears_previous_frames(redis_mem):
+    """重开同一任务必须从零收。留着上一轮的帧会让"已收 3/3"在新一轮直接成立。"""
+    client_bake.open_job(7, SPEC)
+    client_bake.put_frame(7, 0, _png())
+    client_bake.open_job(7, SPEC)
+    with pytest.raises(ClientBakeError, match="缺第 0 帧"):
+        client_bake.collect_frames(7, 3)
+
+
+def test_public_view_is_json_safe(redis_mem):
+    client_bake.open_job(7, SPEC)
+    view = client_bake.public_view(7)
+    assert view["task_id"] == 7
+    assert view["model_url"] == SPEC.model_url
+    assert view["frames"] == 3
+    assert view["received"] == 0
+    assert isinstance(view["deadline_at"], float)
+
+
+def test_enabled_defaults_on_and_reads_env(monkeypatch):
+    monkeypatch.delenv("WINDUP_RENDER3D_CLIENT_BAKE", raising=False)
+    assert client_bake.enabled() is True
+    monkeypatch.setenv("WINDUP_RENDER3D_CLIENT_BAKE", "0")
+    assert client_bake.enabled() is False
+    monkeypatch.setenv("WINDUP_RENDER3D_CLIENT_BAKE", "off")
+    assert client_bake.enabled() is False
+
+
+def test_clear_removes_both_keys(redis_mem):
+    client_bake.open_job(7, SPEC)
+    client_bake.put_frame(7, 0, _png())
+    client_bake.clear(7)
+    assert client_bake.load_spec(7) is None

--- a/backend/tests/test_render3d_client_bake_route.py
+++ b/backend/tests/test_render3d_client_bake_route.py
@@ -1,0 +1,167 @@
+"""默认路径:三渲二的出帧挂给浏览器,worker 不下模型也不起出帧台(#714)。
+
+与 ``test_render3d_client_bake`` 分工:那份验 Redis 登记与收帧的形状,这份验**编排层
+真的走到了那一支**,以及交回的帧仍要过服务端的每一道闸。
+
+最容易漏的两条,都在这里钉住:
+
+  ① **模型仍被下到应用机。** 出帧在浏览器里跑,而 worker 照旧 fetch 一遍 60MB GLB ——
+     省下的只有 Chromium,上行和内存一分没省,而且没有任何一处会报错。
+  ② **闸口跟着搬走。** 帧来自客户端就不再验空帧 / 不再对账帧数,于是全透明帧和少一张
+     的序列直接进交付,下游帧数、时长、成色全部自洽。
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from windup_ai_engine.impl import CharacterGenerator
+from windup_ai_engine.strategy.concrete import RenderFrameStrategy
+from windup_app.server.orchestrator import client_bake
+from windup_app.server.orchestrator.client_bake import ActionAwaitingClientBake
+from windup_app.server.orchestrator.executor import ActionTaskExecutor, ProjectConstraints
+from windup_app.server.orchestrator.model import ActionType as InputActionType
+from windup_app.server.orchestrator.model import CharacterActionInput
+from windup_common.models import ActionSpec, ActionType, CharacterCard, Facing, GenRoute
+
+OUTFIT = "outfit-default"
+MODEL_URL = "https://cdn.test/media/model-3d/rigged.glb"
+
+
+def _png(w: int = 64, h: int = 96, *, blank: bool = False) -> bytes:
+    """真 RGBA PNG。``blank`` 造全透明帧 —— 那正是出帧台在角色出画时会安静产出的东西。"""
+    image = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    if not blank:
+        for y in range(20, 80):
+            for x in range(24, 40):
+                image.putpixel((x, y), (200, 60, 60, 255))
+    buffer = io.BytesIO()
+    image.save(buffer, "PNG")
+    return buffer.getvalue()
+
+
+class _NullProgress:
+    def step(self, stage: str, i: int, total: int, note: str = "") -> None:
+        pass
+
+
+def _generator() -> CharacterGenerator:
+    """真 generator + 真 strategy,**出帧台传 None** —— 这条路上本就不该有它。"""
+    return CharacterGenerator({GenRoute.RENDER_3D: RenderFrameStrategy(None, directions=4)})
+
+
+def _spec(n_frames: int = 4) -> ActionSpec:
+    return ActionSpec(
+        action=ActionType.WALK, poses=[""] * n_frames, facing=Facing.SIDE
+    )
+
+
+@pytest.fixture
+def opened(monkeypatch):
+    """把 Redis 与延迟队列换成内存桩,返回记录下来的登记。"""
+    jobs: dict[int, client_bake.ClientBakeSpec] = {}
+    monkeypatch.setattr(
+        client_bake, "open_job", lambda task_id, spec: jobs.setdefault(task_id, spec) and 0.0
+    )
+    monkeypatch.setattr("windup_app.server.orchestrator.executor.is_own_media", lambda url: True)
+    return jobs
+
+
+def test_default_path_hands_baking_to_the_browser_and_never_fetches_the_model(opened):
+    """默认路径:登记出帧任务、抛等待态,且**一次模型下载都不发生**。"""
+    executor = ActionTaskExecutor(
+        generator=_generator(),
+        upload=lambda _png: pytest.fail("还没出帧就上传了"),
+        fetch_master=lambda _input: pytest.fail("走三渲二不该去下载母版"),
+        fetch_model3d=lambda url: pytest.fail(
+            "出帧交给浏览器了,应用机不该再下这份 GLB —— 省下 Chromium 但没省上行"
+        ),
+        fetch_constraints=lambda *_: ProjectConstraints(sprite_w=64, sprite_h=64),
+    )
+    with pytest.raises(ActionAwaitingClientBake):
+        executor._produce_action(
+            CharacterActionInput(
+                character_id=1,
+                action_type=InputActionType.WALK,
+                num_frames=4,
+                outfit_id=OUTFIT,
+                model_3d_url=MODEL_URL,
+            ),
+            ProjectConstraints(sprite_w=64, sprite_h=64),
+            task_id=11,
+        )
+    spec = opened[11]
+    assert spec.model_url == MODEL_URL
+    assert (spec.clip, spec.direction, spec.frames) == ("walk", "e", 4)
+    assert spec.material in ("cel", "lit", "clay", "toon", "orig")
+
+
+def test_model_url_outside_own_storage_is_refused(monkeypatch):
+    """地址不是自家对象存储就不能发给浏览器 —— 那等于借用户的浏览器和登录态发请求。"""
+    monkeypatch.setattr("windup_app.server.orchestrator.executor.is_own_media", lambda url: False)
+    executor = ActionTaskExecutor(
+        generator=_generator(),
+        upload=lambda _png: "https://cdn.test/f.png",
+        fetch_constraints=lambda *_: ProjectConstraints(sprite_w=64, sprite_h=64),
+    )
+    with pytest.raises(Exception, match="不在自家对象存储"):
+        executor._produce_action(
+            CharacterActionInput(
+                character_id=1,
+                action_type=InputActionType.WALK,
+                num_frames=4,
+                outfit_id=OUTFIT,
+                model_3d_url="https://evil.test/x.glb",
+            ),
+            ProjectConstraints(sprite_w=64, sprite_h=64),
+            task_id=12,
+        )
+
+
+def test_plan_is_the_only_source_of_render_parameters():
+    """出帧参数只有一份真相源。朝向表分叉不会报错,只会让角色朝反方向走。"""
+    from windup_framework.providers.render3d import DIRECTIONS_4, DIRECTIONS_8
+
+    for directions, table in ((4, DIRECTIONS_4), (8, DIRECTIONS_8)):
+        plan = RenderFrameStrategy(None, directions=directions).plan(_spec())
+        assert plan.camera_yaw == float(table[plan.direction])
+        assert (plan.width, plan.height) == (1536, 2560)
+
+
+def test_finish_rendered_runs_the_same_gates_as_server_side_baking():
+    """浏览器交回的帧走完 _finish:帧数对账、脚线对齐、成色测量一道不少。"""
+    generated = _generator().finish_rendered(
+        [_png()] * 4, CharacterCard(name="c", desc=""), _spec(4), _NullProgress(), canvas=(64, 64)
+    )
+    assert len(generated.frames) == 4
+    assert len(generated.durations) == 4
+    assert generated.quality is not None
+
+
+def test_finish_rendered_rejects_wrong_frame_count():
+    """少一帧的后果是"步子没走完的动作",下游全部自洽 —— 只能在这里拦。"""
+    with pytest.raises(ValueError, match="契约要 4 帧"):
+        _generator().finish_rendered(
+            [_png()] * 3, CharacterCard(name="c", desc=""), _spec(4), _NullProgress(),
+            canvas=(64, 64),
+        )
+
+
+def test_finish_rendered_rejects_all_transparent_frames():
+    """客户端自报的覆盖率只是它的说法;服务端必须自己再数一遍。"""
+    with pytest.raises(ValueError, match="几乎全透明"):
+        _generator().finish_rendered(
+            [_png(), _png(blank=True), _png(), _png()],
+            CharacterCard(name="c", desc=""), _spec(4), _NullProgress(), canvas=(64, 64),
+        )
+
+
+def test_derive_without_a_stage_says_so_instead_of_crashing_obscurely():
+    """出帧台缺席时报错要指得准 —— 不然只会看到一句 AttributeError。"""
+    with pytest.raises(RuntimeError, match="没有注入出帧台"):
+        RenderFrameStrategy(None, directions=4).derive(
+            CharacterCard(name="c", desc=""), _spec(4), b"GLB", _NullProgress()
+        )

--- a/backend/tests/test_render3d_route_and_assets.py
+++ b/backend/tests/test_render3d_route_and_assets.py
@@ -207,12 +207,17 @@ def _real_generator(renderer) -> CharacterGenerator:
     })
 
 
-def test_real_server_path_reaches_render3d_when_the_outfit_has_a_model():
+def test_real_server_path_reaches_render3d_when_the_outfit_has_a_model(monkeypatch):
     """造型带 model_3d_url → 编排层真的走到渲帧策略,而不是 i2v。
 
     这条钉的正是"路线永不可达"那个缺陷:它只断言**编排层自己**选对了路线,
     没有任何替身代替这一步。
+
+    显式关掉浏览器出帧(#714):默认路径已经改成把出帧挂给浏览器,而本用例的被测对象是
+    **服务端渲**那一支(过渡机与 `WINDUP_RENDER3D_CLIENT_BAKE=0` 回退仍走它)。
+    默认路径另有用例。
     """
+    monkeypatch.setenv("WINDUP_RENDER3D_CLIENT_BAKE", "0")
     renderer = _FakeRenderer()
     executor = ActionTaskExecutor(
         generator=_real_generator(renderer),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,10 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-      # 出帧依赖只装进 worker：backend 不出帧，不该背 700MB 量级的浏览器
-      target: runtime-render3d
+      # 三渲二出帧已交给用户浏览器（#714），worker 只做后处理，不再需要 node/Chromium/three。
+      # 过渡机要回退到服务端渲（WINDUP_RENDER3D_CLIENT_BAKE=0）时，把这个变量设成
+      # runtime-render3d 重建——两者必须同时改，只关开关不换镜像会在出帧那一步才报错。
+      target: ${WINDUP_WORKER_TARGET:-runtime}
     container_name: windup-worker
     restart: unless-stopped
     env_file:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,8 @@
         "markdown-to-jsx": "^9.10.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-router": "^8.3.0"
+        "react-router": "^8.3.0",
+        "three": "^0.185.1"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.3",
@@ -24,6 +25,7 @@
         "@types/node": "^24.13.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/three": "^0.185.0",
         "@vitejs/plugin-react": "^6.0.3",
         "@vitest/coverage-v8": "^4.1.10",
         "ajv": "^8.20.0",
@@ -389,6 +391,13 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -2041,6 +2050,13 @@
         }
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2163,6 +2179,35 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.0.tgz",
+      "integrity": "sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vercel/oidc": {
       "version": "3.2.0",
@@ -2810,6 +2855,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3335,6 +3387,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -3761,6 +3820,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "markdown-to-jsx": "^9.10.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-router": "^8.3.0"
+    "react-router": "^8.3.0",
+    "three": "^0.185.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",
@@ -31,6 +32,7 @@
     "@types/node": "^24.13.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.185.0",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.10",
     "ajv": "^8.20.0",

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -112,6 +112,8 @@ export type { GenerationApiConfig, GenerationTransport } from './generation/api'
 /* 三渲二资产 —— 母版预检结果与造型级 3D 模型的建造状态 */
 export { createRender3DApis, render3DApis, Render3DContractError } from './render3d/api'
 export type {
+  BakeCompletion,
+  BakeJob,
   MasterFacts,
   MasterPrecheckReport,
   MasterRejectCode,

--- a/frontend/src/entities/render3d/api.ts
+++ b/frontend/src/entities/render3d/api.ts
@@ -1,6 +1,7 @@
 import { createApiClient, getApiAccessToken, type ApiClient } from '@/shared/api'
 
 import type {
+  BakeJob,
   MasterFacts,
   MasterPrecheckReport,
   MasterRejectCode,
@@ -28,6 +29,9 @@ const REJECT_CODES = new Set<MasterRejectCode>([
 ])
 
 const WARNING_CODES = new Set<MasterWarningCode>(['limbs_fused', 'extra_component'])
+
+/** 与出帧台的材质表同一份。多一个少一个都会让下游在渲完之后才抛。 */
+const BAKE_MATERIALS = new Set(['cel', 'lit', 'clay', 'toon', 'orig'])
 
 const ASSET_STATES = new Set<Render3DAssetState>([
   'absent',
@@ -146,6 +150,29 @@ function parseAsset(value: unknown): Render3DAsset {
   }
 }
 
+function parseBakeJob(value: unknown): BakeJob {
+  const raw = requireRecord(value, '出帧任务')
+  const material = requireString(raw.material, 'material')
+  // 材质在这里就校验:出帧台对认不出的取值当场抛,而那时候已经把模型下下来了。
+  if (!BAKE_MATERIALS.has(material)) {
+    throw new Render3DContractError(`material 未知：${material}`)
+  }
+  return {
+    taskId: requireNumber(raw.task_id, 'task_id'),
+    modelUrl: requireString(raw.model_url, 'model_url'),
+    clip: requireString(raw.clip, 'clip'),
+    direction: requireString(raw.direction, 'direction'),
+    cameraYaw: requireNumber(raw.camera_yaw, 'camera_yaw'),
+    frames: requireNumber(raw.frames, 'frames'),
+    width: requireNumber(raw.width, 'width'),
+    height: requireNumber(raw.height, 'height'),
+    material,
+    minCoverage: requireNumber(raw.min_coverage, 'min_coverage'),
+    deadlineAt: requireNumber(raw.deadline_at, 'deadline_at'),
+    received: requireNumber(raw.received, 'received'),
+  }
+}
+
 function outfitPath(characterId: string, outfitId: string): string {
   return `/render3d/characters/${encodeURIComponent(characterId)}/outfits/${encodeURIComponent(outfitId)}`
 }
@@ -198,6 +225,44 @@ export function createRender3DApis(client: ApiClient = defaultClient()): Render3
         }),
       )
     },
+
+    async getBakeJob(taskId) {
+      try {
+        return parseBakeJob(await client.request<unknown>(`/render3d/bake/${taskId}`))
+      } catch (error) {
+        // 契约不符要炸,"没有登记"是正常结果:任务不走三渲二、或已经收口了。
+        if (error instanceof Render3DContractError) throw error
+        return null
+      }
+    },
+
+    async putBakeFrame(taskId, index, png) {
+      const form = new FormData()
+      // 不手动设置 Content-Type,浏览器会为 FormData 自动附加 boundary。
+      form.append('file', png, `f${String(index).padStart(2, '0')}.png`)
+      const raw = requireRecord(
+        await client.request<unknown>(`/render3d/bake/${taskId}/frames/${index}`, {
+          method: 'POST',
+          body: form,
+        }),
+        '交帧结果',
+      )
+      return requireNumber(raw.received, 'received')
+    },
+
+    async completeBake(taskId, completion) {
+      await client.request<unknown>(`/render3d/bake/${taskId}/complete`, {
+        method: 'POST',
+        json: { clip: completion.clip, sample_times: completion.sampleTimes },
+      })
+    },
+
+    async failBake(taskId, reason) {
+      await client.request<unknown>(`/render3d/bake/${taskId}/fail`, {
+        method: 'POST',
+        json: { reason },
+      })
+    },
   }
 }
 
@@ -215,4 +280,8 @@ export const render3DApis: Render3DApis = {
     createRender3DApis().approveOutfitAsset(characterId, outfitId),
   discardOutfitAsset: (characterId, outfitId) =>
     createRender3DApis().discardOutfitAsset(characterId, outfitId),
+  getBakeJob: (taskId) => createRender3DApis().getBakeJob(taskId),
+  putBakeFrame: (taskId, index, png) => createRender3DApis().putBakeFrame(taskId, index, png),
+  completeBake: (taskId, completion) => createRender3DApis().completeBake(taskId, completion),
+  failBake: (taskId, reason) => createRender3DApis().failBake(taskId, reason),
 }

--- a/frontend/src/entities/render3d/bake-api.test.ts
+++ b/frontend/src/entities/render3d/bake-api.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ApiClient } from '@/shared/api'
+import { createRender3DApis, Render3DContractError } from './api'
+
+const JOB = {
+  task_id: 41,
+  model_url: 'https://cdn.test/media/model-3d/rigged.glb',
+  clip: 'walk',
+  direction: 'e',
+  camera_yaw: 0,
+  frames: 8,
+  width: 1536,
+  height: 2560,
+  material: 'cel',
+  min_coverage: 0.005,
+  deadline_at: 4_102_444_800,
+  received: 0,
+}
+
+function client(handler: (path: string, options?: Record<string, unknown>) => unknown): {
+  api: ApiClient
+  calls: Array<{ path: string; method: string; body?: unknown; json?: unknown }>
+} {
+  const calls: Array<{ path: string; method: string; body?: unknown; json?: unknown }> = []
+  const api: ApiClient = {
+    request: vi.fn(async (path: string, options?: Record<string, unknown>) => {
+      calls.push({
+        path,
+        method: (options?.method as string) ?? 'GET',
+        body: options?.body,
+        json: options?.json,
+      })
+      return handler(path, options)
+    }) as ApiClient['request'],
+    requestList: vi.fn() as ApiClient['requestList'],
+  }
+  return { api, calls }
+}
+
+describe('出帧任务的网络边界', () => {
+  it('把后端的 snake_case 转成前端形状', async () => {
+    const { api } = client(() => JOB)
+    const job = await createRender3DApis(api).getBakeJob(41)
+    expect(job).toEqual({
+      taskId: 41,
+      modelUrl: JOB.model_url,
+      clip: 'walk',
+      direction: 'e',
+      cameraYaw: 0,
+      frames: 8,
+      width: 1536,
+      height: 2560,
+      material: 'cel',
+      minCoverage: 0.005,
+      deadlineAt: JOB.deadline_at,
+      received: 0,
+    })
+  })
+
+  it('没有登记是正常结果,返回 null 而不是抛', async () => {
+    const { api } = client(() => {
+      throw new Error('404')
+    })
+    await expect(createRender3DApis(api).getBakeJob(41)).resolves.toBeNull()
+  })
+
+  it('材质认不出当场抛 —— 否则要等模型下完、渲到一半才发现', async () => {
+    const { api } = client(() => ({ ...JOB, material: 'studio' }))
+    await expect(createRender3DApis(api).getBakeJob(41)).rejects.toBeInstanceOf(
+      Render3DContractError,
+    )
+  })
+
+  it('缺字段当契约错处理,不给默认值', async () => {
+    const { api } = client(() => {
+      const { min_coverage: _dropped, ...rest } = JOB
+      return rest
+    })
+    await expect(createRender3DApis(api).getBakeJob(41)).rejects.toBeInstanceOf(
+      Render3DContractError,
+    )
+  })
+
+  it('交帧走 multipart,不手动设 Content-Type', async () => {
+    const { api, calls } = client(() => ({ task_id: 41, index: 0, received: 1 }))
+    const png = new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' })
+    const received = await createRender3DApis(api).putBakeFrame(41, 0, png)
+    expect(received).toBe(1)
+    expect(calls[0].path).toBe('/render3d/bake/41/frames/0')
+    expect(calls[0].method).toBe('POST')
+    expect(calls[0].body).toBeInstanceOf(FormData)
+  })
+
+  it('报交齐带上片段名与采样时刻', async () => {
+    const { api, calls } = client(() => ({}))
+    await createRender3DApis(api).completeBake(41, { clip: 'walk', sampleTimes: [0, 0.5] })
+    expect(calls[0].path).toBe('/render3d/bake/41/complete')
+    expect(calls[0].json).toEqual({ clip: 'walk', sample_times: [0, 0.5] })
+  })
+
+  it('报失败带上原因', async () => {
+    const { api, calls } = client(() => ({}))
+    await createRender3DApis(api).failBake(41, 'WebGL 起不来')
+    expect(calls[0].path).toBe('/render3d/bake/41/fail')
+    expect(calls[0].json).toEqual({ reason: 'WebGL 起不来' })
+  })
+})

--- a/frontend/src/entities/render3d/index.ts
+++ b/frontend/src/entities/render3d/index.ts
@@ -80,6 +80,35 @@ export interface Render3DAsset {
   cost: Render3DAssetCost
 }
 
+/**
+ * 一个待浏览器出帧的任务(#714)。字段与后端 `RenderPlan` 一一对应 —— 出帧参数只有
+ * 一份真相源,前端不推导也不补默认值:朝向、材质、画布、帧数任何一项在两边分叉都
+ * 不会报错,只会安静地渲出另一个东西。
+ */
+export interface BakeJob {
+  taskId: number
+  /** 绑骨模型地址,由后端校验过在自家对象存储上。**浏览器直接拉,不经应用机。** */
+  modelUrl: string
+  clip: string
+  direction: string
+  cameraYaw: number
+  frames: number
+  width: number
+  height: number
+  material: string
+  /** 低于它判空帧。与后端同一口径,自己不要另定一个。 */
+  minCoverage: number
+  /** 期限(epoch 秒)。到点后端按超时收口,不必前端自己计时。 */
+  deadlineAt: number
+  /** 后端已收到的帧数,用于断线后接着传。 */
+  received: number
+}
+
+export interface BakeCompletion {
+  clip: string
+  sampleTimes: number[]
+}
+
 export interface Render3DApis {
   /** 零成本母版预检。**不触发任何按次计费调用**,确认闸上可以随便调。 */
   precheckMaster(
@@ -93,4 +122,10 @@ export interface Render3DApis {
   approveOutfitAsset(characterId: string, outfitId: string): Promise<Render3DAsset>
   /** 模型不合格 → 丢弃重来。 */
   discardOutfitAsset(characterId: string, outfitId: string): Promise<Render3DAsset>
+  /** 取该任务的出帧参数;没有登记说明不需要浏览器出帧(或已收口)。 */
+  getBakeJob(taskId: number): Promise<BakeJob | null>
+  putBakeFrame(taskId: number, index: number, png: Blob): Promise<number>
+  completeBake(taskId: number, completion: BakeCompletion): Promise<void>
+  /** 渲不出来就早报,别等期限耗完 —— 那笔冻结的积分一直挂着。 */
+  failBake(taskId: number, reason: string): Promise<void>
 }

--- a/frontend/src/features/client-bake/attach.test.ts
+++ b/frontend/src/features/client-bake/attach.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { bakeJob, stubRender3DApis } from '@/test/render3d-apis'
+import { attachClientBake } from './attach'
+
+vi.mock('./stage', async () => {
+  const actual = await vi.importActual<typeof import('./stage')>('./stage')
+  return {
+    ...actual,
+    BakeStage: {
+      create: vi.fn(async () => ({
+        availableClips: () => ({ walk: 1.0667 }),
+        setCamYaw: () => undefined,
+        setup: (_clip: string, i: number) => i * 0.1,
+        coverage: () => 0.01,
+        grab: async () => new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])]),
+        dispose: () => undefined,
+      })),
+    },
+  }
+})
+
+const noSleep = async () => undefined
+
+describe('把出帧接到任务订阅上', () => {
+  it('登记还没写好时重试,写好了就开渲', async () => {
+    // 建单与登记之间隔着一次 MQ 投递,第一次问多半问不到。
+    let asked = 0
+    const apis = stubRender3DApis({
+      getBakeJob: async () => {
+        asked += 1
+        return asked < 3 ? null : bakeJob({ frames: 2 })
+      },
+    })
+    await expect(attachClientBake(41, { apis, sleep: noSleep })).resolves.toBe(true)
+    expect(asked).toBe(3)
+  })
+
+  it('一直问不到就是这条任务走 i2v,收手不报错', async () => {
+    const apis = stubRender3DApis({ getBakeJob: async () => null })
+    await expect(attachClientBake(41, { apis, sleep: noSleep })).resolves.toBe(false)
+  })
+
+  it('重试次数有上限,不会一直问下去', async () => {
+    let asked = 0
+    const apis = stubRender3DApis({
+      getBakeJob: async () => {
+        asked += 1
+        return null
+      },
+    })
+    await attachClientBake(41, { apis, sleep: noSleep })
+    expect(asked).toBeLessThanOrEqual(6)
+  })
+
+  it('渲完把帧交上去', async () => {
+    const uploaded: number[] = []
+    let completed = false
+    const apis = stubRender3DApis({
+      getBakeJob: async () => bakeJob({ frames: 2 }),
+      putBakeFrame: async (_taskId, index) => {
+        uploaded.push(index)
+        return uploaded.length
+      },
+      completeBake: async () => {
+        completed = true
+      },
+    })
+    await attachClientBake(41, { apis, sleep: noSleep })
+    expect(uploaded).toEqual([0, 1])
+    expect(completed).toBe(true)
+  })
+})

--- a/frontend/src/features/client-bake/attach.ts
+++ b/frontend/src/features/client-bake/attach.ts
@@ -1,0 +1,51 @@
+/**
+ * 把浏览器出帧接到已有的任务订阅上(#714)。
+ *
+ * 不另立状态机:任务的终态仍由 `generationApis.subscribe` 收 —— 出帧只是这条任务中间
+ * 的一段,渲完交回后端由 worker 续跑后处理,成功与失败都还是原来那条事件。
+ */
+import { render3DApis } from '@/entities'
+
+import { runClientBake } from '.'
+
+import type { Render3DApis } from '@/entities'
+
+/**
+ * 建单与登记之间隔着一次 MQ 投递,所以第一次问多半问不到。
+ *
+ * 退避到 20 秒:三渲二任务在这个窗口内一定已经登记好了(登记就发生在 worker 接到消息
+ * 的那几行里);问不到就是这条任务走的 i2v,不必再问。
+ */
+const RETRY_DELAYS_MS = [800, 1600, 3200, 6000, 8000]
+
+export interface AttachClientBakeOptions {
+  apis?: Render3DApis
+  sleep?: (ms: number) => Promise<void>
+  onProgress?: (done: number, total: number) => void
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/**
+ * 问这条任务需不需要浏览器出帧;需要就跑完它。
+ *
+ * @returns 是否真的出了帧。false = 这条任务不走三渲二(或已收口)。
+ */
+export async function attachClientBake(
+  taskId: number,
+  { apis = render3DApis, sleep = defaultSleep, onProgress }: AttachClientBakeOptions = {},
+): Promise<boolean> {
+  for (const delay of RETRY_DELAYS_MS) {
+    const job = await apis.getBakeJob(taskId)
+    if (job) {
+      await runClientBake({
+        job,
+        apis,
+        onProgress: onProgress && (({ done, total }) => onProgress(done, total)),
+      })
+      return true
+    }
+    await sleep(delay)
+  }
+  return false
+}

--- a/frontend/src/features/client-bake/index.test.ts
+++ b/frontend/src/features/client-bake/index.test.ts
@@ -9,6 +9,8 @@ const stage = vi.hoisted(() => ({
   yaw: null as number | null,
   disposed: 0,
   grabError: null as Error | null,
+  createError: null as Error | null,
+  createdContexts: 0,
 }))
 
 vi.mock('./stage', async () => {
@@ -16,24 +18,32 @@ vi.mock('./stage', async () => {
   return {
     ...actual,
     BakeStage: {
-      create: vi.fn(async () => ({
-        availableClips: () => stage.clips,
-        setCamYaw: (deg: number) => {
-          stage.yaw = deg
-        },
-        setup: (clip: string, i: number, n: number) => {
-          stage.setups.push([clip, i, n])
-          return i * 0.1
-        },
-        coverage: () => stage.coverage,
-        grab: async () => {
-          if (stage.grabError) throw stage.grabError
-          return new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' })
-        },
-        dispose: () => {
+      create: vi.fn(async () => {
+        stage.createdContexts++
+        if (stage.createError) {
+          // 真实现在 load 失败时会先 dispose 再抛;替身照做,否则这条用例测不到东西。
           stage.disposed++
-        },
-      })),
+          throw stage.createError
+        }
+        return {
+          availableClips: () => stage.clips,
+          setCamYaw: (deg: number) => {
+            stage.yaw = deg
+          },
+          setup: (clip: string, i: number, n: number) => {
+            stage.setups.push([clip, i, n])
+            return i * 0.1
+          },
+          coverage: () => stage.coverage,
+          grab: async () => {
+            if (stage.grabError) throw stage.grabError
+            return new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' })
+          },
+          dispose: () => {
+            stage.disposed++
+          },
+        }
+      }),
     },
   }
 })
@@ -47,6 +57,8 @@ beforeEach(() => {
   stage.yaw = null
   stage.disposed = 0
   stage.grabError = null
+  stage.createError = null
+  stage.createdContexts = 0
 })
 
 describe('浏览器出帧驱动', () => {
@@ -158,6 +170,21 @@ describe('浏览器出帧驱动', () => {
     stage.grabError = new Error('炸了')
     await expect(runClientBake({ job: bakeJob(), apis: stubRender3DApis() })).rejects.toThrow()
     expect(stage.disposed).toBe(1)
+  })
+
+  it('模型加载失败照样上报,不当成"没这回事"', async () => {
+    // 上下文有没有真的释放在这里测不到(jsdom 没有 WebGL,桩里 dispose 是我自己调的)。
+    // 这条只钉运行时行为:建台失败要抛出去、要报给后端,不能把任务悬着。
+    stage.createError = new Error('Bad glTF')
+    let failed = ''
+    const apis = stubRender3DApis({
+      failBake: async (_taskId, reason) => {
+        failed = reason
+      },
+    })
+    await expect(runClientBake({ job: bakeJob(), apis })).rejects.toThrow('Bad glTF')
+    expect(failed).toBe('Bad glTF')
+    expect(stage.createdContexts).toBe(1)
   })
 
   it('逐帧回报进度', async () => {

--- a/frontend/src/features/client-bake/index.test.ts
+++ b/frontend/src/features/client-bake/index.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { bakeJob, stubRender3DApis } from '@/test/render3d-apis'
+
+const stage = vi.hoisted(() => ({
+  clips: { walk: 1.0667 } as Record<string, number>,
+  coverage: 0.01,
+  setups: [] as Array<[string, number, number]>,
+  yaw: null as number | null,
+  disposed: 0,
+  grabError: null as Error | null,
+}))
+
+vi.mock('./stage', async () => {
+  const actual = await vi.importActual<typeof import('./stage')>('./stage')
+  return {
+    ...actual,
+    BakeStage: {
+      create: vi.fn(async () => ({
+        availableClips: () => stage.clips,
+        setCamYaw: (deg: number) => {
+          stage.yaw = deg
+        },
+        setup: (clip: string, i: number, n: number) => {
+          stage.setups.push([clip, i, n])
+          return i * 0.1
+        },
+        coverage: () => stage.coverage,
+        grab: async () => {
+          if (stage.grabError) throw stage.grabError
+          return new Blob([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], { type: 'image/png' })
+        },
+        dispose: () => {
+          stage.disposed++
+        },
+      })),
+    },
+  }
+})
+
+const { runClientBake, BakeAborted } = await import('.')
+
+beforeEach(() => {
+  stage.clips = { walk: 1.0667 }
+  stage.coverage = 0.01
+  stage.setups = []
+  stage.yaw = null
+  stage.disposed = 0
+  stage.grabError = null
+})
+
+describe('浏览器出帧驱动', () => {
+  it('按 plan 的朝向与帧数逐帧交付,最后报交齐', async () => {
+    const uploaded: number[] = []
+    let completed: { clip: string; sampleTimes: number[] } | null = null
+    const apis = stubRender3DApis({
+      putBakeFrame: async (_taskId, index) => {
+        uploaded.push(index)
+        return uploaded.length
+      },
+      completeBake: async (_taskId, completion) => {
+        completed = completion
+      },
+    })
+    const job = bakeJob({ frames: 3, cameraYaw: 90, direction: 'n' })
+    await runClientBake({ job, apis })
+
+    expect(stage.yaw).toBe(90)
+    expect(stage.setups).toEqual([
+      ['walk', 0, 3],
+      ['walk', 1, 3],
+      ['walk', 2, 3],
+    ])
+    expect(uploaded).toEqual([0, 1, 2])
+    expect(completed).toEqual({ clip: 'walk', sampleTimes: [0, 0.1, 0.2] })
+    expect(stage.disposed).toBe(1)
+  })
+
+  it('覆盖率不足当场失败,并且不把那一帧传上去', async () => {
+    // 角色出画 / 片段选错都会安静地产出全透明帧,而外面照样以为成功了。
+    stage.coverage = 0.0001
+    const uploaded: number[] = []
+    let failed = ''
+    const apis = stubRender3DApis({
+      putBakeFrame: async (_t, index) => {
+        uploaded.push(index)
+        return 1
+      },
+      completeBake: async () => expect.unreachable('全透明帧却报了交齐'),
+      failBake: async (_t, reason) => {
+        failed = reason
+      },
+    })
+    await expect(runClientBake({ job: bakeJob(), apis })).rejects.toThrow('几乎全透明')
+    expect(uploaded).toEqual([])
+    expect(failed).toContain('几乎全透明')
+  })
+
+  it('模型里没有要的片段时报出实际有哪些', async () => {
+    stage.clips = { idle: 10.0333, run: 0.7333 }
+    let failed = ''
+    const apis = stubRender3DApis({
+      failBake: async (_t, reason) => {
+        failed = reason
+      },
+    })
+    await expect(runClientBake({ job: bakeJob({ clip: 'walk' }), apis })).rejects.toThrow(
+      /没有片段/,
+    )
+    expect(failed).toContain('idle')
+  })
+
+  it('一个片段都没有时说清是绑骨没带动作', async () => {
+    stage.clips = {}
+    await expect(runClientBake({ job: bakeJob(), apis: stubRender3DApis() })).rejects.toThrow(
+      /没有任何动画片段/,
+    )
+  })
+
+  it('任何失败都主动上报 —— 否则那笔冻结的积分要等满期限才解冻', async () => {
+    stage.grabError = new Error('WebGL 上下文丢失')
+    let failed: string | null = null
+    const apis = stubRender3DApis({
+      failBake: async (_t, reason) => {
+        failed = reason
+      },
+    })
+    await expect(runClientBake({ job: bakeJob(), apis })).rejects.toThrow('WebGL 上下文丢失')
+    expect(failed).toBe('WebGL 上下文丢失')
+  })
+
+  it('取消不上报失败 —— 那是用户自己的动作,任务留给期限兜底', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    let failCalled = false
+    const apis = stubRender3DApis({
+      failBake: async () => {
+        failCalled = true
+      },
+    })
+    await expect(
+      runClientBake({ job: bakeJob(), apis, signal: controller.signal }),
+    ).rejects.toBeInstanceOf(BakeAborted)
+    expect(failCalled).toBe(false)
+  })
+
+  it('上报失败本身失败时,不掩盖原来的错', async () => {
+    stage.grabError = new Error('原始故障')
+    const apis = stubRender3DApis({
+      failBake: async () => {
+        throw new Error('网络也断了')
+      },
+    })
+    await expect(runClientBake({ job: bakeJob(), apis })).rejects.toThrow('原始故障')
+  })
+
+  it('无论成败都释放 WebGL 上下文 —— 浏览器对同时存在的上下文有硬上限', async () => {
+    stage.grabError = new Error('炸了')
+    await expect(runClientBake({ job: bakeJob(), apis: stubRender3DApis() })).rejects.toThrow()
+    expect(stage.disposed).toBe(1)
+  })
+
+  it('逐帧回报进度', async () => {
+    const seen: number[] = []
+    await runClientBake({
+      job: bakeJob({ frames: 3 }),
+      apis: stubRender3DApis(),
+      onProgress: ({ done, total }) => {
+        expect(total).toBe(3)
+        seen.push(done)
+      },
+    })
+    expect(seen).toEqual([1, 2, 3])
+  })
+})

--- a/frontend/src/features/client-bake/index.ts
+++ b/frontend/src/features/client-bake/index.ts
@@ -1,0 +1,95 @@
+/**
+ * 浏览器出帧驱动 —— 后端 `bake_driver.mjs` 的同位替代(#714)。
+ *
+ * 那份用 Playwright 驱动无头 Chromium,跑在 4 核无 GPU 的应用机上只能走 SwiftShader
+ * 软件光栅(实测峰值想吃 7.6 个核);这份跑在用户浏览器里,用的是用户自己的显卡。
+ *
+ * **判定不跟着搬。** 帧数对账、空帧自检、脚线对齐、成色闸仍在服务端做 —— 这里做的
+ * 自检只是"早点炸",不是替服务端把关。客户端自报的数只是它的说法。
+ */
+import { BakeStage, StageError } from './stage'
+
+import type { BakeJob, Render3DApis } from '@/entities/render3d'
+
+export { BakeStage, StageError, MATERIALS, isStageMaterial } from './stage'
+export type { StageMaterial, StageRigInfo } from './stage'
+
+export interface BakeProgress {
+  /** 已交帧数。 */
+  done: number
+  total: number
+}
+
+export interface RunClientBakeOptions {
+  job: BakeJob
+  apis: Render3DApis
+  onProgress?: (progress: BakeProgress) => void
+  signal?: AbortSignal
+}
+
+/** 出帧中途被放弃(用户离开页面 / 上层取消)。不当失败上报,任务留给期限兜底。 */
+export class BakeAborted extends Error {
+  constructor() {
+    super('出帧已取消')
+    this.name = 'BakeAborted'
+  }
+}
+
+/**
+ * 跑完一个出帧任务:拉模型 → 逐帧渲 → 逐帧传 → 报交齐。
+ *
+ * 任何一步失败都要**主动告诉后端**,否则这笔冻结的积分要等满期限才解冻,用户在界面上
+ * 看到的是一个一直转的进度条。只有"取消"不上报 —— 那是用户自己的动作。
+ */
+export async function runClientBake(options: RunClientBakeOptions): Promise<void> {
+  const { job, apis, onProgress, signal } = options
+  const throwIfAborted = () => {
+    if (signal?.aborted) throw new BakeAborted()
+  }
+
+  let stage: BakeStage | null = null
+  try {
+    throwIfAborted()
+    stage = await BakeStage.create({
+      modelUrl: job.modelUrl,
+      material: job.material,
+      width: job.width,
+      height: job.height,
+    })
+    const clips = stage.availableClips()
+    if (!Object.keys(clips).length) {
+      throw new StageError('模型里没有任何动画片段 —— 绑骨时没带 MotionType?')
+    }
+    if (!(job.clip in clips)) {
+      throw new StageError(
+        `模型里没有片段 ${JSON.stringify(job.clip)};有的是 ${JSON.stringify(Object.keys(clips))}`,
+      )
+    }
+    stage.setCamYaw(job.cameraYaw)
+
+    const sampleTimes: number[] = []
+    for (let i = 0; i < job.frames; i++) {
+      throwIfAborted()
+      sampleTimes.push(stage.setup(job.clip, i, job.frames))
+      const coverage = stage.coverage()
+      if (coverage < job.minCoverage) {
+        // 角色出画或片段选错都会安静地产出全透明帧,而外面照样以为成功了。
+        throw new StageError(
+          `第 ${i} 帧几乎全透明(覆盖率 ${coverage.toFixed(5)} < ${job.minCoverage})`,
+        )
+      }
+      await apis.putBakeFrame(job.taskId, i, await stage.grab())
+      onProgress?.({ done: i + 1, total: job.frames })
+    }
+    throwIfAborted()
+    await apis.completeBake(job.taskId, { clip: job.clip, sampleTimes })
+  } catch (error) {
+    if (error instanceof BakeAborted) throw error
+    await apis
+      .failBake(job.taskId, error instanceof Error ? error.message : String(error))
+      .catch(() => undefined)
+    throw error
+  } finally {
+    stage?.dispose()
+  }
+}

--- a/frontend/src/features/client-bake/stage.ts
+++ b/frontend/src/features/client-bake/stage.ts
@@ -1,0 +1,420 @@
+/**
+ * 三渲二出帧台 —— 绑骨模型 → 逐帧 WebGL 缓冲。
+ *
+ * 与后端 `providers/render3d/stage/bake_stage.html` 是**同一个台子的两个宿主**:那份由
+ * Playwright 无头驱动,这份跑在用户浏览器里(#714)。七条硬约束逐条对齐,它们都是拿
+ * 教训换的,任何一条走样都不会报错、只会安静地渲出另一个东西:
+ *
+ *  1. 取 WebGL 缓冲,不截页面 —— 页面合成会把 canvas 的透明底换成 body 背景色,
+ *     于是 alpha 全 255、四条门禁全"PASS"全是假的。
+ *  2. `mixer.setTime(t)` 取样,不靠实时播放 —— 同一帧两次跑必须一致。
+ *  3. `setPixelRatio(1)` + 关 AA —— 前者免得 devicePixelRatio 让不同机器出不同尺寸,
+ *     后者因为像素精灵要硬边(开 AA 实测留下上万个半透明柔边像素)。
+ *  4. 构图一次算定、跨所有片段与所有朝向固定;横向跨度取 `max(X, Z)`,多朝向转相机
+ *     不转模型 —— 按单一水平轴定构图的话转到 90° 时取景就变了,各朝向对不齐。
+ *  5. 覆盖率不足视为失败,不上传全透明帧。
+ *  6. 不在 3D 里锁地 —— 实测 hip 设成常量后 12 帧输出完全一致,即位移信息没了。
+ *  7. 材质取值严格校验,认不出当场抛 —— 静默兜底会让"换材质做对照"实际没换。
+ */
+import * as THREE from 'three'
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+
+/** 出帧台**真正认识**的材质,每个对应一个不同的渲染分支。与后端 `MATERIALS` 同表。 */
+export const MATERIALS = ['cel', 'lit', 'clay', 'toon', 'orig'] as const
+export type StageMaterial = (typeof MATERIALS)[number]
+
+export function isStageMaterial(value: string): value is StageMaterial {
+  return (MATERIALS as readonly string[]).includes(value)
+}
+
+export interface StageRigInfo {
+  loader: string
+  rootBone: string | null
+  bones: number
+  skinned: number
+  verts: number
+  orthoH: number
+  material: StageMaterial
+}
+
+export interface StageOptions {
+  modelUrl: string
+  material: string
+  width: number
+  height: number
+}
+
+export class StageError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'StageError'
+  }
+}
+
+/** 一次出帧的全部状态。用完必须 `dispose()`,WebGL 上下文数量浏览器有上限。 */
+export class BakeStage {
+  private readonly renderer: THREE.WebGLRenderer
+  private readonly scene = new THREE.Scene()
+  private readonly cam = new THREE.OrthographicCamera(-1, 1, 1, -1, -20, 20)
+  private readonly material: StageMaterial
+  private readonly width: number
+  private readonly height: number
+
+  private model!: THREE.Object3D
+  private mixer!: THREE.AnimationMixer
+  private clips: Record<string, THREE.AnimationClip> = {}
+  private current: THREE.AnimationAction | null = null
+  private unionBox!: THREE.Box3
+  private orthoH = 1.2
+  private camYaw = 0
+  private rootBone: string | null = null
+  private loader = 'gltf'
+  private probe: HTMLCanvasElement | null = null
+
+  private constructor(options: StageOptions) {
+    if (!isStageMaterial(options.material)) {
+      throw new StageError(
+        `未知材质 ${options.material};只认 ${MATERIALS.join(' / ')}。别兜底 —— 静默落到同一分支正是这条线踩过的仪器陷阱。`,
+      )
+    }
+    this.material = options.material
+    this.width = options.width
+    this.height = options.height
+    this.renderer = new THREE.WebGLRenderer({
+      antialias: false,
+      alpha: true,
+      preserveDrawingBuffer: true,
+    })
+    this.renderer.setPixelRatio(1)
+    this.renderer.setSize(this.width, this.height, false)
+    this.renderer.setClearColor(0x000000, 0)
+  }
+
+  static async create(options: StageOptions): Promise<BakeStage> {
+    const stage = new BakeStage(options)
+    await stage.load(options.modelUrl)
+    return stage
+  }
+
+  private async load(url: string): Promise<void> {
+    // cel 是零光照平涂(灯位变化不改颜色),其余分支才需要灯。
+    if (this.material !== 'cel') {
+      const lights = new THREE.Group()
+      lights.add(
+        new THREE.DirectionalLight(0xfff4e0, 2.2).translateX(1.2).translateY(1.6).translateZ(1.0),
+        new THREE.DirectionalLight(0xc8dcff, 0.6).translateX(-1.3).translateY(0.4).translateZ(0.8),
+        new THREE.AmbientLight(0xffffff, 0.35),
+      )
+      this.scene.add(lights)
+    }
+    const root = new THREE.Group()
+    this.scene.add(root)
+
+    let animations: THREE.AnimationClip[]
+    if (/\.fbx(\?|$)/i.test(url)) {
+      const { FBXLoader } = await import('three/examples/jsm/loaders/FBXLoader.js')
+      const object = await new FBXLoader().loadAsync(url)
+      this.model = object
+      animations = object.animations ?? []
+      this.loader = 'fbx'
+    } else {
+      const gltf = await new GLTFLoader().loadAsync(url)
+      this.model = gltf.scene
+      animations = gltf.animations ?? []
+      this.loader = 'gltf'
+    }
+    root.add(this.model)
+    this.normalize()
+    if (this.material !== 'orig') this.rebuildMaterials()
+    for (const clip of animations) this.clips[clip.name] = clip
+    this.mixer = new THREE.AnimationMixer(this.model)
+    this.rootBone = this.topBoneName()
+    if (this.rootBone) for (const clip of animations) this.flattenRootXZ(clip, this.rootBone)
+    this.unionBox = this.computeUnionBox()
+    this.placeCam()
+  }
+
+  /** 总高缩到 1.0、脚底落在 y=0 —— 1.0 与 root_motion 的单位一致。 */
+  private normalize(): void {
+    this.model.updateMatrixWorld(true)
+    let box = new THREE.Box3().setFromObject(this.model)
+    const rawH = box.max.y - box.min.y
+    if (!Number.isFinite(rawH) || rawH <= 0) {
+      throw new StageError('模型包围盒量不出高度 —— 空模型或坏 GLB')
+    }
+    this.model.scale.setScalar(1.0 / rawH)
+    this.model.updateMatrixWorld(true)
+    box = new THREE.Box3().setFromObject(this.model)
+    this.model.position.y -= box.min.y
+    this.model.position.x -= (box.max.x + box.min.x) / 2
+    this.model.position.z -= (box.max.z + box.min.z) / 2
+    this.model.updateMatrixWorld(true)
+  }
+
+  private toonRamp(): THREE.Texture {
+    const canvas = document.createElement('canvas')
+    canvas.width = 3
+    canvas.height = 1
+    const ctx = canvas.getContext('2d')!
+    ;['#4a4a52', '#9a9aa6', '#f2f2f6'].forEach((color, i) => {
+      ctx.fillStyle = color
+      ctx.fillRect(i, 0, 1, 1)
+    })
+    const texture = new THREE.CanvasTexture(canvas)
+    texture.minFilter = THREE.NearestFilter
+    texture.magFilter = THREE.NearestFilter
+    return texture
+  }
+
+  private rebuildMaterials(): void {
+    const ramp = this.material === 'toon' ? this.toonRamp() : null
+    const rebuild = (src: THREE.Material): THREE.Material => {
+      // side 必须继承源材质:图生 3D + 减面的网格普遍带 doubleSided,丢掉等于开背面
+      // 剔除,而减面后一个三角形只有约一个像素,表现为满身单像素白斑。
+      const side = (src as THREE.MeshStandardMaterial).side ?? THREE.FrontSide
+      const map = (src as THREE.MeshStandardMaterial).map ?? null
+      const srcColor = (src as THREE.MeshStandardMaterial).color
+      const color = srcColor ? srcColor.clone() : new THREE.Color(0xcccccc)
+      switch (this.material) {
+        case 'cel':
+          return new THREE.MeshBasicMaterial({
+            map,
+            color: map ? new THREE.Color(0xffffff) : color,
+            side,
+          })
+        case 'lit':
+          return new THREE.MeshStandardMaterial({
+            map,
+            color: 0xffffff,
+            roughness: 0.68,
+            metalness: 0.15,
+            side,
+          })
+        case 'clay':
+          return new THREE.MeshStandardMaterial({
+            color: 0xb9bec4,
+            roughness: 0.62,
+            metalness: 0.0,
+            side,
+          })
+        case 'toon':
+          return new THREE.MeshToonMaterial({ map, color, gradientMap: ramp, side })
+        default:
+          throw new StageError(`材质 ${this.material} 在表里但没有对应分支 —— 别静默兜底`)
+      }
+    }
+    this.model.traverse((node) => {
+      const mesh = node as THREE.Mesh
+      if (!mesh.isMesh) return
+      // 逐个材质组替换,不能只拿 material[0] 赋给整个网格:一个 mesh 可以有多个材质组
+      // (皮肤 / 头发 / 眼睛 / 衣服),那样做会让所有组都用第一个组的贴图渲染 ——
+      // 外观整个变了,而帧数、覆盖率、成色一道都不会红。
+      if (Array.isArray(mesh.material)) {
+        mesh.material = mesh.material.map((m) => (m ? rebuild(m) : m))
+      } else if (mesh.material) {
+        mesh.material = rebuild(mesh.material)
+      }
+    })
+  }
+
+  private topBoneName(): string | null {
+    let top: string | null = null
+    this.model.traverse((node) => {
+      const bone = node as THREE.Bone
+      if (bone.isBone && !top && !(bone.parent && (bone.parent as THREE.Bone).isBone)) {
+        top = bone.name
+      }
+    })
+    return top
+  }
+
+  /**
+   * 把根骨的水平位移就地压平。留着它有两个后果:构图会把整条行进路径纳进来,角色被
+   * 缩成一小点;序列帧里角色在画布上平移,引擎侧没法用。竖直分量保留 —— 重心起伏是
+   * 姿态的一部分,不是位移。
+   */
+  private flattenRootXZ(clip: THREE.AnimationClip, boneName: string): void {
+    // 只认根骨自己的位置轨。认宽了会把子骨(如 Spine)的位移也剥掉,那是姿态不是位移。
+    const track = clip.tracks.find((t) => t.name === `${boneName}.position`)
+    if (!track) return
+    const values = track.values
+    const x0 = values[0]
+    const z0 = values[2]
+    for (let i = 0; i < values.length; i += 3) {
+      values[i] = x0
+      values[i + 2] = z0
+    }
+  }
+
+  /**
+   * 构图包围盒。**不能用 `Box3.setFromObject` 量 SkinnedMesh 的动画包围盒**:蒙皮变形
+   * 在 GPU 上做,CPU 侧的几何顶点从来不动,量出来永远是绑定姿态的盒子(症状:含跳跃
+   * 在内的五个动作量出来高度全一样,于是跳跃腾空时头切出画面)。改量骨骼世界位置。
+   */
+  private computeUnionBox(nPerClip = 24): THREE.Box3 {
+    const box = new THREE.Box3()
+    const bones: THREE.Object3D[] = []
+    this.model.traverse((node) => {
+      if ((node as THREE.Bone).isBone) bones.push(node)
+    })
+    const names = Object.keys(this.clips)
+    if (!names.length) {
+      // 无动画时量绑定姿态。少了这一支循环一次都不执行,空 Box3 的 min/max 是 ±Infinity,
+      // 相机位置算成 NaN,渲出全透明帧而不报错。
+      box.expandByObject(this.model)
+      return box
+    }
+    const v = new THREE.Vector3()
+    for (const name of names) {
+      this.useClip(name)
+      for (let i = 0; i < nPerClip; i++) {
+        this.sample(i, nPerClip)
+        if (bones.length) {
+          for (const bone of bones) box.expandByPoint(v.setFromMatrixPosition(bone.matrixWorld))
+        } else {
+          box.expandByObject(this.model)
+        }
+      }
+    }
+    if (bones.length) box.expandByScalar(0.1) // 骨骼是线,网格有厚度
+    if (!Number.isFinite(box.min.y) || !Number.isFinite(box.max.y)) {
+      throw new StageError('构图包围盒是空的 —— 相机会被算成 NaN 并渲出全透明帧')
+    }
+    return box
+  }
+
+  private placeCam(): void {
+    const pad = 0.08
+    const spanY = this.unionBox.max.y - this.unionBox.min.y + pad * 2
+    const spanH =
+      Math.max(
+        this.unionBox.max.x - this.unionBox.min.x,
+        this.unionBox.max.z - this.unionBox.min.z,
+      ) +
+      pad * 2
+    this.orthoH = Math.max(spanY, spanH * (this.height / this.width), 1.2)
+
+    // 基准视角:相机在 −X,屏幕右 = 前进轴 +Z,角色天然朝右。不用"把精灵水平镜像"
+    // 代替 —— 角色左右不对称(单侧腕带),镜像会把不对称细节翻到另一边。
+    let v: [number, number, number] = [-1, 0, 0]
+    if (this.camYaw) {
+      const r = (this.camYaw * Math.PI) / 180
+      const c = Math.cos(r)
+      const s = Math.sin(r)
+      v = [v[0] * c + v[2] * s, v[1], -v[0] * s + v[2] * c]
+    }
+    const n = Math.hypot(v[0], v[1], v[2])
+    const d = 4
+    const cy = (this.unionBox.max.y + this.unionBox.min.y) / 2
+    this.cam.position.set((v[0] / n) * d, cy + (v[1] / n) * d, (v[2] / n) * d)
+    this.cam.lookAt(0, cy, 0)
+    const aspect = this.width / this.height
+    this.cam.top = this.orthoH / 2
+    this.cam.bottom = -this.orthoH / 2
+    this.cam.left = (-this.orthoH * aspect) / 2
+    this.cam.right = (this.orthoH * aspect) / 2
+    this.cam.updateProjectionMatrix()
+  }
+
+  private useClip(name: string): boolean {
+    const clip = this.clips[name]
+    if (!clip) return false
+    this.mixer.stopAllAction()
+    this.current = this.mixer.clipAction(clip)
+    this.current.reset().play()
+    return true
+  }
+
+  /** 摆到 clip 的第 i/n 个取样点。**不含尾点** —— 循环动画首尾重复会多一张卡顿帧。 */
+  private sample(i: number, n: number): number {
+    if (!this.current) return 0
+    const t = (i / n) * this.current.getClip().duration
+    this.mixer.setTime(0) // 先归零再定位,避免累积误差
+    this.mixer.setTime(t)
+    this.model.updateMatrixWorld(true)
+    return t
+  }
+
+  availableClips(): Record<string, number> {
+    return Object.fromEntries(
+      Object.entries(this.clips).map(([name, clip]) => [name, +clip.duration.toFixed(4)]),
+    )
+  }
+
+  rigInfo(): StageRigInfo {
+    let bones = 0
+    let skinned = 0
+    let verts = 0
+    this.model.traverse((node) => {
+      if ((node as THREE.Bone).isBone) bones++
+      const mesh = node as THREE.SkinnedMesh
+      if (mesh.isSkinnedMesh) skinned++
+      if (mesh.isMesh) verts += mesh.geometry.attributes.position.count
+    })
+    return {
+      loader: this.loader,
+      rootBone: this.rootBone,
+      bones,
+      skinned,
+      verts,
+      orthoH: +this.orthoH.toFixed(4),
+      material: this.material,
+    }
+  }
+
+  setCamYaw(deg: number): void {
+    this.camYaw = deg
+    this.placeCam()
+  }
+
+  /** 摆姿势并渲一帧,返回该帧的采样时刻。 */
+  setup(clip: string, i: number, n: number): number {
+    if (!this.useClip(clip)) {
+      throw new StageError(
+        `模型里没有片段 ${JSON.stringify(clip)};有的是 ${JSON.stringify(Object.keys(this.clips))}`,
+      )
+    }
+    const t = this.sample(i, n)
+    this.renderer.render(this.scene, this.cam)
+    return +t.toFixed(4)
+  }
+
+  /**
+   * 本帧非透明像素占比。**与后端 `_coverage` 同一口径**(缩到 128 宽再数 alpha>8):
+   * 两边算法不同的话,这边自检过了服务端再判一次会无故打回。
+   */
+  coverage(): number {
+    this.renderer.render(this.scene, this.cam)
+    const src = this.renderer.domElement
+    const w = 128
+    const h = Math.max(1, Math.round((src.height / src.width) * w))
+    if (!this.probe) this.probe = document.createElement('canvas')
+    this.probe.width = w
+    this.probe.height = h
+    const ctx = this.probe.getContext('2d', { willReadFrequently: true })!
+    ctx.clearRect(0, 0, w, h)
+    ctx.drawImage(src, 0, 0, w, h)
+    const data = ctx.getImageData(0, 0, w, h).data
+    let n = 0
+    for (let i = 3; i < data.length; i += 4) if (data[i] > 8) n++
+    return n / (w * h)
+  }
+
+  /** 取这一帧的 PNG。**从 WebGL 缓冲取,不截页面** —— 见文件头第 1 条。 */
+  async grab(): Promise<Blob> {
+    this.renderer.render(this.scene, this.cam)
+    const blob = await new Promise<Blob | null>((resolve) =>
+      this.renderer.domElement.toBlob(resolve, 'image/png'),
+    )
+    // 形状守卫:空画布时浏览器会给出 0 字节或非 PNG 的产物,而下游只按"有没有文件"
+    // 收帧,坏帧会一路当成正常产物交付。覆盖率自检是第二道,这里先炸得更早更清楚。
+    if (!blob || blob.size === 0) throw new StageError('截取到空帧(WebGL 缓冲取不出内容)')
+    return blob
+  }
+
+  dispose(): void {
+    this.renderer.dispose()
+    this.renderer.forceContextLoss()
+    this.probe = null
+  }
+}

--- a/frontend/src/features/client-bake/stage.ts
+++ b/frontend/src/features/client-bake/stage.ts
@@ -91,8 +91,16 @@ export class BakeStage {
   }
 
   static async create(options: StageOptions): Promise<BakeStage> {
+    // 构造函数里就拿到了 WebGL 上下文,而 load 会因为模型坏 / 没动画 / 归一化量不出高度
+    // 而抛。抛出去的话调用方手里还是 null,dispose 永远轮不到 —— 用户重试几次就把浏览器
+    // 的上下文配额耗光,之后连本来能出的帧也出不了。
     const stage = new BakeStage(options)
-    await stage.load(options.modelUrl)
+    try {
+      await stage.load(options.modelUrl)
+    } catch (error) {
+      stage.dispose()
+      throw error
+    }
     return stage
   }
 

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -220,10 +220,15 @@ function createGenerationHarness() {
   return { apis, emit, listeners, snapshots }
 }
 
-function createController(run = createRun(), directionalMovement: DirectionalMovement = 'single') {
+function createController(
+  run = createRun(),
+  directionalMovement: DirectionalMovement = 'single',
+  runClientBake?: (taskId: string) => Promise<boolean>,
+) {
   const workflow = createWorkflowApis(run)
   const generation = createGenerationHarness()
   const asyncErrors: Error[] = []
+  const bakedTasks: string[] = []
   const controller = createWorkflowController({
     workflow: run,
     workflowRunApis: workflow.apis,
@@ -232,8 +237,16 @@ function createController(run = createRun(), directionalMovement: DirectionalMov
     now: () => '2026-08-09T00:00:00.000Z',
     onAsyncError: (error) => asyncErrors.push(error),
     directionalMovement,
+    // 默认注入空实现:真实现会动态 import three.js 并起 WebGL,jsdom 里跑不了,
+    // 而且只有一条用例关心它。
+    runClientBake:
+      runClientBake ??
+      (async (taskId) => {
+        bakedTasks.push(String(taskId))
+        return false
+      }),
   })
-  return { controller, workflow, generation, asyncErrors }
+  return { controller, workflow, generation, asyncErrors, bakedTasks }
 }
 
 function completedAnimationEvent(taskId = 'task-2'): GenerationEvent {
@@ -4012,5 +4025,55 @@ describe('WorkflowController', () => {
       actionType: 'walk',
     })
     expect(controller.getWorkflow().nodes[4].phase).toBe('generating')
+  })
+})
+
+describe('三渲二出帧交给浏览器', () => {
+  it('整段动作开始跑之后，问一次这条任务要不要浏览器出帧', async () => {
+    const run = createRun([
+      ...completedCharacterNodes(),
+      firstFrameNode({
+        status: 'passed',
+        phase: 'completed',
+        selectedFirstFrameUrl: 'https://img/first.png',
+      }),
+      generationMethodNode({ status: 'passed', phase: 'completed', method: '3d-to-2d' }),
+      fullFrameNode({ status: 'active' }),
+      reviewNode(),
+    ])
+    const { controller, bakedTasks } = createController(run)
+
+    await controller.generateCompleteAnimation('action-walk:action-full-frame', {
+      characterId: 'character-backend-1',
+      referenceMedia: [],
+    })
+    await flushAsyncWork()
+
+    expect(bakedTasks).toHaveLength(1)
+  })
+
+  it('出帧失败交给 onAsyncError，不把这条 Run 卡死', async () => {
+    const run = createRun([
+      ...completedCharacterNodes(),
+      firstFrameNode({
+        status: 'passed',
+        phase: 'completed',
+        selectedFirstFrameUrl: 'https://img/first.png',
+      }),
+      generationMethodNode({ status: 'passed', phase: 'completed', method: '3d-to-2d' }),
+      fullFrameNode({ status: 'active' }),
+      reviewNode(),
+    ])
+    const { controller, asyncErrors } = createController(run, 'single', async () => {
+      throw new Error('WebGL 上下文创建失败')
+    })
+
+    await controller.generateCompleteAnimation('action-walk:action-full-frame', {
+      characterId: 'character-backend-1',
+      referenceMedia: [],
+    })
+    await flushAsyncWork()
+
+    expect(asyncErrors.map((error) => error.message)).toContain('WebGL 上下文创建失败')
   })
 })

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -145,6 +145,11 @@ export interface CreateWorkflowControllerOptions {
   onAsyncError: (error: Error) => void
   /** 项目方向模式；缺省按旧单向 WorkflowRun 兼容。 */
   directionalMovement?: DirectionalMovement
+  /**
+   * 三渲二出帧在浏览器里跑（#714）。缺省用真实实现；测试注入替身，避免在 jsdom 里
+   * 起 WebGL。返回 false 表示这条任务不需要浏览器出帧（走 i2v 或已收口）。
+   */
+  runClientBake?: (taskId: Generation['id']) => Promise<boolean>
 }
 
 /**
@@ -294,6 +299,15 @@ export function createAutoPrepareProject(
   }
 }
 
+/**
+ * 三渲二出帧的默认实现。**动态 import** —— three.js 只有这条路线用得着,静态引进来
+ * 会让每个进首页的用户都先下一份它。
+ */
+async function defaultRunClientBake(taskId: Generation['id']): Promise<boolean> {
+  const { attachClientBake } = await import('@/features/client-bake/attach')
+  return attachClientBake(Number(taskId))
+}
+
 export function createWorkflowController({
   workflow,
   workflowRunApis,
@@ -303,6 +317,7 @@ export function createWorkflowController({
   prepareProject,
   onAsyncError,
   directionalMovement = 'single',
+  runClientBake = defaultRunClientBake,
 }: CreateWorkflowControllerOptions): WorkflowController {
   let current = workflow ? structuredClone(workflow) : null
   let interrupted = false
@@ -1525,6 +1540,13 @@ export function createWorkflowController({
       const latest = await generationApis.get(requireWorkflow().projectId, taskId, expectation)
       if (latest.status === 'completed' || latest.status === 'failed') {
         await settleGeneration(nodeId, taskId, latest)
+        return
+      }
+      if (expectation.type === 'complete_animation') {
+        // 三渲二把出帧挂给浏览器：渲完交回后端，终态仍由上面那条订阅收。这里不另立
+        // 状态机，出帧失败也由 runner 报给后端，任务照常走失败终态。
+        // 只问整段动作那一类：母版与首帧走生图，不经出帧台。
+        void runClientBake(taskId).catch((cause: unknown) => onAsyncError(asError(cause)))
       }
     } catch (cause) {
       stopSubscription(key)

--- a/frontend/src/test/render3d-apis.ts
+++ b/frontend/src/test/render3d-apis.ts
@@ -1,4 +1,4 @@
-import type { MasterPrecheckReport, Render3DApis, Render3DAsset } from '@/entities'
+import type { BakeJob, MasterPrecheckReport, Render3DApis, Render3DAsset } from '@/entities'
 
 /**
  * 三渲二资产的测试替身。
@@ -46,6 +46,25 @@ export function absentAsset(overrides: Partial<Render3DAsset> = {}): Render3DAss
   }
 }
 
+/** 一个刚挂出来的出帧任务。数字取自实测口径:竖屏 1536×2560、8 帧、覆盖率阈值 0.005。 */
+export function bakeJob(overrides: Partial<BakeJob> = {}): BakeJob {
+  return {
+    taskId: 1,
+    modelUrl: 'https://media.example.com/media/model-3d/rigged.glb',
+    clip: 'walk',
+    direction: 'e',
+    cameraYaw: 0,
+    frames: 8,
+    width: 1536,
+    height: 2560,
+    material: 'cel',
+    minCoverage: 0.005,
+    deadlineAt: 4_102_444_800,
+    received: 0,
+    ...overrides,
+  }
+}
+
 export function stubRender3DApis(overrides: Partial<Render3DApis> = {}): Render3DApis {
   return {
     precheckMaster: async () => acceptedReport(),
@@ -53,6 +72,10 @@ export function stubRender3DApis(overrides: Partial<Render3DApis> = {}): Render3
     buildOutfitAsset: async () => absentAsset({ state: 'awaiting_review' }),
     approveOutfitAsset: async () => absentAsset({ state: 'ready' }),
     discardOutfitAsset: async () => absentAsset(),
+    getBakeJob: async () => null,
+    putBakeFrame: async () => 1,
+    completeBake: async () => undefined,
+    failBake: async () => undefined,
     ...overrides,
   }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -108,6 +108,55 @@
         "title": "AssistantMessageResponse",
         "type": "object"
       },
+      "BakeCompleteRequest": {
+        "description": "浏览器自报交齐了。帧本身已逐帧 POST 上来,这里只带回可对账的采样信息。",
+        "properties": {
+          "clip": {
+            "minLength": 1,
+            "title": "Clip",
+            "type": "string"
+          },
+          "sample_times": {
+            "items": {
+              "type": "number"
+            },
+            "title": "Sample Times",
+            "type": "array"
+          }
+        },
+        "required": [
+          "clip"
+        ],
+        "title": "BakeCompleteRequest",
+        "type": "object"
+      },
+      "BakeFailRequest": {
+        "description": "浏览器自报渲不出来(WebGL 起不来 / 模型加载失败 / 用户关了页面前的兜底)。",
+        "properties": {
+          "reason": {
+            "default": "",
+            "maxLength": 200,
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "title": "BakeFailRequest",
+        "type": "object"
+      },
+      "Body_put_bake_frame_render3d_bake__task_id__frames__index__post": {
+        "properties": {
+          "file": {
+            "contentMediaType": "application/octet-stream",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_put_bake_frame_render3d_bake__task_id__frames__index__post",
+        "type": "object"
+      },
       "Body_reconstruct_pixel_grid_tools_pixel_perfect_reconstruct_post": {
         "properties": {
           "cols": {
@@ -4887,6 +4936,217 @@
         "summary": "List Transactions",
         "tags": [
           "quota"
+        ]
+      }
+    },
+    "/render3d/bake/{task_id}": {
+      "get": {
+        "description": "取这个任务的出帧参数。没有登记就是不需要浏览器出帧(或已收口)。",
+        "operationId": "get_bake_job_render3d_bake__task_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_dict_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Bake Job",
+        "tags": [
+          "render3d"
+        ]
+      }
+    },
+    "/render3d/bake/{task_id}/complete": {
+      "post": {
+        "description": "帧交齐 → 交回 worker 续跑后处理。\n\n**不信前端说交齐了**:这里按登记的帧数点数,少一帧就不放行 —— 少给的后果是一段\n步子没走完的动作,而帧数、时长、成色在下游全都自洽,没有一道会红。",
+        "operationId": "complete_bake_render3d_bake__task_id__complete_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BakeCompleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_dict_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Complete Bake",
+        "tags": [
+          "render3d"
+        ]
+      }
+    },
+    "/render3d/bake/{task_id}/fail": {
+      "post": {
+        "description": "浏览器自报渲不出来。早报早失败、早解冻,不必等到期限耗完。",
+        "operationId": "fail_bake_render3d_bake__task_id__fail_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BakeFailRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_dict_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Fail Bake",
+        "tags": [
+          "render3d"
+        ]
+      }
+    },
+    "/render3d/bake/{task_id}/frames/{index}": {
+      "post": {
+        "description": "收一帧 PNG。逐帧收而不是一次收一整包:32 帧一起传要几十 MB 的请求体常驻内存。",
+        "operationId": "put_bake_frame_render3d_bake__task_id__frames__index__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "index",
+            "required": true,
+            "schema": {
+              "title": "Index",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_put_bake_frame_render3d_bake__task_id__frames__index__post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_dict_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Bake Frame",
+        "tags": [
+          "render3d"
         ]
       }
     },


### PR DESCRIPTION
## Summary

三渲二的出帧从 worker 内的 Playwright 搬到用户浏览器。出帧参数收敛成一份 `RenderPlan`，服务端渲与浏览器渲共用它；帧经 Redis 短时中转交回 worker，像素化、脚线对齐、成色闸与帧数对账仍在服务端做。

worker 镜像默认目标从 `runtime-render3d` 回到 `runtime`（2.53GB → 820MB，其中 `/ms-playwright` 656MB）。`WINDUP_RENDER3D_CLIENT_BAKE=0` 连同 `WINDUP_WORKER_TARGET=runtime-render3d` 一起回退到服务端渲——两者必须同时改，只关开关不换镜像会一直跑到出帧那一步才报缺 node/playwright/three。

## 为什么

部署机 4 核 / 7941MB / 无 GPU，出帧只能走 SwiftShader 软件光栅，实测峰值 CPU 760%（需要 7.6 个核）。同一台机上 i2v 抽帧抠图的峰值内存问题见 #690 / #695，两者是同一台 4C8G 上的两笔账，本 PR 不碰那边的算法。

## 实测：浏览器渲的帧与服务端渲的帧是同一张

同一份绑骨 GLB（49 骨 / 51,388 顶点）、同一 clip `walk`、8 帧 1536×2560、材质 `cel`、朝向 `e`，两边各渲一遍逐帧比对：

| 帧 | 不同像素 / 3,932,160 | 最大通道差 | 主体包围盒差 |
|---|---|---|---|
| 0 | 0（sha256 完全相同） | 0 | 0,0,0,0 |
| 1 | 11 | 3 | 0,0,0,0 |
| 2 | 2 | 1 | 0,0,0,0 |
| 3 | 15 | 20 | 0,0,0,0 |
| 4 | 9 | 11 | 0,0,0,0 |
| 5 | 12 | 29 | 0,0,0,0 |
| 6 | 11 | 68 | 0,0,0,0 |
| 7 | 37 | 2 | 0,0,0,0 |

最差一帧差 37 个像素，占 0.0009%；主体包围盒逐帧零偏差。`rigInfo` 与 `sample_times` 两边完全一致（`[0, 0.1333, 0.2667, 0.4, 0.5333, 0.6667, 0.8, 0.9333]`），说明构图、采样时刻、材质、根位移压平、相机全部对齐。剩下的差异是同一块 GPU 上两个 WebGL 上下文的光栅化非确定性。

不承诺跨设备逐位一致：交付帧随用户 GPU 与驱动变化，导出包不再有同一套精灵逐位一致的保证。这是本方案接受的代价，换掉应用机的 CPU 与镜像体积。

## 出帧台只有一份行为契约

前端的 `BakeStage` 与后端 `bake_stage.html` 七条硬约束逐条对齐，`stage.ts` 文件头逐条写明了各自是拿什么教训换的：WebGL 缓冲不截页面、`mixer.setTime` 不实时播放、`setPixelRatio(1)` 且关 AA、构图一次算定且横向跨度取 `max(X,Z)`、覆盖率不足判失败、不在 3D 里锁地、材质取值严格校验不静默兜底。

覆盖率与后端 `_coverage` 同一口径（缩到 128 宽再数 `alpha > 8`），两边算法不同的话客户端自检过了服务端再判一次会无故打回。

## 闸口一道不减

客户端自报的数只是它的说法，服务端全部重判：

- 帧数对账：按登记的帧数点，少一帧不放行——少给的后果是一段步子没走完的动作，而下游帧数、时长、成色全部自洽
- 空帧自检：服务端自己数一遍覆盖率，全透明帧拒收
- PNG magic：空画布时 `toDataURL` 会给出没有 base64 段的串
- 片段名对账：交回的 clip 与登记的不符则拒
- 归属校验：帧是交付产物，只有任务归属者能往里塞
- 单帧上限 2MB（实测单帧 178–209KB，10 倍余量）

模型地址在发给浏览器之前过 `is_own_media`——不校验等于让任意 URL 借用户的浏览器和登录态发一次请求。

## 三渲二默认路径不再下模型

原路径要 `fetch_own_media` 把整份 GLB 拉进 worker 内存（还卡在 `MAX_FETCH_BYTES = 16MiB` 上）。新路径由浏览器直接拉，worker 一个字节都不碰。测试里 `fetch_model3d` 直接 `pytest.fail`——省下 Chromium 但没省上行的话，这条会红。

## 任务 SLA

关标签 / 切后台 / 手机 WebGL 失败一律判任务失败可重试。浏览器渲不出来会主动报 `POST /bake/{id}/fail`，早报早解冻；不报也有 900 秒期限兜底（比 i2v 的 30 分钟短：那边等的是上游算力，这边等的是一个开着的页面）。

three.js 走动态 import，独立成 `three.core` 分块（239.90 kB / gzip 63.59 kB），不进主 bundle。

## 不包含

- 不改帧数对账、`_lastmile`、成色闸与写回 `actions` 的行为
- 不改 i2v 抽帧抠图算法（#690 / #695 的范围）
- 不改三渲二的计费口径与人工确认闸
- 不做多朝向出参的 UI
- 服务端抽检重渲（若日后必须可复现，另开）

## Test plan

- [x] 后端 `uv run ruff check .` / `uv run lint-imports` / `uv run pytest -q --cov=packages`：**1655 passed, 14 skipped**，三条都跑在最后一次编辑之后
- [x] 前端 `npm run format:check` / `lint` / `typecheck` / `test:coverage` / `build`：**1138 passed, 79 files**，五条都跑在最后一次编辑之后
- [x] 新增 27 条用例：Redis 登记与收帧 12 条、编排层路线 7 条、HTTP 端点 8 条；前端 13 条驱动与 7 条网络边界，另加 2 条 controller 接线
- [x] 真浏览器逐帧比对服务端 Playwright 产物（数据见上）
- [x] `test_real_server_path_reaches_render3d_when_the_outfit_has_a_model` 改为显式 `WINDUP_RENDER3D_CLIENT_BAKE=0`——它的被测对象是服务端渲那一支，默认路径另有用例

Closes #714
