### PR TITLE
fix(quick-start): keep one composer appearance

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -748,7 +748,12 @@ describe('QuickStartPage', () => {
 
     fireEvent.change(composer, { target: { value: '银发骑士' } })
     fireEvent.keyDown(composer, { key: 'Enter', code: 'Enter' })
-    fireEvent.click(await screen.findByRole('button', { name: '停止生成' }))
+    const stop = await screen.findByRole('button', { name: '停止生成' })
+    expect(stop.className).toContain('rounded-full')
+    expect(stop.className).toContain('bg-app-accent')
+    expect(stop.className).not.toContain('bg-app-ink')
+    expect(stop.textContent).toBe('')
+    fireEvent.click(stop)
 
     await waitFor(() => {
       expect(composer.disabled).toBe(false)
@@ -1169,14 +1174,21 @@ describe('QuickStartPage', () => {
     const conversationControls = composer.querySelector(
       '[data-layout="quick-start-composer-controls"]',
     )
-    expect(conversationForm?.className).toContain('grid-cols-[1fr_auto]')
-    expect(conversationSurface?.className).not.toContain('border-app-line-strong')
-    expect(conversationSurface?.className).not.toContain('shadow-app-panel')
+    expect(conversationForm?.className).toContain('relative')
+    expect(conversationForm?.className).toContain('flex-col')
+    expect(conversationSurface?.className).toContain('rounded-app-surface')
+    expect(conversationSurface?.className).toContain('border-app-line-strong')
+    expect(conversationSurface?.className).toContain('shadow-app-panel')
     expect(conversationControls?.className).toContain('hidden')
-    expect(conversationForm?.querySelector('button')?.className).not.toContain('absolute')
+    const conversationSubmit = screen.getByRole('button', { name: '继续' })
+    expect(conversationSubmit.className).toContain('absolute')
+    expect(conversationSubmit.className).toContain('rounded-full')
+    expect(conversationSubmit.textContent).toBe('')
     expect(input.tagName).toBe('TEXTAREA')
     expect(input.rows).toBe(1)
     expect(input.className).toContain('[field-sizing:content]')
+    expect(input.className).toContain('min-h-[52px]')
+    expect(input.className).toContain('pr-14')
     expect(input.value).toBe('')
     expect(
       screen.getByText('我会保留角色的核心特征，并整理成适合母版生成的完整描述。'),

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1203,18 +1203,10 @@ function QuickStartInput({
             onSubmit={(event) => void submit(event)}
             autoComplete="off"
             data-prompt-state={promptState}
-            className={
-              hasConversation
-                ? 'quick-start-agent-composer grid grid-cols-[1fr_auto] items-center gap-1.5 overflow-hidden rounded-xl border border-app-line-strong bg-app-surface-raised p-1.5 shadow-app-panel transition-shadow focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
-                : 'quick-start-agent-composer relative flex flex-col'
-            }
+            className="quick-start-agent-composer relative flex flex-col"
           >
             <label
-              className={
-                hasConversation
-                  ? 'relative ml-2 min-w-0 overflow-hidden rounded-lg'
-                  : 'relative block min-h-[52px] min-w-0 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
-              }
+              className="relative block min-h-[52px] min-w-0 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]"
               htmlFor="quick-start-prompt"
             >
               <span className="sr-only">创作指令</span>
@@ -1243,21 +1235,15 @@ function QuickStartInput({
                         ? '描述动作，可留空生成待机动作…'
                         : '描述角色的外形、身份和气质…'
                 }
-                className={`block max-h-40 w-full min-w-0 resize-none overflow-y-auto border-0 bg-transparent text-[15px] text-app-ink outline-none [field-sizing:content] placeholder:text-app-faint ${
-                  hasConversation
-                    ? 'min-h-10 px-4 py-2.5 leading-5'
-                    : 'min-h-[52px] py-[14px] pr-14 pl-4 leading-6'
-                } ${promptState === 'rewriting' ? 'text-transparent caret-transparent' : ''}`}
+                className={`block min-h-[52px] max-h-40 w-full min-w-0 resize-none overflow-y-auto border-0 bg-transparent py-[14px] pr-14 pl-4 text-[15px] leading-6 text-app-ink outline-none [field-sizing:content] placeholder:text-app-faint ${
+                  promptState === 'rewriting' ? 'text-transparent caret-transparent' : ''
+                }`}
               />
               {promptState === 'rewriting' ? (
                 <span
                   data-prompt-rewrite
                   aria-hidden="true"
-                  className={`quick-start-prompt-rewrite absolute inset-0 flex max-h-40 items-start overflow-y-auto text-[15px] text-app-ink ${
-                    hasConversation
-                      ? 'min-h-10 px-4 py-2.5 leading-5'
-                      : 'min-h-[52px] py-[14px] pr-14 pl-4 leading-6'
-                  }`}
+                  className="quick-start-prompt-rewrite absolute inset-0 flex min-h-[52px] max-h-40 items-start overflow-y-auto py-[14px] pr-14 pl-4 text-[15px] leading-6 text-app-ink"
                 >
                   <KineticCopyCycle
                     active
@@ -1277,21 +1263,12 @@ function QuickStartInput({
               disabled={
                 entryCanInterrupt ? false : !canSubmit || entryBusy || Boolean(unavailableReason)
               }
-              className={`z-10 grid place-items-center border-0 text-app-canvas transition-[opacity,transform,background] duration-150 hover:-translate-y-px active:scale-95 disabled:cursor-default disabled:opacity-25 ${
-                hasConversation
-                  ? 'h-10 min-w-10 rounded-lg px-3'
-                  : 'absolute right-[6px] bottom-[6px] size-10 rounded-full'
-              } ${entryCanInterrupt ? 'bg-app-ink' : 'bg-app-accent hover:bg-app-accent-hover'}`}
+              className="absolute right-[6px] bottom-[6px] z-10 grid size-10 place-items-center rounded-full border-0 bg-app-accent text-app-canvas transition-[opacity,transform,background] duration-150 hover:-translate-y-px hover:bg-app-accent-hover active:scale-95 disabled:cursor-default disabled:opacity-25"
             >
               {entryCanInterrupt ? (
-                <Stop aria-hidden="true" size={16} weight="fill" />
+                <Stop aria-hidden="true" size={18} weight="bold" />
               ) : (
-                <span className="inline-flex items-center gap-2">
-                  {hasConversation ? (
-                    <span className="text-sm font-bold">{buttonLabel}</span>
-                  ) : null}
-                  <ArrowUp aria-hidden="true" size={hasConversation ? 16 : 19} weight="bold" />
-                </span>
+                <ArrowUp aria-hidden="true" size={19} weight="bold" />
               )}
             </button>
             <input


### PR DESCRIPTION
修复 Quick Start 输入框在对话与忙碌状态下切换为另一套视觉的问题，所有状态继续使用已冻结的同一套输入框与圆形图标按钮。

## Why

PR #693 为 `hasConversation` 单独建立了 composer 样式分支，导致输入框高度、圆角、间距和按钮几何在首次回复后变化；忙碌状态还会切换成黑色方形 Stop 按钮。这破坏了 #679 已冻结的视觉基线。

## Changes

- 删除对话状态专属的 composer、输入面与按钮样式分支。
- 初始、对话、Agent 整理和生成状态统一复用同一套外框、间距和圆形按钮。
- 可中断状态仅将箭头替换为 Stop 图标，保留按钮表面与尺寸。
- 增加针对对话态和中断态的视觉契约测试。

## Implementation

- 只调整 `QuickStartInput` 现有 Tailwind class 与图标渲染，不新增组件或状态。
- 保留原有提交、中断、上传、画风、方向和 Agent 流程。

## Verification

- [x] `npm test -- --run src/pages/quick-start/index.test.tsx`：103 passed
- [x] `npm run typecheck`
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`
- [x] `npm run format:check -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`
- [x] `npm run build`
- [x] `git diff --check`

## Scope

- 本 PR 不修改 API、Agent 规划、生成流程、WorkflowRun 或后端逻辑。
- 按用户要求不附截图，不执行页面视觉验收。

## Related Issues

Closes #727
Refs #693
Refs #679
