### PR TITLE
fix(agent): accept workflow tool definitions

### DIFF
--- a/backend/packages/app/src/windup_app/web/api/agent.py
+++ b/backend/packages/app/src/windup_app/web/api/agent.py
@@ -108,6 +108,7 @@ bearer_scheme = HTTPBearer(auto_error=False)
 MAX_REQUEST_BYTES = 64 * 1_024
 MAX_MESSAGES = 16
 MAX_MESSAGE_CHARS = 8_000
+MAX_TOOLS = 4
 MAX_OUTPUT_TOKENS = 1_024
 
 
@@ -151,7 +152,10 @@ class ChatRequest(BaseModel):
 
     model: str | None = Field(default=None, max_length=128)
     messages: list[ChatMessage] = Field(min_length=1, max_length=MAX_MESSAGES)
-    tools: list[ToolDefinition] | None = Field(default=None, max_length=1)
+    # The workflow Agent may choose one action from character and first-frame
+    # tools in the same turn; the provider response is still normalized to one
+    # tool call below.
+    tools: list[ToolDefinition] | None = Field(default=None, max_length=MAX_TOOLS)
     tool_choice: Literal["auto", "none", "required"] | None = None
     temperature: float | None = Field(default=None, ge=0, le=2)
     stream: Literal[False] = False

--- a/backend/tests/test_agent_api.py
+++ b/backend/tests/test_agent_api.py
@@ -242,6 +242,49 @@ def test_ai_chat_preserves_one_tool_call_from_real_provider(
     }
 
 
+def test_ai_chat_accepts_multiple_tool_definitions_for_one_turn(
+    auth_client,
+    install_openai_provider: Callable[..., list[dict[str, Any]]],
+):
+    provider_requests = install_openai_provider(auth_client, _text_completion())
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "regenerate_character_template",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "refine_character_template",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "candidateId": {"type": "string"},
+                        "adjustmentPrompt": {"type": "string"},
+                    },
+                    "required": ["candidateId", "adjustmentPrompt"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+    ]
+
+    response = auth_client.post("/ai/chat", json=_request_body(tools=tools))
+
+    assert response.status_code == 200
+    assert [tool["function"]["name"] for tool in provider_requests[0]["tools"]] == [
+        "regenerate_character_template",
+        "refine_character_template",
+    ]
+
+
 def test_ai_chat_rejects_oversized_history_before_provider(auth_client):
     calls = 0
 
@@ -373,7 +416,10 @@ def test_ai_chat_binds_user_and_request_id_into_gateway_trace(
     request_id = response.headers["x-request-id"]
     assert response.status_code == 200
     proxy_logs = [r.message for r in caplog.records if r.name == "windup.ai.proxy"]
-    assert any(f"AI chat started request_id={request_id} user_id=1" in msg for msg in proxy_logs)
+    assert any(
+        f"AI chat started request_id={request_id} user_id=1" in msg
+        for msg in proxy_logs
+    )
     assert any(
         f"AI chat completed request_id={request_id} user_id=1" in msg
         and "finish_reason=stop" in msg

--- a/openapi.json
+++ b/openapi.json
@@ -1193,7 +1193,7 @@
                 "items": {
                   "$ref": "#/components/schemas/ToolDefinition"
                 },
-                "maxItems": 1,
+                "maxItems": 4,
                 "type": "array"
               },
               {


### PR DESCRIPTION
修复 Quick Start 候选母版未选择时 Agent 无法继续对话的问题。代理现在接受候选流程所需的多个 Tool 定义，用户可以继续讨论而不会在请求校验阶段收到“请求参数无效”。

## Why

候选态同时提供整批重新生成和单候选微调两个 Tool。后端 `/ai/chat` 请求模型却把 `tools` 限制为一个，导致 FastAPI 在模型调用前返回 422；前端因此无法继续讨论。

## Changes

- 将 Agent 请求的 Tool 定义上限从 1 调整为 4，覆盖角色母版和动作首帧的工作流 Tool 集合。
- 保留模型响应最多一个 Tool Call 的现有边界。
- 增加真实 API 边界回归测试，并同步 OpenAPI 合同。

## Implementation

- 修改 `backend/packages/app/src/windup_app/web/api/agent.py` 的 `ChatRequest` 校验模型。
- 测试通过真实 FastAPI TestClient 和 provider transport，验证两个候选 Tool 定义能到达 provider。

## Verification

- [x] `uv run ruff check .`：通过
- [x] `uv run pytest tests/test_agent_api.py -q`：12 passed
- [x] `uv run python -m scripts.export_openapi`：OpenAPI 无漂移

## Scope

- 本 PR 不包含前端交互改动、模型提示词改动或生成流程改动。
- Tool 请求大小、消息数量、单字段长度和单轮单 Tool Call 限制保持不变。

## Related Issues

Closes #750
