### PR TITLE
feat(quick-start): show queued task count

### DIFF
--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -1023,6 +1023,32 @@ describe('createGenerationApis', () => {
     )
   })
 
+  it('重连对账保留 GET 快照里的排队位置', async () => {
+    let streamOptions: EventStreamOptions | undefined
+    const request = vi.fn(async () =>
+      success(taskData({ status: 'pending', result: null, queue_ahead: 2 })),
+    )
+    const apis = createGenerationApis({
+      baseUrl: 'https://api.test',
+      transport: {
+        request,
+        stream: vi.fn((_url: string, options: NonNullable<typeof streamOptions>) => {
+          streamOptions = options
+          return vi.fn()
+        }),
+      },
+    })
+    const onEvent = vi.fn()
+
+    apis.subscribe('42', '91', { type: 'character_template' }, onEvent, vi.fn())
+    streamOptions?.onReconnect?.()
+
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalledOnce())
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: '91', status: 'pending', queueAhead: 2 }),
+    )
+  })
+
   it('任务在 SSE 断线窗口内结束时，重连后仍然交付终态', async () => {
     const encoder = new TextEncoder()
     const runningThenDrop = new Response(
@@ -1791,6 +1817,41 @@ describe('createGenerationApis', () => {
       ),
     )
     expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('轮询降级保留 GET 快照里的排队位置', async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(success(taskData({ status: 'pending', result: null, queue_ahead: 4 })))
+      .mockResolvedValueOnce(success(taskData()))
+    const onEvent = vi.fn()
+    const apis = createGenerationApis({
+      pollIntervalMs: 1,
+      transport: {
+        request,
+        stream: vi.fn((_url, options) => {
+          queueMicrotask(() =>
+            options.onError(
+              new EventStreamError('SSE 请求失败（HTTP 404）', false, undefined, 404),
+            ),
+          )
+          return vi.fn()
+        }),
+      },
+    })
+
+    apis.subscribe('42', '91', { type: 'character_template' }, onEvent, vi.fn())
+
+    await vi.waitFor(() =>
+      expect(onEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: '91', status: 'pending', queueAhead: 4 }),
+      ),
+    )
+    await vi.waitFor(() =>
+      expect(onEvent).toHaveBeenLastCalledWith(
+        expect.objectContaining({ taskId: '91', status: 'completed' }),
+      ),
+    )
   })
 
   it('轮询降级遇到一次网络错误后继续查询直到终态', async () => {

--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -180,6 +180,25 @@ describe('createGenerationApis', () => {
     })
   })
 
+  it('把等待任务前方的队列数量映射到生成快照', async () => {
+    const request = vi.fn(async () =>
+      success(
+        taskData({
+          status: 'pending',
+          result: null,
+          queue_ahead: 3,
+        }),
+      ),
+    )
+    const apis = createGenerationApis({
+      transport: { request, stream: vi.fn(() => vi.fn()) },
+    })
+
+    const generation = await apis.get('42', '91', { type: 'character_template' })
+
+    expect(generation.queueAhead).toBe(3)
+  })
+
   it.each([1, 2, 3, 4] as const)('允许调用方显式请求 %i 张图片候选', async (candidateCount) => {
     const request = vi.fn(async (_url: string, _init?: RequestInit) =>
       success(

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -57,6 +57,7 @@ interface GenerationTaskDto {
   inputPayload: Record<string, unknown> | null
   result: Record<string, unknown> | null
   errorMessage: string | null
+  queueAhead?: number
 }
 
 type BackendGenerationType = 'character_image' | 'character_direction_set' | 'character_action'
@@ -107,6 +108,14 @@ function dtoNullableString(value: unknown, field: string): string | null {
   if (value === null) return null
   if (typeof value !== 'string') throw new GenerationApiError(`生成任务 ${field} 无效`, 200)
   return value
+}
+
+function dtoQueueAhead(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new GenerationApiError('生成任务 queue_ahead 无效', 200)
+  }
+  return value as number
 }
 
 function backendTaskType(value: unknown): BackendGenerationType {
@@ -193,6 +202,7 @@ function parseTaskDto(value: unknown): GenerationTaskDto {
     inputPayload,
     result: dtoNullableRecord(value.result, 'result'),
     errorMessage: dtoNullableString(value.error_message, 'error_message'),
+    queueAhead: dtoQueueAhead(value.queue_ahead),
   }
 }
 
@@ -597,6 +607,7 @@ function mapTask(
         declaredFrameCount(dto.inputPayload, resolvedExpectation),
       ),
       error: dto.errorMessage,
+      ...(dto.queueAhead === undefined ? {} : { queueAhead: dto.queueAhead }),
     },
     ...(candidateCount === undefined ? {} : { candidateCount }),
   }
@@ -741,6 +752,7 @@ function mapEvent<TType extends GenerationTaskType>(
       ? null
       : dtoNullableString(value.error_message, 'error_message')
   validateStatusError(status, error)
+  const queueAhead = dtoQueueAhead(value.queue_ahead)
   return {
     taskId: String(taskId),
     type: expectation.type,
@@ -753,6 +765,7 @@ function mapEvent<TType extends GenerationTaskType>(
       inputPayload === undefined ? undefined : declaredFrameCount(inputPayload, expectation),
     ),
     error,
+    ...(queueAhead === undefined ? {} : { queueAhead }),
   }
 }
 

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -945,6 +945,17 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
       let terminalHandled = false
       let stopStream: () => void = () => undefined
 
+      // GET 快照和 SSE 事件共用同一份订阅契约：降级轮询与重连对账也要带上队列位置。
+      const eventFromSnapshot = (generation: Generation<GenerationTaskType>) =>
+        ({
+          taskId: generation.id,
+          type: generation.type,
+          status: generation.status,
+          result: generation.result,
+          error: generation.error,
+          ...(generation.queueAhead === undefined ? {} : { queueAhead: generation.queueAhead }),
+        }) as GenerationEvent
+
       const pollUntilTerminal = async () => {
         if (polling) return
         polling = true
@@ -952,13 +963,7 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
           try {
             const generation = await apis.get(projectId, id, expectation)
             if (pollingController.signal.aborted) return
-            onEvent({
-              taskId: generation.id,
-              type: generation.type,
-              status: generation.status,
-              result: generation.result,
-              error: generation.error,
-            } as GenerationEvent)
+            onEvent(eventFromSnapshot(generation))
             if (isTerminalStatus(generation.status)) {
               return
             }
@@ -980,13 +985,7 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
           if (pollingController.signal.aborted || terminalHandled) return
           const terminal = isTerminalStatus(generation.status)
           if (terminal) terminalHandled = true
-          onEvent({
-            taskId: generation.id,
-            type: generation.type,
-            status: generation.status,
-            result: generation.result,
-            error: generation.error,
-          } as GenerationEvent)
+          onEvent(eventFromSnapshot(generation))
           if (terminal) {
             stopStream()
           }

--- a/frontend/src/entities/generation/index.ts
+++ b/frontend/src/entities/generation/index.ts
@@ -197,6 +197,8 @@ export interface Generation<TType extends GenerationTaskType = GenerationTaskTyp
   result: GenerationResult | null
   /** status 为 failed 时有值。 */
   error: string | null
+  /** pending 时前方仍占用生成队列的任务数；缺省表示后端尚未提供。 */
+  queueAhead?: number
 }
 
 export interface GenerationProgress {

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -175,6 +175,7 @@ function serviceFor(run: WorkflowRun | null, overrides: Partial<QuickStartMock> 
     resolveCharacterInfo: vi.fn(async () => ({ characterId: 'character-1', outfitId: 'outfit-1' })),
     getTemplateCandidates: vi.fn(async () => []),
     getActionFrames: vi.fn(async () => []),
+    getQueueAhead: vi.fn(async () => 0),
     getExportModel: vi.fn(async () => null),
     ...overrides,
   }
@@ -3283,6 +3284,20 @@ describe('QuickStartPage', () => {
       expect(await screen.findByLabelText(new RegExp(label, 'u'))).toBeTruthy()
       view.unmount()
     }
+  })
+
+  it('只在当前生成任务排队时把前方任务数附在闪烁提示后', async () => {
+    const run = workflow(setupAndTemplate({ phase: 'generating' }))
+    const service = serviceFor(run, { getQueueAhead: vi.fn(async () => 2) })
+
+    renderAt('/quick-start/run-1', service)
+
+    const progress = await screen.findByLabelText('角色生成进度，排队中，前方还有 2 个任务')
+    await waitFor(() =>
+      expect(progress.textContent?.replaceAll('\u00a0', ' ')).toBe(
+        '勾勒角色轮廓（排队中，前方还有 2 个任务）',
+      ),
+    )
   })
 
   it('只重试 Quick Start 中失败的源方向', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -2385,6 +2385,7 @@ function QuickStartRun({
     [],
   )
   const [actionFrames, setActionFrames] = useState<readonly QuickStartFrame[]>([])
+  const [queueAhead, setQueueAhead] = useState(0)
   const [pixelPerfectFrames, setPixelPerfectFrames] = useState<readonly QuickStartFrame[]>([])
   const [pixelPerfectStatus, setPixelPerfectStatus] = useState<'idle' | 'working' | 'ready'>('idle')
   const [actionVersion, setActionVersion] = useState<PixelPerfectVersion>('original')
@@ -2600,6 +2601,7 @@ function QuickStartRun({
     setRun(null)
     setSelectedCandidates({})
     setSelectedFirstFrames({})
+    setQueueAhead(0)
     releasePixelPerfectUrls()
     setPixelPerfectFrames([])
     setPixelPerfectReplacementEntries([])
@@ -2685,6 +2687,7 @@ function QuickStartRun({
       setActionFrames([])
       setFailedDirections([])
       setExportModel(null)
+      setQueueAhead(0)
       return
     }
     const templateIsSelecting = run.nodes.some(
@@ -2706,17 +2709,26 @@ function QuickStartRun({
       session.getTemplateCandidates(),
       session.getFirstFrameCandidates(),
       session.getActionFrames(),
+      session.getQueueAhead(),
       session.getExportModel(),
       session.getFailedGenerationDirections(),
     ])
       .then(
-        ([nextCandidates, nextFirstFrameCandidates, nextFrames, nextExportModel, nextFailed]) => {
+        ([
+          nextCandidates,
+          nextFirstFrameCandidates,
+          nextFrames,
+          nextQueueAhead,
+          nextExportModel,
+          nextFailed,
+        ]) => {
           if (!active) return
           if (templateIsSelecting && nextCandidates.length > 0) setCandidates(nextCandidates)
           if (firstFrameIsSelecting && nextFirstFrameCandidates.length > 0) {
             setFirstFrameCandidates(nextFirstFrameCandidates)
           }
           if (nextFrames.length > 0) setActionFrames(nextFrames)
+          setQueueAhead(nextQueueAhead)
           setExportModel(nextExportModel)
           setFailedDirections(nextFailed)
         },
@@ -2728,6 +2740,26 @@ function QuickStartRun({
       active = false
     }
   }, [reportWorkflowError, run, session])
+
+  useEffect(() => {
+    if (!session || queueAhead <= 0) return
+    let active = true
+    const poll = () => {
+      void session
+        .getQueueAhead()
+        .then((nextQueueAhead) => {
+          if (active) setQueueAhead(nextQueueAhead)
+        })
+        .catch((cause) => {
+          if (active) reportWorkflowError(cause, '读取排队状态失败')
+        })
+    }
+    const interval = window.setInterval(poll, 2_000)
+    return () => {
+      active = false
+      window.clearInterval(interval)
+    }
+  }, [queueAhead, reportWorkflowError, session])
 
   const saveCompletedAction = useCallback(async () => {
     const targetSession = session
@@ -3272,7 +3304,11 @@ function QuickStartRun({
                 </>
               ) : (
                 <>
-                  <GenerationProgressCopy label="角色生成进度" kind="character-template" />
+                  <GenerationProgressCopy
+                    label="角色生成进度"
+                    kind="character-template"
+                    queueAhead={queueAhead}
+                  />
                   <div
                     data-layout="agent-result-set"
                     className="grid w-full max-w-2xl grid-cols-3 gap-3"
@@ -3400,7 +3436,11 @@ function QuickStartRun({
                     </>
                   ) : (
                     <>
-                      <GenerationProgressCopy label="动作首帧生成进度" kind="action-first-frame" />
+                      <GenerationProgressCopy
+                        label="动作首帧生成进度"
+                        kind="action-first-frame"
+                        queueAhead={queueAhead}
+                      />
                       <div
                         data-layout="agent-result-set"
                         className="grid w-full max-w-2xl grid-cols-3 gap-3"
@@ -3512,7 +3552,11 @@ function QuickStartRun({
                     </>
                   ) : (
                     <>
-                      <GenerationProgressCopy label="完整动作生成进度" kind="action-full-frame" />
+                      <GenerationProgressCopy
+                        label="完整动作生成进度"
+                        kind="action-full-frame"
+                        queueAhead={queueAhead}
+                      />
                       <div
                         data-layout="agent-result-set"
                         className="grid w-full max-w-2xl grid-cols-3 gap-3"

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -332,6 +332,48 @@ function actionRun(firstFramePending = false): WorkflowRun {
 }
 
 describe('createQuickStartService', () => {
+  it('读取当前活跃生成步骤前方的任务数', async () => {
+    const run: WorkflowRun = {
+      id: 'run-queued',
+      projectId: 'project-1',
+      version: 1,
+      storageStatus: 'active',
+      nodes: [
+        ...setupNodes(),
+        {
+          id: 'character-template',
+          type: 'character-template',
+          status: 'active',
+          phase: 'generating',
+          dependsOnNodeIds: ['character-setup'],
+          generations: [{ taskId: 'task-queued', role: 'character_template' }],
+          error: null,
+          selectedImageUrl: null,
+        },
+      ],
+    }
+    const generationApis = pendingGenerationApis()
+    generationApis.get = vi.fn(async () => ({
+      id: 'task-queued',
+      projectId: 'project-1',
+      type: 'character_template' as const,
+      status: 'pending' as const,
+      result: null,
+      error: null,
+      queueAhead: 4,
+    }))
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis([run]),
+      generationApis,
+      prepareProject: vi.fn(),
+      projectApis: projectReader(),
+    })
+
+    const session = await service.open(run.id)
+
+    await expect(session.getQueueAhead()).resolves.toBe(4)
+  })
+
   it('恢复自动交付 Run 后用唯一母版和唯一首帧推进到完整动画', async () => {
     const run: WorkflowRun = {
       id: 'run-auto',

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -110,6 +110,8 @@ export interface QuickStartSession {
   resolveCharacterInfo(): Promise<{ characterId: string; outfitId: string } | null>
   getTemplateCandidates(): Promise<readonly QuickStartCandidate[]>
   getActionFrames(): Promise<readonly QuickStartFrame[]>
+  /** 当前活跃生成步骤里，排在最靠后的任务前方还有多少个任务。 */
+  getQueueAhead(): Promise<number>
   /** 只生成当前会话预览，不写回 WorkflowRun 或角色资产。 */
   pixelPerfectActionFrames?(
     frames: readonly QuickStartFrame[],
@@ -909,6 +911,33 @@ export function createQuickStartService({
         }
         ensureAutomaticAdvance()
         return controller.getWorkflow()
+      },
+      async getQueueAhead() {
+        const activeNode = controller
+          .getWorkflow()
+          .nodes.find(
+            (node) =>
+              !node.deletedAt &&
+              node.status === 'active' &&
+              node.phase === 'generating' &&
+              (node.type === 'character-template' ||
+                node.type === 'action-first-frame' ||
+                node.type === 'action-full-frame'),
+          )
+        if (!activeNode) return 0
+        const role =
+          activeNode.type === 'character-template'
+            ? 'character_template'
+            : activeNode.type === 'action-first-frame'
+              ? 'first_frame'
+              : 'complete_animation'
+        const generations = await controller.getGenerations(activeNode.id, role)
+        return Math.max(
+          0,
+          ...generations
+            .filter((generation) => generation.status === 'pending')
+            .map((generation) => generation.queueAhead ?? 0),
+        )
       },
       async addAction(outfitId, actionDescription) {
         const prompt = actionDescription.trim()

--- a/frontend/src/shared/ui/generation-progress-copy.test.tsx
+++ b/frontend/src/shared/ui/generation-progress-copy.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { GenerationProgressCopy } from './generation-progress-copy'
+
+afterEach(cleanup)
+
+describe('GenerationProgressCopy', () => {
+  it('把排队提示拼进原提示语并复用逐字动画', () => {
+    const view = render(
+      <GenerationProgressCopy kind="character-template" label="角色生成进度" queueAhead={2} />,
+    )
+    const copy = screen.getByLabelText('角色生成进度，排队中，前方还有 2 个任务')
+    const line = copy.querySelector('.kinetic-copy-line-inner')
+    const expected = '勾勒角色轮廓（排队中，前方还有 2 个任务）'
+
+    expect(line?.textContent?.replaceAll('\u00a0', ' ')).toBe(expected)
+    expect(line?.querySelectorAll('.kinetic-copy-character')).toHaveLength(
+      Array.from(expected).length,
+    )
+    view.unmount()
+
+    const withoutQueue = render(
+      <GenerationProgressCopy kind="character-template" label="角色生成进度" queueAhead={0} />,
+    )
+    expect(withoutQueue.container.textContent).not.toContain('排队中')
+  })
+})

--- a/frontend/src/shared/ui/generation-progress-copy.tsx
+++ b/frontend/src/shared/ui/generation-progress-copy.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { KineticCopyCycle, type KineticCopyMessage } from './kinetic-copy-cycle'
 import './generation-progress-copy.css'
 
@@ -47,6 +49,13 @@ export interface GenerationProgressCopyProps {
   kind: GenerationProgressKind
   label: string
   placement?: 'conversation' | 'node'
+  queueAhead?: number
+}
+
+function appendQueueStatus(message: KineticCopyMessage, suffix: string): KineticCopyMessage {
+  if (Array.isArray(message)) return message.map((line) => `${line}${suffix}`)
+  const copy = message as Exclude<KineticCopyMessage, readonly string[]>
+  return { ...copy, lines: copy.lines.map((line) => `${line}${suffix}`) }
 }
 
 /** 同一生成阶段在不同入口共用文案顺序、逐字进入和停留高光。 */
@@ -54,7 +63,21 @@ export function GenerationProgressCopy({
   kind,
   label,
   placement = 'conversation',
+  queueAhead,
 }: GenerationProgressCopyProps) {
+  const queueStatus =
+    typeof queueAhead === 'number' && queueAhead > 0
+      ? `（排队中，前方还有 ${queueAhead} 个任务）`
+      : ''
+  const messages = useMemo(
+    () =>
+      queueStatus
+        ? GENERATION_PROGRESS_MESSAGES[kind].map((message) =>
+            appendQueueStatus(message, queueStatus),
+          )
+        : GENERATION_PROGRESS_MESSAGES[kind],
+    [kind, queueStatus],
+  )
   return (
     <div
       data-generation-progress
@@ -63,8 +86,8 @@ export function GenerationProgressCopy({
     >
       <KineticCopyCycle
         active
-        ariaLabel={label}
-        messages={GENERATION_PROGRESS_MESSAGES[kind]}
+        ariaLabel={queueStatus ? `${label}，排队中，前方还有 ${queueAhead} 个任务` : label}
+        messages={messages}
         motionMode="characters"
         firstCycleMs={7_540}
         cycleMs={8_000}


### PR DESCRIPTION
Quick Start 接入生成任务的排队数量；仅在前方仍有任务时，把状态追加到现有生成提示中，并沿用原有字体、逐字进入与闪烁动画。

## Why

后端 PR #724 已提供 `queue_ahead`，但前端生成快照和 Quick Start 提示尚未消费该字段，等待中的任务仍只显示通用生成文案。

## Changes

- 将 `queue_ahead` 映射为非负的 `Generation.queueAhead`，兼容未提供字段的响应。
- Quick Start 读取当前活跃生成步骤的排队数量；仅在数值大于 0 时显示“（排队中，前方还有 N 个任务）”。
- 排队数量降为 0 后隐藏括号提示；角色母版、动作首帧和完整动作共用同一行为。

## Implementation

- 任务查询和 SSE 快照共用同一字段校验与映射。
- 多方向任务取当前活跃步骤中的最大 `queueAhead`，等待期间每 2 秒刷新，进入运行态后停止刷新。
- 排队文案直接拼入 `GenerationProgressCopy` 的消息序列，不增加样式或第二套动画。

## Verification

- [x] `npx oxfmt --check <9 changed frontend files>`：通过。
- [x] `npx oxlint <9 changed frontend files>`：通过。
- [x] `npm run typecheck`：通过。
- [x] `npm test -- --run src/entities/generation/api.test.ts src/shared/ui/generation-progress-copy.test.tsx src/pages/quick-start/service.test.ts src/pages/quick-start/index.test.tsx`：4 个文件、263 个测试通过。

## Scope

- 本 PR 不修改后端排队计算、扣费、生成并发或任务状态机。
- 本 PR 不修改现有字体、颜色、动画时序或像素化流程。

## Related Issues

Closes #722
Refs #724
