### PR TITLE
feat(quick-start): support existing project context

### DIFF
--- a/frontend/src/features/quick-start-agent/production.ts
+++ b/frontend/src/features/quick-start-agent/production.ts
@@ -147,6 +147,7 @@ export function createProductionQuickStartAgentDependencies(
           prompt: input.prompt,
           directionalMovement: input.directionalMovement,
           gameStyle,
+          projectId: input.projectId,
           ...(input.automaticDelivery
             ? {
                 automaticDelivery: {

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -170,7 +170,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
     async (
       prompt: string,
       directionalMovement: QuickStartDirectionalMovement = 'single',
-      options?: { gameStyle?: string; automaticDelivery?: boolean },
+      options?: { gameStyle?: string; projectId?: string; automaticDelivery?: boolean },
     ): Promise<QuickStartAgentResult> => {
       if (running.current) throw new Error('Planner 正在处理上一条输入')
       if (state.status !== 'proposal') throw new Error('提示词提案已失效')

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -78,6 +78,8 @@ export interface QuickStartAgentTurnOptions {
 export interface ConfirmProposalOptions {
   /** 画风原样透传给宿主；取值范围由宿主定义，本模块不认识业务对象。 */
   gameStyle?: string
+  /** 宿主选择的已有项目；缺省时继续自动创建项目。 */
+  projectId?: string
   /** 用户选择确认后由 Controller 自动交付，不再暴露中间候选选择。 */
   automaticDelivery?: boolean
 }
@@ -101,6 +103,7 @@ export type StartCharacterGenerationAction = (input: {
   actionType?: QuickStartActionType
   directionalMovement?: QuickStartDirectionalMovement
   gameStyle?: string
+  projectId?: string
   automaticDelivery?: boolean
 }) => Promise<{ runId: string }>
 
@@ -325,7 +328,7 @@ export function createQuickStartAgent({
     proposalId: string,
     prompt: string,
     directionalMovement: QuickStartDirectionalMovement = 'single',
-    { gameStyle, automaticDelivery }: ConfirmProposalOptions = {},
+    { gameStyle, projectId, automaticDelivery }: ConfirmProposalOptions = {},
   ): Promise<QuickStartAgentResult> {
     assertAuthorized()
     if (running) throw new Error('Planner 正在处理上一条输入')
@@ -348,6 +351,7 @@ export function createQuickStartAgent({
         ...(proposal.actionType ? { actionType: proposal.actionType } : {}),
         directionalMovement,
         gameStyle,
+        projectId,
         ...(automaticDelivery ? { automaticDelivery: true } : {}),
       })
       return { kind: 'generated', runId, ...proposal, optimizedPrompt: effectivePrompt }

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -111,6 +111,8 @@ export interface ApplyGenerationResultInput {
 
 export interface PrepareQuickStartProjectOptions {
   gameStyle?: ArtStyle
+  /** 传入时复用已有项目；缺省时保持 Quick Start 自动建项目。 */
+  projectId?: Project['id']
 }
 
 export type PrepareQuickStartProject = (
@@ -123,6 +125,7 @@ export interface StartCharacterGenerationInput {
   prompt: string
   directionalMovement?: DirectionalMovement
   gameStyle?: ArtStyle
+  projectId?: Project['id']
   automaticDelivery?: { actionPrompt?: string; actionType?: 'walk' }
 }
 
@@ -258,9 +261,17 @@ function boundedProjectName(value: string, maxLength: number): string {
 }
 
 export function createAutoPrepareProject(
-  projectApis: Pick<ProjectApis, 'create'>,
+  projectApis: Pick<ProjectApis, 'create' | 'get'>,
 ): PrepareQuickStartProject {
   return async (prompt, directionalMovement = 'single', options) => {
+    if (options?.projectId) {
+      const project = await projectApis.get(options.projectId)
+      return {
+        id: project.id,
+        spriteSize: project.spriteSize,
+        directionalMovement: project.directionalMovement,
+      }
+    }
     const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
     let lastConflict: unknown
 
@@ -407,6 +418,7 @@ export function createWorkflowController({
     prompt,
     directionalMovement: selectedDirectionalMovement = 'single',
     gameStyle,
+    projectId,
     automaticDelivery,
   }: StartCharacterGenerationInput): Promise<StartCharacterGenerationResult> {
     ensureRunning()
@@ -418,6 +430,7 @@ export function createWorkflowController({
     const actionType = actionPrompt ? automaticDelivery?.actionType : undefined
     const project = await prepareProject(normalizedPrompt, selectedDirectionalMovement, {
       gameStyle,
+      projectId,
     })
     generationDirections = getDirectionProfile(
       project.directionalMovement ?? selectedDirectionalMovement,

--- a/frontend/src/pages/project-create/index.test.tsx
+++ b/frontend/src/pages/project-create/index.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { MemoryRouter, Route, Routes, useParams } from 'react-router'
+import { MemoryRouter, Route, Routes, useLocation, useParams } from 'react-router'
 
 import { AppRoutes } from '@/app'
 import { ProjectCreatePage } from '@/pages/project-create'
@@ -90,6 +90,11 @@ function installWorkflowBackend(failWorkflowAttempts = 0) {
 function WorkflowDestination() {
   const { runId } = useParams()
   return <h1>Workflow Editor {runId}</h1>
+}
+
+function QuickStartDestination() {
+  const location = useLocation()
+  return <h1>{`${location.pathname}${location.search}`}</h1>
 }
 
 async function renderWorkflowProjectCreate() {
@@ -190,6 +195,27 @@ describe('ProjectCreatePage', () => {
     })
     // 归属由后端从 JWT 取；请求体再带 user_id 就等于宣称可以替别人建项目。
     expect(Object.hasOwn(body, 'user_id')).toBe(false)
+  })
+
+  it('从 Quick Start 手动新建项目后返回并选中新项目', async () => {
+    const backend = installBackend()
+    render(
+      <AuthenticatedAuthSession>
+        <MemoryRouter initialEntries={['/projects/new?entry=quick-start']}>
+          <Routes>
+            <Route path="/projects/new" element={<ProjectCreatePage />} />
+            <Route path="/quick-start" element={<QuickStartDestination />} />
+          </Routes>
+        </MemoryRouter>
+      </AuthenticatedAuthSession>,
+    )
+    await screen.findByRole('button', { name: '创建项目' })
+
+    fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
+    fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
+
+    expect(await screen.findByRole('heading', { name: '/quick-start?projectId=4242' })).toBeTruthy()
+    expect(creationRequests(backend)).toHaveLength(1)
   })
 
   it('没有登录凭证时先进入登录面板，不挂载创建页面', async () => {

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -40,6 +40,7 @@ export function ProjectCreatePage() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const opensWorkflowEditor = searchParams.get('entry') === 'workflow-editor'
+  const returnsToQuickStart = searchParams.get('entry') === 'quick-start'
   /**
    * 能不能建项目只取决于有没有登录：后端 `/projects` 不在鉴权白名单里，
    * 归属也从 access token 里取。登录模块尚未接入时没有人注册 provider，
@@ -96,6 +97,10 @@ export function ProjectCreatePage() {
           nodes: initialWorkflowNodes(),
         })
         navigate(`/workflow-editor/${encodeURIComponent(workflow.id)}`)
+        return
+      }
+      if (returnsToQuickStart) {
+        navigate(`/quick-start?${new URLSearchParams({ projectId: project.id })}`)
         return
       }
       navigate(`/projects/${project.id}`)
@@ -301,7 +306,9 @@ export function ProjectCreatePage() {
                   ? createdProject
                     ? '项目已经创建；重试只会继续创建工作流，不会重复创建项目。'
                     : '创建项目和初始工作流后，直接进入工作流画布。'
-                  : '创建后进入该项目的资产工作区。'
+                  : returnsToQuickStart
+                    ? '创建后返回 Quick Start，并将新项目作为角色生成约束。'
+                    : '创建后进入该项目的资产工作区。'
                 : '创建项目需要先登录。登录模块尚未接入，创建入口暂时保持关闭。'}
             </small>
             <button

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -12,7 +12,12 @@ import { BrowserRouter, MemoryRouter, Route, Routes, useLocation, useNavigate } 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { QuickStartCandidate, QuickStartEntryService, QuickStartSession } from './service'
-import { WorkflowRunConflictError, type WorkflowRun } from '@/entities'
+import {
+  WorkflowRunConflictError,
+  type Project,
+  type ProjectApis,
+  type WorkflowRun,
+} from '@/entities'
 import { ApiError } from '@/shared/api'
 import type { ExportPackageModel } from '@/features/export-package'
 import { readActiveRun, rememberActiveRun } from '@/features/active-run'
@@ -290,10 +295,31 @@ function agentFor(
   }
 }
 
+const existingProject: Project = {
+  id: '42',
+  workflowId: null,
+  name: '星海计划',
+  perspective: 'side',
+  directionalMovement: 'four-way',
+  spriteSize: { width: 128, height: 192 },
+  gameStyle: 'pixel',
+  sampleImageUrl: null,
+  createdAt: '2026-08-25T00:00:00Z',
+  updatedAt: '2026-08-25T00:00:00Z',
+}
+
+function projectReader(project: Project = existingProject): Pick<ProjectApis, 'list' | 'get'> {
+  return {
+    list: vi.fn(async () => ({ items: [project], total: 1, page: 1, pageSize: 20 })),
+    get: vi.fn(async () => project),
+  }
+}
+
 function renderAt(
   path: string,
   service: QuickStartEntryService,
   agent: CreateQuickStartAgentOptions = agentFor(),
+  projects: Pick<ProjectApis, 'list' | 'get'> = projectReader(),
 ) {
   function PlaytestLocation() {
     const location = useLocation()
@@ -304,11 +330,25 @@ function renderAt(
       <Routes>
         <Route
           path="/quick-start"
-          element={<QuickStartPage service={service} activeRunUserId="7" agent={agent} />}
+          element={
+            <QuickStartPage
+              service={service}
+              activeRunUserId="7"
+              agent={agent}
+              projectApis={projects}
+            />
+          }
         />
         <Route
           path="/quick-start/:runId"
-          element={<QuickStartPage service={service} activeRunUserId="7" agent={agent} />}
+          element={
+            <QuickStartPage
+              service={service}
+              activeRunUserId="7"
+              agent={agent}
+              projectApis={projects}
+            />
+          }
         />
         <Route path="/projects/:projectId/assets" element={<PlaytestLocation />} />
         <Route path="/playtest/:characterId/:outfitId" element={<PlaytestLocation />} />
@@ -810,6 +850,53 @@ describe('QuickStartPage', () => {
     expect(template.textContent).toBe('添加母版')
     expect(style.getAttribute('aria-expanded')).toBe('false')
     expect(send.className).toContain('rounded-full')
+  })
+
+  it('defaults to automatic project creation and can target an existing project', async () => {
+    const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-created' }))
+    const planner = vi.fn(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'quick_start_decision',
+          input: {
+            kind: 'proposal',
+            optimizedPrompt: '银发骑士，全身像',
+            actionPrompt: '向前行走',
+            actionType: 'walk',
+            optimizationSummary: '整理角色与动作描述。',
+          },
+        },
+      ],
+    }))
+    renderAt('/quick-start', serviceFor(null), { planner, startCharacterGeneration })
+
+    const project = screen.getByRole('button', { name: '选择项目，当前自动创建' })
+    fireEvent.click(project)
+    fireEvent.click(await screen.findByRole('menuitemradio', { name: '星海计划' }))
+
+    expect(screen.getByRole('button', { name: '选择项目，当前星海计划' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '生成方向，当前四向' })).toBeTruthy()
+    expect(screen.getByTestId('quick-start-selected-style').textContent).toBe('像素')
+
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '银发骑士向前行走' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    fireEvent.click(await screen.findByRole('button', { name: '确认并生成' }))
+
+    await waitFor(() =>
+      expect(startCharacterGeneration).toHaveBeenCalledWith({
+        prompt: '银发骑士，全身像',
+        actionPrompt: '向前行走',
+        actionType: 'walk',
+        directionalMovement: 'four-way',
+        gameStyle: 'pixel',
+        automaticDelivery: true,
+        projectId: '42',
+      }),
+    )
   })
 
   it('opens generation direction as an animated slider control below the composer', () => {

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -870,10 +870,16 @@ describe('QuickStartPage', () => {
         },
       ],
     }))
-    renderAt('/quick-start', serviceFor(null), { planner, startCharacterGeneration })
+    const projects = projectReader()
+    renderAt('/quick-start', serviceFor(null), { planner, startCharacterGeneration }, projects)
+
+    await waitFor(() => expect(projects.list).toHaveBeenCalledWith({ page: 1, pageSize: 3 }))
 
     const project = screen.getByRole('button', { name: '选择项目，当前自动创建' })
     fireEvent.click(project)
+    expect(screen.getByRole('menuitem', { name: '新建项目' }).getAttribute('href')).toBe(
+      '/projects/new?entry=quick-start',
+    )
     fireEvent.click(await screen.findByRole('menuitemradio', { name: '星海计划' }))
 
     expect(screen.getByRole('button', { name: '选择项目，当前星海计划' })).toBeTruthy()
@@ -897,6 +903,16 @@ describe('QuickStartPage', () => {
         projectId: '42',
       }),
     )
+  })
+
+  it('restores a newly created project from the Quick Start return URL', async () => {
+    const projects = projectReader()
+    renderAt('/quick-start?projectId=42', serviceFor(null), agentFor(), projects)
+
+    expect(await screen.findByRole('button', { name: '选择项目，当前星海计划' })).toBeTruthy()
+    expect(projects.get).toHaveBeenCalledWith('42')
+    expect(screen.getByRole('button', { name: '生成方向，当前四向' })).toBeTruthy()
+    expect(screen.getByTestId('quick-start-selected-style').textContent).toBe('像素')
   })
 
   it('opens generation direction as an animated slider control below the composer', () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -41,6 +41,9 @@ import {
   type DirectionalMovement,
   type WorkflowRun,
   WorkflowRunConflictError,
+  projectApis as defaultProjectApis,
+  type Project,
+  type ProjectApis,
 } from '@/entities'
 import { forgetActiveRun, isMissingActiveRunError, syncActiveRun } from '@/features/active-run'
 import { useOptionalAuthSession } from '@/features/auth-session'
@@ -181,6 +184,7 @@ type AgentConversationRecord = {
   turns: readonly AgentConversationTurn[]
   /** 入口处选的画风；不随草稿存住的话，刷新后画风选择器已隐藏而值悄悄回到不指定。 */
   gameStyle?: ArtStyle
+  projectId?: string | null
 }
 
 type AgentConversationStorageName = 'localStorage' | 'sessionStorage'
@@ -221,6 +225,18 @@ function readAgentDraftGameStyle(key: string): ArtStyle {
     return isArtStyle(parsed.gameStyle) ? parsed.gameStyle : 'unspecified'
   } catch {
     return 'unspecified'
+  }
+}
+
+function readAgentDraftProjectId(key: string): string | null {
+  try {
+    const stored = window.sessionStorage.getItem(key)
+    if (!stored) return null
+    const parsed: unknown = JSON.parse(stored)
+    if (typeof parsed !== 'object' || parsed === null || !('projectId' in parsed)) return null
+    return typeof parsed.projectId === 'string' && parsed.projectId ? parsed.projectId : null
+  } catch {
+    return null
   }
 }
 
@@ -408,6 +424,7 @@ export interface QuickStartPageProps {
   activeRunUserId?: string
   /** app 组合层注入 Planner 与绑定到现有 WorkflowController 的唯一写 action。 */
   agent: CreateQuickStartAgentOptions
+  projectApis?: Pick<ProjectApis, 'list' | 'get'>
 }
 
 /** Quick Start 独立完成 AI 入口；它不跳转 Workflow Editor。 */
@@ -415,6 +432,7 @@ export function QuickStartPage({
   service,
   activeRunUserId: providedActiveRunUserId,
   agent,
+  projectApis = defaultProjectApis,
 }: QuickStartPageProps) {
   const { runId } = useParams()
   const location = useLocation()
@@ -448,6 +466,7 @@ export function QuickStartPage({
       agent={agent}
       activeRunUserId={activeRunUserId}
       onSessionCreated={setCreatedSession}
+      projectApis={projectApis}
     />
   )
 }
@@ -621,11 +640,13 @@ function QuickStartInput({
   agent,
   activeRunUserId,
   onSessionCreated,
+  projectApis,
 }: {
   service: QuickStartEntryService
   agent: CreateQuickStartAgentOptions
   activeRunUserId: string | null
   onSessionCreated: (session: QuickStartSession) => void
+  projectApis: Pick<ProjectApis, 'list' | 'get'>
 }) {
   const navigate = useNavigate()
   const [prompt, setPrompt] = useState('')
@@ -638,6 +659,17 @@ function QuickStartInput({
       ? readAgentDraftGameStyle(agentDraftConversationStorageKey(activeRunUserId, draftId))
       : 'unspecified'
   })
+  const [projectId, setProjectId] = useState<string | null>(() => {
+    const draftId = readAgentDraftId()
+    return draftId
+      ? readAgentDraftProjectId(agentDraftConversationStorageKey(activeRunUserId, draftId))
+      : null
+  })
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null)
+  const [projects, setProjects] = useState<readonly Project[]>([])
+  const [projectMenuOpen, setProjectMenuOpen] = useState(false)
+  const projectIdRef = useRef(projectId)
+  projectIdRef.current = projectId
   const gameStyleRef = useRef(gameStyle)
   gameStyleRef.current = gameStyle
   const [submitting, setSubmitting] = useState(false)
@@ -709,11 +741,58 @@ function QuickStartInput({
       writeAgentConversation(
         'sessionStorage',
         agentDraftConversationStorageKey(activeRunUserId, draftId),
-        { turns, gameStyle: gameStyleRef.current },
+        { turns, gameStyle: gameStyleRef.current, projectId: projectIdRef.current },
       )
     },
     [activeRunUserId, ensureDraftId],
   )
+
+  useEffect(() => {
+    let cancelled = false
+    void projectApis.list({ page: 1, pageSize: 100 }).then(
+      (result) => {
+        if (cancelled) return
+        setProjects(result.items)
+        const restoredId = projectIdRef.current
+        if (restoredId) {
+          const project = result.items.find((item) => item.id === restoredId)
+          if (project) {
+            setSelectedProject(project)
+            setDirectionalMovement(project.directionalMovement)
+            setGameStyle(project.gameStyle)
+          } else {
+            setProjectId(null)
+          }
+        }
+      },
+      () => {
+        if (!cancelled) setProjects([])
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [projectApis])
+
+  function chooseProject(project: Project | null) {
+    setProjectMenuOpen(false)
+    setProjectId(project?.id ?? null)
+    setSelectedProject(project)
+    if (project) {
+      setDirectionalMovement(project.directionalMovement)
+      setGameStyle(project.gameStyle)
+    }
+    const draftId = ensureDraftId()
+    writeAgentConversation(
+      'sessionStorage',
+      agentDraftConversationStorageKey(activeRunUserId, draftId),
+      {
+        turns: conversationTurnsRef.current,
+        gameStyle: project?.gameStyle ?? gameStyleRef.current,
+        projectId: project?.id ?? null,
+      },
+    )
+  }
 
   const persistRunConversation = useCallback(
     (turns: readonly AgentConversationTurn[], runId: string) => {
@@ -840,7 +919,7 @@ function QuickStartInput({
       const result = await agentSession.confirmProposal(
         state.optimizedPrompt,
         directionalMovement,
-        { gameStyle, automaticDelivery: true },
+        { gameStyle, automaticDelivery: true, ...(projectId ? { projectId } : {}) },
       )
       if (result.kind === 'generated') await handoffGenerated(result)
     } catch {
@@ -868,7 +947,7 @@ function QuickStartInput({
       writeAgentConversation(
         'sessionStorage',
         agentDraftConversationStorageKey(activeRunUserId, draftId),
-        { turns: conversationTurnsRef.current, gameStyle: next },
+        { turns: conversationTurnsRef.current, gameStyle: next, projectId: projectIdRef.current },
       )
     }
   }
@@ -991,7 +1070,7 @@ function QuickStartInput({
         normalizedPrompt,
         abortController.signal,
         directionalMovement,
-        { gameStyle },
+        { gameStyle, ...(projectId ? { projectId } : {}) },
       )
       const handoffPromise = new Promise<void>((resolve) => {
         handoffTimer.current = setTimeout(() => {
@@ -1023,7 +1102,10 @@ function QuickStartInput({
     appendConversationTurn({ role: 'user', content: DIRECTIONAL_MOVEMENT[movement] })
     setPromptState('confirmed')
     try {
-      const result = await agentSession.confirmProposal(confirmedPrompt, movement, { gameStyle })
+      const result = await agentSession.confirmProposal(confirmedPrompt, movement, {
+        gameStyle,
+        ...(projectId ? { projectId } : {}),
+      })
       if (result.kind === 'generated') await handoffGenerated(result)
     } catch {
       setPromptState('direction')
@@ -1303,6 +1385,57 @@ function QuickStartInput({
             >
               {!hasConversation ? (
                 <div className="flex items-center gap-1">
+                  <div className="relative">
+                    <button
+                      type="button"
+                      aria-label={`选择项目，当前${selectedProject?.name ?? '自动创建'}`}
+                      aria-expanded={projectMenuOpen}
+                      disabled={entryBusy}
+                      onClick={() => {
+                        setStyleMenuOpen(false)
+                        setDirectionMenuOpen(false)
+                        setProjectMenuOpen((open) => !open)
+                      }}
+                      className="inline-flex h-10 max-w-44 items-center gap-1 rounded-app-control px-3 text-sm font-medium text-app-ink-soft transition hover:bg-app-surface-muted hover:text-app-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-45"
+                    >
+                      <span className="truncate">{selectedProject?.name ?? '自动创建'}</span>
+                      <CaretDown
+                        aria-hidden="true"
+                        size={14}
+                        weight="bold"
+                        className={projectMenuOpen ? 'rotate-180' : ''}
+                      />
+                    </button>
+                    {projectMenuOpen ? (
+                      <div
+                        role="menu"
+                        aria-label="选择项目"
+                        className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-40 gap-1 p-1.5 opacity-100`}
+                      >
+                        <button
+                          type="button"
+                          role="menuitemradio"
+                          aria-checked={projectId === null}
+                          onClick={() => chooseProject(null)}
+                          className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === null ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
+                        >
+                          自动创建
+                        </button>
+                        {projects.map((project) => (
+                          <button
+                            key={project.id}
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={projectId === project.id}
+                            onClick={() => chooseProject(project)}
+                            className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === project.id ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
+                          >
+                            {project.name}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
                   <IconActionButton
                     label={templateFile ? `更换母版 ${templateFile.name}` : '添加母版'}
                     disabled={entryBusy}
@@ -1314,7 +1447,7 @@ function QuickStartInput({
                   <div className="relative">
                     <IconActionButton
                       label={`选择画风，当前${ART_STYLE[gameStyle]}`}
-                      disabled={entryBusy}
+                      disabled={entryBusy || Boolean(selectedProject)}
                       onClick={() => {
                         setDirectionMenuOpen(false)
                         setStyleMenuOpen((open) => !open)
@@ -1378,7 +1511,7 @@ function QuickStartInput({
                         type="button"
                         aria-label={`生成方向，当前${DIRECTIONAL_MOVEMENT[directionalMovement]}`}
                         aria-expanded={directionMenuOpen}
-                        disabled={entryBusy}
+                        disabled={entryBusy || Boolean(selectedProject)}
                         onClick={() => {
                           setStyleMenuOpen(false)
                           setDirectionSliderValue(directionalMovementIndex)

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -19,8 +19,11 @@ import {
   ArrowClockwise,
   ArrowUp,
   CaretDown,
+  Check,
   CopySimple,
+  FolderOpen,
   Play,
+  Plus,
   PlusCircle,
   Stack,
   Stop,
@@ -649,6 +652,7 @@ function QuickStartInput({
   projectApis: Pick<ProjectApis, 'list' | 'get'>
 }) {
   const navigate = useNavigate()
+  const [entrySearchParams] = useSearchParams()
   const [prompt, setPrompt] = useState('')
   const [directionalMovement, setDirectionalMovement] = useState<DirectionalMovement>('single')
   const [confirmedPrompt, setConfirmedPrompt] = useState<string | null>(null)
@@ -660,6 +664,8 @@ function QuickStartInput({
       : 'unspecified'
   })
   const [projectId, setProjectId] = useState<string | null>(() => {
+    const requestedProjectId = entrySearchParams.get('projectId')
+    if (requestedProjectId) return requestedProjectId
     const draftId = readAgentDraftId()
     return draftId
       ? readAgentDraftProjectId(agentDraftConversationStorageKey(activeRunUserId, draftId))
@@ -749,24 +755,26 @@ function QuickStartInput({
 
   useEffect(() => {
     let cancelled = false
-    void projectApis.list({ page: 1, pageSize: 100 }).then(
-      (result) => {
+    const restoredId = projectIdRef.current
+    void Promise.all([
+      projectApis.list({ page: 1, pageSize: 3 }),
+      restoredId ? projectApis.get(restoredId) : Promise.resolve(null),
+    ]).then(
+      ([result, restoredProject]) => {
         if (cancelled) return
         setProjects(result.items)
-        const restoredId = projectIdRef.current
-        if (restoredId) {
-          const project = result.items.find((item) => item.id === restoredId)
-          if (project) {
-            setSelectedProject(project)
-            setDirectionalMovement(project.directionalMovement)
-            setGameStyle(project.gameStyle)
-          } else {
-            setProjectId(null)
-          }
+        if (restoredId && restoredProject && projectIdRef.current === restoredId) {
+          setSelectedProject(restoredProject)
+          setDirectionalMovement(restoredProject.directionalMovement)
+          setGameStyle(restoredProject.gameStyle)
         }
       },
       () => {
-        if (!cancelled) setProjects([])
+        if (!cancelled) {
+          setProjects([])
+          setProjectId(null)
+          setSelectedProject(null)
+        }
       },
     )
     return () => {
@@ -1457,15 +1465,6 @@ function QuickStartInput({
                         aria-label="选择项目"
                         className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-40 gap-1 p-1.5 opacity-100`}
                       >
-                        <button
-                          type="button"
-                          role="menuitemradio"
-                          aria-checked={projectId === null}
-                          onClick={() => chooseProject(null)}
-                          className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === null ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
-                        >
-                          自动创建
-                        </button>
                         {projects.map((project) => (
                           <button
                             key={project.id}
@@ -1473,11 +1472,40 @@ function QuickStartInput({
                             role="menuitemradio"
                             aria-checked={projectId === project.id}
                             onClick={() => chooseProject(project)}
-                            className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === project.id ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
+                            className={`flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === project.id ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
                           >
-                            {project.name}
+                            <FolderOpen aria-hidden="true" size={15} weight="regular" />
+                            <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                            {projectId === project.id ? (
+                              <Check aria-hidden="true" size={14} weight="bold" />
+                            ) : null}
                           </button>
                         ))}
+                        <div className="my-1 border-t border-app-line" />
+                        <Link
+                          to="/projects/new?entry=quick-start"
+                          role="menuitem"
+                          onClick={() => setProjectMenuOpen(false)}
+                          className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-xs text-app-ink-soft transition hover:bg-app-surface-muted"
+                        >
+                          <Plus aria-hidden="true" size={15} weight="bold" />
+                          新建项目
+                        </Link>
+                        <button
+                          type="button"
+                          role="menuitemradio"
+                          aria-checked={projectId === null}
+                          onClick={() => chooseProject(null)}
+                          className={`flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === null ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
+                        >
+                          <span aria-hidden="true" className="w-[15px] text-center">
+                            ×
+                          </span>
+                          <span className="flex-1">自动创建</span>
+                          {projectId === null ? (
+                            <Check aria-hidden="true" size={14} weight="bold" />
+                          ) : null}
+                        </button>
                       </div>
                     ) : null}
                   </div>

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1385,6 +1385,51 @@ function QuickStartInput({
             >
               {!hasConversation ? (
                 <div className="flex items-center gap-1">
+                  <IconActionButton
+                    label={templateFile ? `更换母版 ${templateFile.name}` : '添加母版'}
+                    disabled={entryBusy}
+                    onClick={() => fileInput.current?.click()}
+                    className={templateFile ? 'text-app-accent' : ''}
+                  >
+                    <MasterFrameIcon />
+                  </IconActionButton>
+                  <div className="relative">
+                    <IconActionButton
+                      label={`选择画风，当前${ART_STYLE[gameStyle]}`}
+                      disabled={entryBusy || Boolean(selectedProject)}
+                      onClick={() => {
+                        setDirectionMenuOpen(false)
+                        setStyleMenuOpen((open) => !open)
+                      }}
+                      expanded={styleMenuOpen}
+                    >
+                      <StyleTileIcon />
+                    </IconActionButton>
+                    {styleMenuOpen ? (
+                      <div
+                        role="menu"
+                        aria-label="选择画风"
+                        className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-32 gap-1 p-1.5 opacity-100`}
+                      >
+                        {ART_STYLE_OPTIONS.map((value) => (
+                          <button
+                            key={value}
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={gameStyle === value}
+                            onClick={() => chooseGameStyle(value)}
+                            className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${
+                              gameStyle === value
+                                ? 'bg-app-accent-soft text-app-accent'
+                                : 'text-app-ink-soft hover:bg-app-surface-muted'
+                            }`}
+                          >
+                            {ART_STYLE[value]}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
                   <div className="relative">
                     <button
                       type="button"
@@ -1431,51 +1476,6 @@ function QuickStartInput({
                             className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === project.id ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
                           >
                             {project.name}
-                          </button>
-                        ))}
-                      </div>
-                    ) : null}
-                  </div>
-                  <IconActionButton
-                    label={templateFile ? `更换母版 ${templateFile.name}` : '添加母版'}
-                    disabled={entryBusy}
-                    onClick={() => fileInput.current?.click()}
-                    className={templateFile ? 'text-app-accent' : ''}
-                  >
-                    <MasterFrameIcon />
-                  </IconActionButton>
-                  <div className="relative">
-                    <IconActionButton
-                      label={`选择画风，当前${ART_STYLE[gameStyle]}`}
-                      disabled={entryBusy || Boolean(selectedProject)}
-                      onClick={() => {
-                        setDirectionMenuOpen(false)
-                        setStyleMenuOpen((open) => !open)
-                      }}
-                      expanded={styleMenuOpen}
-                    >
-                      <StyleTileIcon />
-                    </IconActionButton>
-                    {styleMenuOpen ? (
-                      <div
-                        role="menu"
-                        aria-label="选择画风"
-                        className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-32 gap-1 p-1.5 opacity-100`}
-                      >
-                        {ART_STYLE_OPTIONS.map((value) => (
-                          <button
-                            key={value}
-                            type="button"
-                            role="menuitemradio"
-                            aria-checked={gameStyle === value}
-                            onClick={() => chooseGameStyle(value)}
-                            className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${
-                              gameStyle === value
-                                ? 'bg-app-accent-soft text-app-accent'
-                                : 'text-app-ink-soft hover:bg-app-surface-muted'
-                            }`}
-                          >
-                            {ART_STYLE[value]}
                           </button>
                         ))}
                       </div>

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -1148,6 +1148,34 @@ describe('createQuickStartService', () => {
     )
   })
 
+  it('reuses an existing project instead of creating another one', async () => {
+    const existingProject = {
+      id: 'project-existing',
+      workflowId: null,
+      name: '星海计划',
+      perspective: 'side' as const,
+      directionalMovement: 'four-way' as const,
+      spriteSize: { width: 128, height: 192 },
+      gameStyle: 'pixel' as const,
+      sampleImageUrl: null,
+      createdAt: '2026-08-25T00:00:00Z',
+      updatedAt: '2026-08-25T00:00:00Z',
+    }
+    const create = vi.fn()
+    const get = vi.fn(async () => existingProject)
+    const prepare = createAutoPrepareProject({ create, get } as unknown as ProjectApis)
+
+    await expect(prepare('银发骑士', 'single', { projectId: existingProject.id })).resolves.toEqual(
+      {
+        id: existingProject.id,
+        directionalMovement: 'four-way',
+        spriteSize: { width: 128, height: 192 },
+      },
+    )
+    expect(get).toHaveBeenCalledWith(existingProject.id)
+    expect(create).not.toHaveBeenCalled()
+  })
+
   it('uses a readable number when the generated project name already exists', async () => {
     const create = vi
       .fn()


### PR DESCRIPTION
Quick Start 现在支持自动创建、手动新建与选择已有项目三种项目上下文；默认自动创建，手动新建完成后会返回 Quick Start 并选中新项目。

## Why

Quick Start 原先只能自动创建项目，已有项目和手动新建项目都无法形成完整的角色创建入口。底层已有按 projectId 创建新 WorkflowRun 的能力，本次补齐入口、回流与参数传递。

## Changes

- 项目菜单显示最近 3 个项目，并提供“新建项目”和“自动创建”。
- 默认保持“自动创建”；选择已有项目后继承项目画风与方向约束。
- 手动新建项目调用现有真实创建页，成功后返回 Quick Start 并自动选中新项目。
- 将可选 projectId 传入 Agent、上传母版和 WorkflowController；草稿仅持久化 projectId。

## Implementation

- 复用 ProjectApis.list/get/create 与现有 `/projects/new`，不新增后端字段或 API。
- createAutoPrepareProject 在传入 projectId 时读取已有项目并跳过 create；未传入时保持原自动创建路径。
- 新建角色仍创建新的 WorkflowRun，由现有 Character.workflowRunId 绑定关系完成落库。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx src/pages/quick-start/service.test.ts src/pages/project-create/index.test.tsx`：173 passed
- [x] `npm run typecheck`：通过
- [x] `npm run format:check`：通过（前序提交）
- [x] `npm run lint -- src/pages/quick-start src/features/workflow-controller src/features/quick-start-agent`：通过（前序提交）
- [x] `npm run build`：通过（前序提交）

## Screenshots

### Desktop

右侧本地预览用于视觉确认，预览注入文件未提交仓库。

## Scope

- 本 PR 不包含：项目搜索、新建后端字段或新 API。
- 项目菜单固定读取最近 3 个项目。

## Related Issues

Closes #715