### PR TITLE
fix(quick-start): 点击外部关闭下拉控件

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -956,6 +956,19 @@ describe('QuickStartPage', () => {
     )
   })
 
+  it('closes the project menu when pressing outside the control', () => {
+    renderAt('/quick-start', serviceFor(null))
+
+    const project = screen.getByRole('button', { name: '选择项目，当前自动创建' })
+    fireEvent.click(project)
+    expect(screen.getByRole('menu', { name: '选择项目' })).toBeTruthy()
+
+    fireEvent.pointerDown(document.body)
+
+    expect(project.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByRole('menu', { name: '选择项目' })).toBeNull()
+  })
+
   it('restores a newly created project from the Quick Start return URL', async () => {
     const projects = projectReader()
     renderAt('/quick-start?projectId=42', serviceFor(null), agentFor(), projects)
@@ -1001,6 +1014,19 @@ describe('QuickStartPage', () => {
     expect(screen.getByRole('button', { name: '生成方向，当前四向' })).toBeTruthy()
     fireEvent.pointerUp(slider, { target: { value: '0.6' } })
     expect(slider.value).toBe('1')
+  })
+
+  it('closes the direction control when pressing outside the control', () => {
+    renderAt('/quick-start', serviceFor(null))
+
+    const direction = screen.getByRole('button', { name: '生成方向，当前单向' })
+    fireEvent.click(direction)
+    const panel = screen.getByRole('group', { name: '生成方向设置' })
+
+    fireEvent.pointerDown(document.body)
+
+    expect(direction.getAttribute('aria-expanded')).toBe('false')
+    expect(panel.getAttribute('data-state')).toBe('closing')
   })
 
   it('keeps browser form history out of the creation composer', () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1191,11 +1191,28 @@ function QuickStartInput({
     : Boolean(prompt.trim()) || Boolean(templateFile)
   const styleMenu = useProductPopoverMotion()
   const directionMenu = useProductPopoverMotion()
+  const projectMenuRoot = useRef<HTMLDivElement>(null)
+  const directionMenuRoot = useRef<HTMLDivElement>(null)
   const [directionDragging, setDirectionDragging] = useState(false)
   const [directionSliderValue, setDirectionSliderValue] = useState(() =>
     QUICK_START_DIRECTIONAL_MOVEMENTS.indexOf(directionalMovement),
   )
   const directionalMovementIndex = QUICK_START_DIRECTIONAL_MOVEMENTS.indexOf(directionalMovement)
+
+  useEffect(() => {
+    if (!projectMenuOpen && !directionMenu.expanded) return
+    function closeMenusOnOutsidePress(event: PointerEvent) {
+      const target = event.target as Node
+      if (projectMenuOpen && !projectMenuRoot.current?.contains(target)) {
+        setProjectMenuOpen(false)
+      }
+      if (directionMenu.expanded && !directionMenuRoot.current?.contains(target)) {
+        directionMenu.close()
+      }
+    }
+    document.addEventListener('pointerdown', closeMenusOnOutsidePress)
+    return () => document.removeEventListener('pointerdown', closeMenusOnOutsidePress)
+  }, [directionMenu, projectMenuOpen])
 
   return (
     <section
@@ -1462,7 +1479,7 @@ function QuickStartInput({
                     </div>
                   </>
                 ) : null}
-                <div className="relative order-first">
+                <div ref={projectMenuRoot} className="relative order-first">
                   <button
                     type="button"
                     aria-label={`选择项目，当前${selectedProject?.name ?? '自动创建'}`}
@@ -1557,7 +1574,7 @@ function QuickStartInput({
                 >
                   {ART_STYLE[gameStyle]}
                 </span>
-                <div className="relative">
+                <div ref={directionMenuRoot} className="relative">
                   <button
                     type="button"
                     aria-label={`生成方向，当前${DIRECTIONAL_MOVEMENT[directionalMovement]}`}


### PR DESCRIPTION
## 变更内容

- 为 Quick Start 项目选择菜单增加控件根节点边界
- 项目菜单展开时，点击触发按钮和菜单之外的区域立即关闭
- 生成方向面板展开时，点击触发按钮和面板之外的区域沿用现有退出动画关闭
- 控件内部点击仍保留原有项目选择和方向滑块交互
- 补充两个外部点击回归测试

## 验证

- [x] 修复前两条新增测试均按预期失败
- [x] Quick Start 测试：119/119 通过
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] 变更文件 `oxfmt` 检查
- [x] `npm run build`

Closes #743