### PR TITLE
fix(quick-start): lift context row above prompt surface

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1518,9 +1518,13 @@ describe('QuickStartPage', () => {
     expect(conversationForm?.className).toContain('rounded-app-surface')
     expect(conversationForm?.className).toContain('border-app-line-strong')
     expect(conversationForm?.className).toContain('shadow-app-panel')
+    expect(conversationForm?.className).toContain('mt-12')
     expect(conversationSurface?.className).not.toContain('border-app-line-strong')
     expect(conversationSurface?.className).not.toContain('shadow-app-panel')
     expect(conversationControls?.className).toContain('flex')
+    expect(conversationControls?.className).toContain('absolute')
+    expect(conversationControls?.className).toContain('bottom-full')
+    expect(conversationControls?.className).not.toContain('order-first')
     expect(
       (
         screen.getByRole('button', {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -1318,7 +1318,7 @@ function QuickStartInput({
             data-prompt-state={promptState}
             className={`quick-start-agent-composer relative flex flex-col ${
               hasConversation
-                ? 'rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
+                ? 'mt-12 rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]'
                 : ''
             }`}
           >
@@ -1403,7 +1403,9 @@ function QuickStartInput({
             />
             <div
               data-layout="quick-start-composer-controls"
-              className="order-first mb-2 flex min-h-10 items-center justify-between gap-3 px-1"
+              className={`mb-2 flex min-h-10 items-center justify-between gap-3 px-1 ${
+                hasConversation ? 'absolute right-0 bottom-full left-0' : 'order-first'
+              }`}
             >
               <div className="flex items-center gap-1">
                 {!hasConversation ? (


### PR DESCRIPTION
修复 Quick Start 对话输入栏上方的“空气墙”：保留项目、画风与方向上下文，同时让该行退出输入表面的正常布局流。

## Why

PR #735 让上下文行在对话阶段持续显示，但该行仍以 `min-h-10` 和 `mb-2` 参与 composer form 布局，因此被包进输入表面；PR #741 仅改变表面 class 归属，没有移除这段内部占位。

## Changes

- 对话阶段将上下文行绝对定位到输入表面上方。
- 使用等高外边距为上下文行保留位置，避免与输入框或对话内容重叠。
- 增加针对正常流、定位方式与上下文行位置的回归断言。

## Implementation

- 仅修改 `QuickStartInput` 的对话态布局 class；初始态 class、输入框、按钮、业务字段与 Agent 回复动画不变。
- 未修改 mock 文件。

## Verification

- [x] `npm test -- --run src/pages/quick-start/index.test.tsx`：117/117 通过。
- [x] `npm run format:check -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run lint -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run typecheck`：通过。
- [x] 本地真实后端与浏览器完成“生成提示词 → 填入输入框”；上下文行 `bottom=631`，输入表面 `top=639`，无重叠。

## Scope

- 本 PR 不包含：初始输入框、提交按钮、项目/画风/方向字段语义、Agent 回复逐字模糊动画及其他 UI 调整。
- 后续事项：无。

## Related Issues

Closes #744