### PR TITLE
feat(quick-start): route uploaded references through Agent

### DIFF
--- a/backend/packages/app/src/windup_app/web/api/agent.py
+++ b/backend/packages/app/src/windup_app/web/api/agent.py
@@ -11,7 +11,7 @@ import json
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -19,7 +19,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 from fastapi.routing import APIRoute
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from windup_framework.config.provider import settings as provider_settings
 from windup_framework.gateway import bind_call_context
@@ -111,15 +111,56 @@ MAX_MESSAGE_CHARS = 8_000
 MAX_OUTPUT_TOKENS = 1_024
 
 
+class ChatTextContentPart(BaseModel):
+    """Bounded text inside one multimodal user message."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["text"]
+    text: str = Field(min_length=1, max_length=MAX_MESSAGE_CHARS)
+
+
+class ChatImageUrl(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    url: str = Field(min_length=1, max_length=2_048, pattern=r"^https?://")
+
+
+class ChatImageContentPart(BaseModel):
+    """One uploaded HTTP(S) image reference; inline base64 remains disallowed."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["image_url"]
+    image_url: ChatImageUrl
+
+
+ChatContentPart = Annotated[
+    ChatTextContentPart | ChatImageContentPart,
+    Field(discriminator="type"),
+]
+
+
 class ChatMessage(BaseModel):
     """One OpenAI-compatible message kept by the browser."""
 
     model_config = ConfigDict(extra="forbid")
 
     role: Literal["system", "user", "assistant", "tool"]
-    content: str | None = Field(default=None, max_length=MAX_MESSAGE_CHARS)
+    content: str | list[ChatContentPart] | None = None
     tool_calls: list[dict[str, Any]] | None = Field(default=None, max_length=1)
     tool_call_id: str | None = Field(default=None, max_length=128)
+
+    @model_validator(mode="after")
+    def bound_multimodal_user_content(self):
+        if isinstance(self.content, list):
+            if self.role != "user":
+                raise ValueError("only user messages may contain multimodal content")
+            if not self.content or len(self.content) > 2:
+                raise ValueError("multimodal user content must contain one or two parts")
+            if sum(isinstance(part, ChatImageContentPart) for part in self.content) != 1:
+                raise ValueError("multimodal user content must contain exactly one image")
+        return self
 
 
 class FunctionDefinition(BaseModel):

--- a/backend/packages/app/src/windup_app/web/api/agent.py
+++ b/backend/packages/app/src/windup_app/web/api/agent.py
@@ -140,6 +140,10 @@ ChatContentPart = Annotated[
     Field(discriminator="type"),
 ]
 
+# The bound lives on the string branch itself: a union field cannot carry it,
+# and plain-text messages must stay as bounded as multimodal text parts.
+BoundedMessageText = Annotated[str, Field(max_length=MAX_MESSAGE_CHARS)]
+
 
 class ChatMessage(BaseModel):
     """One OpenAI-compatible message kept by the browser."""
@@ -147,7 +151,7 @@ class ChatMessage(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     role: Literal["system", "user", "assistant", "tool"]
-    content: str | list[ChatContentPart] | None = None
+    content: BoundedMessageText | list[ChatContentPart] | None = None
     tool_calls: list[dict[str, Any]] | None = Field(default=None, max_length=1)
     tool_call_id: str | None = Field(default=None, max_length=128)
 

--- a/backend/tests/test_agent_api.py
+++ b/backend/tests/test_agent_api.py
@@ -221,6 +221,30 @@ def test_ai_chat_returns_text_from_real_provider(
     assert "max_tokens" not in provider_requests[0]
 
 
+def test_ai_chat_forwards_multimodal_user_content(
+    auth_client,
+    install_openai_provider: Callable[..., list[dict[str, Any]]],
+):
+    provider_requests = install_openai_provider(auth_client, _text_completion())
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "参考这张图片创建角色"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://cdn.windup.test/hero.png"},
+                },
+            ],
+        }
+    ]
+
+    response = auth_client.post("/ai/chat", json=_request_body(messages=messages))
+
+    assert response.status_code == 200
+    assert provider_requests[0]["messages"] == messages
+
+
 def test_ai_chat_preserves_one_tool_call_from_real_provider(
     auth_client,
     install_openai_provider: Callable[..., list[dict[str, Any]]],

--- a/backend/tests/test_agent_api.py
+++ b/backend/tests/test_agent_api.py
@@ -285,6 +285,24 @@ def test_ai_chat_rejects_oversized_history_before_provider(auth_client):
     assert calls == 0
 
 
+def test_ai_chat_rejects_oversized_plain_text_before_provider(auth_client):
+    calls = 0
+
+    def forbidden_factory(*_args: Any, **_kwargs: Any):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("oversized message reached the paid provider")
+
+    auth_client.app.state.chat_model_factory = forbidden_factory
+    messages = [{"role": "user", "content": "x" * 8_001}]
+
+    response = auth_client.post("/ai/chat", json=_request_body(messages=messages))
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+    assert calls == 0
+
+
 def test_ai_chat_rejects_oversized_body_before_provider(auth_client):
     calls = 0
 

--- a/frontend/src/features/quick-start-agent/planner.protocol.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.protocol.test.ts
@@ -15,6 +15,46 @@ function completion(choice: Record<string, unknown>) {
 }
 
 describe('AI SDK OpenAI-compatible protocol fixture', () => {
+  it('serializes an uploaded reference as an image URL content part', async () => {
+    let requestBody: Record<string, unknown> | null = null
+    const planner = createAiSdkQuickStartPlanner({
+      baseURL: 'https://api.windup.test/ai/v1',
+      fetch: vi.fn(async (input, init) => {
+        requestBody = JSON.parse(await new Request(input, init).text())
+        return completion({
+          message: { role: 'assistant', content: '我会先判断这张图是否适合作为角色参考。' },
+          finish_reason: 'stop',
+        })
+      }),
+    })
+
+    await planner({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: '参考这张图片创建角色' },
+            { type: 'image', image: new URL('https://cdn.windup.test/hero.png') },
+          ],
+        },
+      ],
+      clarificationUsed: false,
+    })
+
+    const capturedBody = requestBody as Record<string, unknown> | null
+    if (!capturedBody) throw new Error('planner request was not captured')
+    expect(capturedBody.messages).toEqual([
+      expect.objectContaining({ role: 'system' }),
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '参考这张图片创建角色' },
+          { type: 'image_url', image_url: { url: 'https://cdn.windup.test/hero.png' } },
+        ],
+      },
+    ])
+  })
+
   it('parses a standard text completion without a custom response parser', async () => {
     let requestBody: Record<string, unknown> | null = null
     const planner = createAiSdkQuickStartPlanner({

--- a/frontend/src/features/quick-start-agent/planner.ts
+++ b/frontend/src/features/quick-start-agent/planner.ts
@@ -192,9 +192,15 @@ function fallbackPlannerResult(
     const call = result.toolCalls[0]
     const input = recordInput(call?.input)
     if (call?.toolName === QUICK_START_DECISION_TOOL && input?.kind === 'proposal') {
-      const latestUserInput = messages
-        .findLast((message) => message.role === 'user')
-        ?.content.trim()
+      const latestUserContent = messages.findLast((message) => message.role === 'user')?.content
+      const latestUserInput =
+        typeof latestUserContent === 'string'
+          ? latestUserContent.trim()
+          : latestUserContent
+              ?.filter((part) => part.type === 'text')
+              .map((part) => part.text)
+              .join('\n')
+              .trim()
       const optimizedPrompt =
         typeof input.optimizedPrompt === 'string' && input.optimizedPrompt.trim()
           ? input.optimizedPrompt.trim().slice(0, 4_000)
@@ -257,6 +263,8 @@ ${artStyleContext}
 
 当前能力面向一个角色及其可选动作。optimizedPrompt 只描述稳定的单角色母版：完整身体、清楚轮廓，保留身份、外观、服装、气质和美术风格。用户明确给出动作时，必须把动作单独写入 actionPrompt；没有动作时省略 actionPrompt，不得替用户补动作。动作明确匹配待机、行走、攻击或跳跃时，分别返回 actionType: "idle"、"walk"、"attack" 或 "jump"，让生成复用已有优化管线；匹配不到时省略 actionType。只要动作会让角色整体发生空间位移，额外返回 locomotion: true；原地动作省略 locomotion。两项判断互相独立。
 
+用户消息可能附带一张参考图片。你必须直接查看图片并与文字作为同一条输入理解：图片不包含清晰的单个角色、角色主体无法辨认或明显不适合作为角色生成参考时，用 blocked 说明原因；信息不足但可以补充时用 clarification。图片有效时，提案描述要保留图中可见的角色身份与外观，但图片仍会由生成管线独立作为原始参考，不能声称仅凭文字已经替代原图。
+
 决策规则：
 1. 对话轮数永远不是 proposal 的触发条件。不得在澄清额度用完后用默认值强制补齐并提案。
 2. “你觉得怎么样”“怎么优化好”“还有什么方案”“刚才我说了什么”等咨询或元对话必须用 reply；不得只靠关键词，要理解最新消息在完整上下文中的意图。
@@ -303,6 +311,9 @@ export function createAiSdkQuickStartPlanner({
     name: 'windup-agent-proxy',
     baseURL: baseURL.replace(/\/+$/u, ''),
     fetch,
+    // Quick Start 只传媒体服务已经落库的 HTTP(S) 引用；保留 URL 可避免 SDK
+    // 先下载图片再内联 base64，突破 /ai/chat 的有界请求合同。
+    supportedUrls: () => ({ 'image/*': [/^https?:\/\//u] }),
   })
   const model = provider.chatModel(modelId)
 

--- a/frontend/src/features/quick-start-agent/production.test.ts
+++ b/frontend/src/features/quick-start-agent/production.test.ts
@@ -226,6 +226,7 @@ describe('Quick Start Agent composition', () => {
       directionalMovement: 'single' as const,
       automaticDelivery: true,
       suggestPixelPerfect: true,
+      referenceMedia: ['https://cdn.windup.test/hero.png'],
     }
     await expect(dependencies.startCharacterGeneration(input)).resolves.toEqual({
       runId: 'run-agent',
@@ -244,6 +245,7 @@ describe('Quick Start Agent composition', () => {
       gameStyle: undefined,
       automaticDelivery: { actionPrompt: '向前行走', actionType: 'walk', locomotion: true },
       suggestPixelPerfect: true,
+      referenceMedia: ['https://cdn.windup.test/hero.png'],
     })
     expect(dispose).toHaveBeenCalledTimes(1)
   })

--- a/frontend/src/features/quick-start-agent/production.ts
+++ b/frontend/src/features/quick-start-agent/production.ts
@@ -4,6 +4,7 @@ import {
   projectApis,
   workflowRunApis,
   type GenerationApis,
+  type MediaReference,
   type WorkflowRunApis,
 } from '@/entities'
 import {
@@ -145,6 +146,7 @@ export function createProductionQuickStartAgentDependencies(
       try {
         return await controller.startCharacterGeneration({
           prompt: input.prompt,
+          referenceMedia: input.referenceMedia as readonly MediaReference[] | undefined,
           directionalMovement: input.directionalMovement,
           gameStyle,
           projectId: input.projectId,

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -111,7 +111,10 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
   ])
 
   const submit = useCallback(
-    async (input: string): Promise<QuickStartAgentResult> => {
+    async (
+      input: string,
+      options?: { referenceMedia?: readonly string[] },
+    ): Promise<QuickStartAgentResult> => {
       if (running.current) throw new Error('Planner 正在处理上一条输入')
       running.current = true
       const controller = new AbortController()
@@ -122,7 +125,10 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
         const activeAgent = ensureAgent()
         const runTurn = started.current ? activeAgent.continue : activeAgent.start
         started.current = true
-        const result = await runTurn(input, { signal: controller.signal })
+        const result = await runTurn(input, {
+          signal: controller.signal,
+          referenceMedia: options?.referenceMedia,
+        })
         if (mounted.current && abortController.current === controller) {
           if (result.kind === 'message') {
             setState({
@@ -139,6 +145,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
               locomotion,
               optimizationSummary,
               suggestPixelPerfect,
+              referenceMedia,
             } = result
             setState({
               status: 'proposal',
@@ -149,6 +156,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
               ...(locomotion ? { locomotion } : {}),
               optimizationSummary,
               ...(suggestPixelPerfect ? { suggestPixelPerfect: true } : {}),
+              ...(referenceMedia?.length ? { referenceMedia } : {}),
             })
           }
         }
@@ -192,6 +200,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
         locomotion,
         optimizationSummary,
         suggestPixelPerfect,
+        referenceMedia,
       } = state
       if (mounted.current) {
         setState({
@@ -203,6 +212,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
           ...(locomotion ? { locomotion } : {}),
           optimizationSummary,
           ...(suggestPixelPerfect ? { suggestPixelPerfect: true } : {}),
+          ...(referenceMedia?.length ? { referenceMedia } : {}),
         })
       }
       try {

--- a/frontend/src/features/quick-start-agent/runtime.test.ts
+++ b/frontend/src/features/quick-start-agent/runtime.test.ts
@@ -238,6 +238,32 @@ describe('createQuickStartAgent', () => {
     })
   })
 
+  it('keeps an uploaded image in the Agent turn and confirmed generation', async () => {
+    const { agent, planner, startCharacterGeneration } = fixture()
+    const proposal = await agent.start('参考这张图片创建角色', {
+      referenceMedia: ['https://cdn.windup.test/hero.png'],
+    })
+    if (proposal.kind !== 'proposal') throw new Error('测试缺少提案')
+
+    expect(planner.mock.calls[0]?.[0].messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '参考这张图片创建角色' },
+          { type: 'image', image: new URL('https://cdn.windup.test/hero.png') },
+        ],
+      },
+    ])
+
+    await agent.confirmProposal(proposal.proposalId, proposal.optimizedPrompt)
+
+    expect(startCharacterGeneration).toHaveBeenCalledWith({
+      prompt: proposal.optimizedPrompt,
+      directionalMovement: 'single',
+      referenceMedia: ['https://cdn.windup.test/hero.png'],
+    })
+  })
+
   it('carries optimized action type and locomotion into automatic delivery', async () => {
     const { agent, startCharacterGeneration } = fixture({
       text: '',

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -23,9 +23,13 @@ const QUICK_START_DECISION_FIELDS = new Set([
 export type QuickStartDirectionalMovement = 'single' | 'four-way' | 'eight-way'
 export type QuickStartActionType = 'idle' | 'walk' | 'attack' | 'jump'
 
+export type PlannerMessageContent =
+  | string
+  | readonly ({ type: 'text'; text: string } | { type: 'image'; image: URL })[]
+
 export interface PlannerMessage {
   role: 'user' | 'assistant'
-  content: string
+  content: PlannerMessageContent
 }
 
 export interface PlannerToolCall {
@@ -64,6 +68,8 @@ export interface CharacterGenerationPlan {
 
 export interface CharacterGenerationProposal extends CharacterGenerationPlan {
   proposalId: string
+  /** 用户上传并由 Agent 看过的原始图片；确认后继续约束母版 Generation。 */
+  referenceMedia?: readonly string[]
 }
 
 export type QuickStartDecision =
@@ -79,6 +85,7 @@ export type QuickStartAgentResult =
 
 export interface QuickStartAgentTurnOptions {
   signal?: AbortSignal
+  referenceMedia?: readonly string[]
 }
 
 export interface ConfirmProposalOptions {
@@ -113,6 +120,7 @@ export type StartCharacterGenerationAction = (input: {
   projectId?: string
   automaticDelivery?: boolean
   suggestPixelPerfect?: boolean
+  referenceMedia?: readonly string[]
 }) => Promise<{ runId: string }>
 
 export interface CreateQuickStartAgentOptions {
@@ -276,6 +284,37 @@ function proposalMessage(plan: CharacterGenerationPlan): string {
   return `${plan.optimizationSummary}\n\n角色：${plan.optimizedPrompt}${action}`
 }
 
+function normalizeReferenceMedia(values: readonly string[] | undefined): readonly string[] {
+  if (!values?.length) return []
+  return values.map((value) => {
+    const normalized = value.trim()
+    const url = new URL(normalized)
+    if ((url.protocol !== 'https:' && url.protocol !== 'http:') || normalized.length > 2_048) {
+      throw new Error('上传图片引用无效')
+    }
+    return normalized
+  })
+}
+
+function referenceMediaFromMessages(messages: readonly PlannerMessage[]): readonly string[] {
+  const content = messages.findLast(
+    (message) => message.role === 'user' && Array.isArray(message.content),
+  )?.content
+  if (!Array.isArray(content)) return []
+  return content.flatMap((part) => (part.type === 'image' ? [part.image.toString()] : []))
+}
+
+function userMessage(input: string, referenceMedia: readonly string[]): PlannerMessage {
+  if (referenceMedia.length === 0) return { role: 'user', content: input }
+  return {
+    role: 'user',
+    content: [
+      { type: 'text', text: input },
+      ...referenceMedia.map((image) => ({ type: 'image' as const, image: new URL(image) })),
+    ],
+  }
+}
+
 export function createQuickStartAgent({
   planner,
   startCharacterGeneration,
@@ -291,6 +330,8 @@ export function createQuickStartAgent({
   let running = false
   let messages: PlannerMessage[] = [...initialMessages]
   let currentProposal = initialProposal
+  let currentReferenceMedia =
+    initialProposal?.referenceMedia ?? referenceMediaFromMessages(initialMessages)
 
   function assertAuthorized() {
     if (revoked) throw new Error('生成授权已失效')
@@ -299,7 +340,7 @@ export function createQuickStartAgent({
 
   async function runTurn(
     input: string,
-    { signal }: QuickStartAgentTurnOptions = {},
+    { signal, referenceMedia }: QuickStartAgentTurnOptions = {},
   ): Promise<QuickStartAgentResult> {
     assertAuthorized()
     if (running) throw new Error('Planner 正在处理上一条输入')
@@ -313,9 +354,11 @@ export function createQuickStartAgent({
     running = true
     currentProposal = null
     try {
+      const nextReferenceMedia = normalizeReferenceMedia(referenceMedia)
+      if (nextReferenceMedia.length > 0) currentReferenceMedia = nextReferenceMedia
       const nextMessages: PlannerMessage[] = [
         ...messages,
-        { role: 'user', content: normalizedInput },
+        userMessage(normalizedInput, nextReferenceMedia),
       ]
       // 用户点击发送后，页面已经展示并持久化这条消息；即使 Planner 失败，
       // runtime 也必须保留同一历史，避免刷新前后得到不同上下文。
@@ -342,6 +385,7 @@ export function createQuickStartAgent({
         ...(decision.locomotion ? { locomotion: decision.locomotion } : {}),
         optimizationSummary: decision.optimizationSummary,
         ...(decision.suggestPixelPerfect ? { suggestPixelPerfect: true } : {}),
+        ...(currentReferenceMedia.length > 0 ? { referenceMedia: [...currentReferenceMedia] } : {}),
       }
       currentProposal = proposal
       messages = [...nextMessages, { role: 'assistant', content: proposalMessage(proposal) }]
@@ -382,6 +426,7 @@ export function createQuickStartAgent({
         projectId,
         ...(automaticDelivery ? { automaticDelivery: true } : {}),
         ...(proposal.suggestPixelPerfect ? { suggestPixelPerfect: true } : {}),
+        ...(proposal.referenceMedia?.length ? { referenceMedia: proposal.referenceMedia } : {}),
       })
       return { kind: 'generated', runId, ...proposal, optimizedPrompt: effectivePrompt }
     } finally {

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -309,6 +309,33 @@ describe('WorkflowController', () => {
     })
   })
 
+  it('uses the uploaded reference when Agent starts character generation', async () => {
+    const workflow = createWorkflowApis()
+    const generation = createGenerationHarness()
+    const controller = createWorkflowController({
+      workflowRunApis: workflow.apis,
+      generationApis: generation.apis,
+      prepareProject: vi.fn(async () => ({
+        id: 'project-agent',
+        spriteSize: { width: 256, height: 256 },
+      })),
+      onAsyncError: () => undefined,
+    })
+
+    await controller.startCharacterGeneration({
+      prompt: '银发像素骑士全身像',
+      referenceMedia: ['https://cdn.windup.test/hero.png' as never],
+    })
+
+    expect(generation.apis.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'character_template',
+        prompt: '银发像素骑士全身像',
+        referenceMedia: ['https://cdn.windup.test/hero.png'],
+      }),
+    )
+  })
+
   it('为 Agent 自动交付持久化动作意图并只生成一个母版候选', async () => {
     const workflow = createWorkflowApis()
     const generation = createGenerationHarness()

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -121,6 +121,8 @@ export type PrepareQuickStartProject = (
 
 export interface StartCharacterGenerationInput {
   prompt: string
+  /** 用户在 Agent 对话中上传的原始图片；与优化后的文字共同约束角色母版。 */
+  referenceMedia?: readonly MediaReference[]
   directionalMovement?: DirectionalMovement
   gameStyle?: ArtStyle
   projectId?: Project['id']
@@ -397,6 +399,7 @@ export function createWorkflowController({
 
   async function startCharacterGeneration({
     prompt,
+    referenceMedia = [],
     directionalMovement: selectedDirectionalMovement = 'single',
     gameStyle,
     projectId,
@@ -429,7 +432,7 @@ export function createWorkflowController({
           dependsOnNodeIds: [],
           generations: [],
           error: null,
-          input: { prompt: normalizedPrompt, referenceMedia: [] },
+          input: { prompt: normalizedPrompt, referenceMedia: [...referenceMedia] },
           ...(suggestPixelPerfect ? { pixelPerfectSuggested: true } : {}),
           ...(automaticDelivery
             ? {

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -135,6 +135,7 @@ function serviceFor(run: WorkflowRun | null, overrides: Partial<QuickStartMock> 
     unavailableReason: null,
     runId: fallbackRun.id,
     start: vi.fn(async () => service),
+    uploadReferenceImage: vi.fn(async () => 'https://cdn.windup.test/hero.png' as never),
     startWithUploadedTemplate: vi.fn(async () => service),
     open: vi.fn(async () => {
       if (!run) throw new Error('not found')
@@ -856,20 +857,21 @@ describe('QuickStartPage', () => {
     expect(userTurns).toHaveLength(1)
   })
 
-  it('aborts uploaded-template startup and restores its prompt', async () => {
-    let startupSignal: AbortSignal | null = null
+  it('aborts reference upload before Agent planning and restores its prompt', async () => {
+    let uploadSignal: AbortSignal | null = null
+    const planner = vi.fn()
     const service = serviceFor(null, {
-      startWithUploadedTemplate: vi.fn(
-        async (_file, _prompt, signal) =>
-          new Promise<QuickStartSession>((_resolve, reject) => {
-            startupSignal = signal
+      uploadReferenceImage: vi.fn(
+        async (_file, signal) =>
+          new Promise<never>((_resolve, reject) => {
+            uploadSignal = signal ?? null
             signal.addEventListener('abort', () =>
               reject(new DOMException('aborted', 'AbortError')),
             )
           }),
       ),
     })
-    renderAt('/quick-start', service)
+    renderAt('/quick-start', service, agentFor({ planner }))
     const composer = screen.getByRole('textbox', { name: '创作指令' }) as HTMLTextAreaElement
     const file = new File(['pixels'], 'hero.png', { type: 'image/png' })
 
@@ -879,10 +881,12 @@ describe('QuickStartPage', () => {
     fireEvent.click(await screen.findByRole('button', { name: '停止生成' }))
 
     await waitFor(() => {
-      expect(startupSignal?.aborted).toBe(true)
+      expect(uploadSignal?.aborted).toBe(true)
       expect(composer.disabled).toBe(false)
       expect(composer.value).toBe('挥手')
     })
+    expect(planner).not.toHaveBeenCalled()
+    expect(service.startWithUploadedTemplate).not.toHaveBeenCalled()
   })
 
   it('uses a larger template icon and shows the selected art style on the right', () => {
@@ -2595,7 +2599,7 @@ describe('QuickStartPage', () => {
     expect(view.queryByRole('img', { name: '角色图候选 1' })).toBeNull()
   })
 
-  it('submits both text and uploaded-template creation from the natural-language entry', async () => {
+  it('routes both text and uploaded references through the Agent entry', async () => {
     const service = serviceFor(null)
     const startCharacterGeneration = vi.fn(async () => ({ runId: 'run-new' }))
     const agent = agentFor({ startCharacterGeneration })
@@ -2621,7 +2625,26 @@ describe('QuickStartPage', () => {
     expect(service.start).not.toHaveBeenCalled()
 
     view.unmount()
-    renderAt('/quick-start', service)
+    const imagePlanner = vi.fn(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'quick_start_decision',
+          input: {
+            kind: 'proposal',
+            optimizedPrompt: '挥手的像素英雄，全身像',
+            actionPrompt: '挥手',
+            optimizationSummary: '图片适合作为单角色参考，我会保留角色外观并生成挥手动作。',
+          },
+        },
+      ],
+    }))
+    const imageGeneration = vi.fn(async () => ({ runId: 'run-new' }))
+    renderAt('/quick-start', service, {
+      planner: imagePlanner,
+      startCharacterGeneration: imageGeneration,
+    })
     const file = new File(['pixels'], 'hero.png', { type: 'image/png' })
     fireEvent.click(screen.getByRole('button', { name: '生成方向，当前单向' }))
     fireEvent.change(screen.getByRole('slider', { name: '生成方向' }), {
@@ -2632,14 +2655,30 @@ describe('QuickStartPage', () => {
     expect(screen.getByText('hero.png')).toBeTruthy()
     fireEvent.change(screen.getByLabelText('创作指令'), { target: { value: '挥手' } })
     fireEvent.click(screen.getByRole('button', { name: '生成角色' }))
+    await waitFor(() => expect(imagePlanner).toHaveBeenCalledTimes(1))
+    const imagePlannerInput = (imagePlanner.mock.calls as unknown as [PlannerInput][])[0]?.[0]
+    if (!imagePlannerInput) throw new Error('image planner was not called')
+    expect(imagePlannerInput.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '挥手' },
+          { type: 'image', image: new URL('https://cdn.windup.test/hero.png') },
+        ],
+      },
+    ])
+    expect(service.startWithUploadedTemplate).not.toHaveBeenCalled()
+    expect(imageGeneration).not.toHaveBeenCalled()
+
+    await confirmAgentGeneration()
     await waitFor(() =>
-      expect(service.startWithUploadedTemplate).toHaveBeenCalledWith(
-        file,
-        '挥手',
-        expect.any(AbortSignal),
-        'eight-way',
-        { gameStyle: 'unspecified' },
-      ),
+      expect(imageGeneration).toHaveBeenCalledWith({
+        prompt: '挥手的像素英雄，全身像',
+        actionPrompt: '挥手',
+        directionalMovement: 'eight-way',
+        gameStyle: 'unspecified',
+        referenceMedia: ['https://cdn.windup.test/hero.png'],
+      }),
     )
   })
 

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -170,7 +170,7 @@ const LEGACY_AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v1'
 const AGENT_DRAFT_HISTORY_STATE_KEY = 'windupQuickStartAgentDraftId'
 
 type AgentConversationTurn =
-  | { role: 'user'; content: string; scope?: 'workflow' }
+  | { role: 'user'; content: string; referenceMedia?: readonly string[]; scope?: 'workflow' }
   | {
       role: 'assistant'
       content: string
@@ -188,6 +188,7 @@ type AgentConversationTurn =
       locomotion?: true
       optimizationSummary: string
       suggestPixelPerfect?: boolean
+      referenceMedia?: readonly string[]
       proposalStatus: 'pending' | 'superseded' | 'adopted' | 'confirmed'
       scope?: 'workflow'
     }
@@ -307,7 +308,23 @@ function readAgentConversation(
       }
       const scope = 'scope' in turn && turn.scope === 'workflow' ? 'workflow' : undefined
       if (turn.role === 'user') {
-        return [{ role: 'user', content: turn.content, ...(scope ? { scope } : {}) }]
+        const referenceMedia =
+          'referenceMedia' in turn &&
+          Array.isArray(turn.referenceMedia) &&
+          turn.referenceMedia.every(
+            (value: unknown) =>
+              typeof value === 'string' && value.length <= 2_048 && /^https?:\/\//u.test(value),
+          )
+            ? turn.referenceMedia
+            : []
+        return [
+          {
+            role: 'user',
+            content: turn.content,
+            ...(referenceMedia.length ? { referenceMedia } : {}),
+            ...(scope ? { scope } : {}),
+          },
+        ]
       }
       if (turn.role !== 'assistant') return []
 
@@ -348,6 +365,14 @@ function readAgentConversation(
               : {}),
             optimizationSummary: turn.optimizationSummary,
             suggestPixelPerfect: 'suggestPixelPerfect' in turn && turn.suggestPixelPerfect === true,
+            ...('referenceMedia' in turn &&
+            Array.isArray(turn.referenceMedia) &&
+            turn.referenceMedia.every(
+              (value: unknown) =>
+                typeof value === 'string' && value.length <= 2_048 && /^https?:\/\//u.test(value),
+            )
+              ? { referenceMedia: turn.referenceMedia }
+              : {}),
             proposalStatus: turn.proposalStatus,
             ...(scope ? { scope } : {}),
           },
@@ -376,7 +401,19 @@ function createAgentSeed(turns: readonly AgentConversationTurn[]): {
       turn.role === 'assistant' && turn.kind === 'proposal' && turn.proposalStatus === 'pending',
   )
   return {
-    messages: turns.map(({ role, content }) => ({ role, content })),
+    messages: turns.map((turn) => ({
+      role: turn.role,
+      content:
+        turn.role === 'user' && turn.referenceMedia?.length
+          ? [
+              { type: 'text' as const, text: turn.content },
+              ...turn.referenceMedia.map((image) => ({
+                type: 'image' as const,
+                image: new URL(image),
+              })),
+            ]
+          : turn.content,
+    })),
     clarificationUsed: turns.some(
       (turn) => turn.role === 'assistant' && turn.kind === 'clarification',
     ),
@@ -390,6 +427,7 @@ function createAgentSeed(turns: readonly AgentConversationTurn[]): {
             ...(pending.locomotion ? { locomotion: pending.locomotion } : {}),
             optimizationSummary: pending.optimizationSummary,
             suggestPixelPerfect: pending.suggestPixelPerfect,
+            ...(pending.referenceMedia?.length ? { referenceMedia: pending.referenceMedia } : {}),
           }
         : null,
   }
@@ -507,7 +545,6 @@ export function QuickStartPage({
       service={activeService}
       agent={agent}
       activeRunUserId={activeRunUserId}
-      onSessionCreated={setCreatedSession}
       projectApis={projectApis}
     />
   )
@@ -695,13 +732,11 @@ function QuickStartInput({
   service,
   agent,
   activeRunUserId,
-  onSessionCreated,
   projectApis,
 }: {
   service: QuickStartEntryService
   agent: CreateQuickStartAgentOptions
   activeRunUserId: string | null
-  onSessionCreated: (session: QuickStartSession) => void
   projectApis: Pick<ProjectApis, 'list' | 'get'>
 }) {
   const navigate = useNavigate()
@@ -1085,84 +1120,72 @@ function QuickStartInput({
 
     if ((!normalizedPrompt && !templateFile) || entryBusy || unavailableReason) return
 
-    if (!templateFile) {
-      setError(null)
+    setError(null)
+    const abortController = templateFile ? new AbortController() : null
+    if (abortController) {
+      submitAbortController.current = abortController
+      setSubmitting(true)
+    }
+    try {
+      const referenceMedia = templateFile
+        ? [await service.uploadReferenceImage(templateFile, abortController?.signal)]
+        : []
+      const effectivePrompt = normalizedPrompt || '请根据这张图片创建角色'
       if (agentSession.state.status === 'proposal') {
         updateProposalStatus(agentSession.state.proposalId, 'superseded')
       }
-      const userTurn: AgentConversationTurn = { role: 'user', content: normalizedPrompt }
+      const userTurn: AgentConversationTurn = {
+        role: 'user',
+        content: effectivePrompt,
+        ...(referenceMedia.length ? { referenceMedia } : {}),
+      }
       if (hasConversation) appendConversationTurn(userTurn)
       else await revealFirstAgentTurn(userTurn)
-      pendingPrompt.current = normalizedPrompt
+      pendingPrompt.current = effectivePrompt
       setPrompt('')
-      try {
-        const result = await agentSession.submit(normalizedPrompt)
-        pendingPrompt.current = null
-        setRevealingFirstAgentTurn(false)
-        if (result.kind === 'message') {
-          appendConversationTurn({
-            role: 'assistant',
-            content: result.message,
-            kind: result.messageKind,
-          })
-          return
-        }
-        if (result.kind === 'proposal') {
-          appendConversationTurn({
-            role: 'assistant',
-            content: `${result.optimizationSummary}\n\n角色：${result.optimizedPrompt}${result.actionPrompt ? `\n动作：${result.actionPrompt}` : ''}`,
-            kind: 'proposal',
-            proposalId: result.proposalId,
-            optimizedPrompt: result.optimizedPrompt,
-            ...(result.actionPrompt ? { actionPrompt: result.actionPrompt } : {}),
-            ...(result.actionType ? { actionType: result.actionType } : {}),
-            ...(result.locomotion ? { locomotion: result.locomotion } : {}),
-            optimizationSummary: result.optimizationSummary,
-            suggestPixelPerfect: result.suggestPixelPerfect,
-            proposalStatus: 'pending',
-          })
-        }
-      } catch (cause) {
-        setRevealingFirstAgentTurn(false)
-        if (!(cause instanceof Error && cause.name === 'AbortError')) {
-          setEntryTransition('idle')
-          setPromptState('collecting')
-        }
-      }
-      return
-    }
 
-    const abortController = new AbortController()
-    submitAbortController.current = abortController
-    setSubmitting(true)
-    setEntryTransition('leaving')
-    setError(null)
-    try {
-      const sessionPromise = service.startWithUploadedTemplate(
-        templateFile,
-        normalizedPrompt,
-        abortController.signal,
-        directionalMovement,
-        { gameStyle, ...(projectId ? { projectId } : {}) },
-      )
-      const handoffPromise = new Promise<void>((resolve) => {
-        handoffTimer.current = setTimeout(() => {
-          handoffTimer.current = null
-          resolve()
-        }, ENTRY_HANDOFF_MS)
+      const result = await agentSession.submit(effectivePrompt, {
+        ...(referenceMedia.length ? { referenceMedia } : {}),
       })
-      const [session] = await Promise.all([sessionPromise, handoffPromise])
-      onSessionCreated(session)
-      navigate(`/quick-start/${encodeURIComponent(session.runId)}`)
+      pendingPrompt.current = null
+      setRevealingFirstAgentTurn(false)
+      if (templateFile) {
+        setTemplateFile(null)
+        if (fileInput.current) fileInput.current.value = ''
+      }
+      if (result.kind === 'message') {
+        appendConversationTurn({
+          role: 'assistant',
+          content: result.message,
+          kind: result.messageKind,
+        })
+        return
+      }
+      if (result.kind === 'proposal') {
+        appendConversationTurn({
+          role: 'assistant',
+          content: `${result.optimizationSummary}\n\n角色：${result.optimizedPrompt}${result.actionPrompt ? `\n动作：${result.actionPrompt}` : ''}`,
+          kind: 'proposal',
+          proposalId: result.proposalId,
+          optimizedPrompt: result.optimizedPrompt,
+          ...(result.actionPrompt ? { actionPrompt: result.actionPrompt } : {}),
+          ...(result.actionType ? { actionType: result.actionType } : {}),
+          ...(result.locomotion ? { locomotion: result.locomotion } : {}),
+          optimizationSummary: result.optimizationSummary,
+          suggestPixelPerfect: result.suggestPixelPerfect,
+          ...(result.referenceMedia?.length ? { referenceMedia: result.referenceMedia } : {}),
+          proposalStatus: 'pending',
+        })
+      }
     } catch (cause) {
-      if (!abortController.signal.aborted) {
-        if (handoffTimer.current) clearTimeout(handoffTimer.current)
-        handoffTimer.current = null
+      setRevealingFirstAgentTurn(false)
+      if (!(cause instanceof Error && cause.name === 'AbortError')) {
         setEntryTransition('idle')
-        setError(errorMessage(cause, '创建失败，请稍后重试'))
+        setPromptState('collecting')
+        if (templateFile) setError(errorMessage(cause, '图片提交失败，请稍后重试'))
       }
     } finally {
-      if (submitAbortController.current === abortController) {
+      if (abortController && submitAbortController.current === abortController) {
         submitAbortController.current = null
         if (!abortController.signal.aborted) setSubmitting(false)
       }

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -135,6 +135,8 @@ export interface QuickStartSession {
 
 export interface QuickStartEntryService {
   readonly unavailableReason: string | null
+  /** 上传为 Agent 与角色母版 Generation 共用的原始参考，不创建 WorkflowRun。 */
+  uploadReferenceImage(file: File, signal?: AbortSignal): Promise<MediaReference>
   start(
     prompt: string,
     directionalMovement?: DirectionalMovement,
@@ -1297,6 +1299,11 @@ export function createQuickStartService({
 
   return {
     unavailableReason: null,
+
+    async uploadReferenceImage(file, signal) {
+      if (!mediaApis) throw new Error('媒体上传服务尚未配置，不能使用角色参考图')
+      return mediaApis.upload(file, 'reference-image', signal)
+    },
 
     async start(prompt, directionalMovement = 'single', options) {
       const normalizedPrompt = prompt.trim()

--- a/openapi.json
+++ b/openapi.json
@@ -1111,6 +1111,7 @@
           "content": {
             "anyOf": [
               {
+                "maxLength": 8000,
                 "type": "string"
               },
               {

--- a/openapi.json
+++ b/openapi.json
@@ -1067,6 +1067,43 @@
         "title": "ChatCompletionResponse",
         "type": "object"
       },
+      "ChatImageContentPart": {
+        "additionalProperties": false,
+        "description": "One uploaded HTTP(S) image reference; inline base64 remains disallowed.",
+        "properties": {
+          "image_url": {
+            "$ref": "#/components/schemas/ChatImageUrl"
+          },
+          "type": {
+            "const": "image_url",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "image_url"
+        ],
+        "title": "ChatImageContentPart",
+        "type": "object"
+      },
+      "ChatImageUrl": {
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "maxLength": 2048,
+            "minLength": 1,
+            "pattern": "^https?://",
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "title": "ChatImageUrl",
+        "type": "object"
+      },
       "ChatMessage": {
         "additionalProperties": false,
         "description": "One OpenAI-compatible message kept by the browser.",
@@ -1074,8 +1111,27 @@
           "content": {
             "anyOf": [
               {
-                "maxLength": 8000,
                 "type": "string"
+              },
+              {
+                "items": {
+                  "discriminator": {
+                    "mapping": {
+                      "image_url": "#/components/schemas/ChatImageContentPart",
+                      "text": "#/components/schemas/ChatTextContentPart"
+                    },
+                    "propertyName": "type"
+                  },
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ChatTextContentPart"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ChatImageContentPart"
+                    }
+                  ]
+                },
+                "type": "array"
               },
               {
                 "type": "null"
@@ -1207,6 +1263,29 @@
           "messages"
         ],
         "title": "ChatRequest",
+        "type": "object"
+      },
+      "ChatTextContentPart": {
+        "additionalProperties": false,
+        "description": "Bounded text inside one multimodal user message.",
+        "properties": {
+          "text": {
+            "maxLength": 8000,
+            "minLength": 1,
+            "title": "Text",
+            "type": "string"
+          },
+          "type": {
+            "const": "text",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "title": "ChatTextContentPart",
         "type": "object"
       },
       "ChatUsageResponse": {


### PR DESCRIPTION
Quick Start 上传角色图片后，图片会作为 Agent 的多模态输入参与澄清、回复和提案；用户确认提案后，原始图片与优化后的文字一起进入角色母版 Generation。

## Why

原先上传角色图片会绕过 Agent 直接启动母版生成，无法让 Agent 判断图片是否有效，也无法沿用文字输入的对话和确认逻辑。

## Changes

- 上传图片先落库为 HTTP(S) 媒体引用，再通过现有 Agent 对话入口提交。
- Agent 可对无效图片返回 blocked 或 clarification，不创建 Run 或 Generation。
- 提案确认后保留原始图片引用，并与优化提示词共同约束角色母版生成。
- 文本输入和其他直接导入调用方保持原有路径。

## Implementation

- 前端 Planner 使用远程 `image_url` 内容段，避免 SDK 下载并内联图片。
- `/ai/chat` 增加有界的用户多模态消息校验，并同步更新 `openapi.json`。
- Quick Start 会话草稿、用户轮次和提案持久化 `referenceMedia`，刷新后恢复同一图片。

## Verification

- [x] `npm test -- src/features/quick-start-agent/runtime.test.ts src/features/quick-start-agent/planner.protocol.test.ts src/features/quick-start-agent/production.test.ts src/features/workflow-controller/controller.test.ts src/pages/quick-start/index.test.tsx`：5 个文件、271 项通过
- [x] `npm run typecheck`：通过
- [x] `npm run format:check`：通过
- [x] `npm run lint`：通过
- [x] `npm run build`：通过
- [x] `uv run pytest tests/test_agent_api.py -q`：12 项通过
- [x] `uv run ruff check packages/app/src/windup_app/web/api/agent.py tests/test_agent_api.py`：通过
- [x] `uv run lint-imports`：2 项契约通过

## Scope

- 本 PR 不包含：浏览器视觉验收、部署或合并操作。
- 生成服务仍使用现有 `referenceMedia` 到 `reference_image_url` 的转换链路。

## Related Issues

Closes #748
