### PR TITLE
fix(quick-start): persist generation context controls

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1431,7 +1431,20 @@ describe('QuickStartPage', () => {
     expect(conversationSurface?.className).toContain('rounded-app-surface')
     expect(conversationSurface?.className).toContain('border-app-line-strong')
     expect(conversationSurface?.className).toContain('shadow-app-panel')
-    expect(conversationControls?.className).toContain('hidden')
+    expect(conversationControls?.className).toContain('flex')
+    expect(
+      (
+        screen.getByRole('button', {
+          name: '选择项目，当前自动创建',
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true)
+    expect(screen.getByTestId('quick-start-selected-style').textContent).toBe('不指定')
+    expect(
+      (screen.getByRole('button', { name: '生成方向，当前单向' }) as HTMLButtonElement).disabled,
+    ).toBe(true)
+    expect(screen.queryByRole('button', { name: '添加母版' })).toBeNull()
+    expect(screen.queryByRole('button', { name: '选择画风，当前不指定' })).toBeNull()
     const conversationSubmit = screen.getByRole('button', { name: '继续' })
     expect(conversationSubmit.className).toContain('absolute')
     expect(conversationSubmit.className).toContain('rounded-full')
@@ -1957,11 +1970,17 @@ describe('QuickStartPage', () => {
     const prompt = await screen.findByRole('textbox', { name: '创作指令' })
     const editingSurface = prompt.closest('label')
     const uploadButton = screen.getByRole('button', { name: '添加母版' })
+    const styleButton = screen.getByRole('button', { name: '选择画风，当前不指定' })
+    const projectButton = screen.getByRole('button', { name: '选择项目，当前自动创建' })
     const directionButton = screen.getByRole('button', { name: '生成方向，当前单向' })
 
     expect(editingSurface?.className).toContain('rounded-app-surface')
     expect(uploadButton.className).toContain('rounded-app-compact')
     expect(directionButton.className).toContain('rounded-app-control')
+    expect(projectButton.parentElement?.className).toContain('order-first')
+    expect(
+      uploadButton.compareDocumentPosition(styleButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
 
     fireEvent.click(directionButton)
     expect(screen.getByRole('group', { name: '生成方向设置' }).className).toContain(

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1372,130 +1372,132 @@ function QuickStartInput({
             />
             <div
               data-layout="quick-start-composer-controls"
-              className={`order-first mb-2 min-h-10 items-center justify-between gap-3 px-1 ${
-                hasConversation ? 'hidden' : 'flex'
-              }`}
+              className="order-first mb-2 flex min-h-10 items-center justify-between gap-3 px-1"
             >
-              {!hasConversation ? (
-                <div className="flex items-center gap-1">
-                  <IconActionButton
-                    label={templateFile ? `更换母版 ${templateFile.name}` : '添加母版'}
-                    disabled={entryBusy}
-                    onClick={() => fileInput.current?.click()}
-                    className={templateFile ? 'text-app-accent' : ''}
-                  >
-                    <MasterFrameIcon />
-                  </IconActionButton>
-                  <div className="relative">
+              <div className="flex items-center gap-1">
+                {!hasConversation ? (
+                  <>
                     <IconActionButton
-                      label={`选择画风，当前${ART_STYLE[gameStyle]}`}
-                      disabled={entryBusy || Boolean(selectedProject)}
-                      onClick={() => {
-                        setDirectionMenuOpen(false)
-                        setStyleMenuOpen((open) => !open)
-                      }}
-                      expanded={styleMenuOpen}
-                    >
-                      <StyleTileIcon />
-                    </IconActionButton>
-                    {styleMenuOpen ? (
-                      <div
-                        role="menu"
-                        aria-label="选择画风"
-                        className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-32 gap-1 p-1.5 opacity-100`}
-                      >
-                        {ART_STYLE_OPTIONS.map((value) => (
-                          <button
-                            key={value}
-                            type="button"
-                            role="menuitemradio"
-                            aria-checked={gameStyle === value}
-                            onClick={() => chooseGameStyle(value)}
-                            className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${
-                              gameStyle === value
-                                ? 'bg-app-accent-soft text-app-accent'
-                                : 'text-app-ink-soft hover:bg-app-surface-muted'
-                            }`}
-                          >
-                            {ART_STYLE[value]}
-                          </button>
-                        ))}
-                      </div>
-                    ) : null}
-                  </div>
-                  <div className="relative">
-                    <button
-                      type="button"
-                      aria-label={`选择项目，当前${selectedProject?.name ?? '自动创建'}`}
-                      aria-expanded={projectMenuOpen}
+                      label={templateFile ? `更换母版 ${templateFile.name}` : '添加母版'}
                       disabled={entryBusy}
-                      onClick={() => {
-                        setStyleMenuOpen(false)
-                        setDirectionMenuOpen(false)
-                        setProjectMenuOpen((open) => !open)
-                      }}
-                      className="inline-flex h-10 max-w-44 items-center gap-1 rounded-app-control px-3 text-sm font-medium text-app-ink-soft transition hover:bg-app-surface-muted hover:text-app-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-45"
+                      onClick={() => fileInput.current?.click()}
+                      className={templateFile ? 'text-app-accent' : ''}
                     >
-                      <span className="truncate">{selectedProject?.name ?? '自动创建'}</span>
+                      <MasterFrameIcon />
+                    </IconActionButton>
+                    <div className="relative">
+                      <IconActionButton
+                        label={`选择画风，当前${ART_STYLE[gameStyle]}`}
+                        disabled={entryBusy || Boolean(selectedProject)}
+                        onClick={() => {
+                          setDirectionMenuOpen(false)
+                          setStyleMenuOpen((open) => !open)
+                        }}
+                        expanded={styleMenuOpen}
+                      >
+                        <StyleTileIcon />
+                      </IconActionButton>
+                      {styleMenuOpen ? (
+                        <div
+                          role="menu"
+                          aria-label="选择画风"
+                          className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-32 gap-1 p-1.5 opacity-100`}
+                        >
+                          {ART_STYLE_OPTIONS.map((value) => (
+                            <button
+                              key={value}
+                              type="button"
+                              role="menuitemradio"
+                              aria-checked={gameStyle === value}
+                              onClick={() => chooseGameStyle(value)}
+                              className={`rounded-app-compact px-3 py-2 text-left text-xs transition ${
+                                gameStyle === value
+                                  ? 'bg-app-accent-soft text-app-accent'
+                                  : 'text-app-ink-soft hover:bg-app-surface-muted'
+                              }`}
+                            >
+                              {ART_STYLE[value]}
+                            </button>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  </>
+                ) : null}
+                <div className="relative order-first">
+                  <button
+                    type="button"
+                    aria-label={`选择项目，当前${selectedProject?.name ?? '自动创建'}`}
+                    aria-expanded={projectMenuOpen}
+                    disabled={entryBusy || hasConversation}
+                    onClick={() => {
+                      setStyleMenuOpen(false)
+                      setDirectionMenuOpen(false)
+                      setProjectMenuOpen((open) => !open)
+                    }}
+                    className={`inline-flex h-10 max-w-44 items-center gap-1 rounded-app-control px-3 text-sm font-medium text-app-ink-soft transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ${hasConversation ? 'pointer-events-none disabled:opacity-100' : 'hover:bg-app-surface-muted hover:text-app-ink disabled:opacity-45'}`}
+                  >
+                    <span className="truncate">{selectedProject?.name ?? '自动创建'}</span>
+                    {!hasConversation ? (
                       <CaretDown
                         aria-hidden="true"
                         size={14}
                         weight="bold"
                         className={projectMenuOpen ? 'rotate-180' : ''}
                       />
-                    </button>
-                    {projectMenuOpen ? (
-                      <div
-                        role="menu"
-                        aria-label="选择项目"
-                        className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-40 gap-1 p-1.5 opacity-100`}
-                      >
-                        {projects.map((project) => (
-                          <button
-                            key={project.id}
-                            type="button"
-                            role="menuitemradio"
-                            aria-checked={projectId === project.id}
-                            onClick={() => chooseProject(project)}
-                            className={`flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === project.id ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
-                          >
-                            <FolderOpen aria-hidden="true" size={15} weight="regular" />
-                            <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                            {projectId === project.id ? (
-                              <Check aria-hidden="true" size={14} weight="bold" />
-                            ) : null}
-                          </button>
-                        ))}
-                        <div className="my-1 border-t border-app-line" />
-                        <Link
-                          to="/projects/new?entry=quick-start"
-                          role="menuitem"
-                          onClick={() => setProjectMenuOpen(false)}
-                          className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-xs text-app-ink-soft transition hover:bg-app-surface-muted"
-                        >
-                          <Plus aria-hidden="true" size={15} weight="bold" />
-                          新建项目
-                        </Link>
+                    ) : null}
+                  </button>
+                  {projectMenuOpen && !hasConversation ? (
+                    <div
+                      role="menu"
+                      aria-label="选择项目"
+                      className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-40 gap-1 p-1.5 opacity-100`}
+                    >
+                      {projects.map((project) => (
                         <button
+                          key={project.id}
                           type="button"
                           role="menuitemradio"
-                          aria-checked={projectId === null}
-                          onClick={() => chooseProject(null)}
-                          className={`flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === null ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
+                          aria-checked={projectId === project.id}
+                          onClick={() => chooseProject(project)}
+                          className={`flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === project.id ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
                         >
-                          <span aria-hidden="true" className="w-[15px] text-center">
-                            ×
-                          </span>
-                          <span className="flex-1">自动创建</span>
-                          {projectId === null ? (
+                          <FolderOpen aria-hidden="true" size={15} weight="regular" />
+                          <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                          {projectId === project.id ? (
                             <Check aria-hidden="true" size={14} weight="bold" />
                           ) : null}
                         </button>
-                      </div>
-                    ) : null}
-                  </div>
+                      ))}
+                      <div className="my-1 border-t border-app-line" />
+                      <Link
+                        to="/projects/new?entry=quick-start"
+                        role="menuitem"
+                        onClick={() => setProjectMenuOpen(false)}
+                        className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-xs text-app-ink-soft transition hover:bg-app-surface-muted"
+                      >
+                        <Plus aria-hidden="true" size={15} weight="bold" />
+                        新建项目
+                      </Link>
+                      <button
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={projectId === null}
+                        onClick={() => chooseProject(null)}
+                        className={`flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === null ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
+                      >
+                        <span aria-hidden="true" className="w-[15px] text-center">
+                          ×
+                        </span>
+                        <span className="flex-1">自动创建</span>
+                        {projectId === null ? (
+                          <Check aria-hidden="true" size={14} weight="bold" />
+                        ) : null}
+                      </button>
+                    </div>
+                  ) : null}
                 </div>
-              ) : null}
+              </div>
               {templateFile && !hasConversation ? (
                 <span className="absolute bottom-full left-3 mb-2 inline-flex max-w-56 items-center gap-1 rounded-app-compact bg-app-surface-raised px-2 py-1 text-xs text-app-ink-soft shadow-app-card">
                   <span className="truncate">{templateFile.name}</span>
@@ -1511,101 +1513,99 @@ function QuickStartInput({
                 </span>
               ) : null}
               <div className="flex items-center gap-1">
-                {!hasConversation ? (
-                  <>
-                    <span
-                      data-testid="quick-start-selected-style"
-                      className="max-w-28 truncate px-2 text-sm font-medium text-app-muted"
+                <span
+                  data-testid="quick-start-selected-style"
+                  className="max-w-28 truncate px-2 text-sm font-medium text-app-muted"
+                >
+                  {ART_STYLE[gameStyle]}
+                </span>
+                <div className="relative">
+                  <button
+                    type="button"
+                    aria-label={`生成方向，当前${DIRECTIONAL_MOVEMENT[directionalMovement]}`}
+                    aria-expanded={directionMenuOpen}
+                    disabled={entryBusy || Boolean(selectedProject) || hasConversation}
+                    onClick={() => {
+                      setStyleMenuOpen(false)
+                      setDirectionSliderValue(directionalMovementIndex)
+                      setDirectionMenuOpen((open) => !open)
+                    }}
+                    className={`inline-flex h-10 items-center gap-1 rounded-app-control px-3 text-sm font-medium text-app-ink-soft transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ${hasConversation ? 'pointer-events-none disabled:opacity-100' : 'hover:bg-app-surface-muted hover:text-app-ink disabled:opacity-45'}`}
+                  >
+                    {DIRECTIONAL_MOVEMENT[directionalMovement]}
+                    {!hasConversation ? (
+                      <CaretDown
+                        aria-hidden="true"
+                        size={14}
+                        weight="bold"
+                        className={`transition-transform duration-200 motion-reduce:transition-none ${directionMenuOpen ? 'rotate-180' : ''}`}
+                      />
+                    ) : null}
+                  </button>
+                  {directionMenuOpen && !hasConversation ? (
+                    <div
+                      role="group"
+                      aria-label="生成方向设置"
+                      className={`${productPopoverClass} quick-start-control-popover absolute right-0 bottom-full z-30 mb-3 w-72 p-5 opacity-100`}
                     >
-                      {ART_STYLE[gameStyle]}
-                    </span>
-                    <div className="relative">
-                      <button
-                        type="button"
-                        aria-label={`生成方向，当前${DIRECTIONAL_MOVEMENT[directionalMovement]}`}
-                        aria-expanded={directionMenuOpen}
-                        disabled={entryBusy || Boolean(selectedProject)}
-                        onClick={() => {
-                          setStyleMenuOpen(false)
-                          setDirectionSliderValue(directionalMovementIndex)
-                          setDirectionMenuOpen((open) => !open)
-                        }}
-                        className="inline-flex h-10 items-center gap-1 rounded-app-control px-3 text-sm font-medium text-app-ink-soft transition hover:bg-app-surface-muted hover:text-app-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-45"
-                      >
-                        {DIRECTIONAL_MOVEMENT[directionalMovement]}
-                        <CaretDown
-                          aria-hidden="true"
-                          size={14}
-                          weight="bold"
-                          className={`transition-transform duration-200 motion-reduce:transition-none ${directionMenuOpen ? 'rotate-180' : ''}`}
-                        />
-                      </button>
-                      {directionMenuOpen ? (
-                        <div
-                          role="group"
-                          aria-label="生成方向设置"
-                          className={`${productPopoverClass} quick-start-control-popover absolute right-0 bottom-full z-30 mb-3 w-72 p-5 opacity-100`}
+                      <div className="mb-4 flex items-center justify-between">
+                        <span className="text-sm text-app-muted">生成方向</span>
+                        <strong
+                          key={directionalMovement}
+                          className="quick-start-direction-value text-sm font-semibold text-app-ink"
                         >
-                          <div className="mb-4 flex items-center justify-between">
-                            <span className="text-sm text-app-muted">生成方向</span>
-                            <strong
-                              key={directionalMovement}
-                              className="quick-start-direction-value text-sm font-semibold text-app-ink"
-                            >
-                              {DIRECTIONAL_MOVEMENT[directionalMovement]}
-                            </strong>
-                          </div>
-                          <div className="mb-2 flex justify-between text-xs text-app-muted">
-                            <span>单向</span>
-                            <span>八向</span>
-                          </div>
-                          <div
-                            data-dragging={directionDragging ? 'true' : 'false'}
-                            className="quick-start-direction-slider-wrap"
-                            style={
-                              {
-                                '--quick-start-direction-progress': `${directionSliderValue * 50}%`,
-                              } as CSSProperties
-                            }
-                          >
-                            <input
-                              type="range"
-                              min="0"
-                              max="2"
-                              step="0.01"
-                              value={directionSliderValue}
-                              aria-label="生成方向"
-                              aria-valuetext={DIRECTIONAL_MOVEMENT[directionalMovement]}
-                              onPointerDown={() => setDirectionDragging(true)}
-                              onPointerUp={(event) => {
-                                const index = Math.round(Number(event.currentTarget.value))
-                                setDirectionDragging(false)
-                                setDirectionSliderValue(index)
-                                setDirectionalMovement(
-                                  QUICK_START_DIRECTIONAL_MOVEMENTS[index] ?? 'single',
-                                )
-                              }}
-                              onPointerCancel={() => setDirectionDragging(false)}
-                              onBlur={(event) => {
-                                const index = Math.round(Number(event.currentTarget.value))
-                                setDirectionDragging(false)
-                                setDirectionSliderValue(index)
-                              }}
-                              onChange={(event) => {
-                                const value = Number(event.target.value)
-                                setDirectionSliderValue(value)
-                                setDirectionalMovement(
-                                  QUICK_START_DIRECTIONAL_MOVEMENTS[Math.round(value)] ?? 'single',
-                                )
-                              }}
-                              className="quick-start-direction-slider"
-                            />
-                          </div>
-                        </div>
-                      ) : null}
+                          {DIRECTIONAL_MOVEMENT[directionalMovement]}
+                        </strong>
+                      </div>
+                      <div className="mb-2 flex justify-between text-xs text-app-muted">
+                        <span>单向</span>
+                        <span>八向</span>
+                      </div>
+                      <div
+                        data-dragging={directionDragging ? 'true' : 'false'}
+                        className="quick-start-direction-slider-wrap"
+                        style={
+                          {
+                            '--quick-start-direction-progress': `${directionSliderValue * 50}%`,
+                          } as CSSProperties
+                        }
+                      >
+                        <input
+                          type="range"
+                          min="0"
+                          max="2"
+                          step="0.01"
+                          value={directionSliderValue}
+                          aria-label="生成方向"
+                          aria-valuetext={DIRECTIONAL_MOVEMENT[directionalMovement]}
+                          onPointerDown={() => setDirectionDragging(true)}
+                          onPointerUp={(event) => {
+                            const index = Math.round(Number(event.currentTarget.value))
+                            setDirectionDragging(false)
+                            setDirectionSliderValue(index)
+                            setDirectionalMovement(
+                              QUICK_START_DIRECTIONAL_MOVEMENTS[index] ?? 'single',
+                            )
+                          }}
+                          onPointerCancel={() => setDirectionDragging(false)}
+                          onBlur={(event) => {
+                            const index = Math.round(Number(event.currentTarget.value))
+                            setDirectionDragging(false)
+                            setDirectionSliderValue(index)
+                          }}
+                          onChange={(event) => {
+                            const value = Number(event.target.value)
+                            setDirectionSliderValue(value)
+                            setDirectionalMovement(
+                              QUICK_START_DIRECTIONAL_MOVEMENTS[Math.round(value)] ?? 'single',
+                            )
+                          }}
+                          className="quick-start-direction-slider"
+                        />
+                      </div>
                     </div>
-                  </>
-                ) : null}
+                  ) : null}
+                </div>
               </div>
             </div>
           </form>


### PR DESCRIPTION
Quick Start 在后续 Agent 对话中持续显示本次生成的项目、画风和方向，并将项目固定为控制栏最左侧上下文。

## Why

进入后续对话后，原控制栏整体消失，用户无法确认角色生成仍受哪个项目、画风和方向约束。

## Changes

- 项目控件移动到控制栏最左端，两个 SVG 操作紧随其右。
- 后续对话持续显示项目、画风和方向，并锁定为只读。
- 后续对话隐藏添加母版和选择画风两个 SVG。

## Implementation

- 复用现有 Quick Start 状态，仅调整控制栏的条件渲染与只读状态。
- 不修改项目菜单、新建项目、Agent 或生成数据链路。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx`：112 passed
- [x] `npm run typecheck`：通过
- [x] `npx oxfmt src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：已格式化

## Screenshots

### Desktop

未附图。

## Scope

- 本 PR 只包含控件位置与后续对话持久化显示。
- 不包含项目内容注入 Agent。

## Related Issues

Closes #734