### PR TITLE
fix(quick-start): 使用滑块方向直接生成

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -333,13 +333,11 @@ function renderInBrowserHistory(
   )
 }
 
-async function confirmAgentGeneration(movement: '单向' | '四向' | '八向' = '单向') {
+async function confirmAgentGeneration() {
   const fill = await screen.findByRole('button', { name: '填入输入框' })
   fireEvent.click(fill)
   const send = await screen.findByRole('button', { name: '发送生成' })
   fireEvent.click(send)
-  await act(async () => undefined)
-  fireEvent.click(await screen.findByRole('button', { name: movement }))
   await act(async () => undefined)
 }
 
@@ -1033,6 +1031,42 @@ describe('QuickStartPage', () => {
     expect(window.sessionStorage.getItem(key)).toContain('"gameStyle":"pixel"')
   })
 
+  it('keeps the slider direction across a refresh before proposal confirmation', async () => {
+    vi.useFakeTimers()
+    const service = serviceFor(null)
+    const startCharacterGeneration = vi.fn(() => new Promise<{ runId: string }>(() => undefined))
+    const agent = agentFor({ startCharacterGeneration })
+    window.history.replaceState(null, '', '/quick-start')
+    const firstView = renderInBrowserHistory(service, agent)
+
+    fireEvent.click(screen.getByRole('button', { name: '生成方向，当前单向' }))
+    fireEvent.change(screen.getByRole('slider', { name: '生成方向' }), {
+      target: { value: '2' },
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
+      target: { value: '云端工坊的银发机械师' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    await act(async () => undefined)
+
+    const draftId = window.history.state?.windupQuickStartAgentDraftId
+    const key = `windup.quick-start.agent-chat.v2:draft:7:${draftId}`
+    expect(window.sessionStorage.getItem(key)).toContain('"directionalMovement":"eight-way"')
+
+    firstView.unmount()
+    renderInBrowserHistory(service, agent)
+    fireEvent.click(screen.getByRole('button', { name: '填入输入框' }))
+    await act(async () => vi.advanceTimersByTimeAsync(760))
+    fireEvent.click(screen.getByRole('button', { name: '发送生成' }))
+    await act(async () => undefined)
+
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: '云端工坊的银发机械师',
+      directionalMovement: 'eight-way',
+      gameStyle: 'unspecified',
+    })
+  })
+
   it('passes the chosen art style into every Agent planning turn', async () => {
     const planner = vi.fn(async (_input: PlannerInput) => ({
       text: '想保留哪个特征？',
@@ -1086,8 +1120,6 @@ describe('QuickStartPage', () => {
       target: { value: '提着蓝色风灯的森林守夜人' },
     })
     fireEvent.click(screen.getByRole('button', { name: '发送生成' }))
-    await act(async () => undefined)
-    fireEvent.click(screen.getByRole('button', { name: '单向' }))
     await act(async () => undefined)
     await act(async () => vi.advanceTimersByTime(460))
 
@@ -1149,13 +1181,17 @@ describe('QuickStartPage', () => {
     expect(window.localStorage.getItem(legacyKey)).toBeNull()
   })
 
-  it('keeps the proposal in chat until the user fills, edits, and sends it', async () => {
+  it('starts with the slider direction after the user edits and sends the proposal', async () => {
     vi.useFakeTimers()
     const service = serviceFor(null)
     const startCharacterGeneration = vi.fn(() => new Promise<{ runId: string }>(() => undefined))
     const agent = agentFor({ startCharacterGeneration })
     renderAt('/quick-start', service, agent)
 
+    fireEvent.click(screen.getByRole('button', { name: '生成方向，当前单向' }))
+    fireEvent.change(screen.getByRole('slider', { name: '生成方向' }), {
+      target: { value: '2' },
+    })
     fireEvent.change(screen.getByRole('textbox', { name: '创作指令' }), {
       target: { value: '云端工坊的银发机械师' },
     })
@@ -1196,7 +1232,7 @@ describe('QuickStartPage', () => {
     const fill = screen.getByRole('button', { name: '填入输入框' })
     expect(fill.className).not.toContain('border')
     expect(fill.hasAttribute('data-inline-arrow-action')).toBe(true)
-    expect(fill.textContent).toContain('编辑后逐步确认')
+    expect(fill.textContent).toContain('编辑后发送生成')
     fireEvent.click(fill)
 
     expect(composer.dataset.promptState).toBe('rewriting')
@@ -1218,12 +1254,9 @@ describe('QuickStartPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '发送生成' }))
     await act(async () => undefined)
-    expect(screen.getByText('最后确认一下：需要单向、四向还是八向？')).toBeTruthy()
+    expect(screen.queryByText('最后确认一下：需要单向、四向还是八向？')).toBeNull()
+    expect(screen.queryByRole('group', { name: '选择生成方向' })).toBeNull()
     expect(input.hasAttribute('disabled')).toBe(true)
-    expect(startCharacterGeneration).not.toHaveBeenCalled()
-
-    fireEvent.click(screen.getByRole('button', { name: '八向' }))
-    await act(async () => undefined)
     expect(startCharacterGeneration).toHaveBeenCalledWith({
       prompt: '云端工坊的银发机械师，佩戴黄铜护目镜',
       directionalMovement: 'eight-way',
@@ -1824,8 +1857,6 @@ describe('QuickStartPage', () => {
     expect(screen.getByRole('button', { name: '发送生成' })).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: '发送生成' }))
     await act(async () => undefined)
-    fireEvent.click(screen.getByRole('button', { name: '单向' }))
-    await act(async () => undefined)
 
     const entry = screen.getByLabelText('创作指令').closest('[data-layout="quick-start-entry"]')
     expect(entry?.getAttribute('data-transition')).toBe('leaving')
@@ -2099,7 +2130,7 @@ describe('QuickStartPage', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
     expect(startCharacterGeneration).not.toHaveBeenCalled()
-    await confirmAgentGeneration('四向')
+    await confirmAgentGeneration()
     await waitFor(() =>
       expect(startCharacterGeneration).toHaveBeenCalledWith({
         prompt: '16-bit 日式 RPG 像素风，清晰轮廓，明亮配色',

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1067,6 +1067,44 @@ describe('QuickStartPage', () => {
     })
   })
 
+  it('persists a slider-only direction change across a refresh', () => {
+    const service = serviceFor(null)
+    const agent = agentFor()
+    window.history.replaceState(null, '', '/quick-start')
+    const firstView = renderInBrowserHistory(service, agent)
+
+    fireEvent.click(screen.getByRole('button', { name: '生成方向，当前单向' }))
+    fireEvent.change(screen.getByRole('slider', { name: '生成方向' }), {
+      target: { value: '2' },
+    })
+
+    const draftId = window.history.state?.windupQuickStartAgentDraftId
+    const key = `windup.quick-start.agent-chat.v2:draft:7:${draftId}`
+    expect(window.sessionStorage.getItem(key)).toContain('"directionalMovement":"eight-way"')
+
+    firstView.unmount()
+    renderInBrowserHistory(service, agent)
+    expect(screen.getByRole('button', { name: '生成方向，当前八向' })).toBeTruthy()
+  })
+
+  it('preserves the slider direction when changing the draft art style', () => {
+    renderAt('/quick-start', serviceFor(null), agentFor())
+
+    fireEvent.click(screen.getByRole('button', { name: '生成方向，当前单向' }))
+    fireEvent.change(screen.getByRole('slider', { name: '生成方向' }), {
+      target: { value: '2' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '选择画风，当前不指定' }))
+    fireEvent.click(screen.getByRole('menuitemradio', { name: '像素' }))
+
+    const draftId = window.history.state?.windupQuickStartAgentDraftId
+    const key = `windup.quick-start.agent-chat.v2:draft:7:${draftId}`
+    expect(JSON.parse(window.sessionStorage.getItem(key) ?? '{}')).toMatchObject({
+      gameStyle: 'pixel',
+      directionalMovement: 'eight-way',
+    })
+  })
+
   it('passes the chosen art style into every Agent planning turn', async () => {
     const planner = vi.fn(async (_input: PlannerInput) => ({
       text: '想保留哪个特征？',

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -183,6 +183,8 @@ type AgentConversationRecord = {
   turns: readonly AgentConversationTurn[]
   /** 入口处选的画风；不随草稿存住的话，刷新后画风选择器已隐藏而值悄悄回到不指定。 */
   gameStyle?: ArtStyle
+  /** 入口滑块选的方向；进入对话后滑块隐藏，刷新时必须恢复原值。 */
+  directionalMovement?: DirectionalMovement
 }
 
 type AgentConversationStorageName = 'localStorage' | 'sessionStorage'
@@ -223,6 +225,24 @@ function readAgentDraftGameStyle(key: string): ArtStyle {
     return isArtStyle(parsed.gameStyle) ? parsed.gameStyle : 'unspecified'
   } catch {
     return 'unspecified'
+  }
+}
+
+function readAgentDraftDirectionalMovement(key: string): DirectionalMovement {
+  try {
+    const stored = window.sessionStorage.getItem(key)
+    if (!stored) return 'single'
+    const parsed: unknown = JSON.parse(stored)
+    if (typeof parsed !== 'object' || parsed === null || !('directionalMovement' in parsed)) {
+      return 'single'
+    }
+    return QUICK_START_DIRECTIONAL_MOVEMENTS.includes(
+      parsed.directionalMovement as DirectionalMovement,
+    )
+      ? (parsed.directionalMovement as DirectionalMovement)
+      : 'single'
+  } catch {
+    return 'single'
   }
 }
 
@@ -636,8 +656,16 @@ function QuickStartInput({
 }) {
   const navigate = useNavigate()
   const [prompt, setPrompt] = useState('')
-  const [directionalMovement, setDirectionalMovement] = useState<DirectionalMovement>('single')
-  const [confirmedPrompt, setConfirmedPrompt] = useState<string | null>(null)
+  const [directionalMovement, setDirectionalMovement] = useState<DirectionalMovement>(() => {
+    const draftId = readAgentDraftId()
+    return draftId
+      ? readAgentDraftDirectionalMovement(
+          agentDraftConversationStorageKey(activeRunUserId, draftId),
+        )
+      : 'single'
+  })
+  const directionalMovementRef = useRef(directionalMovement)
+  directionalMovementRef.current = directionalMovement
   const [templateFile, setTemplateFile] = useState<File | null>(null)
   const [gameStyle, setGameStyle] = useState<ArtStyle>(() => {
     const draftId = readAgentDraftId()
@@ -651,7 +679,7 @@ function QuickStartInput({
   const [revealingFirstAgentTurn, setRevealingFirstAgentTurn] = useState(false)
   const [entryTransition, setEntryTransition] = useState<'idle' | 'leaving'>('idle')
   const [promptState, setPromptState] = useState<
-    'collecting' | 'rewriting' | 'ready' | 'direction' | 'confirmed'
+    'collecting' | 'rewriting' | 'ready' | 'confirmed'
   >('collecting')
   const [error, setError] = useState<string | null>(null)
   const draftIdRef = useRef(readAgentDraftId())
@@ -686,12 +714,7 @@ function QuickStartInput({
   const agentPlanning = agentSession.state.status === 'planning'
   const agentThinking = agentPlanning || revealingFirstAgentTurn
   const generationStarting = promptState === 'confirmed'
-  const entryBusy =
-    submitting ||
-    agentThinking ||
-    promptState === 'rewriting' ||
-    promptState === 'direction' ||
-    generationStarting
+  const entryBusy = submitting || agentThinking || promptState === 'rewriting' || generationStarting
   const entryCanInterrupt = submitting || agentPlanning
   const hasPrompt = Boolean(prompt.trim())
   const hasConversation = conversationTurns.length > 0
@@ -716,7 +739,11 @@ function QuickStartInput({
       writeAgentConversation(
         'sessionStorage',
         agentDraftConversationStorageKey(activeRunUserId, draftId),
-        { turns, gameStyle: gameStyleRef.current },
+        {
+          turns,
+          gameStyle: gameStyleRef.current,
+          directionalMovement: directionalMovementRef.current,
+        },
       )
     },
     [activeRunUserId, ensureDraftId],
@@ -929,14 +956,15 @@ function QuickStartInput({
 
     if (agentSession.state.status === 'proposal' && promptState === 'ready') {
       if (!normalizedPrompt) return
-      setConfirmedPrompt(normalizedPrompt)
-      setPrompt('')
-      setPromptState('direction')
-      appendConversationTurn({
-        role: 'assistant',
-        content: '最后确认一下：需要单向、四向还是八向？',
-        kind: 'clarification',
-      })
+      setPromptState('confirmed')
+      try {
+        const result = await agentSession.confirmProposal(normalizedPrompt, directionalMovement, {
+          gameStyle,
+        })
+        if (result.kind === 'generated') await handoffGenerated(result)
+      } catch {
+        setPromptState('ready')
+      }
       return
     }
 
@@ -1025,25 +1053,8 @@ function QuickStartInput({
     }
   }
 
-  async function chooseDirectionalMovement(movement: DirectionalMovement) {
-    if (!confirmedPrompt || promptState !== 'direction') return
-    setDirectionalMovement(movement)
-    appendConversationTurn({ role: 'user', content: DIRECTIONAL_MOVEMENT[movement] })
-    setPromptState('confirmed')
-    try {
-      const result = await agentSession.confirmProposal(confirmedPrompt, movement, { gameStyle })
-      if (result.kind === 'generated') await handoffGenerated(result)
-    } catch {
-      setPromptState('direction')
-    }
-  }
-
   const inputLocked =
-    submitting ||
-    agentThinking ||
-    promptState === 'rewriting' ||
-    promptState === 'direction' ||
-    generationStarting
+    submitting || agentThinking || promptState === 'rewriting' || generationStarting
   const awaitingGenerationConfirmation =
     agentSession.state.status === 'proposal' && promptState === 'ready'
   const buttonLabel = submitting
@@ -1152,20 +1163,6 @@ function QuickStartInput({
               {agentSession.state.status === 'error' ? (
                 <div role="alert" data-conversation-kind="agent" className="min-w-0">
                   <AgentCopy lines={[agentSession.state.message]} tone="danger" />
-                </div>
-              ) : null}
-              {promptState === 'direction' ? (
-                <div className="flex flex-wrap gap-2" aria-label="选择生成方向">
-                  {QUICK_START_DIRECTIONAL_MOVEMENTS.map((movement) => (
-                    <button
-                      key={movement}
-                      type="button"
-                      onClick={() => void chooseDirectionalMovement(movement)}
-                      className="rounded-full border border-app-line bg-app-surface-raised px-4 py-2 text-sm font-semibold text-app-ink transition hover:border-app-accent hover:text-app-accent"
-                    >
-                      {DIRECTIONAL_MOVEMENT[movement]}
-                    </button>
-                  ))}
                 </div>
               ) : null}
             </div>
@@ -1529,7 +1526,7 @@ function PromptProposal({
             </button>
           ) : null}
           <InlineArrowAction aria-label="填入输入框" disabled={disabled} onClick={onFill}>
-            编辑后逐步确认
+            编辑后发送生成
           </InlineArrowAction>
         </div>
       ) : status === 'superseded' ? (

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -732,8 +732,9 @@ function QuickStartInput({
     return draftId
   }, [])
 
-  const persistDraftConversation = useCallback(
-    (turns: readonly AgentConversationTurn[]) => {
+  const persistAgentDraft = useCallback(
+    (updates: Partial<AgentConversationRecord> = {}) => {
+      const turns = updates.turns ?? conversationTurnsRef.current
       conversationTurnsRef.current = turns
       const draftId = ensureDraftId()
       writeAgentConversation(
@@ -741,8 +742,8 @@ function QuickStartInput({
         agentDraftConversationStorageKey(activeRunUserId, draftId),
         {
           turns,
-          gameStyle: gameStyleRef.current,
-          directionalMovement: directionalMovementRef.current,
+          gameStyle: updates.gameStyle ?? gameStyleRef.current,
+          directionalMovement: updates.directionalMovement ?? directionalMovementRef.current,
         },
       )
     },
@@ -775,9 +776,9 @@ function QuickStartInput({
       const next = [...conversationTurnsRef.current, turn]
       conversationTurnsRef.current = next
       setConversationTurns(next)
-      persistDraftConversation(next)
+      persistAgentDraft({ turns: next })
     },
-    [persistDraftConversation],
+    [persistAgentDraft],
   )
 
   async function revealFirstAgentTurn(turn: AgentConversationTurn) {
@@ -838,7 +839,7 @@ function QuickStartInput({
     )
     conversationTurnsRef.current = next
     setConversationTurns(next)
-    persistDraftConversation(next)
+    persistAgentDraft({ turns: next })
     return next
   }
 
@@ -895,16 +896,16 @@ function QuickStartInput({
   }
 
   function chooseGameStyle(next: ArtStyle) {
+    gameStyleRef.current = next
     setGameStyle(next)
     setStyleMenuOpen(false)
-    const draftId = draftIdRef.current
-    if (draftId) {
-      writeAgentConversation(
-        'sessionStorage',
-        agentDraftConversationStorageKey(activeRunUserId, draftId),
-        { turns: conversationTurnsRef.current, gameStyle: next },
-      )
-    }
+    persistAgentDraft({ gameStyle: next })
+  }
+
+  function chooseDirectionalMovement(next: DirectionalMovement) {
+    directionalMovementRef.current = next
+    setDirectionalMovement(next)
+    persistAgentDraft({ directionalMovement: next })
   }
 
   function stopEntryWork() {
@@ -922,7 +923,7 @@ function QuickStartInput({
         const nextTurns = turns.slice(0, -1)
         conversationTurnsRef.current = nextTurns
         setConversationTurns(nextTurns)
-        persistDraftConversation(nextTurns)
+        persistAgentDraft({ turns: nextTurns })
       }
     }
     pendingPrompt.current = null
@@ -1440,7 +1441,7 @@ function QuickStartInput({
                                 const index = Math.round(Number(event.currentTarget.value))
                                 setDirectionDragging(false)
                                 setDirectionSliderValue(index)
-                                setDirectionalMovement(
+                                chooseDirectionalMovement(
                                   QUICK_START_DIRECTIONAL_MOVEMENTS[index] ?? 'single',
                                 )
                               }}
@@ -1453,7 +1454,7 @@ function QuickStartInput({
                               onChange={(event) => {
                                 const value = Number(event.target.value)
                                 setDirectionSliderValue(value)
-                                setDirectionalMovement(
+                                chooseDirectionalMovement(
                                   QUICK_START_DIRECTIONAL_MOVEMENTS[Math.round(value)] ?? 'single',
                                 )
                               }}


### PR DESCRIPTION
## 修改内容

- 移除 Agent 最后对单向、四向、八向的追问
- 移除对话中的方向选择按键和对应中间状态
- 用户确认提示词后，直接使用入口滑块当前方向开始生成
- 统一持久化方向、画风与对话，滑块或画风单独变更后刷新仍保留
- 将提案操作文案改为“编辑后发送生成”

## 验证

- Quick Start 页面测试：116 passed
- `npm run lint`：通过
- `npm run typecheck`：通过
- `npm run build`：通过
- 本次两个文件 `oxfmt --check`：通过
- `git diff --check`：通过

Closes #670

