### PR TITLE
fix: 修正四向八向九宫格与角色朝向

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -112,6 +112,20 @@ class ProjectConstraints:
     sprite_sample_url: str = ""  # 项目风格参考图 URL
 
 
+def _image_view_prompt(cons: ProjectConstraints) -> str:
+    """避免多方向角色被项目默认侧视角锁成同一朝向。"""
+
+    if cons.directions <= 1:
+        return f"{cons.view}, full body head to feet, centered."
+    projection = "" if cons.perspective == 1 else f"{cons.view}. "
+    return (
+        f"{projection}Use one fixed game-sprite camera and projection for the whole direction set. "
+        "Rotate the character, not the camera, to the requested compass direction. "
+        "Keep body proportions, pose, scale, framing, and ground contact identical. "
+        "Full body head to feet, centered."
+    )
+
+
 def _load_constraints(session: Session, project_id: int | None) -> ProjectConstraints:
     """查 Project 组装全局约束;无 project_id / 查不到 → 缺省。"""
     if project_id is None:
@@ -864,7 +878,7 @@ class ImageTaskExecutor:
         )
         parts = [
             base,
-            f"{cons.view}, full body head to feet, centered.",
+            _image_view_prompt(cons),
             direction_prompt(input.direction),
         ]
         if cons.style:

--- a/backend/packages/common/src/windup_common/directions.py
+++ b/backend/packages/common/src/windup_common/directions.py
@@ -25,6 +25,7 @@ _REQUIRED_DIRECTIONS: dict[int, tuple[ActionDirection, ...]] = {
     3: tuple(ActionDirection),
 }
 
+
 def required_directions_for_movement(movement: int) -> tuple[ActionDirection, ...]:
     """返回项目必须真实生成的方向；未知项目配置按单向兼容。"""
 
@@ -38,14 +39,14 @@ def is_required_direction(movement: int, direction: ActionDirection) -> bool:
 
 
 _DIRECTION_PROMPTS: dict[ActionDirection, str] = {
-    ActionDirection.EAST: "The character faces and moves to the right, in the east direction.",
-    ActionDirection.WEST: "The character faces and moves to the left, in the west direction.",
-    ActionDirection.NORTH: "The character faces away from the viewer, toward the north direction.",
-    ActionDirection.SOUTH: "The character faces toward the viewer, toward the south direction.",
-    ActionDirection.NORTH_EAST: "The character faces diagonally away from the viewer and to the right, toward north-east.",
-    ActionDirection.NORTH_WEST: "The character faces diagonally away from the viewer and to the left, toward north-west.",
-    ActionDirection.SOUTH_EAST: "The character faces diagonally toward the viewer and to the right, toward south-east.",
-    ActionDirection.SOUTH_WEST: "The character faces diagonally toward the viewer and to the left, toward south-west.",
+    ActionDirection.EAST: "Show a strict right-facing side profile toward east.",
+    ActionDirection.WEST: "Show a strict left-facing side profile toward west.",
+    ActionDirection.NORTH: "Show a full back view facing away from the viewer toward north.",
+    ActionDirection.SOUTH: "Show a full front view facing the viewer toward south.",
+    ActionDirection.NORTH_EAST: "Show a back-right three-quarter view toward north-east.",
+    ActionDirection.NORTH_WEST: "Show a back-left three-quarter view toward north-west.",
+    ActionDirection.SOUTH_EAST: "Show a front-right three-quarter view toward south-east.",
+    ActionDirection.SOUTH_WEST: "Show a front-left three-quarter view toward south-west.",
 }
 
 

--- a/backend/packages/common/src/windup_common/directions.py
+++ b/backend/packages/common/src/windup_common/directions.py
@@ -39,14 +39,14 @@ def is_required_direction(movement: int, direction: ActionDirection) -> bool:
 
 
 _DIRECTION_PROMPTS: dict[ActionDirection, str] = {
-    ActionDirection.EAST: "Show a strict right-facing side profile toward east.",
-    ActionDirection.WEST: "Show a strict left-facing side profile toward west.",
-    ActionDirection.NORTH: "Show a full back view facing away from the viewer toward north.",
-    ActionDirection.SOUTH: "Show a full front view facing the viewer toward south.",
-    ActionDirection.NORTH_EAST: "Show a back-right three-quarter view toward north-east.",
-    ActionDirection.NORTH_WEST: "Show a back-left three-quarter view toward north-west.",
-    ActionDirection.SOUTH_EAST: "Show a front-right three-quarter view toward south-east.",
-    ActionDirection.SOUTH_WEST: "Show a front-left three-quarter view toward south-west.",
+    ActionDirection.EAST: "The character's screen-space heading points to the right edge of the frame (east).",
+    ActionDirection.WEST: "The character's screen-space heading points to the left edge of the frame (west).",
+    ActionDirection.NORTH: "The character's screen-space heading points to the top edge of the frame (north).",
+    ActionDirection.SOUTH: "The character's screen-space heading points to the bottom edge of the frame (south).",
+    ActionDirection.NORTH_EAST: "The character's screen-space heading points to the upper-right corner of the frame (north-east).",
+    ActionDirection.NORTH_WEST: "The character's screen-space heading points to the upper-left corner of the frame (north-west).",
+    ActionDirection.SOUTH_EAST: "The character's screen-space heading points to the lower-right corner of the frame (south-east).",
+    ActionDirection.SOUTH_WEST: "The character's screen-space heading points to the lower-left corner of the frame (south-west).",
 }
 
 
@@ -54,5 +54,8 @@ def direction_prompt(direction: ActionDirection) -> str:
     """返回给图片/视频模型的强方向锁，避免模型自行转身。"""
 
     return (
-        f"{_DIRECTION_PROMPTS[direction]} Keep this direction unchanged; do not turn."
+        f"{_DIRECTION_PROMPTS[direction]} Keep the camera position, angle, and "
+        "projection unchanged. Throughout every frame, the character remains oriented "
+        "to this screen-space heading. The body, head, torso, hips, and feet maintain "
+        "this heading. Do not turn or drift toward another direction."
     )

--- a/backend/tests/test_directional_generation.py
+++ b/backend/tests/test_directional_generation.py
@@ -46,4 +46,7 @@ def test_every_action_direction_has_an_independent_provider_prompt_lock():
     assert len(set(prompts.values())) == len(ActionDirection)
     for direction, prompt in prompts.items():
         assert direction.value.replace("_", "-") in prompt.lower()
+        assert "throughout every frame" in prompt.lower()
+        assert "maintain this heading" in prompt.lower()
+        assert "rotate" not in prompt.lower()
         assert "do not turn" in prompt.lower()

--- a/backend/tests/test_master_cutout.py
+++ b/backend/tests/test_master_cutout.py
@@ -21,6 +21,7 @@ from sqlalchemy.pool import StaticPool
 from windup_app.server.orchestrator.executor import ImageTaskExecutor, ProjectConstraints
 from windup_app.server.orchestrator.model import CharacterImageInput, TaskStatus
 from windup_app.server.orchestrator.service import AiGenerationService
+from windup_common.directions import ActionDirection
 from windup_framework.db.base import Base
 from windup_framework.mq.model import MqMessage  # noqa: F401 — register metadata
 
@@ -198,6 +199,106 @@ def test_confirmed_master_is_sent_as_identity_reference_without_style_sample():
 
     assert seen["refs"] == [master]
     assert "preserve its identity" in str(seen["prompt"])
+
+
+@pytest.mark.parametrize(
+    ("direction", "orientation"),
+    [
+        (ActionDirection.EAST, "strict right-facing side profile"),
+        (ActionDirection.WEST, "strict left-facing side profile"),
+        (ActionDirection.NORTH, "full back view"),
+        (ActionDirection.SOUTH, "full front view"),
+        (ActionDirection.NORTH_EAST, "back-right three-quarter view"),
+        (ActionDirection.NORTH_WEST, "back-left three-quarter view"),
+        (ActionDirection.SOUTH_EAST, "front-right three-quarter view"),
+        (ActionDirection.SOUTH_WEST, "front-left three-quarter view"),
+    ],
+)
+def test_multidirectional_master_prompt_rotates_character_without_side_view_conflict(
+    direction,
+    orientation,
+):
+    master = _master()
+    seen: dict[str, str] = {}
+
+    class _RecordingGen:
+        def gen_image(self, prompt, refs):
+            del refs
+            seen["prompt"] = prompt
+            return master
+
+    executor = ImageTaskExecutor(
+        image=_RecordingGen(),
+        matte=_BackgroundMatte(),
+        upload=lambda _png: "https://cdn.example.com/result.png",
+    )
+
+    executor._produce_image(
+        CharacterImageInput(
+            prompt="像素风勇者",
+            width=64,
+            height=64,
+            num_images=1,
+            direction=direction,
+        ),
+        ProjectConstraints(
+            directions=8,
+            view="side view, horizontal side-scroller",
+            sprite_w=64,
+            sprite_h=64,
+        ),
+    )
+
+    prompt = seen["prompt"].lower()
+    assert "side view, horizontal side-scroller" not in prompt
+    assert "rotate the character, not the camera" in prompt
+    assert orientation in prompt
+
+
+@pytest.mark.parametrize(
+    ("perspective", "view"),
+    [
+        (2, "top-down view"),
+        (3, "2.5D three-quarter view"),
+    ],
+)
+def test_multidirectional_master_prompt_preserves_non_side_projection(
+    perspective,
+    view,
+):
+    master = _master()
+    seen: dict[str, str] = {}
+
+    class _RecordingGen:
+        def gen_image(self, prompt, refs):
+            del refs
+            seen["prompt"] = prompt
+            return master
+
+    ImageTaskExecutor(
+        image=_RecordingGen(),
+        matte=_BackgroundMatte(),
+        upload=lambda _png: "https://cdn.example.com/result.png",
+    )._produce_image(
+        CharacterImageInput(
+            prompt="像素风勇者",
+            width=64,
+            height=64,
+            num_images=1,
+            direction=ActionDirection.NORTH,
+        ),
+        ProjectConstraints(
+            directions=8,
+            perspective=perspective,
+            view=view,
+            sprite_w=64,
+            sprite_h=64,
+        ),
+    )
+
+    prompt = seen["prompt"]
+    assert view in prompt
+    assert "Rotate the character, not the camera" in prompt
 
 
 def test_cutout_failure_fails_the_task_instead_of_delivering_gray():

--- a/backend/tests/test_master_cutout.py
+++ b/backend/tests/test_master_cutout.py
@@ -202,21 +202,21 @@ def test_confirmed_master_is_sent_as_identity_reference_without_style_sample():
 
 
 @pytest.mark.parametrize(
-    ("direction", "orientation"),
+    ("direction", "heading"),
     [
-        (ActionDirection.EAST, "strict right-facing side profile"),
-        (ActionDirection.WEST, "strict left-facing side profile"),
-        (ActionDirection.NORTH, "full back view"),
-        (ActionDirection.SOUTH, "full front view"),
-        (ActionDirection.NORTH_EAST, "back-right three-quarter view"),
-        (ActionDirection.NORTH_WEST, "back-left three-quarter view"),
-        (ActionDirection.SOUTH_EAST, "front-right three-quarter view"),
-        (ActionDirection.SOUTH_WEST, "front-left three-quarter view"),
+        (ActionDirection.EAST, "right edge of the frame"),
+        (ActionDirection.WEST, "left edge of the frame"),
+        (ActionDirection.NORTH, "top edge of the frame"),
+        (ActionDirection.SOUTH, "bottom edge of the frame"),
+        (ActionDirection.NORTH_EAST, "upper-right corner of the frame"),
+        (ActionDirection.NORTH_WEST, "upper-left corner of the frame"),
+        (ActionDirection.SOUTH_EAST, "lower-right corner of the frame"),
+        (ActionDirection.SOUTH_WEST, "lower-left corner of the frame"),
     ],
 )
-def test_multidirectional_master_prompt_rotates_character_without_side_view_conflict(
+def test_multidirectional_master_prompt_uses_projection_neutral_screen_heading(
     direction,
-    orientation,
+    heading,
 ):
     master = _master()
     seen: dict[str, str] = {}
@@ -252,7 +252,16 @@ def test_multidirectional_master_prompt_rotates_character_without_side_view_conf
     prompt = seen["prompt"].lower()
     assert "side view, horizontal side-scroller" not in prompt
     assert "rotate the character, not the camera" in prompt
-    assert orientation in prompt
+    assert heading in prompt
+    assert not any(
+        camera_view in prompt
+        for camera_view in (
+            "side profile",
+            "front view",
+            "back view",
+            "three-quarter view",
+        )
+    )
 
 
 @pytest.mark.parametrize(

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1719,7 +1719,7 @@ describe('QuickStartPage', () => {
     expect(choices.every((choice) => !choice.className.includes('row-span-2'))).toBe(true)
   })
 
-  it('母版确认后把四向首帧堆叠在一个大方框内且不再逐方向选择', async () => {
+  it('母版确认后把四向首帧放入中心留空的九宫格且不再逐方向选择', async () => {
     const run = workflow(
       setupAndTemplate({
         selectedImageUrl: 'east.png',
@@ -1750,7 +1750,14 @@ describe('QuickStartPage', () => {
     )
 
     const directionSet = await screen.findByRole('group', { name: '四向首帧集合' })
-    expect(directionSet.getAttribute('data-layout')).toBe('direction-first-frame-stack')
+    expect(directionSet.getAttribute('data-layout')).toBe('direction-first-frame-grid')
+    expect(directionSet.className).toContain('grid-cols-3')
+    expect(directionSet.children).toHaveLength(9)
+    expect(screen.getByLabelText('中心留空')).toBeTruthy()
+    expect(screen.getByLabelText('西北方向为空')).toBeTruthy()
+    expect(screen.getByLabelText('东北方向为空')).toBeTruthy()
+    expect(screen.getByLabelText('西南方向为空')).toBeTruthy()
+    expect(screen.getByLabelText('东南方向为空')).toBeTruthy()
     await waitFor(() => expect(directionSet.querySelectorAll('img')).toHaveLength(4))
     expect(screen.getByRole('img', { name: '东方向首帧' })).toBeTruthy()
     expect(screen.getByRole('img', { name: '西方向首帧' })).toBeTruthy()
@@ -1948,7 +1955,11 @@ describe('QuickStartPage', () => {
     for (const [, label] of directions) {
       expect(await screen.findByRole('img', { name: `${label}方向首帧` })).toBeTruthy()
     }
-    expect(screen.getByRole('group', { name: '八向首帧集合' })).toBeTruthy()
+    const directionSet = screen.getByRole('group', { name: '八向首帧集合' })
+    expect(directionSet.getAttribute('data-layout')).toBe('direction-first-frame-grid')
+    expect(directionSet.className).toContain('grid-cols-3')
+    expect(directionSet.children).toHaveLength(9)
+    expect(screen.getByLabelText('中心留空')).toBeTruthy()
   })
 
   it('keeps the natural-language creation entry visible when no run is selected', () => {

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1719,6 +1719,37 @@ describe('QuickStartPage', () => {
     expect(choices.every((choice) => !choice.className.includes('row-span-2'))).toBe(true)
   })
 
+  it('单向母版使用单格大预览，不渲染九宫格空位', async () => {
+    const run = workflow(
+      setupAndTemplate({
+        selectedImageUrl: 'east.png',
+        selectedImages: { east: 'east.png' },
+        status: 'active',
+        phase: 'selecting',
+        generations: [{ taskId: 'template-east', role: 'character_template' }],
+      }),
+    )
+    renderAt(
+      '/quick-start/run-1',
+      serviceFor(run, {
+        getTemplateCandidates: vi.fn(
+          async () =>
+            [
+              { direction: 'east', index: 0, imageUrl: 'east.png' },
+            ] satisfies readonly QuickStartCandidate[],
+        ),
+      }),
+    )
+
+    const directionSet = await screen.findByRole('group', { name: '单向首帧集合' })
+    expect(directionSet.getAttribute('data-layout')).toBe('direction-first-frame-single')
+    expect(directionSet.className).toContain('grid-cols-1')
+    expect(directionSet.children).toHaveLength(1)
+    expect(screen.getByRole('img', { name: '东方向首帧' })).toBeTruthy()
+    expect(screen.queryByLabelText('中心留空')).toBeNull()
+    expect(screen.queryByLabelText('西方向为空')).toBeNull()
+  })
+
   it('母版确认后把四向首帧放入中心留空的九宫格且不再逐方向选择', async () => {
     const run = workflow(
       setupAndTemplate({

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1824,15 +1824,21 @@ function DirectionFirstFrameGrid({
 }) {
   const directionCountLabel =
     directions.length === 8 ? '八向' : directions.length === 4 ? '四向' : '单向'
+  const isSingleDirection = directions.length === 1
+  const layoutDirections = isSingleDirection ? directions : DIRECTION_SHEET_LAYOUT
   const expectedDirections = new Set(directions)
   return (
     <div
       role="group"
       aria-label={`${directionCountLabel}首帧集合`}
-      data-layout="direction-first-frame-grid"
-      className="grid aspect-square w-full max-w-xl grid-cols-3 gap-2 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-muted p-4 shadow-app-card sm:p-5"
+      data-layout={
+        isSingleDirection ? 'direction-first-frame-single' : 'direction-first-frame-grid'
+      }
+      className={`grid aspect-square w-full max-w-xl gap-2 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-muted p-4 shadow-app-card sm:p-5 ${
+        isSingleDirection ? 'grid-cols-1' : 'grid-cols-3'
+      }`}
     >
-      {DIRECTION_SHEET_LAYOUT.map((direction, cellIndex) => {
+      {layoutDirections.map((direction, cellIndex) => {
         if (!direction) {
           return (
             <div

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1803,7 +1803,19 @@ function DirectionCandidatePicker({
   )
 }
 
-function DirectionFirstFrameStack({
+const DIRECTION_SHEET_LAYOUT: readonly (ActionDirection | null)[] = [
+  'north_west',
+  'north',
+  'north_east',
+  'west',
+  null,
+  'east',
+  'south_west',
+  'south',
+  'south_east',
+]
+
+function DirectionFirstFrameGrid({
   directions,
   selections,
 }: {
@@ -1812,14 +1824,33 @@ function DirectionFirstFrameStack({
 }) {
   const directionCountLabel =
     directions.length === 8 ? '八向' : directions.length === 4 ? '四向' : '单向'
+  const expectedDirections = new Set(directions)
   return (
     <div
       role="group"
       aria-label={`${directionCountLabel}首帧集合`}
-      data-layout="direction-first-frame-stack"
-      className="grid aspect-square w-full max-w-xl grid-cols-2 gap-3 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-muted p-4 shadow-app-card sm:p-5"
+      data-layout="direction-first-frame-grid"
+      className="grid aspect-square w-full max-w-xl grid-cols-3 gap-2 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-muted p-4 shadow-app-card sm:p-5"
     >
-      {directions.map((direction) => {
+      {DIRECTION_SHEET_LAYOUT.map((direction, cellIndex) => {
+        if (!direction) {
+          return (
+            <div
+              key={`center-${cellIndex}`}
+              aria-label="中心留空"
+              className="rounded-xl border border-dashed border-app-line/40 bg-app-canvas/20"
+            />
+          )
+        }
+        if (!expectedDirections.has(direction)) {
+          return (
+            <div
+              key={direction}
+              aria-label={`${DIRECTION_LABELS[direction]}方向为空`}
+              className="rounded-xl border border-dashed border-app-line/30 bg-app-canvas/20"
+            />
+          )
+        }
         const imageUrl = selections[direction]
         return imageUrl ? (
           <figure
@@ -1849,18 +1880,6 @@ function DirectionFirstFrameStack({
     </div>
   )
 }
-
-const DIRECTION_SHEET_LAYOUT: readonly (ActionDirection | null)[] = [
-  'north_west',
-  'north',
-  'north_east',
-  'west',
-  null,
-  'east',
-  'south_west',
-  'south',
-  'south_east',
-]
 
 function DirectionSheetCandidatePicker({
   sheets,
@@ -2874,7 +2893,7 @@ function QuickStartRun({
                         : '全部方向会保持同一个角色造型。',
                     ]}
                   />
-                  <DirectionFirstFrameStack
+                  <DirectionFirstFrameGrid
                     directions={templateDirections}
                     selections={templateSelections}
                   />


### PR DESCRIPTION
## 改动说明

- 将 Quick Start 四向/八向首帧集合统一为固定 3×3 九宫格，中心始终留空。
- 四向只填东、西、南、北，斜向格留空；八向填满中心外八格。
- 横版多方向图片生成不再叠加统一 `side view`，避免正面、背面及斜向被锁成同一侧身。
- 保留俯视与 2.5D 项目的摄像机投影，只旋转角色，不旋转摄像机。
- 强化八个方向的正面、背面、左右侧面及四个斜向描述。

## 验证

- 前端相关测试：165 个通过。
- TypeScript 类型检查：通过。
- 后端相关测试：27 个通过。
- Ruff：通过。
- `git diff --check`：通过。

Closes #719
Refs #222