### PR TITLE
fix(quick-start): restore conversation composer surface

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1441,11 +1441,11 @@ describe('QuickStartPage', () => {
     const conversationControls = composer.querySelector(
       '[data-layout="quick-start-composer-controls"]',
     )
-    expect(conversationForm?.className).toContain('relative')
-    expect(conversationForm?.className).toContain('flex-col')
-    expect(conversationSurface?.className).toContain('rounded-app-surface')
-    expect(conversationSurface?.className).toContain('border-app-line-strong')
-    expect(conversationSurface?.className).toContain('shadow-app-panel')
+    expect(conversationForm?.className).toContain('rounded-app-surface')
+    expect(conversationForm?.className).toContain('border-app-line-strong')
+    expect(conversationForm?.className).toContain('shadow-app-panel')
+    expect(conversationSurface?.className).not.toContain('border-app-line-strong')
+    expect(conversationSurface?.className).not.toContain('shadow-app-panel')
     expect(conversationControls?.className).toContain('flex')
     expect(
       (

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1310,10 +1310,18 @@ function QuickStartInput({
             onSubmit={(event) => void submit(event)}
             autoComplete="off"
             data-prompt-state={promptState}
-            className="quick-start-agent-composer relative flex flex-col"
+            className={`quick-start-agent-composer relative flex flex-col ${
+              hasConversation
+                ? 'rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
+                : ''
+            }`}
           >
             <label
-              className="relative block min-h-[52px] min-w-0 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]"
+              className={`relative block min-h-[52px] min-w-0 overflow-hidden ${
+                hasConversation
+                  ? ''
+                  : 'rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
+              }`}
               htmlFor="quick-start-prompt"
             >
               <span className="sr-only">创作指令</span>


### PR DESCRIPTION
恢复 Quick Start 对话态输入区的一体化表面，消除输入框与上下文控件之间的独立边框和阴影分隔。

## Why

对话开始后，输入文本区域单独持有边框、背景和阴影，使其与下方项目、画风、生成方向控件形成视觉断层。

## Changes

- 对话态由外层表单统一持有圆角、边框、背景和阴影。
- 内层输入标签在对话态保持透明且无独立边框、阴影。
- 保持初始输入框、现有控件、提交按钮和 Agent 动画不变。

## Implementation

- 仅根据 `hasConversation` 切换现有表面样式的归属，不调整组件结构、交互状态或业务字段。
- 增加回归断言，固定对话态表面由表单持有、输入标签不再形成第二层表面。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx`：114 项通过。
- [x] `npm run typecheck`：通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] 本地浏览器：验证填入提示词后外层表单持有唯一边框和阴影，内层标签无边框、无阴影。

## Scope

- 本 PR 不包含：Agent 动画、初始输入框、上下文控件、提交按钮、字段或接口改动。
- 后续事项：无。

## Related Issues

Closes #740
