### PR TITLE
fix(quick-start): keep context outside prompt surface

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1515,11 +1515,11 @@ describe('QuickStartPage', () => {
     const conversationControls = composer.querySelector(
       '[data-layout="quick-start-composer-controls"]',
     )
-    expect(conversationForm?.className).toContain('rounded-app-surface')
-    expect(conversationForm?.className).toContain('border-app-line-strong')
-    expect(conversationForm?.className).toContain('shadow-app-panel')
-    expect(conversationSurface?.className).not.toContain('border-app-line-strong')
-    expect(conversationSurface?.className).not.toContain('shadow-app-panel')
+    expect(conversationForm?.className).not.toContain('border-app-line-strong')
+    expect(conversationForm?.className).not.toContain('shadow-app-panel')
+    expect(conversationSurface?.className).toContain('rounded-app-surface')
+    expect(conversationSurface?.className).toContain('border-app-line-strong')
+    expect(conversationSurface?.className).toContain('shadow-app-panel')
     expect(conversationControls?.className).toContain('flex')
     expect(
       (

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1316,18 +1316,10 @@ function QuickStartInput({
             onSubmit={(event) => void submit(event)}
             autoComplete="off"
             data-prompt-state={promptState}
-            className={`quick-start-agent-composer relative flex flex-col ${
-              hasConversation
-                ? 'rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
-                : ''
-            }`}
+            className="quick-start-agent-composer relative flex flex-col"
           >
             <label
-              className={`relative block min-h-[52px] min-w-0 overflow-hidden ${
-                hasConversation
-                  ? ''
-                  : 'rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
-              }`}
+              className="relative block min-h-[52px] min-w-0 overflow-hidden rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]"
               htmlFor="quick-start-prompt"
             >
               <span className="sr-only">创作指令</span>


### PR DESCRIPTION
恢复 Quick Start 原有紧凑输入框，同时保留后续对话中的项目、画风和方向只读信息。

## Why

#741 把输入框边框从 `label` 移到整个 `form`，导致持久化信息与输入框合成新的高面板布局。

## Changes

- 将边框、圆角、背景和阴影恢复到原有输入框 `label`。
- 保留项目、画风和方向在后续对话中的持久只读显示。
- 保留后续对话隐藏两个 SVG 编辑入口的现有行为。

## Implementation

- 仅恢复 composer surface 的 DOM 样式归属，并更新对应回归断言。

## Verification

- [x] `npm test -- src/pages/quick-start/index.test.tsx`：117 项通过。
- [x] `npm run typecheck`：通过。

## Scope

- 本 PR 不包含：项目选择、新建项目、Agent 行为或生成数据流改动。
- 后续事项：无。

## Related Issues

Closes #744