### PR TITLE
feat(quota): add one-time credit redemption

### DIFF
--- a/backend/packages/app/src/windup_app/bootstrap/app.py
+++ b/backend/packages/app/src/windup_app/bootstrap/app.py
@@ -23,7 +23,7 @@ from windup_app.server.character.model import Character  # noqa: F401
 from windup_app.server.character.service import service as character_service
 from windup_app.server.project.model import Project  # noqa: F401
 from windup_app.server.project.service import service as project_service
-from windup_app.server.quota.model import CreditAccount, CreditTransaction, InviteCode, InviteRecord  # noqa: F401
+from windup_app.server.quota import model as quota_model  # noqa: F401
 from windup_app.server.user.model import User  # noqa: F401
 from windup_app.server.workflow_run.model import WorkflowRun  # noqa: F401
 from windup_app.server.action_preset import ACTION_PRESETS

--- a/backend/packages/app/src/windup_app/server/quota/interface.py
+++ b/backend/packages/app/src/windup_app/server/quota/interface.py
@@ -86,6 +86,12 @@ class QuotaService(ABC):
     ) -> None:
         """入账：增加可用余额与累计获得。"""
 
+    @abstractmethod
+    def redeem_code(
+        self, session: Session, user_id: int, code: str
+    ) -> tuple[int, CreditAccountView]:
+        """兑换一次性积分码，返回入账数量和更新后的账户。"""
+
     # -- 流水查询 ---------------------------------------------------------
 
     @abstractmethod

--- a/backend/packages/app/src/windup_app/server/quota/model.py
+++ b/backend/packages/app/src/windup_app/server/quota/model.py
@@ -9,6 +9,7 @@ ORM 模型
 
     windup_credit_account    积分账户（每用户一行）
     windup_credit_transaction  积分流水（不可变账本）
+    windup_credit_redemption_code  一次性积分兑换码
     windup_invite_code       邀请码
     windup_invite_record     邀请记录
     windup_token_usage       Token 用量记录
@@ -107,6 +108,38 @@ class CreditTransaction(Base):
     balance_after: Mapped[int] = mapped_column(
         BigInteger().with_variant(Integer, "sqlite"),
         nullable=False,
+    )
+    create_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class CreditRedemptionCode(Base):
+    """一次性积分兑换码；只保存摘要，避免数据库泄露兑换明文。"""
+
+    __tablename__ = "windup_credit_redemption_code"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    code_hash: Mapped[str] = mapped_column(
+        String(64), unique=True, index=True, nullable=False
+    )
+    amount: Mapped[int] = mapped_column(Integer, nullable=False, default=1000)
+    redeemed_by: Mapped[int | None] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"),
+        index=True,
+        nullable=True,
+    )
+    redeemed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
     create_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/packages/app/src/windup_app/server/quota/redemption.py
+++ b/backend/packages/app/src/windup_app/server/quota/redemption.py
@@ -1,0 +1,60 @@
+"""积分兑换码的生成用例；明文只从运维脚本输出，不进入持久化模型。"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import datetime
+
+from sqlalchemy import select
+
+from windup_app.server.quota.model import CreditRedemptionCode
+from windup_app.server.quota.service import redemption_code_hash
+
+_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+_BODY_LENGTH = 12
+_AMOUNT = 1000
+
+
+def _format_code(body: str) -> str:
+    return f"WU-{body[:4]}-{body[4:8]}-{body[8:]}"
+
+
+def _new_code() -> str:
+    body = "".join(secrets.choice(_ALPHABET) for _ in range(_BODY_LENGTH))
+    return _format_code(body)
+
+
+def create_codes(
+    session, *, count: int, expires_at: datetime | None = None
+) -> list[str]:
+    """生成兑换码并 flush；提交事务由调用方控制。"""
+    if count < 1:
+        raise ValueError("count must be positive")
+
+    codes: list[str] = []
+    hashes: set[str] = set()
+    while len(codes) < count:
+        code = _new_code()
+        digest = redemption_code_hash(code)
+        if digest in hashes:
+            continue
+        if (
+            session.scalar(
+                select(CreditRedemptionCode.id).where(
+                    CreditRedemptionCode.code_hash == digest
+                )
+            )
+            is not None
+        ):
+            continue
+        hashes.add(digest)
+        codes.append(code)
+        session.add(
+            CreditRedemptionCode(
+                code_hash=digest,
+                amount=_AMOUNT,
+                expires_at=expires_at,
+            )
+        )
+    session.flush()
+    return codes

--- a/backend/packages/app/src/windup_app/server/quota/service.py
+++ b/backend/packages/app/src/windup_app/server/quota/service.py
@@ -11,13 +11,14 @@ rollback，故本实现只 ``flush``（把变更发到当前事务、取回生�
 - 入账（赠送/奖励）：余额 + 累计获得同步递增
 """
 
+import hashlib
 import logging
 import re
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Literal
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -29,6 +30,7 @@ from windup_app.server.quota.interface import QuotaService
 from windup_app.server.quota.model import (
     CreditAccount,
     CreditAccountView,
+    CreditRedemptionCode,
     CreditTransaction,
     CreditTransactionView,
     InviteCode,
@@ -43,6 +45,7 @@ logger = logging.getLogger("windup.quota.service")
 _INVITE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 _INVITE_CODE_LENGTH = 8
 _INVITE_CODE_RE = re.compile(rf"^[{re.escape(_INVITE_ALPHABET)}]{{4,16}}$")
+_REDEMPTION_CODE_RE = re.compile(r"^WU[A-Z0-9]{12}$")
 
 
 def normalize_invite_code(code: str) -> str:
@@ -55,6 +58,19 @@ def parse_invite_code(code: str) -> str:
     if _INVITE_CODE_RE.fullmatch(normalized) is None:
         raise BizException("邀请码无效", code=BizCode.BAD_REQUEST)
     return normalized
+
+
+def normalize_redemption_code(code: str) -> str:
+    """把展示用分隔符去掉后转成兑换码的规范形式。"""
+    normalized = re.sub(r"[-\s]", "", code.strip().upper())
+    if _REDEMPTION_CODE_RE.fullmatch(normalized) is None:
+        raise BizException("兑换码无效或已使用", code=BizCode.BAD_REQUEST)
+    return normalized
+
+
+def redemption_code_hash(code: str) -> str:
+    """兑换码由高熵随机串生成，摘要足以阻断数据库明文泄露。"""
+    return hashlib.sha256(normalize_redemption_code(code).encode("ascii")).hexdigest()
 
 
 def _new_invite_code() -> str:
@@ -362,6 +378,69 @@ class SqlAlchemyQuotaService(QuotaService):
             reason,
             account.balance,
         )
+
+    def redeem_code(
+        self, session: Session, user_id: int, code: str
+    ) -> tuple[int, CreditAccountView]:
+        """原子占用兑换码并将额度写入不可变积分账本。"""
+        code_hash = redemption_code_hash(code)
+        account = self._get_account_for_update(session, user_id)
+        redemption = session.scalar(
+            select(CreditRedemptionCode).where(
+                CreditRedemptionCode.code_hash == code_hash
+            )
+        )
+        if redemption is None:
+            raise BizException("兑换码无效或已使用", code=BizCode.BAD_REQUEST)
+        if redemption.expires_at is not None and _is_expired(redemption.expires_at):
+            raise BizException("兑换码无效或已使用", code=BizCode.BAD_REQUEST)
+
+        ref_id = f"redemption:{redemption.id}"
+        if redemption.redeemed_by is not None:
+            if (
+                redemption.redeemed_by == user_id
+                and self._txn_for(session, ref_id, int(CreditReason.REDEMPTION))
+                is not None
+            ):
+                return redemption.amount, _to_account_view(account)
+            raise BizException("兑换码无效或已使用", code=BizCode.BAD_REQUEST)
+
+        redeemed_at = _now()
+        claimed = session.execute(
+            update(CreditRedemptionCode)
+            .where(
+                CreditRedemptionCode.id == redemption.id,
+                CreditRedemptionCode.redeemed_by.is_(None),
+                or_(
+                    CreditRedemptionCode.expires_at.is_(None),
+                    CreditRedemptionCode.expires_at > redeemed_at,
+                ),
+            )
+            .values(redeemed_by=user_id, redeemed_at=redeemed_at)
+        )
+        if claimed.rowcount != 1:
+            raise BizException("兑换码无效或已使用", code=BizCode.BAD_REQUEST)
+        session.expire(redemption, ["redeemed_by", "redeemed_at"])
+        account.balance += redemption.amount
+        account.total_earned += redemption.amount
+        session.flush()
+        self._write_txn(
+            session,
+            user_id,
+            redemption.amount,
+            CreditReason.REDEMPTION,
+            BillingMode.PREPAID,
+            account.balance,
+            ref_id,
+        )
+        logger.info(
+            "[WINDUP] 兑换码入账 | user_id=%s redemption_id=%s amount=%s balance=%s",
+            user_id,
+            redemption.id,
+            redemption.amount,
+            account.balance,
+        )
+        return redemption.amount, _to_account_view(account)
 
     # -- 流水查询 ---------------------------------------------------------
 

--- a/backend/packages/app/src/windup_app/web/api/quota.py
+++ b/backend/packages/app/src/windup_app/web/api/quota.py
@@ -4,6 +4,7 @@
 --------
 GET  /quota/balance          查询积分余额
 GET  /quota/transactions     查询积分流水（分页）
+POST /quota/redeem            兑换一次性积分码
 GET  /quota/invite/code      获取我的邀请码
 POST /quota/invite/generate  签发新邀请码
 """
@@ -73,6 +74,19 @@ class InviteCodeOut(BaseModel):
     update_at: datetime
 
 
+class RedeemCodeIn(BaseModel):
+    """积分兑换码提交参数。"""
+
+    code: str
+
+
+class RedeemCodeOut(BaseModel):
+    """积分兑换结果及刷新账户所需的最新汇总。"""
+
+    credited: int
+    account: CreditAccountOut
+
+
 # -- 端点 ----------------------------------------------------------------
 
 
@@ -123,6 +137,25 @@ def list_transactions(
         total=total,
         page=page,
         page_size=page_size,
+    )
+
+
+@router.post("/redeem", response_model=Response[RedeemCodeOut])
+def redeem_code(
+    payload: RedeemCodeIn,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> Response[RedeemCodeOut]:
+    """兑换一次性积分码；账户、兑换码和流水共用一个事务。"""
+    credited, account = service.redeem_code(
+        session, request.state.current_user.id, payload.code
+    )
+    return Response.success(
+        RedeemCodeOut(
+            credited=credited,
+            account=CreditAccountOut.model_validate(account),
+        ),
+        message=f"已到账 {credited:,} 积分",
     )
 
 

--- a/backend/packages/common/src/windup_common/enums/quota.py
+++ b/backend/packages/common/src/windup_common/enums/quota.py
@@ -23,6 +23,7 @@ class CreditReason(IntEnum):
     REFUND = 6             # 退款 / 回退 / 解冻退回
     FROZEN = 7             # 预付费冻结（占用余额）
     CAPTURED = 8    # 预付费实际扣减（冻结转消耗）
+    REDEMPTION = 9  # 兑换码入账
     # AGENT_TOKEN = 9        # Agent token 消耗（后付费）先不实现后付费场景
 
 
@@ -34,4 +35,3 @@ class BillingMode(IntEnum):
 
     PREPAID = 0    # 预付费（生成任务：冻结→扣减/解冻）
     # POSTPAID = 1   # 后付费（Agent token：用完再扣）
-

--- a/backend/scripts/create_credit_redemption_codes.py
+++ b/backend/scripts/create_credit_redemption_codes.py
@@ -1,0 +1,27 @@
+"""生成一次性积分兑换码并把明文输出给运营人员。"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+
+from windup_app.server.quota.redemption import create_codes
+from windup_app.server.quota.model import CreditRedemptionCode
+from windup_framework.db import Base, SessionLocal, engine
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--count", type=int, required=True)
+    parser.add_argument("--expires-at", type=datetime.fromisoformat)
+    args = parser.parse_args()
+
+    Base.metadata.create_all(engine, tables=[CreditRedemptionCode.__table__])
+    with SessionLocal.begin() as session:
+        for code in create_codes(session, count=args.count, expires_at=args.expires_at):
+            print(code)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -25,6 +25,7 @@ from windup_app.server.character.model import Character
 from windup_app.server.project.model import Project
 from windup_app.server.quota.model import (
     CreditAccount,
+    CreditRedemptionCode,
     CreditTransaction,
     InviteCode,
     InviteRecord,
@@ -125,6 +126,7 @@ def engine():
             Character.__table__,
             WorkflowRun.__table__,
             CreditAccount.__table__,
+            CreditRedemptionCode.__table__,
             CreditTransaction.__table__,
             InviteCode.__table__,
             InviteRecord.__table__,

--- a/backend/tests/test_quota.py
+++ b/backend/tests/test_quota.py
@@ -6,6 +6,7 @@
 """
 
 from datetime import datetime, timezone
+from unittest.mock import Mock
 
 import pytest
 from sqlalchemy import select
@@ -15,8 +16,12 @@ from windup_common.enums.quota import CreditReason
 from windup_framework.config.quota import settings as quota_settings
 from windup_common.exceptions import BizException
 
-from windup_app.server.quota.model import CreditAccount, CreditTransaction
-from windup_app.server.quota.service import SqlAlchemyQuotaService
+from windup_app.server.quota.model import (
+    CreditAccount,
+    CreditRedemptionCode,
+    CreditTransaction,
+)
+from windup_app.server.quota.service import SqlAlchemyQuotaService, redemption_code_hash
 
 
 @pytest.fixture()
@@ -77,6 +82,25 @@ def auth_quota_client(engine, user_with_account):
 
     yield client
     app.dependency_overrides.clear()
+
+
+def add_redemption_code(
+    db_session: Session,
+    code: str = "WUABCDEFGHJKLM",
+    *,
+    amount: int = 1000,
+    expires_at=None,
+    redeemed_by=None,
+) -> CreditRedemptionCode:
+    row = CreditRedemptionCode(
+        code_hash=redemption_code_hash(code),
+        amount=amount,
+        expires_at=expires_at,
+        redeemed_by=redeemed_by,
+    )
+    db_session.add(row)
+    db_session.flush()
+    return row
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -356,6 +380,123 @@ class TestCredit:
     def test_credit_nonexistent_account(self, db_session, quota_service):
         with pytest.raises(BizException, match="积分账户不存在"):
             quota_service.credit(db_session, 99999, 50, CreditReason.ADMIN_ADJUST)
+
+
+class TestRedeemCode:
+    def test_redeem_does_not_credit_when_database_claim_loses_race(
+        self, quota_service, monkeypatch
+    ):
+        account = CreditAccount(
+            id=11,
+            user_id=1,
+            balance=100,
+            frozen=0,
+            total_earned=100,
+            total_spent=0,
+        )
+        redemption = CreditRedemptionCode(
+            id=21,
+            code_hash=redemption_code_hash("WUABCDEFGHJKLM"),
+            amount=1000,
+        )
+        fake_session = Mock(spec=Session)
+        fake_session.scalar.return_value = redemption
+        fake_session.execute.return_value.rowcount = 0
+        monkeypatch.setattr(
+            quota_service, "_get_account_for_update", lambda _session, _user_id: account
+        )
+
+        with pytest.raises(BizException, match="兑换码无效或已使用"):
+            quota_service.redeem_code(fake_session, 1, "WUABCDEFGHJKLM")
+
+        assert account.balance == 100
+        assert account.total_earned == 100
+        fake_session.add.assert_not_called()
+
+    def test_redeem_adds_balance_and_writes_reasoned_transaction(
+        self, db_session, quota_service, user_with_account
+    ):
+        code = "WUABCDEFGHJKLM"
+        redemption = add_redemption_code(db_session, code)
+
+        credited, account = quota_service.redeem_code(
+            db_session, user_with_account.id, code
+        )
+
+        assert credited == 1000
+        assert account.balance == quota_settings.register_gift_amount + 1000
+        assert account.total_earned == quota_settings.register_gift_amount + 1000
+        assert (
+            db_session.get(CreditRedemptionCode, redemption.id).redeemed_by
+            == user_with_account.id
+        )
+        txn = db_session.scalar(
+            select(CreditTransaction).where(
+                CreditTransaction.ref_id == f"redemption:{redemption.id}",
+                CreditTransaction.reason == CreditReason.REDEMPTION,
+            )
+        )
+        assert txn is not None
+        assert txn.delta == 1000
+
+    def test_redeem_same_code_twice_is_idempotent_for_same_user(
+        self, db_session, quota_service, user_with_account
+    ):
+        code = "WUABCDEFGHJKLM"
+        add_redemption_code(db_session, code)
+
+        first = quota_service.redeem_code(db_session, user_with_account.id, code)
+        second = quota_service.redeem_code(db_session, user_with_account.id, code)
+
+        assert first[0] == second[0] == 1000
+        assert (
+            first[1].balance
+            == second[1].balance
+            == quota_settings.register_gift_amount + 1000
+        )
+        assert first[1].total_earned == second[1].total_earned
+        assert (
+            db_session.scalar(
+                select(CreditTransaction).where(
+                    CreditTransaction.reason == CreditReason.REDEMPTION
+                )
+            )
+            is not None
+        )
+        assert (
+            db_session.scalar(
+                select(CreditTransaction).where(
+                    CreditTransaction.reason == CreditReason.REDEMPTION
+                )
+            ).delta
+            == 1000
+        )
+
+    def test_redeem_rejects_expired_code_without_changing_account(
+        self, db_session, quota_service, user_with_account
+    ):
+        code = "WUABCDEFGHJKLM"
+        add_redemption_code(
+            db_session,
+            code,
+            expires_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        )
+
+        with pytest.raises(BizException, match="兑换码无效或已使用"):
+            quota_service.redeem_code(db_session, user_with_account.id, code)
+
+        account = db_session.scalar(
+            select(CreditAccount).where(CreditAccount.user_id == 1)
+        )
+        assert account.balance == quota_settings.register_gift_amount
+        assert (
+            db_session.scalars(
+                select(CreditTransaction).where(
+                    CreditTransaction.reason == CreditReason.REDEMPTION
+                )
+            ).all()
+            == []
+        )
 
 
 # -- 流水查询 ---------------------------------------------------------------
@@ -645,6 +786,37 @@ class TestQuotaAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert data["code"] == 401
+
+    def test_redeem_invalid_code_returns_business_error(self, auth_quota_client):
+        """兑换无效兑换码时不应落账，并返回可读业务错误。"""
+        resp = auth_quota_client.post(
+            "/quota/redeem",
+            json={"code": "WU-INVALID-CODE"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["code"] == 400
+        assert resp.json()["message"] == "兑换码无效或已使用"
+
+    def test_redeem_valid_code_returns_updated_account(
+        self, auth_quota_client, db_session, user_with_account
+    ):
+        add_redemption_code(db_session)
+        db_session.commit()
+
+        resp = auth_quota_client.post(
+            "/quota/redeem",
+            json={"code": "WU-ABCD-EFGH-JKLM"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["code"] == 200
+        assert data["data"]["credited"] == 1000
+        assert (
+            data["data"]["account"]["balance"]
+            == quota_settings.register_gift_amount + 1000
+        )
 
 
 def _gift_account(session: Session, user_id: int) -> None:

--- a/backend/tests/test_redemption_codes.py
+++ b/backend/tests/test_redemption_codes.py
@@ -1,0 +1,33 @@
+from windup_app.server.quota.redemption import create_codes
+
+from windup_app.server.quota.model import CreditRedemptionCode
+from windup_app.server.quota.service import redemption_code_hash
+
+
+def test_create_codes_returns_printable_codes_and_persists_only_hashes(db_session):
+    codes = create_codes(db_session, count=3)
+
+    assert len(codes) == 3
+    assert all(code.startswith("WU-") for code in codes)
+    assert len(set(codes)) == 3
+
+    rows = db_session.query(CreditRedemptionCode).all()
+    assert len(rows) == 3
+    assert {row.code_hash for row in rows} == {
+        redemption_code_hash(code) for code in codes
+    }
+
+
+def test_create_codes_skips_a_code_that_already_exists(db_session, monkeypatch):
+    existing_code = "WU-ABCD-EFGH-JKLM"
+    replacement_code = "WU-NPQR-STUV-WXYZ"
+    db_session.add(
+        CreditRedemptionCode(code_hash=redemption_code_hash(existing_code), amount=1000)
+    )
+    db_session.flush()
+    generated = iter([existing_code, replacement_code])
+    monkeypatch.setattr(
+        "windup_app.server.quota.redemption._new_code", lambda: next(generated)
+    )
+
+    assert create_codes(db_session, count=1) == [replacement_code]

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -51,6 +51,7 @@ function createQuotaMock(): QuotaApis & {
   return {
     getBalance: vi.fn(async () => creditAccount),
     listTransactions: vi.fn(async () => ({ items: [], total: 0, page: 1, pageSize: 20 })),
+    redeemCode: vi.fn(async () => ({ credited: 1000, account: creditAccount })),
     getInviteCode: vi.fn(async () => ({
       code: 'AB23CD45',
       usedCount: 0,

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -13,6 +13,7 @@ export { createQuotaApis, quotaApis } from './quota'
 export type {
   CreateQuotaApisOptions,
   CreditAccount,
+  CreditRedemptionResult,
   CreditTransaction,
   InviteCode,
   CreditTransactionDirection,

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -125,6 +125,31 @@ describe('createQuotaApis', () => {
     expect(request).toHaveBeenNthCalledWith(1, '/quota/invite/generate', { method: 'POST' })
   })
 
+  it('提交兑换码并映射入账后的积分账户', async () => {
+    request.mockResolvedValue({ credited: 1000, account: accountResponse })
+
+    const apis = createQuotaApis({ client })
+
+    await expect(apis.redeemCode(' wu-abcd-efgh ')).resolves.toEqual({
+      credited: 1000,
+      account: {
+        id: '11',
+        userId: '7',
+        balance: 90,
+        frozen: 10,
+        totalEarned: 150,
+        totalSpent: 50,
+        createdAt: '2026-08-12T01:02:03Z',
+        updatedAt: '2026-08-17T01:02:03Z',
+      },
+    })
+    expect(request).toHaveBeenCalledWith('/quota/redeem', {
+      method: 'POST',
+      json: { code: ' wu-abcd-efgh ' },
+      replayAfterAuth: false,
+    })
+  })
+
   it('将方向、原因和时间范围作为服务端筛选参数', async () => {
     requestList.mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 50 })
 

--- a/frontend/src/entities/quota/api.ts
+++ b/frontend/src/entities/quota/api.ts
@@ -39,6 +39,11 @@ interface InviteCodeDto {
   update_at: string
 }
 
+interface CreditRedemptionResultDto {
+  credited: number
+  account: CreditAccountDto
+}
+
 export interface CreateQuotaApisOptions extends ApiClientOptions {
   client?: ApiClient
 }
@@ -109,6 +114,14 @@ export function createQuotaApis(options: CreateQuotaApisOptions = {}): QuotaApis
       )
       return { ...result, items: result.items.map(toCreditTransaction) }
     },
+    async redeemCode(code: string) {
+      const result = await protectedClient.request<CreditRedemptionResultDto>('/quota/redeem', {
+        method: 'POST',
+        json: { code },
+        replayAfterAuth: false,
+      })
+      return { credited: result.credited, account: toCreditAccount(result.account) }
+    },
     async getInviteCode() {
       return toInviteCode(await protectedClient.request<InviteCodeDto>('/quota/invite/code'))
     },
@@ -131,6 +144,7 @@ function getDefaultApis(): QuotaApis {
 export const quotaApis: QuotaApis = {
   getBalance: () => getDefaultApis().getBalance(),
   listTransactions: (query) => getDefaultApis().listTransactions(query),
+  redeemCode: (code) => getDefaultApis().redeemCode(code),
   getInviteCode: () => getDefaultApis().getInviteCode(),
   generateInviteCode: () => getDefaultApis().generateInviteCode(),
 }

--- a/frontend/src/entities/quota/index.ts
+++ b/frontend/src/entities/quota/index.ts
@@ -2,6 +2,7 @@ export { createQuotaApis, quotaApis } from './api'
 export type { CreateQuotaApisOptions } from './api'
 export type {
   CreditAccount,
+  CreditRedemptionResult,
   CreditTransaction,
   InviteCode,
   CreditTransactionDirection,

--- a/frontend/src/entities/quota/types.ts
+++ b/frontend/src/entities/quota/types.ts
@@ -46,9 +46,16 @@ export interface InviteCode {
   updatedAt: string
 }
 
+/** 兑换码入账结果；account 是本次事务提交后的最新账户快照。 */
+export interface CreditRedemptionResult {
+  credited: number
+  account: CreditAccount
+}
+
 export interface QuotaApis {
   getBalance(): Promise<CreditAccount>
   listTransactions(query?: QuotaTransactionPageQuery): Promise<Paged<CreditTransaction>>
+  redeemCode(code: string): Promise<CreditRedemptionResult>
   getInviteCode(): Promise<InviteCode>
   generateInviteCode(): Promise<InviteCode>
 }

--- a/frontend/src/features/quota/index.test.ts
+++ b/frontend/src/features/quota/index.test.ts
@@ -45,6 +45,7 @@ function createQuotaApis(): QuotaApis & {
       page,
       pageSize,
     })),
+    redeemCode: vi.fn(async () => ({ credited: 1000, account })),
     getInviteCode: vi.fn(async () => ({
       code: 'AB23CD45',
       usedCount: 0,
@@ -171,6 +172,7 @@ describe('quota queries', () => {
       CREDIT_REASON_OPTIONS.map(({ label }) => label),
     )
     expect(getCreditReasonLabel(4)).toBe('生成角色动作')
+    expect(getCreditReasonLabel(9)).toBe('兑换码入账')
     expect(getCreditReasonLabel(99)).toBe('积分变动（原因码 99）')
     expect(formatCreditDateTime('not-a-date')).toBe('时间未知')
   })

--- a/frontend/src/features/quota/index.ts
+++ b/frontend/src/features/quota/index.ts
@@ -164,6 +164,7 @@ export const CREDIT_REASON_OPTIONS = [
   { value: 6, label: '退款 / 回退' },
   { value: 7, label: '积分冻结' },
   { value: 8, label: '实际扣减' },
+  { value: 9, label: '兑换码入账' },
 ] as const
 
 const reasonLabels: Readonly<Record<number, string>> = Object.fromEntries(

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -189,6 +189,111 @@ describe('AccountPage', () => {
     expect(screen.getByText('-12')).toBeTruthy()
   })
 
+  it('从积分账户右上角打开兑换码对话框，并在关闭后归还焦点', async () => {
+    vi.spyOn(quotaApis, 'getBalance').mockResolvedValue({
+      id: '11',
+      userId: '7',
+      balance: 90,
+      frozen: 0,
+      totalEarned: 100,
+      totalSpent: 10,
+      createdAt: '2026-08-12T01:02:03Z',
+      updatedAt: '2026-08-17T01:02:03Z',
+    })
+    vi.spyOn(quotaApis, 'listTransactions').mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    })
+
+    renderAccount()
+    fireEvent.click(await screen.findByRole('button', { name: '积分账户' }))
+    const trigger = await screen.findByRole('button', { name: '填写积分兑换码' })
+
+    fireEvent.click(trigger)
+    const dialog = screen.getByRole('dialog', { name: '兑换积分' })
+    expect(screen.getByLabelText('兑换码')).toBeTruthy()
+    expect(document.activeElement).toBe(dialog)
+
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    expect(screen.queryByRole('dialog', { name: '兑换积分' })).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('兑换成功后显示入账积分并刷新账户与流水', async () => {
+    const initialAccount = {
+      id: '11',
+      userId: '7',
+      balance: 90,
+      frozen: 0,
+      totalEarned: 100,
+      totalSpent: 10,
+      createdAt: '2026-08-12T01:02:03Z',
+      updatedAt: '2026-08-17T01:02:03Z',
+    }
+    const redeemedAccount = {
+      ...initialAccount,
+      balance: 1090,
+      totalEarned: 1100,
+      updatedAt: '2026-08-17T02:03:04Z',
+    }
+    const getBalance = vi
+      .spyOn(quotaApis, 'getBalance')
+      .mockResolvedValueOnce(initialAccount)
+      .mockResolvedValue(redeemedAccount)
+    const listTransactions = vi
+      .spyOn(quotaApis, 'listTransactions')
+      .mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 20 })
+    const redeemCode = vi
+      .spyOn(quotaApis, 'redeemCode')
+      .mockResolvedValue({ credited: 1000, account: redeemedAccount })
+
+    renderAccount()
+    fireEvent.click(await screen.findByRole('button', { name: '积分账户' }))
+    fireEvent.click(await screen.findByRole('button', { name: '填写积分兑换码' }))
+    fireEvent.change(screen.getByLabelText('兑换码'), {
+      target: { value: '  WU-ABCD-EFGH  ' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '确认兑换' }))
+
+    await waitFor(() => expect(redeemCode).toHaveBeenCalledWith('WU-ABCD-EFGH'))
+    expect(await screen.findByText('+1,000')).toBeTruthy()
+    await waitFor(() => expect(getBalance).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(listTransactions).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('1,090')).toBeTruthy()
+  })
+
+  it('兑换失败时显示后端错误并保留输入', async () => {
+    vi.spyOn(quotaApis, 'getBalance').mockResolvedValue({
+      id: '11',
+      userId: '7',
+      balance: 90,
+      frozen: 0,
+      totalEarned: 100,
+      totalSpent: 10,
+      createdAt: '2026-08-12T01:02:03Z',
+      updatedAt: '2026-08-17T01:02:03Z',
+    })
+    vi.spyOn(quotaApis, 'listTransactions').mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    })
+    vi.spyOn(quotaApis, 'redeemCode').mockRejectedValue(new Error('兑换码无效或已使用'))
+
+    renderAccount()
+    fireEvent.click(await screen.findByRole('button', { name: '积分账户' }))
+    fireEvent.click(await screen.findByRole('button', { name: '填写积分兑换码' }))
+    const input = screen.getByLabelText('兑换码')
+    fireEvent.change(input, { target: { value: 'WU-USED-CODE' } })
+    fireEvent.click(screen.getByRole('button', { name: '确认兑换' }))
+
+    expect((await screen.findByRole('alert')).textContent).toContain('兑换码无效或已使用')
+    expect((input as HTMLInputElement).value).toBe('WU-USED-CODE')
+  })
+
   it('在账号中心直接管理邀请奖励', async () => {
     vi.spyOn(quotaApis, 'getBalance').mockResolvedValue({
       id: '11',

--- a/frontend/src/pages/account/index.tsx
+++ b/frontend/src/pages/account/index.tsx
@@ -1,8 +1,18 @@
-import { useEffect, useId, useReducer, useRef, useState, type FormEvent } from 'react'
+import { Gift, X } from '@phosphor-icons/react'
+import {
+  useEffect,
+  useId,
+  useReducer,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+} from 'react'
 import { useSearchParams } from 'react-router'
 
 import accountBadgeArtwork from '@/assets/account/illustrations/account-badge.webp'
-import type { User } from '@/entities'
+import { quotaApis, type CreditRedemptionResult, type User } from '@/entities'
 import { useAuthSession } from '@/features/auth-session'
 import {
   CREDIT_REASON_OPTIONS,
@@ -49,6 +59,177 @@ function formatCredits(value: number): string {
   return value.toLocaleString('zh-CN')
 }
 
+function CreditRedemptionDialog({
+  onClose,
+  onRedeemed,
+  returnFocusRef,
+}: {
+  onClose: () => void
+  onRedeemed: (result: CreditRedemptionResult) => void
+  returnFocusRef: RefObject<HTMLButtonElement | null>
+}) {
+  const dialogRef = useRef<HTMLElement>(null)
+  const titleId = useId()
+  const descriptionId = useId()
+  const codeId = useId()
+  const errorId = useId()
+  const [code, setCode] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<CreditRedemptionResult | null>(null)
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    dialogRef.current?.focus()
+    return () => {
+      document.body.style.overflow = previousOverflow
+      if (returnFocusRef.current) returnFocusRef.current.focus()
+      else if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus()
+    }
+  }, [returnFocusRef])
+
+  function handleDialogKeyDown(event: ReactKeyboardEvent<HTMLElement>) {
+    if (event.key === 'Escape') {
+      if (!submitting) onClose()
+      return
+    }
+    if (event.key !== 'Tab') return
+    const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    )
+    if (!focusable?.length) return
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (
+      event.shiftKey &&
+      (document.activeElement === first || document.activeElement === dialogRef.current)
+    ) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
+  async function redeem(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (submitting) return
+    const normalizedCode = code.trim()
+    if (!normalizedCode) {
+      setError('请输入兑换码')
+      return
+    }
+
+    setSubmitting(true)
+    setError(null)
+    try {
+      const nextResult = await quotaApis.redeemCode(normalizedCode)
+      setResult(nextResult)
+      onRedeemed(nextResult)
+    } catch (requestError) {
+      setError(errorMessage(requestError))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] grid place-items-center overflow-y-auto overscroll-contain bg-app-ink/20 p-4 backdrop-blur-sm"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget && !submitting) onClose()
+      }}
+    >
+      <section
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        onKeyDown={handleDialogKeyDown}
+        className="w-full max-w-md rounded-2xl border border-app-line bg-app-surface-raised p-5 shadow-2xl outline-none sm:p-6"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 id={titleId} className="text-lg font-semibold tracking-[-0.02em] text-app-ink">
+              兑换积分
+            </h3>
+            <p id={descriptionId} className="mt-1.5 text-sm leading-6 text-app-muted">
+              输入兑换码，验证成功后积分会立即到账。
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="关闭兑换积分"
+            disabled={submitting}
+            onClick={onClose}
+            className="grid size-11 shrink-0 place-items-center rounded-lg text-app-muted transition-colors hover:bg-app-surface-muted hover:text-app-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <X size={18} weight="bold" aria-hidden="true" />
+          </button>
+        </div>
+
+        {result ? (
+          <div className="mt-6">
+            <p className="text-xs font-medium tracking-[0.08em] text-app-muted">兑换成功</p>
+            <p className="mt-2 font-mono text-4xl font-semibold tracking-[-0.04em] text-app-accent">
+              +{formatCredits(result.credited)}
+            </p>
+            <p role="status" aria-live="polite" className="mt-2 text-sm text-app-muted">
+              当前可用积分 {formatCredits(result.account.balance)}
+            </p>
+            <button type="button" onClick={onClose} className="account-primary-button mt-6 w-full">
+              完成
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={redeem} className="mt-6">
+            <label htmlFor={codeId} className="text-sm font-medium text-app-ink-soft">
+              兑换码
+            </label>
+            <input
+              id={codeId}
+              name="credit-redemption-code"
+              type="text"
+              value={code}
+              maxLength={32}
+              autoComplete="off"
+              spellCheck={false}
+              aria-invalid={error ? 'true' : undefined}
+              aria-describedby={error ? errorId : descriptionId}
+              disabled={submitting}
+              onChange={(event) => {
+                setCode(event.target.value)
+                if (error) setError(null)
+              }}
+              placeholder="WU-XXXX-XXXX-XXXX"
+              className="account-field mt-2 font-mono tracking-[0.06em]"
+            />
+            <div className="mt-2 min-h-5">
+              {error && (
+                <p id={errorId} role="alert" className="text-sm text-app-danger">
+                  {error}
+                </p>
+              )}
+            </div>
+            <button
+              type="submit"
+              disabled={submitting || !code.trim()}
+              className="account-primary-button mt-4 w-full"
+            >
+              {submitting ? '正在兑换…' : '确认兑换'}
+            </button>
+          </form>
+        )}
+      </section>
+    </div>
+  )
+}
+
 function QuotaSection() {
   const balance = useQuotaBalance(true)
   const transactions = useQuotaTransactions(true)
@@ -58,6 +239,8 @@ function QuotaSection() {
   const [endDate, setEndDate] = useState('')
   const [pageSize, setPageSize] = useState('20')
   const [filterError, setFilterError] = useState<string | null>(null)
+  const [redemptionOpen, setRedemptionOpen] = useState(false)
+  const redemptionTriggerRef = useRef<HTMLButtonElement>(null)
   const account = balance.status === 'ready' ? balance.account : null
   const summaryRows: Array<[string, string]> = [
     ['可用积分', account ? formatCredits(account.balance) : '—'],
@@ -98,10 +281,33 @@ function QuotaSection() {
 
   return (
     <div>
-      <header>
-        <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">积分账户</h2>
-        <p className="mt-1.5 text-sm text-app-muted">查看当前余额与最近的积分变动记录。</p>
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">积分账户</h2>
+          <p className="mt-1.5 text-sm text-app-muted">查看当前余额与最近的积分变动记录。</p>
+        </div>
+        <button
+          ref={redemptionTriggerRef}
+          type="button"
+          aria-label="填写积分兑换码"
+          title="填写积分兑换码"
+          onClick={() => setRedemptionOpen(true)}
+          className="grid size-11 shrink-0 place-items-center rounded-lg text-app-muted transition-colors hover:bg-app-surface-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+        >
+          <Gift size={19} weight="regular" aria-hidden="true" />
+        </button>
       </header>
+
+      {redemptionOpen && (
+        <CreditRedemptionDialog
+          onClose={() => setRedemptionOpen(false)}
+          returnFocusRef={redemptionTriggerRef}
+          onRedeemed={() => {
+            balance.reload()
+            transactions.reload()
+          }}
+        />
+      )}
 
       <dl className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         {summaryRows.map(([label, value]) => (

--- a/frontend/src/pages/account/index.tsx
+++ b/frontend/src/pages/account/index.tsx
@@ -80,12 +80,13 @@ function CreditRedemptionDialog({
 
   useEffect(() => {
     const previouslyFocused = document.activeElement
+    const returnFocusTarget = returnFocusRef.current
     const previousOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
     dialogRef.current?.focus()
     return () => {
       document.body.style.overflow = previousOverflow
-      if (returnFocusRef.current) returnFocusRef.current.focus()
+      if (returnFocusTarget) returnFocusTarget.focus()
       else if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus()
     }
   }, [returnFocusRef])

--- a/frontend/src/pages/invite/index.test.tsx
+++ b/frontend/src/pages/invite/index.test.tsx
@@ -7,18 +7,20 @@ import type { QuotaApis } from '@/entities'
 import { InviteSection } from './index'
 
 function createApis(): QuotaApis & Record<keyof QuotaApis, ReturnType<typeof vi.fn>> {
+  const account = {
+    id: '11',
+    userId: '7',
+    balance: 100,
+    frozen: 0,
+    totalEarned: 100,
+    totalSpent: 0,
+    createdAt: '2026-08-12T01:02:03Z',
+    updatedAt: '2026-08-17T01:02:03Z',
+  }
   return {
-    getBalance: vi.fn(async () => ({
-      id: '11',
-      userId: '7',
-      balance: 100,
-      frozen: 0,
-      totalEarned: 100,
-      totalSpent: 0,
-      createdAt: '2026-08-12T01:02:03Z',
-      updatedAt: '2026-08-17T01:02:03Z',
-    })),
+    getBalance: vi.fn(async () => account),
     listTransactions: vi.fn(async () => ({ items: [], total: 0, page: 1, pageSize: 20 })),
+    redeemCode: vi.fn(async () => ({ credited: 1000, account })),
     getInviteCode: vi.fn(async () => ({
       code: 'AB23CD45',
       usedCount: 2,

--- a/openapi.json
+++ b/openapi.json
@@ -2354,6 +2354,38 @@
         "title": "ProjectPatch",
         "type": "object"
       },
+      "RedeemCodeIn": {
+        "description": "积分兑换码提交参数。",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "RedeemCodeIn",
+        "type": "object"
+      },
+      "RedeemCodeOut": {
+        "description": "积分兑换结果及刷新账户所需的最新汇总。",
+        "properties": {
+          "account": {
+            "$ref": "#/components/schemas/CreditAccountOut"
+          },
+          "credited": {
+            "title": "Credited",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "credited",
+          "account"
+        ],
+        "title": "RedeemCodeOut",
+        "type": "object"
+      },
       "RefreshRequest": {
         "description": "刷新 token 请求。",
         "properties": {
@@ -2739,6 +2771,48 @@
           }
         },
         "title": "Response[ProjectOut]",
+        "type": "object"
+      },
+      "Response_RedeemCodeOut_": {
+        "properties": {
+          "code": {
+            "default": 200,
+            "description": "业务状态码:成功 200,失败非 200",
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RedeemCodeOut"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "业务数据"
+          },
+          "message": {
+            "default": "success",
+            "description": "提示信息",
+            "title": "Message",
+            "type": "string"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "响应时间;默认不携带,不携带时省略",
+            "title": "Timestamp"
+          }
+        },
+        "title": "Response[RedeemCodeOut]",
         "type": "object"
       },
       "Response_TokenResponse_": {
@@ -4774,6 +4848,48 @@
           }
         },
         "summary": "Generate Invite Code",
+        "tags": [
+          "quota"
+        ]
+      }
+    },
+    "/quota/redeem": {
+      "post": {
+        "description": "兑换一次性积分码；账户、兑换码和流水共用一个事务。",
+        "operationId": "redeem_code_quota_redeem_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RedeemCodeIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_RedeemCodeOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Redeem Code",
         "tags": [
           "quota"
         ]


### PR DESCRIPTION
在用户中心新增一次性积分兑换码：用户从积分账户卡片右上角进入兑换流程，成功后固定到账 1,000 积分，并立即刷新余额与积分流水。

## Why

积分账户此前只能查看余额和流水，缺少由用户主动填写兑换码的入口。兑换需要由服务端持有一次性、可审计的事实来源，并保证并发提交不会重复入账。

## Changes

- 在积分账户标题右上角增加礼物图标和可访问的兑换对话框，覆盖提交中、错误、成功与焦点归还状态。
- 新增 `POST /quota/redeem`，有效兑换码固定增加 1,000 积分，并写入“兑换码入账”流水。
- 新增批量生成脚本，明文只在生成时输出一次，数据库仅保存摘要。

## Implementation

- 兑换码通过高熵随机串生成，持久化时仅保存 SHA-256 摘要。
- 兑换码占用使用带 `redeemed_by IS NULL` 条件的原子更新；账户余额、累计获得与积分流水在同一数据库事务内提交。
- 同一用户重试保持幂等；无效、过期或已被其他用户占用的兑换码返回统一错误，不泄露状态。
- 前端写请求关闭认证恢复后的自动重放，成功后重新读取账户汇总与流水。

## Verification

- [x] `backend/.venv/bin/pytest backend/tests/test_quota.py backend/tests/test_redemption_codes.py -q`：62 passed。
- [x] `backend/.venv/bin/ruff check <changed backend files>`：通过。
- [x] `backend/.venv/bin/lint-imports`：2 个分层契约通过。
- [x] `backend/.venv/bin/python -m scripts.export_openapi`：重新导出后 `openapi.json` 无漂移。
- [x] `npm test -- src/entities/quota/api.test.ts src/features/quota/index.test.ts src/pages/account/index.test.tsx src/app/layout/app-header.test.tsx src/pages/invite/index.test.tsx`：78 passed。
- [x] `npm run typecheck`：通过。
- [x] `npm run build`：通过。
- [x] `npx oxfmt --check <changed frontend files>` 与 `npx oxlint <changed frontend files>`：通过。
- [x] 真实本地 PostgreSQL、Redis、FastAPI、Vite 与密码登录链路：有效码到账 1,000、流水新增 1 条；同一用户重复请求后余额不再增加且流水仍为 1 条。

## Screenshots

### Desktop

<img width="2049" height="1175" alt="积分兑换成功后的账户页面" src="https://github.com/user-attachments/assets/050bfa9d-a365-4207-9bb0-492eee034857" />

## Scope

- 本 PR 不包含：兑换码管理后台、积分商城、不同额度兑换码、部署或生产数据库发码。
- 后续事项：代码合并并部署后，再在目标环境运行生成脚本签发正式兑换码。

## Related Issues

Closes #730
