### PR TITLE
feat(project): add automatic title extraction

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/impl/__init__.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/impl/__init__.py
@@ -2,5 +2,6 @@
 
 from .character_generator import CharacterGenerator
 from .character_namer import LangChainCharacterNamer
+from .project_namer import LangChainProjectNamer
 
-__all__ = ["CharacterGenerator", "LangChainCharacterNamer"]
+__all__ = ["CharacterGenerator", "LangChainCharacterNamer", "LangChainProjectNamer"]

--- a/backend/packages/ai_engine/src/windup_ai_engine/impl/project_namer.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/impl/project_namer.py
@@ -1,0 +1,46 @@
+"""用 LangChain Chat 模型从创作描述中提取项目标题。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from windup_framework.providers import create_chat_model
+
+NAME_MAX_LEN = 20
+
+_SYSTEM_PROMPT = (
+    "你根据角色创作描述拟一个适合项目列表展示的项目标题。"
+    "标题要概括作品主题或资产集合，不要照抄完整外观描述，也不要只把具体人物名字当标题。"
+    "只输出标题本身，不要引号、标点或解释。"
+    f"标题不超过 {NAME_MAX_LEN} 个字，优先中文。"
+)
+
+
+def _clean_name(raw: str) -> str:
+    return raw.strip().strip("\"'“”‘’").strip()[:NAME_MAX_LEN]
+
+
+class LangChainProjectNamer:
+    """项目起名器的 LangChain 实现；与角色命名共享模型接入，不共享 Prompt。"""
+
+    def __init__(self, chat_model: Any | None = None) -> None:
+        self._model = chat_model
+
+    def _chat_model(self) -> Any:
+        if self._model is None:
+            self._model = create_chat_model()
+        return self._model
+
+    def name_from_description(self, description: str) -> str:
+        result = self._chat_model().invoke(
+            [
+                SystemMessage(content=_SYSTEM_PROMPT),
+                HumanMessage(content=description),
+            ]
+        )
+        content = getattr(result, "content", result)
+        if not isinstance(content, str):
+            content = str(content or "")
+        return _clean_name(content)

--- a/backend/packages/app/src/windup_app/bootstrap/app.py
+++ b/backend/packages/app/src/windup_app/bootstrap/app.py
@@ -18,9 +18,11 @@ from windup_framework.gateway.models import AIGatewayAttempt, AIGatewayAttemptDe
 
 # 模型导入：触发 Base.metadata 注册，确保 create_all 能发现所有表
 from windup_ai_engine.impl.character_namer import LangChainCharacterNamer
+from windup_ai_engine.impl.project_namer import LangChainProjectNamer
 from windup_app.server.character.model import Character  # noqa: F401
 from windup_app.server.character.service import service as character_service
 from windup_app.server.project.model import Project  # noqa: F401
+from windup_app.server.project.service import service as project_service
 from windup_app.server.quota.model import CreditAccount, CreditTransaction, InviteCode, InviteRecord  # noqa: F401
 from windup_app.server.user.model import User  # noqa: F401
 from windup_app.server.workflow_run.model import WorkflowRun  # noqa: F401
@@ -125,6 +127,8 @@ def create_app() -> FastAPI:
     # 测试若已注入假 namer，不要覆盖。
     if character_service._namer is None:
         character_service._namer = LangChainCharacterNamer()
+    if project_service._namer is None:
+        project_service._namer = LangChainProjectNamer()
 
     @app.get("/health", include_in_schema=False)
     def health() -> dict[str, str]:

--- a/backend/packages/app/src/windup_app/server/project/naming.py
+++ b/backend/packages/app/src/windup_app/server/project/naming.py
@@ -1,0 +1,54 @@
+"""创建项目时解析最终名称：用户输入优先，否则 LLM，再否则描述兜底。"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+NAME_MAX_LEN = 20
+FALLBACK_NAME = "未命名项目"
+
+
+class ProjectNamer(Protocol):
+    """server 侧项目起名器契约，避免 web 层依赖 ai_engine。"""
+
+    def name_from_description(self, description: str) -> str: ...
+
+
+def _clip(value: str) -> str:
+    return value[:NAME_MAX_LEN]
+
+
+def resolve_project_name(
+    name: str | None,
+    description: str | None,
+    namer: ProjectNamer | None = None,
+) -> str:
+    """把可空的项目名和命名上下文收成入库用的非空短标题。"""
+    cleaned_name = (name or "").strip()
+    if cleaned_name:
+        return _clip(cleaned_name)
+
+    cleaned_description = (description or "").strip()
+    if cleaned_description and namer is not None:
+        try:
+            generated = (namer.name_from_description(cleaned_description) or "").strip()
+        except Exception:
+            generated = ""
+        if generated:
+            return _clip(generated)
+
+    if cleaned_description:
+        return _clip(cleaned_description)
+    return FALLBACK_NAME
+
+
+def numbered_project_name(base_name: str, sequence: int) -> str:
+    """为重名自动标题追加可读编号，同时守住数据库 20 字上限。"""
+    if sequence <= 1:
+        return _clip(base_name)
+    suffix = f" {sequence}"
+    max_base_length = NAME_MAX_LEN - len(suffix)
+    characters = list(base_name)
+    if len(characters) > max_base_length:
+        characters = characters[: max_base_length - 1] + ["…"]
+    return f"{''.join(characters)}{suffix}"

--- a/backend/packages/app/src/windup_app/server/project/service.py
+++ b/backend/packages/app/src/windup_app/server/project/service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from windup_app.server.project.interface import UNSET, ProjectService, UnsetType
 from windup_app.server.project.model import Project
+from windup_app.server.project.naming import ProjectNamer
 from windup_app.server.character.model import Character
 
 
@@ -38,6 +39,9 @@ def _character_preview(
 
 class SqlAlchemyProjectService(ProjectService):
     """基于 SQLAlchemy session 的项目 CRUD 实现。"""
+
+    def __init__(self, namer: ProjectNamer | None = None) -> None:
+        self._namer = namer
 
     def create_project(self, session: Session, **fields) -> Project:
         project = Project(**fields)

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -18,6 +18,7 @@ from windup_app.server.character.cleanup import extract_object_keys
 from windup_app.server.character.service import service as character_service
 from windup_app.server.media.service import service as media_service
 from windup_app.server.project.interface import UNSET
+from windup_app.server.project.naming import numbered_project_name, resolve_project_name
 from windup_app.server.project.service import service
 
 logger = logging.getLogger("windup.project.api")
@@ -55,7 +56,8 @@ class ProjectCreate(BaseModel):
     """创建项目请求。"""
 
     workflow_id: int | None = None
-    project_name: str = Field(min_length=1, max_length=20)
+    project_name: str | None = Field(default=None, min_length=1, max_length=20)
+    name_context: str | None = None
     character_perspective: int = Field(ge=1, le=3)
     directional_movement: int = Field(ge=1, le=3)
     sprite_width: int = Field(ge=32, le=2048)
@@ -135,28 +137,39 @@ def create_project(
     session: Session = Depends(get_session),
 ) -> Response[ProjectOut]:
     user_id = request.state.current_user.id
-    if service.project_name_exists(
-        session, user_id=user_id, project_name=body.project_name
-    ):
-        logger.warning(
-            "[WINDUP] 创建拒绝-名称重复 | user_id=%s project_name=%s",
-            user_id,
-            body.project_name,
-        )
-        raise BizException("项目名称已存在", code=BizCode.BAD_REQUEST)
-    try:
-        fields = body.model_dump()
-        fields["game_style"] = _stored_style(body.game_style)
-        project = service.create_project(session, user_id=user_id, **fields)
-    except IntegrityError:
-        logger.warning(
-            "[WINDUP] 创建拒绝-并发冲突 | user_id=%s project_name=%s",
-            user_id,
-            body.project_name,
-        )
-        session.rollback()
-        raise BizException("项目名称已存在", code=BizCode.BAD_REQUEST) from None
-    return Response.success(ProjectOut.model_validate(project), message="创建成功")
+    automatic_name = not (body.project_name or "").strip()
+    base_name = resolve_project_name(body.project_name, body.name_context, service._namer)
+    fields = body.model_dump(exclude={"project_name", "name_context"})
+    fields["game_style"] = _stored_style(body.game_style)
+
+    for sequence in range(1, 101 if automatic_name else 2):
+        project_name = numbered_project_name(base_name, sequence)
+        if service.project_name_exists(
+            session, user_id=user_id, project_name=project_name
+        ):
+            if automatic_name:
+                continue
+            logger.warning(
+                "[WINDUP] 创建拒绝-名称重复 | user_id=%s project_name=%s",
+                user_id,
+                project_name,
+            )
+            raise BizException("项目名称已存在", code=BizCode.BAD_REQUEST)
+        try:
+            project = service.create_project(
+                session, user_id=user_id, project_name=project_name, **fields
+            )
+            return Response.success(ProjectOut.model_validate(project), message="创建成功")
+        except IntegrityError:
+            logger.warning(
+                "[WINDUP] 创建并发重名 | user_id=%s project_name=%s",
+                user_id,
+                project_name,
+            )
+            session.rollback()
+            if not automatic_name:
+                break
+    raise BizException("项目名称已存在", code=BizCode.BAD_REQUEST)
 
 
 @router.get("", response_model=ListResponse[ProjectListOut])

--- a/backend/tests/test_project_api.py
+++ b/backend/tests/test_project_api.py
@@ -7,10 +7,35 @@
 
 from types import SimpleNamespace
 
+import pytest
 from sqlalchemy import event
 
 from windup_app.server.character import cleanup as character_cleanup
 from windup_app.web.api import project as project_api
+
+
+class _FakeProjectNamer:
+    def __init__(self, result="雾港计划", error=None):
+        self.result = result
+        self.error = error
+        self.calls = []
+
+    def name_from_description(self, description):
+        self.calls.append(description)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+@pytest.fixture(autouse=True)
+def _inject_fake_project_namer():
+    project_service = project_api.service
+    original = getattr(project_service, "_namer", None)
+    project_service._namer = _FakeProjectNamer()
+    try:
+        yield
+    finally:
+        project_service._namer = original
 
 
 def _payload(**overrides):
@@ -41,6 +66,64 @@ def test_create_success(auth_client):
     assert body["data"]["project_name"] == "新建"
     assert body["data"]["create_at"]
     assert "timestamp" not in body
+
+
+def test_create_without_name_extracts_project_title(auth_client):
+    description = "一位提着风灯、披深色斗篷的像素守夜人"
+
+    resp = auth_client.post(
+        "/projects",
+        json=_payload(project_name=None, name_context=description),
+    )
+
+    assert resp.json()["code"] == 200
+    assert resp.json()["data"]["project_name"] == "雾港计划"
+    assert project_api.service._namer.calls == [description]
+
+
+def test_create_with_explicit_name_skips_project_namer(auth_client):
+    resp = auth_client.post(
+        "/projects",
+        json=_payload(project_name="用户项目", name_context="角色描述"),
+    )
+
+    assert resp.json()["data"]["project_name"] == "用户项目"
+    assert project_api.service._namer.calls == []
+
+
+def test_create_automatic_duplicate_uses_readable_sequence(auth_client):
+    project_api.service._namer = _FakeProjectNamer(result="雾" * 20)
+    payload = _payload(project_name=None, name_context="同一份角色描述")
+
+    first = auth_client.post("/projects", json=payload).json()
+    second = auth_client.post("/projects", json=payload).json()
+
+    assert first["data"]["project_name"] == "雾" * 20
+    assert second["data"]["project_name"] == f"{'雾' * 17}… 2"
+    assert len(second["data"]["project_name"]) == 20
+
+
+def test_create_namer_failure_falls_back_to_description(auth_client):
+    project_api.service._namer = _FakeProjectNamer(error=RuntimeError("timeout"))
+    description = "这是一段超过二十个字的角色描述用来作为项目名称兜底"
+
+    resp = auth_client.post(
+        "/projects",
+        json=_payload(project_name=None, name_context=description),
+    )
+
+    assert resp.json()["code"] == 200
+    assert resp.json()["data"]["project_name"] == description[:20]
+
+
+def test_create_without_name_or_context_uses_unnamed_fallback(auth_client):
+    resp = auth_client.post(
+        "/projects",
+        json=_payload(project_name=None, name_context=None),
+    )
+
+    assert resp.json()["code"] == 200
+    assert resp.json()["data"]["project_name"] == "未命名项目"
 
 
 def test_create_duplicate_name_returns_400(auth_client):

--- a/backend/tests/test_project_namer.py
+++ b/backend/tests/test_project_namer.py
@@ -1,0 +1,30 @@
+"""LangChain 项目起名器：项目标题与角色称呼使用不同提示词。"""
+
+from types import SimpleNamespace
+
+from windup_ai_engine.impl.project_namer import LangChainProjectNamer
+
+
+class _FakeChat:
+    def __init__(self, content):
+        self.content = content
+        self.messages = None
+
+    def invoke(self, messages):
+        self.messages = messages
+        return SimpleNamespace(content=self.content)
+
+
+def test_project_namer_requests_a_project_title_and_cleans_model_text():
+    chat = _FakeChat('  "雾港守夜计划"  ')
+    namer = LangChainProjectNamer(chat_model=chat)
+
+    assert namer.name_from_description("一位提着风灯的像素守夜人") == "雾港守夜计划"
+    assert "项目" in chat.messages[0].content
+    assert "角色称呼" not in chat.messages[0].content
+
+
+def test_project_namer_truncates_to_20_chars():
+    namer = LangChainProjectNamer(chat_model=_FakeChat("风" * 25))
+
+    assert namer.name_from_description("一段描述") == "风" * 20

--- a/frontend/src/entities/project/index.test.ts
+++ b/frontend/src/entities/project/index.test.ts
@@ -105,6 +105,27 @@ describe('projectApis', () => {
     })
   })
 
+  it('serializes project naming context without fabricating a project name', async () => {
+    let request: Request | undefined
+    const { projectApis } = await loadProjectApis(async (input, init) => {
+      request = new Request(input, init)
+      return jsonResponse({ ...projectDto, project_name: '雾港计划' })
+    })
+
+    await projectApis.create({
+      nameContext: '一位提着风灯、披深色斗篷的像素守夜人',
+      perspective: 'side',
+      directionalMovement: 'single',
+      spriteSize: { width: 256, height: 256 },
+    })
+
+    const body = await request?.json()
+    expect(body).toMatchObject({
+      name_context: '一位提着风灯、披深色斗篷的像素守夜人',
+    })
+    expect(body).not.toHaveProperty('project_name')
+  })
+
   it('requests one Project by its backend resource path', async () => {
     let requestUrl = ''
     const { projectApis } = await loadProjectApis(async (input) => {

--- a/frontend/src/entities/project/index.ts
+++ b/frontend/src/entities/project/index.ts
@@ -23,7 +23,9 @@ export interface Project {
  */
 export interface CreateProjectInput {
   workflowId?: string | null
-  name: string
+  /** 手动创建时显式提供；Quick Start 改由后端从 nameContext 提取项目标题。 */
+  name?: string
+  nameContext?: string
   perspective: CharacterPerspective
   directionalMovement: DirectionalMovement
   spriteSize: { width: number; height: number }
@@ -233,6 +235,7 @@ export const projectApis: ProjectApis = {
                 ? null
                 : toBackendId(input.workflowId, 'workflowId'),
           project_name: input.name,
+          name_context: input.nameContext,
           character_perspective: perspectiveToDto[input.perspective],
           directional_movement: movementToDto[input.directionalMovement],
           sprite_width: input.spriteSize.width,

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -33,12 +33,8 @@ import {
   type ArtStyle,
   getDirectionProfile,
   isImageCandidateCount,
-  ProjectNameConflictError,
   WorkflowRunConflictError,
 } from '@/entities'
-
-const PROJECT_NAME_MAX_LENGTH = 20
-const QUICK_START_PROJECT_NAME_ATTEMPTS = 100
 
 export interface AddActionInput {
   /** 首帧节点 ID；完整动画和审核节点在此 ID 后追加稳定后缀。 */
@@ -252,45 +248,22 @@ interface PendingGenerationAttachment {
   generation: Generation
 }
 
-function boundedProjectName(value: string, maxLength: number): string {
-  const characters = Array.from(value)
-  return characters.length > maxLength
-    ? `${characters.slice(0, maxLength - 1).join('')}…`
-    : characters.join('')
-}
-
 export function createAutoPrepareProject(
   projectApis: Pick<ProjectApis, 'create'>,
 ): PrepareQuickStartProject {
   return async (prompt, directionalMovement = 'single', options) => {
-    const normalizedPrompt = prompt.trim().replace(/\s+/gu, ' ') || '未命名项目'
-    let lastConflict: unknown
-
-    for (let sequence = 1; sequence <= QUICK_START_PROJECT_NAME_ATTEMPTS; sequence += 1) {
-      const suffix = sequence === 1 ? '' : ` ${sequence}`
-      const maxBaseLength = PROJECT_NAME_MAX_LENGTH - Array.from(suffix).length
-      const base = boundedProjectName(normalizedPrompt, maxBaseLength)
-
-      try {
-        const project = await projectApis.create({
-          name: `${base}${suffix}`,
-          perspective: 'side',
-          directionalMovement,
-          spriteSize: { width: 256, height: 256 },
-          gameStyle: options?.gameStyle,
-        })
-        return {
-          id: project.id,
-          spriteSize: project.spriteSize,
-          directionalMovement: project.directionalMovement,
-        }
-      } catch (error) {
-        if (!(error instanceof ProjectNameConflictError)) throw error
-        lastConflict = error
-      }
+    const project = await projectApis.create({
+      nameContext: prompt.trim().replace(/\s+/gu, ' '),
+      perspective: 'side',
+      directionalMovement,
+      spriteSize: { width: 256, height: 256 },
+      gameStyle: options?.gameStyle,
+    })
+    return {
+      id: project.id,
+      spriteSize: project.spriteSize,
+      directionalMovement: project.directionalMovement,
     }
-
-    throw lastConflict
   }
 }
 

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -17,7 +17,7 @@ import {
   createRealQuickStartService,
   type QuickStartMediaApis,
 } from './service'
-import { ProjectNameConflictError, WorkflowRunConflictError } from '@/entities'
+import { WorkflowRunConflictError } from '@/entities'
 import { registerApiAccessTokenProvider } from '@/shared/api'
 
 function createWorkflowRunApis(initialRuns: readonly WorkflowRun[] = []): WorkflowRunApis {
@@ -1104,7 +1104,7 @@ describe('createQuickStartService', () => {
     )
   })
 
-  it('creates a readable bounded project name without a hash suffix', async () => {
+  it('sends the character description as project naming context', async () => {
     const create = vi.fn(async (input) => ({
       id: 'project-1',
       ...input,
@@ -1119,15 +1119,14 @@ describe('createQuickStartService', () => {
       directionalMovement: 'single',
       spriteSize: { width: 256, height: 256 },
     })
-    const createdName = create.mock.calls[0]?.[0].name
-    expect(Array.from(createdName ?? '')).toHaveLength(20)
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: '一位名字特别长的像素角色设定用于验证截…',
+        nameContext: '一位名字特别长的像素角色设定用于验证截断继续',
         perspective: 'side',
         directionalMovement: 'single',
       }),
     )
+    expect(create.mock.calls[0]?.[0]).not.toHaveProperty('name')
   })
 
   it('creates the Quick Start project with the selected directional movement', async () => {
@@ -1149,50 +1148,7 @@ describe('createQuickStartService', () => {
     )
   })
 
-  it('uses a readable number when the generated project name already exists', async () => {
-    const create = vi
-      .fn()
-      .mockRejectedValueOnce(new ProjectNameConflictError())
-      .mockResolvedValueOnce({
-        id: 'project-2',
-        name: '会挥剑的像素骑士 2',
-        spriteSize: { width: 256, height: 256 },
-      })
-    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
-
-    await expect(prepare('会挥剑的像素骑士')).resolves.toEqual({
-      id: 'project-2',
-      spriteSize: { width: 256, height: 256 },
-    })
-    expect(create).toHaveBeenNthCalledWith(1, expect.objectContaining({ name: '会挥剑的像素骑士' }))
-    expect(create).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ name: '会挥剑的像素骑士 2' }),
-    )
-  })
-
-  it('continues to the next readable project name after five conflicts', async () => {
-    const create = vi.fn()
-    for (let sequence = 1; sequence <= 5; sequence += 1) {
-      create.mockRejectedValueOnce(new ProjectNameConflictError())
-    }
-    create.mockResolvedValueOnce({
-      id: 'project-6',
-      name: '像素骑士 6',
-      spriteSize: { width: 256, height: 256 },
-    })
-    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
-
-    await expect(prepare('像素骑士')).resolves.toEqual({
-      id: 'project-6',
-      spriteSize: { width: 256, height: 256 },
-    })
-
-    expect(create).toHaveBeenCalledTimes(6)
-    expect(create).toHaveBeenNthCalledWith(6, expect.objectContaining({ name: '像素骑士 6' }))
-  })
-
-  it('uses a readable fallback for an empty project prompt', async () => {
+  it('leaves the empty-context fallback to the backend naming contract', async () => {
     const create = vi.fn(async (input) => ({
       id: 'project-fallback',
       ...input,
@@ -1202,7 +1158,7 @@ describe('createQuickStartService', () => {
 
     await prepare('   ')
 
-    expect(create).toHaveBeenCalledWith(expect.objectContaining({ name: '未命名项目' }))
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ nameContext: '' }))
   })
 
   it('does not retry project creation errors other than name conflicts', async () => {
@@ -1221,39 +1177,6 @@ describe('createQuickStartService', () => {
 
     await expect(prepare('像素骑士')).rejects.toBe(unrelatedError)
     expect(create).toHaveBeenCalledTimes(1)
-  })
-
-  it('keeps long numbered project names readable within the backend limit', async () => {
-    const create = vi
-      .fn()
-      .mockRejectedValueOnce(new ProjectNameConflictError())
-      .mockResolvedValueOnce({
-        id: 'project-long-2',
-        name: '一位名字特别长的像素角色设定用于验… 2',
-        spriteSize: { width: 256, height: 256 },
-      })
-    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
-
-    await prepare('一位名字特别长的像素角色设定用于验证截断继续')
-
-    expect(create).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ name: '一位名字特别长的像素角色设定用于验证截…' }),
-    )
-    expect(create).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ name: '一位名字特别长的像素角色设定用于验… 2' }),
-    )
-    expect(Array.from(create.mock.calls[1]?.[0].name ?? '')).toHaveLength(20)
-  })
-
-  it('stops after a bounded number of conflicting project names', async () => {
-    const conflict = new ProjectNameConflictError()
-    const create = vi.fn().mockRejectedValue(conflict)
-    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
-
-    await expect(prepare('像素骑士')).rejects.toBe(conflict)
-    expect(create).toHaveBeenCalledTimes(100)
   })
 
   it('creates one persisted node graph and starts the character image task', async () => {

--- a/openapi.json
+++ b/openapi.json
@@ -2066,11 +2066,29 @@
             "default": "unspecified",
             "title": "Game Style"
           },
+          "name_context": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name Context"
+          },
           "project_name": {
-            "maxLength": 20,
-            "minLength": 1,
-            "title": "Project Name",
-            "type": "string"
+            "anyOf": [
+              {
+                "maxLength": 20,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Name"
           },
           "sprite_height": {
             "maximum": 2048.0,
@@ -2108,7 +2126,6 @@
           }
         },
         "required": [
-          "project_name",
           "character_perspective",
           "directional_movement",
           "sprite_width",


### PR DESCRIPTION
Quick Start 创建项目时改由后端从角色描述提取独立的项目标题，项目与角色共享输入上下文，但使用各自的命名语义与命名器。

## Why

项目名称原先由前端直接截断角色描述生成，导致项目列表展示外观提示词片段。角色已有后端名称提取与降级链路，项目缺少对应的领域能力。

## Changes

- 项目创建接口支持可选 `project_name` 与 `name_context`，自动名称写入既有 `Project.project_name`。
- 新增项目专用名称解析与 LangChain 命名器；显式名称优先，模型失败时回退到描述截断，无上下文时使用「未命名项目」。
- 自动名称冲突由后端生成不超过 20 字的可读编号；显式重名仍返回原有业务错误。
- Quick Start 只提交规范化后的命名上下文，不再在浏览器中截断角色描述或重试项目名称。
- 更新 OpenAPI 契约以及前后端定向回归测试。

## Implementation

- `server/project` 持有项目命名契约和唯一名称分配规则，`ai_engine` 提供独立的模型适配器，并在 composition root 懒装配。
- 项目命名模型与角色命名模型复用 Chat Provider，但不共享命名器或系统指令。

## Verification

- [x] `uv run ruff check <changed Python files>`：通过
- [x] `uv run lint-imports`：2 个分层契约通过
- [x] `uv run python -m scripts.export_openapi`：重复导出无漂移
- [x] `uv run pytest tests/test_project_api.py tests/test_project_namer.py tests/test_smoke.py -q`：26 项通过
- [x] `npm run format:check -- <changed frontend files>`：通过
- [x] `npm run lint`：通过
- [x] `npm run typecheck`：通过
- [x] `npm test -- --run src/entities/project/index.test.ts src/pages/quick-start/service.test.ts src/pages/project-create/index.test.ts`：76 项通过
- [x] `npm run build`：通过

## Scope

- 本 PR 不修改角色命名逻辑、角色生成提示词、图片生成链路或历史项目名称。
- 本 PR 不改变手动创建项目时显式名称优先及显式重名报错的行为。

## Related Issues

Closes #725
