### PR TITLE
feat(quick-start): add asset version downloads

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -508,12 +508,12 @@ describe('AppHeader', () => {
     fireEvent.click(accountMenu)
     expect(menuSurface.getAttribute('data-state')).toBe('closing')
     expect(menuSurface.getAttribute('aria-hidden')).toBe('true')
-    expect(menuSurface.classList.contains('app-header-account-menu-out')).toBe(true)
+    expect(menuSurface.classList.contains('product-popover-out')).toBe(true)
     expect(menuSurface.classList.contains('invisible')).toBe(false)
     expect(screen.queryByRole('link', { name: '打开账号中心' })).toBeNull()
 
     await waitFor(() => expect(menuSurface.getAttribute('data-state')).toBe('closed'))
-    expect(menuSurface.classList.contains('invisible')).toBe(true)
+    expect(menuSurface.classList.contains('product-popover-closed')).toBe(true)
   })
 
   it('打开账号菜单时查询并展示最新可用积分', async () => {

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -6,7 +6,13 @@ import type { QuotaApis } from '@/entities'
 import { readActiveRun, subscribeActiveRun } from '@/features/active-run'
 import { AUTH_SESSION_STORAGE_PREFIX, useAuthSession } from '@/features/auth-session'
 import { useQuotaBalance } from '@/features/quota'
-import { productControlClass, productMenuItemClass, productPopoverClass } from '@/shared/ui'
+import {
+  productControlClass,
+  productMenuItemClass,
+  productPopoverClass,
+  productPopoverMotionClass,
+  useProductPopoverMotion,
+} from '@/shared/ui'
 import { PageBackButton } from './page-back-button'
 
 interface ProductNavigationItem {
@@ -17,14 +23,11 @@ interface ProductNavigationItem {
   isActive: (pathname: string) => boolean
 }
 
-type AccountMenuState = 'closed' | 'open' | 'closing'
-
 export interface AppHeaderProps {
   quotaApis?: QuotaApis
   variant?: 'product' | 'marketing'
 }
 
-const accountMenuExitDurationMs = 260
 const inviteHintStorageKey = `${AUTH_SESSION_STORAGE_PREFIX}invite-hint-seen.v1`
 
 /** 四个入口对应四种去处：回首页、看资产、做新东西、核验已完成的造型。 */
@@ -116,18 +119,16 @@ export function AppHeader({
   const { pathname, search, hash } = useLocation()
   const navigate = useNavigate()
   const session = useAuthSession()
-  const [accountMenuState, setAccountMenuState] = useState<AccountMenuState>('closed')
+  const accountMenu = useProductPopoverMotion()
   const [inviteHintVisible, setInviteHintVisible] = useState(false)
-  const accountMenuOpen = accountMenuState === 'open'
   const creditBalance = useQuotaBalance(
-    accountMenuState !== 'closed' && session.state.status === 'authenticated',
+    accountMenu.mounted && session.state.status === 'authenticated',
     quotaApis,
   )
   const [wave, setWave] = useState({ entry: '', playId: 0 })
   const activeRunUserId = session.state.status === 'authenticated' ? session.state.user.id : null
   const [activeRunId, setActiveRunId] = useState<string | null>(null)
-  const [activeRunMenuState, setActiveRunMenuState] = useState<AccountMenuState>('closed')
-  const activeRunMenuOpen = activeRunMenuState === 'open'
+  const activeRunMenu = useProductPopoverMotion()
   const accountEntry = `/?${new URLSearchParams({
     account: 'login',
     returnTo: `${pathname}${search}${hash}`,
@@ -142,15 +143,6 @@ export function AppHeader({
     refresh()
     return subscribeActiveRun(activeRunUserId, refresh)
   }, [activeRunUserId])
-
-  useEffect(() => {
-    if (accountMenuState !== 'closing') {
-      return
-    }
-
-    const timer = window.setTimeout(() => setAccountMenuState('closed'), accountMenuExitDurationMs)
-    return () => window.clearTimeout(timer)
-  }, [accountMenuState])
 
   useEffect(() => {
     if (pathname !== '/workspace' || session.state.status !== 'authenticated') {
@@ -178,7 +170,7 @@ export function AppHeader({
 
   function toggleAccountMenu() {
     dismissInviteHint()
-    setAccountMenuState((state) => (state === 'open' ? 'closing' : 'open'))
+    accountMenu.toggle()
   }
 
   function dismissInviteHint() {
@@ -187,23 +179,19 @@ export function AppHeader({
   }
 
   function finishAccountMenuMotion() {
-    if (accountMenuState === 'closing') {
-      setAccountMenuState('closed')
-    }
+    accountMenu.finish()
   }
 
   function toggleActiveRunMenu() {
-    setActiveRunMenuState((state) => (state === 'open' ? 'closing' : 'open'))
+    activeRunMenu.toggle()
   }
 
   function closeActiveRunMenu() {
-    setActiveRunMenuState((state) => (state === 'open' ? 'closing' : state))
+    activeRunMenu.close()
   }
 
   function finishActiveRunMenuMotion() {
-    if (activeRunMenuState === 'closing') {
-      setActiveRunMenuState('closed')
-    }
+    activeRunMenu.finish()
   }
 
   function playTextWave(entry: string) {
@@ -268,7 +256,7 @@ export function AppHeader({
                   <button
                     type="button"
                     aria-label="创作，有任务进行中"
-                    aria-expanded={activeRunMenuOpen}
+                    aria-expanded={activeRunMenu.expanded}
                     aria-current={active ? 'page' : undefined}
                     data-motion="text-wave"
                     onClick={() => {
@@ -291,18 +279,14 @@ export function AppHeader({
 
                   <div
                     data-testid="active-run-menu"
-                    data-state={activeRunMenuState}
+                    data-state={activeRunMenu.state}
                     data-motion="scale-fade"
-                    aria-hidden={activeRunMenuOpen ? undefined : true}
-                    inert={!activeRunMenuOpen}
+                    aria-hidden={activeRunMenu.expanded ? undefined : true}
+                    inert={!activeRunMenu.expanded}
                     onAnimationEnd={finishActiveRunMenuMotion}
-                    className={`${productPopoverClass} absolute top-[calc(100%+0.5rem)] left-1/2 grid min-w-44 origin-top -translate-x-1/2 overflow-hidden p-1.5 ${
-                      activeRunMenuState === 'open'
-                        ? 'visible app-header-account-menu-in'
-                        : activeRunMenuState === 'closing'
-                          ? 'visible pointer-events-none app-header-account-menu-out'
-                          : 'invisible pointer-events-none -translate-y-2 scale-[0.82] opacity-0'
-                    }`}
+                    className={`${productPopoverClass} absolute top-[calc(100%+0.5rem)] left-1/2 grid min-w-44 origin-top -translate-x-1/2 overflow-hidden p-1.5 ${productPopoverMotionClass(
+                      activeRunMenu.state,
+                    )}`}
                   >
                     <Link
                       to={`/quick-start/${encodeURIComponent(activeRunId)}`}
@@ -398,16 +382,16 @@ export function AppHeader({
               <button
                 type="button"
                 aria-label="打开账号菜单"
-                aria-expanded={accountMenuOpen}
+                aria-expanded={accountMenu.expanded}
                 title={session.state.user.email}
                 onClick={toggleAccountMenu}
                 className={`${productControlClass('chrome', 'max-w-24 gap-2 px-2.5 font-medium active:translate-y-px active:scale-[0.97] motion-reduce:transform-none sm:max-w-36')} ${
-                  accountMenuOpen ? 'bg-app-accent-muted text-app-accent' : ''
+                  accountMenu.expanded ? 'bg-app-accent-muted text-app-accent' : ''
                 }`}
               >
                 <span
                   className={`grid h-7 w-7 shrink-0 place-items-center rounded-full bg-app-accent-muted font-serif text-[11px] text-app-accent transition-transform duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none ${
-                    accountMenuOpen ? 'scale-110' : 'scale-100'
+                    accountMenu.expanded ? 'scale-110' : 'scale-100'
                   }`}
                 >
                   {(session.state.user.nickname || session.state.user.email).slice(0, 1)}
@@ -419,18 +403,14 @@ export function AppHeader({
 
               <div
                 data-testid="account-menu"
-                data-state={accountMenuState}
+                data-state={accountMenu.state}
                 data-motion="scale-fade"
-                aria-hidden={accountMenuOpen ? undefined : true}
-                inert={!accountMenuOpen}
+                aria-hidden={accountMenu.expanded ? undefined : true}
+                inert={!accountMenu.expanded}
                 onAnimationEnd={finishAccountMenuMotion}
-                className={`${productPopoverClass} absolute top-[calc(100%+0.5rem)] right-0 grid min-w-44 origin-top-right overflow-hidden p-1.5 ${
-                  accountMenuState === 'open'
-                    ? 'visible app-header-account-menu-in'
-                    : accountMenuState === 'closing'
-                      ? 'visible pointer-events-none app-header-account-menu-out'
-                      : 'invisible pointer-events-none -translate-y-2 scale-[0.82] opacity-0'
-                }`}
+                className={`${productPopoverClass} absolute top-[calc(100%+0.5rem)] right-0 grid min-w-44 origin-top-right overflow-hidden p-1.5 ${productPopoverMotionClass(
+                  accountMenu.state,
+                )}`}
               >
                 <div
                   aria-label="积分余额"
@@ -460,7 +440,7 @@ export function AppHeader({
                   to="/account"
                   aria-label="打开账号中心"
                   aria-current={pathname.startsWith('/account') ? 'page' : undefined}
-                  onClick={() => setAccountMenuState('closing')}
+                  onClick={accountMenu.close}
                   className={`${productMenuItemClass} text-app-ink-soft`}
                 >
                   账号中心

--- a/frontend/src/features/export-package/export-panel.test.tsx
+++ b/frontend/src/features/export-package/export-panel.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { ExportPackageModel } from './model'
-import { ExportButton, ExportPanel } from './export-panel'
+import { AssetVersionExportButton, ExportButton, ExportPanel } from './export-panel'
 
 const model = {
   stage: 'action-assets',
@@ -212,5 +212,121 @@ describe('ExportPanel', () => {
     const button = screen.getByRole('button', { name: '导出完整动作资产' })
     expect(button.querySelector('svg')).toBeTruthy()
     expect(button.querySelector('[role="tooltip"]')?.textContent).toBe('导出完整动作资产')
+  })
+
+  it('有完美像素版时先选择下载版本，再导出命名清晰的单个资产包', async () => {
+    const pixelPerfectModel = {
+      ...model,
+      actions: model.actions.map((action) => ({
+        ...action,
+        sequences: action.sequences.map((sequence) => ({
+          ...sequence,
+          frames: sequence.frames.map((frame) => ({
+            ...frame,
+            imageUrl: '/pixel-perfect-walk.png',
+          })),
+        })),
+      })),
+    } satisfies ExportPackageModel
+    const exporter = vi.fn().mockResolvedValue({
+      blob: new Blob(['zip'], { type: 'application/zip' }),
+      filename: 'windup-Aster-character-1.zip',
+    })
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:versioned-export'),
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: vi.fn() })
+    const downloads: string[] = []
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloads.push(this.download)
+      })
+
+    render(
+      <AssetVersionExportButton
+        originalModel={model}
+        pixelPerfectModel={pixelPerfectModel}
+        exporter={exporter}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '选择下载版本' }))
+    const menu = screen.getByRole('menu', { name: '选择下载版本' })
+    expect(menu.className).toContain('rounded-app-surface')
+    expect(screen.getByRole('menuitem', { name: /原始资产/u })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /完美像素版/u })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /全部下载/u })).toBeTruthy()
+    expect(screen.queryByText('保留生成时的原始画面')).toBeNull()
+    expect(screen.queryByText('使用像素网格重建结果')).toBeNull()
+    expect(screen.queryByText('分别下载两套 ZIP 资产包')).toBeNull()
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /完美像素版/u }))
+
+    await waitFor(() =>
+      expect(exporter).toHaveBeenCalledWith(pixelPerfectModel, expect.any(Function)),
+    )
+    expect(click).toHaveBeenCalledTimes(1)
+    expect(downloads).toEqual(['windup-Aster-character-1-pixel-perfect.zip'])
+    expect(screen.queryByRole('menu', { name: '选择下载版本' })).toBeNull()
+  })
+
+  it('全部下载会分别导出原始资产与完美像素版', async () => {
+    const pixelPerfectModel = { ...model, characterImageUrl: '/pixel-perfect-master.png' }
+    const exporter = vi.fn().mockResolvedValue({
+      blob: new Blob(['zip'], { type: 'application/zip' }),
+      filename: 'windup-Aster-character-1.zip',
+    })
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn().mockReturnValueOnce('blob:original').mockReturnValueOnce('blob:pixel-perfect'),
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: vi.fn() })
+    const downloads: string[] = []
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(
+      function (this: HTMLAnchorElement) {
+        downloads.push(this.download)
+      },
+    )
+
+    render(
+      <AssetVersionExportButton
+        originalModel={model}
+        pixelPerfectModel={pixelPerfectModel}
+        exporter={exporter}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '选择下载版本' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: /全部下载/u }))
+
+    await waitFor(() => expect(exporter).toHaveBeenCalledTimes(2))
+    expect(exporter.mock.calls.map(([requestedModel]) => requestedModel)).toEqual([
+      model,
+      pixelPerfectModel,
+    ])
+    expect(downloads).toEqual([
+      'windup-Aster-character-1-original.zip',
+      'windup-Aster-character-1-pixel-perfect.zip',
+    ])
+  })
+
+  it('下载版本菜单支持 Escape 关闭并把焦点还给下载按钮', async () => {
+    render(<AssetVersionExportButton originalModel={model} pixelPerfectModel={model} />)
+
+    const trigger = screen.getByRole('button', { name: '选择下载版本' })
+    fireEvent.click(trigger)
+    const original = screen.getByRole('menuitem', { name: /原始资产/u })
+    await waitFor(() => expect(document.activeElement).toBe(original))
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    const closingMenu = screen.getByTestId('asset-version-menu')
+    expect(closingMenu.getAttribute('data-state')).toBe('closing')
+    expect(closingMenu.className).toContain('product-popover-out')
+    expect(document.activeElement).toBe(trigger)
+    fireEvent.animationEnd(closingMenu)
+    await waitFor(() => expect(screen.queryByTestId('asset-version-menu')).toBeNull())
   })
 })

--- a/frontend/src/features/export-package/export-panel.tsx
+++ b/frontend/src/features/export-package/export-panel.tsx
@@ -1,6 +1,12 @@
-import { useId, useState, type ReactNode } from 'react'
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react'
 import { ArrowClockwise, Check, CircleNotch, DownloadSimple } from '@phosphor-icons/react'
 
+import {
+  productMenuItemClass,
+  productPopoverClass,
+  productPopoverMotionClass,
+  useProductPopoverMotion,
+} from '@/shared/ui'
 import type { ExportPackageModel } from './model'
 import {
   createAssetExportPlan,
@@ -52,21 +58,38 @@ const STAGE_LABELS: Readonly<Record<ExportPackageModel['stage'], string>> = {
 
 const defaultExporter: AssetExporter = (model, onPhase) => exportGameAssets(model, { onPhase })
 
+interface ExportRequest {
+  model: ExportPackageModel
+  filenameSuffix?: string
+}
+
+function addFilenameSuffix(filename: string, suffix?: string): string {
+  if (!suffix) return filename
+  const extensionIndex = filename.lastIndexOf('.')
+  return extensionIndex > 0
+    ? `${filename.slice(0, extensionIndex)}-${suffix}${filename.slice(extensionIndex)}`
+    : `${filename}-${suffix}`
+}
+
 function useExportAction(model: ExportPackageModel, exporter: AssetExporter) {
   const [state, setState] = useState<ExportState>({ status: 'idle' })
   const working = state.status === 'working'
 
-  const startExport = async () => {
+  const startExport = async (requests: readonly ExportRequest[] = [{ model }]) => {
     if (working) return
     setState({ status: 'working', phase: 'validating' })
     try {
-      const result = await exporter(model, (phase) => setState({ status: 'working', phase }))
-      const url = URL.createObjectURL(result.blob)
-      const anchor = document.createElement('a')
-      anchor.href = url
-      anchor.download = result.filename
-      anchor.click()
-      URL.revokeObjectURL(url)
+      for (const request of requests) {
+        const result = await exporter(request.model, (phase) =>
+          setState({ status: 'working', phase }),
+        )
+        const url = URL.createObjectURL(result.blob)
+        const anchor = document.createElement('a')
+        anchor.href = url
+        anchor.download = addFilenameSuffix(result.filename, request.filenameSuffix)
+        anchor.click()
+        URL.revokeObjectURL(url)
+      }
       setState({ status: 'success' })
     } catch (error) {
       setState({
@@ -77,6 +100,149 @@ function useExportAction(model: ExportPackageModel, exporter: AssetExporter) {
   }
 
   return { state, working, startExport }
+}
+
+export function AssetVersionExportButton({
+  originalModel,
+  pixelPerfectModel,
+  exporter = defaultExporter,
+  className = '',
+}: {
+  originalModel: ExportPackageModel
+  pixelPerfectModel: ExportPackageModel
+  exporter?: AssetExporter
+  className?: string
+}) {
+  const { state, working, startExport } = useExportAction(originalModel, exporter)
+  const menu = useProductPopoverMotion()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const menuId = useId()
+  const tooltipId = useId()
+  const label =
+    state.status === 'working'
+      ? PHASE_LABELS[state.phase]
+      : state.status === 'failure'
+        ? '重新选择下载版本'
+        : state.status === 'success'
+          ? '下载完成'
+          : '选择下载版本'
+
+  useEffect(() => {
+    if (!menu.expanded) return
+    menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus()
+    const closeFromOutside = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) menu.close()
+    }
+    const closeFromKeyboard = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        menu.close()
+        triggerRef.current?.focus()
+      }
+    }
+    document.addEventListener('pointerdown', closeFromOutside)
+    document.addEventListener('keydown', closeFromKeyboard)
+    return () => {
+      document.removeEventListener('pointerdown', closeFromOutside)
+      document.removeEventListener('keydown', closeFromKeyboard)
+    }
+  }, [menu])
+
+  const choose = (requests: readonly ExportRequest[]) => {
+    menu.close()
+    triggerRef.current?.focus()
+    void startExport(requests)
+  }
+
+  return (
+    <div ref={rootRef} className="relative grid min-w-0 gap-1">
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={working}
+        aria-label={label}
+        aria-describedby={tooltipId}
+        aria-haspopup="menu"
+        aria-expanded={menu.expanded}
+        aria-controls={menu.mounted ? menuId : undefined}
+        title={state.status === 'failure' ? state.message : undefined}
+        onClick={menu.toggle}
+        className={`group/export-action relative grid size-10 shrink-0 place-items-center rounded-lg transition focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+      >
+        {state.status === 'working' ? (
+          <CircleNotch aria-hidden="true" size={18} weight="bold" className="animate-spin" />
+        ) : state.status === 'success' ? (
+          <Check aria-hidden="true" size={18} weight="bold" />
+        ) : state.status === 'failure' ? (
+          <ArrowClockwise aria-hidden="true" size={18} weight="bold" />
+        ) : (
+          <DownloadSimple aria-hidden="true" size={18} weight="bold" />
+        )}
+        <span
+          id={tooltipId}
+          role="tooltip"
+          className="pointer-events-none invisible absolute top-full left-1/2 z-20 mt-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-app-ink px-2 py-1 text-[11px] font-medium text-app-canvas opacity-0 shadow-app-card transition group-hover/export-action:visible group-hover/export-action:opacity-100 group-focus-within/export-action:visible group-focus-within/export-action:opacity-100"
+        >
+          {label}
+        </span>
+      </button>
+
+      {menu.mounted ? (
+        <div
+          ref={menuRef}
+          id={menuId}
+          data-testid="asset-version-menu"
+          data-state={menu.state}
+          data-motion="scale-fade"
+          data-popover-placement="top"
+          role="menu"
+          aria-label="选择下载版本"
+          aria-hidden={menu.expanded ? undefined : true}
+          inert={!menu.expanded}
+          onAnimationEnd={menu.finish}
+          className={`${productPopoverClass} absolute bottom-full left-0 z-30 mb-3 grid min-w-44 overflow-hidden p-1.5 ${productPopoverMotionClass(menu.state)}`}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => choose([{ model: originalModel, filenameSuffix: 'original' }])}
+            className={`${productMenuItemClass} text-left text-app-ink-soft`}
+          >
+            原始资产
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => choose([{ model: pixelPerfectModel, filenameSuffix: 'pixel-perfect' }])}
+            className={`${productMenuItemClass} text-left text-app-ink-soft`}
+          >
+            完美像素版
+          </button>
+          <div className="mx-3 my-1 border-t border-app-ink/10" />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() =>
+              choose([
+                { model: originalModel, filenameSuffix: 'original' },
+                { model: pixelPerfectModel, filenameSuffix: 'pixel-perfect' },
+              ])
+            }
+            className={`${productMenuItemClass} text-left text-app-accent`}
+          >
+            全部下载
+          </button>
+        </div>
+      ) : null}
+
+      {state.status === 'failure' ? (
+        <span role="alert" className="max-w-64 text-[11px] font-medium leading-4 text-app-danger">
+          导出失败：{state.message}
+        </span>
+      ) : null}
+    </div>
+  )
 }
 
 export function ExportPanel({

--- a/frontend/src/features/export-package/index.ts
+++ b/frontend/src/features/export-package/index.ts
@@ -1,5 +1,5 @@
 /** 将预览台当前角色资产打包下载；与发布到资产库是两件事。 */
-export { ExportButton, ExportPanel } from './export-panel'
+export { AssetVersionExportButton, ExportButton, ExportPanel } from './export-panel'
 export type { ExportButtonProps, ExportPanelProps } from './export-panel'
 export type {
   ExportAction,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -105,17 +105,17 @@ body,
   animation: app-header-back-strip 220ms cubic-bezier(0.65, 0, 0.35, 1) both;
 }
 
-@keyframes app-header-account-menu-in {
+@keyframes product-popover-in {
   0% {
     opacity: 0;
-    transform: translate3d(0, -8px, 0) scale(0.82);
+    transform: translate3d(0, var(--product-popover-shift-y, -8px), 0) scale(0.82);
   }
   56% {
     opacity: 1;
-    transform: translate3d(0, 1.5px, 0) scale(1.025);
+    transform: translate3d(0, calc(var(--product-popover-shift-y, -8px) * -0.1875), 0) scale(1.025);
   }
   78% {
-    transform: translate3d(0, -0.5px, 0) scale(0.996);
+    transform: translate3d(0, calc(var(--product-popover-shift-y, -8px) * 0.0625), 0) scale(0.996);
   }
   100% {
     opacity: 1;
@@ -123,33 +123,40 @@ body,
   }
 }
 
-.app-header-account-menu-in,
-.app-header-account-menu-out {
+.product-popover-in,
+.product-popover-out {
   backface-visibility: hidden;
   will-change: opacity, transform;
 }
 
-.app-header-account-menu-in {
-  animation: app-header-account-menu-in 340ms cubic-bezier(0.22, 0.8, 0.25, 1) both;
+.product-popover-in {
+  animation: product-popover-in 220ms cubic-bezier(0.22, 0.8, 0.25, 1) both;
 }
 
-@keyframes app-header-account-menu-out {
+@keyframes product-popover-out {
   0% {
     opacity: 1;
     transform: translate3d(0, 0, 0) scale(1);
   }
-  38% {
-    opacity: 1;
-    transform: translate3d(0, 1px, 0) scale(1.015);
-  }
   100% {
     opacity: 0;
-    transform: translate3d(0, -8px, 0) scale(0.82);
+    transform: translate3d(0, var(--product-popover-shift-y, -8px), 0) scale(0.82);
   }
 }
 
-.app-header-account-menu-out {
-  animation: app-header-account-menu-out 260ms cubic-bezier(0.55, 0, 1, 0.45) both;
+.product-popover-out {
+  animation: product-popover-out 110ms cubic-bezier(0.55, 0, 1, 0.45) both;
+}
+
+.product-popover-closed {
+  pointer-events: none;
+  visibility: hidden;
+  opacity: 0;
+  transform: translate3d(0, var(--product-popover-shift-y, -8px), 0) scale(0.82);
+}
+
+[data-popover-placement='top'] {
+  --product-popover-shift-y: 8px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -164,12 +171,12 @@ body,
     animation-delay: 0ms;
   }
 
-  .app-header-account-menu-in {
+  .product-popover-in {
     animation: none;
   }
 
-  .app-header-account-menu-out {
-    animation: app-header-account-menu-out 0.01ms both;
+  .product-popover-out {
+    animation: product-popover-out 0.01ms both;
   }
 }
 

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -968,6 +968,21 @@ describe('QuickStartPage', () => {
     expect(screen.getByTestId('quick-start-selected-style').textContent).toBe('像素')
   })
 
+  it('keeps the style menu mounted for the shared closing motion', () => {
+    renderAt('/quick-start', serviceFor(null))
+
+    const style = screen.getByRole('button', { name: '选择画风，当前不指定' })
+    fireEvent.click(style)
+    const menu = screen.getByTestId('quick-start-style-menu')
+    expect(menu.className).toContain('product-popover-in')
+
+    fireEvent.click(style)
+    expect(menu.getAttribute('data-state')).toBe('closing')
+    expect(menu.className).toContain('product-popover-out')
+    fireEvent.animationEnd(menu)
+    return waitFor(() => expect(screen.queryByTestId('quick-start-style-menu')).toBeNull())
+  })
+
   it('opens generation direction as an animated slider control below the composer', () => {
     renderAt('/quick-start', serviceFor(null))
 
@@ -1858,14 +1873,17 @@ describe('QuickStartPage', () => {
       'blob:https://windup.test/pixel-0',
     )
     expect(pixelVersion.closest('[data-pixel-perfect-comparison]')?.children).toHaveLength(2)
-    expect(
-      screen.getByRole('button', { name: '导出完美像素版' }).closest('[data-agent-actions]'),
-    ).toBeTruthy()
+    const exportVersions = screen.getByRole('button', { name: '选择下载版本' })
+    expect(exportVersions.closest('[data-agent-actions]')).toBeTruthy()
+    fireEvent.click(exportVersions)
+    expect(screen.getByRole('menuitem', { name: /原始资产/u })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /完美像素版/u })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /全部下载/u })).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: '查看原图' }))
     expect(screen.getByRole('img', { name: '完整动作预览' }).getAttribute('src')).toBe(
       'https://example.test/original-0.png',
     )
-    expect(screen.getByRole('button', { name: '导出原图' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '选择下载版本' })).toBeTruthy()
   })
 
   it('discards pixel-perfect frames when the action changed while processing', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -51,7 +51,11 @@ import {
 } from '@/entities'
 import { forgetActiveRun, isMissingActiveRunError, syncActiveRun } from '@/features/active-run'
 import { useOptionalAuthSession } from '@/features/auth-session'
-import { ExportButton, type ExportPackageModel } from '@/features/export-package'
+import {
+  AssetVersionExportButton,
+  ExportButton,
+  type ExportPackageModel,
+} from '@/features/export-package'
 import { useQuickStartAgent, useQuickStartWorkflowAgent } from '@/features/quick-start-agent/react'
 import type {
   CharacterGenerationProposal,
@@ -66,6 +70,8 @@ import {
   GenerationProgressCopy,
   KineticCopyCycle,
   productPopoverClass,
+  productPopoverMotionClass,
+  useProductPopoverMotion,
   type KineticCopyMessage,
 } from '@/shared/ui'
 import {
@@ -577,6 +583,7 @@ function AgentActions({
   onCopy,
   exportModel,
   exportLabel,
+  versionedExportModels,
   onOpenAssetWorkspace,
   onOpenPlaytest,
   playtestDisabled = false,
@@ -589,6 +596,10 @@ function AgentActions({
   onCopy?: () => void
   exportModel?: ExportPackageModel | null
   exportLabel?: string
+  versionedExportModels?: {
+    original: ExportPackageModel
+    pixelPerfect: ExportPackageModel
+  }
   onOpenAssetWorkspace?: () => void
   onOpenPlaytest?: () => void
   playtestDisabled?: boolean
@@ -614,7 +625,13 @@ function AgentActions({
           <ArrowClockwise aria-hidden="true" size={18} weight="bold" />
         </IconActionButton>
       ) : null}
-      {exportModel ? (
+      {versionedExportModels ? (
+        <AssetVersionExportButton
+          originalModel={versionedExportModels.original}
+          pixelPerfectModel={versionedExportModels.pixelPerfect}
+          className="text-app-muted hover:bg-app-surface-muted hover:text-app-accent"
+        />
+      ) : exportModel ? (
         <ExportButton
           model={exportModel}
           idleLabel={exportLabel}
@@ -956,7 +973,7 @@ function QuickStartInput({
 
   function chooseGameStyle(next: ArtStyle) {
     setGameStyle(next)
-    setStyleMenuOpen(false)
+    styleMenu.close()
     const draftId = draftIdRef.current
     if (draftId) {
       writeAgentConversation(
@@ -1152,8 +1169,8 @@ function QuickStartInput({
   const canSubmit = awaitingGenerationConfirmation
     ? Boolean(prompt.trim())
     : Boolean(prompt.trim()) || Boolean(templateFile)
-  const [styleMenuOpen, setStyleMenuOpen] = useState(false)
-  const [directionMenuOpen, setDirectionMenuOpen] = useState(false)
+  const styleMenu = useProductPopoverMotion()
+  const directionMenu = useProductPopoverMotion()
   const [directionDragging, setDirectionDragging] = useState(false)
   const [directionSliderValue, setDirectionSliderValue] = useState(() =>
     QUICK_START_DIRECTIONAL_MOVEMENTS.indexOf(directionalMovement),
@@ -1390,18 +1407,25 @@ function QuickStartInput({
                         label={`选择画风，当前${ART_STYLE[gameStyle]}`}
                         disabled={entryBusy || Boolean(selectedProject)}
                         onClick={() => {
-                          setDirectionMenuOpen(false)
-                          setStyleMenuOpen((open) => !open)
+                          directionMenu.close()
+                          styleMenu.toggle()
                         }}
-                        expanded={styleMenuOpen}
+                        expanded={styleMenu.expanded}
                       >
                         <StyleTileIcon />
                       </IconActionButton>
-                      {styleMenuOpen ? (
+                      {styleMenu.mounted ? (
                         <div
+                          data-testid="quick-start-style-menu"
+                          data-state={styleMenu.state}
+                          data-motion="scale-fade"
+                          data-popover-placement="top"
                           role="menu"
                           aria-label="选择画风"
-                          className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-32 gap-1 p-1.5 opacity-100`}
+                          aria-hidden={styleMenu.expanded ? undefined : true}
+                          inert={!styleMenu.expanded}
+                          onAnimationEnd={styleMenu.finish}
+                          className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-32 gap-1 p-1.5 ${productPopoverMotionClass(styleMenu.state)}`}
                         >
                           {ART_STYLE_OPTIONS.map((value) => (
                             <button
@@ -1431,8 +1455,8 @@ function QuickStartInput({
                     aria-expanded={projectMenuOpen}
                     disabled={entryBusy || hasConversation}
                     onClick={() => {
-                      setStyleMenuOpen(false)
-                      setDirectionMenuOpen(false)
+                      styleMenu.close()
+                      directionMenu.close()
                       setProjectMenuOpen((open) => !open)
                     }}
                     className={`inline-flex h-10 max-w-44 items-center gap-1 rounded-app-control px-3 text-sm font-medium text-app-ink-soft transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ${hasConversation ? 'pointer-events-none disabled:opacity-100' : 'hover:bg-app-surface-muted hover:text-app-ink disabled:opacity-45'}`}
@@ -1523,12 +1547,12 @@ function QuickStartInput({
                   <button
                     type="button"
                     aria-label={`生成方向，当前${DIRECTIONAL_MOVEMENT[directionalMovement]}`}
-                    aria-expanded={directionMenuOpen}
+                    aria-expanded={directionMenu.expanded}
                     disabled={entryBusy || Boolean(selectedProject) || hasConversation}
                     onClick={() => {
-                      setStyleMenuOpen(false)
+                      styleMenu.close()
                       setDirectionSliderValue(directionalMovementIndex)
-                      setDirectionMenuOpen((open) => !open)
+                      directionMenu.toggle()
                     }}
                     className={`inline-flex h-10 items-center gap-1 rounded-app-control px-3 text-sm font-medium text-app-ink-soft transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ${hasConversation ? 'pointer-events-none disabled:opacity-100' : 'hover:bg-app-surface-muted hover:text-app-ink disabled:opacity-45'}`}
                   >
@@ -1538,15 +1562,21 @@ function QuickStartInput({
                         aria-hidden="true"
                         size={14}
                         weight="bold"
-                        className={`transition-transform duration-200 motion-reduce:transition-none ${directionMenuOpen ? 'rotate-180' : ''}`}
+                        className={`transition-transform duration-200 motion-reduce:transition-none ${directionMenu.expanded ? 'rotate-180' : ''}`}
                       />
                     ) : null}
                   </button>
-                  {directionMenuOpen && !hasConversation ? (
+                  {directionMenu.mounted && !hasConversation ? (
                     <div
+                      data-state={directionMenu.state}
+                      data-motion="scale-fade"
+                      data-popover-placement="top"
                       role="group"
                       aria-label="生成方向设置"
-                      className={`${productPopoverClass} quick-start-control-popover absolute right-0 bottom-full z-30 mb-3 w-72 p-5 opacity-100`}
+                      aria-hidden={directionMenu.expanded ? undefined : true}
+                      inert={!directionMenu.expanded}
+                      onAnimationEnd={directionMenu.finish}
+                      className={`${productPopoverClass} quick-start-control-popover absolute right-0 bottom-full z-30 mb-3 w-72 p-5 ${productPopoverMotionClass(directionMenu.state)}`}
                     >
                       <div className="mb-4 flex items-center justify-between">
                         <span className="text-sm text-app-muted">生成方向</span>
@@ -3077,10 +3107,6 @@ function QuickStartRun({
     actionStep?.id,
     new Map(pixelPerfectReplacementEntries),
   )
-  const visibleVersionExportModel =
-    actionVersion === 'pixel-perfect' ? pixelPerfectVersionModel : actionExportModel
-  const visibleVersionExportLabel =
-    actionVersion === 'pixel-perfect' ? '导出完美像素版' : '导出原图'
   const entryAgentConversationTurns = agentConversationTurns.filter(
     (turn) => turn.scope !== 'workflow',
   )
@@ -3458,8 +3484,15 @@ function QuickStartRun({
                   )}
                   {isActionFailed || actionExportModel || reviewStep?.status === 'passed' ? (
                     <AgentActions
-                      exportModel={visibleVersionExportModel}
-                      exportLabel={pixelPerfectReady ? visibleVersionExportLabel : undefined}
+                      exportModel={actionExportModel}
+                      versionedExportModels={
+                        pixelPerfectReady && actionExportModel && pixelPerfectVersionModel
+                          ? {
+                              original: actionExportModel,
+                              pixelPerfect: pixelPerfectVersionModel,
+                            }
+                          : undefined
+                      }
                       onOpenAssetWorkspace={
                         reviewStep?.status === 'passed'
                           ? () =>

--- a/frontend/src/pages/quick-start/quick-start-motion.css
+++ b/frontend/src/pages/quick-start/quick-start-motion.css
@@ -256,7 +256,6 @@
 
 .quick-start-control-popover {
   transform-origin: 84% 100%;
-  animation: quick-start-control-popover-in 260ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 
 .quick-start-direction-value {
@@ -334,19 +333,6 @@
   outline: 2px solid var(--color-app-accent);
   outline-offset: 3px;
   border-radius: 0.75rem;
-}
-
-@keyframes quick-start-control-popover-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.94);
-    filter: blur(4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-    filter: blur(0);
-  }
 }
 
 @keyframes quick-start-direction-value-in {

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -18,5 +18,11 @@ export type { KineticCopyCycleProps, KineticCopyMessage } from './kinetic-copy-c
 export { PixelMatrix } from './pixel-matrix'
 export { FrameAnimationPlayer } from './frame-animation-player'
 export type { FrameAnimationFrame, FrameAnimationPlayerProps } from './frame-animation-player'
-export { productControlClass, productMenuItemClass, productPopoverClass } from './product-control'
-export type { ProductControlVariant } from './product-control'
+export {
+  productControlClass,
+  productMenuItemClass,
+  productPopoverClass,
+  productPopoverMotionClass,
+} from './product-control'
+export type { ProductControlVariant, ProductPopoverMotionState } from './product-control'
+export { useProductPopoverMotion } from './product-popover-motion'

--- a/frontend/src/shared/ui/product-control.test.ts
+++ b/frontend/src/shared/ui/product-control.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { productControlClass, productMenuItemClass, productPopoverClass } from './product-control'
+import {
+  productControlClass,
+  productMenuItemClass,
+  productPopoverClass,
+  productPopoverMotionClass,
+} from './product-control'
 
 describe('product control styles', () => {
   it('keeps primary and secondary actions on the same control geometry', () => {
@@ -24,5 +29,11 @@ describe('product control styles', () => {
     expect(productPopoverClass).toContain('rounded-app-surface')
     expect(productPopoverClass).toContain('border-app-line-strong')
     expect(productMenuItemClass).toContain('rounded-app-compact')
+  })
+
+  it('shares one scale-fade motion contract across product popovers', () => {
+    expect(productPopoverMotionClass('open')).toContain('product-popover-in')
+    expect(productPopoverMotionClass('closing')).toContain('product-popover-out')
+    expect(productPopoverMotionClass('closed')).toContain('product-popover-closed')
   })
 })

--- a/frontend/src/shared/ui/product-control.ts
+++ b/frontend/src/shared/ui/product-control.ts
@@ -21,3 +21,11 @@ export const productPopoverClass =
 
 export const productMenuItemClass =
   'flex min-h-10 items-center rounded-app-compact px-3 text-[13px] transition-colors hover:bg-app-accent-muted focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-app-accent'
+
+export type ProductPopoverMotionState = 'closed' | 'open' | 'closing'
+
+export function productPopoverMotionClass(state: ProductPopoverMotionState): string {
+  if (state === 'open') return 'visible product-popover-in'
+  if (state === 'closing') return 'visible pointer-events-none product-popover-out'
+  return 'product-popover-closed'
+}

--- a/frontend/src/shared/ui/product-popover-motion.ts
+++ b/frontend/src/shared/ui/product-popover-motion.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export type ProductPopoverMotionState = 'closed' | 'open' | 'closing'
+
+const PRODUCT_POPOVER_EXIT_MS = 110
+
+/** 浮层关闭时先保留节点完成退出动画，再从布局与可访问树中移除。 */
+export function useProductPopoverMotion() {
+  const [state, setState] = useState<ProductPopoverMotionState>('closed')
+
+  useEffect(() => {
+    if (state !== 'closing') return
+    const timer = window.setTimeout(() => setState('closed'), PRODUCT_POPOVER_EXIT_MS)
+    return () => window.clearTimeout(timer)
+  }, [state])
+
+  const toggle = useCallback(() => {
+    setState((current) => (current === 'open' ? 'closing' : 'open'))
+  }, [])
+  const close = useCallback(() => {
+    setState((current) => (current === 'open' ? 'closing' : current))
+  }, [])
+  const finish = useCallback(() => {
+    setState((current) => (current === 'closing' ? 'closed' : current))
+  }, [])
+
+  return {
+    state,
+    expanded: state === 'open',
+    mounted: state !== 'closed',
+    toggle,
+    close,
+    finish,
+  }
+}


### PR DESCRIPTION
完美像素化完成后，Quick Start 下载按钮可明确导出原始资产、完美像素版或两套资产，同时统一产品浮层的弹出与收回动效。

## Why

当前完成完美像素化后，下载按钮只会导出画面中选中的版本，用户无法在下载时确认资产版本，也不能一次取得两套资产；头像、画风与方向菜单的浮层退出行为也不一致。

## Changes

- 完美像素化未完成时保留原有一键下载。
- 完美像素化完成后提供“原始资产”“完美像素版”“全部下载”三个选项。
- 单独下载文件名增加 `-original.zip` 或 `-pixel-perfect.zip`；全部下载依次导出两套 ZIP。
- 头像、画风、方向与下载菜单复用同一套浮层进入和退出状态。
- 支持点击外部、`Escape` 关闭下载菜单并归还焦点。

## Implementation

- `AssetVersionExportButton` 接收原始与完美像素化两份 `ExportPackageModel`，继续复用现有导出管线，不修改资源格式与生成接口。
- `useProductPopoverMotion` 统一 `closed / open / closing` 状态，在退出动画完成后卸载节点，并提供 110ms 超时兜底与 `prefers-reduced-motion` 支持。

## Verification

- [x] `npx oxfmt --check <13 changed frontend files>`：通过。
- [x] `npx oxlint <13 changed frontend files>`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npm test -- --run src/shared/ui/product-control.test.ts src/features/export-package/export-panel.test.tsx src/app/layout/app-header.test.tsx src/pages/quick-start/index.test.tsx --maxWorkers=1`：4 个测试文件，164 个测试通过。
- [x] `npm run build`：通过。
- [x] 前端视觉验收：用户已确认通过。

## Scope

- 本 PR 不包含资产库保存与版本管理。
- 本 PR 不修改完美像素化算法、接口或生成流程。

## Related Issues

Closes #731
