### PR TITLE
feat(generation): 四向/八向立绘 sheet 与源方向发布合同

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
@@ -4,6 +4,7 @@ from .actions import build_attack_prompt, build_idle_prompt
 from .custom import MAX_ACTION_CHARS, build_custom_prompt
 from .jump import JUMP_PHASES, build_jump_prompt
 from .presets import ACTION_PRESETS, ActionPreset
+from .view_sheet import VIEW_SHEET_PROMPT_VERSION, build_view_sheet_prompt
 from .walk import build_walk_prompt
 
 # 改动本包任何一个 build_*_prompt 的输出(包括 prompts/*.md 模板)都必须连带把这个
@@ -22,4 +23,6 @@ __all__ = [
     "ACTION_PRESETS",
     "ActionPreset",
     "PROMPT_VERSION",
+    "VIEW_SHEET_PROMPT_VERSION",
+    "build_view_sheet_prompt",
 ]

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/view_sheet.md
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/view_sheet.md
@@ -1,0 +1,116 @@
+# 四向 / 八向立绘 sheet 图生图提示词
+
+身份锚是已确认的**正视图**（`south`，面对镜头）。东 / 北 / 对角从图生图转相机；
+西 / 西北 / 西南生产路径水平翻转后上传，不调模型 —— 这三节仍保留，避免执行器误调时
+落到空提示词。
+
+正文只写正向计数句。构图约束（单主体、全身、灰底）放在 `## framing`，不抄进每个朝向。
+
+## identity
+
+```text
+This is an image-to-image task. The attached image is the confirmed FRONT-VIEW character master.
+Preserve that identity exactly: the same face, hairstyle, body proportions, outfit, colors,
+accessories, and silhouette. Change only the camera azimuth around the same standing figure.
+Same idle pose, same scale, same costume, same character.
+```
+
+## pose
+
+```text
+Neutral idle standing pose, weight centered over both feet, knees easy, arms hanging in a
+natural A-stance with a little space between the hands and the hips, head upright, no walk,
+no attack, no twist of the hips against the torso.
+```
+
+## framing
+
+```text
+Full body from head to feet, character centered in frame, orthographic sprite projection,
+flat even lighting, plain light-gray background. Exactly one character is in the frame,
+and the whole body stays inside the frame.
+```
+
+## elevation.side
+
+```text
+Eye-level camera, orthographic, no vanishing point, feet and head the same scale.
+```
+
+## elevation.top-down
+
+```text
+Elevated camera looking slightly down, about thirty to forty-five degrees, orthographic
+top-down sprite angle, no vanishing point.
+```
+
+## elevation.isometric
+
+```text
+Elevated three-quarter camera, about thirty to forty-five degrees, isometric sprite angle,
+orthographic, no vanishing point.
+```
+
+## south
+
+```text
+Front view, camera on the south, zero-degree azimuth. The character faces the viewer:
+the face, chest, and both shoulders are square to the camera, both eyes visible,
+the left and right sides of the outfit matching the master.
+```
+
+## east
+
+```text
+Right-side profile, camera on the east, ninety-degree azimuth. The character faces right:
+a true side view, one eye, the right shoulder and right arm toward the camera,
+the left side of the body hidden, the same standing pose as the front master.
+```
+
+## north
+
+```text
+Back view, camera on the north, one-hundred-eighty-degree azimuth. The character faces away:
+the back of the head, the back, and both shoulder blades visible, the face hidden,
+left and right reversed from the front master, the same standing pose.
+```
+
+## west
+
+```text
+Left-side profile, camera on the west, two-hundred-seventy-degree azimuth. The character
+faces left: a true side view, one eye, the left shoulder toward the camera,
+the same standing pose as the front master.
+```
+
+## south_east
+
+```text
+Three-quarter front view to the right, camera on the south-east, forty-five-degree azimuth.
+The face and the right side are both visible, the left side receding, the same standing pose
+as the front master.
+```
+
+## north_east
+
+```text
+Three-quarter back view to the right, camera on the north-east, one-hundred-thirty-five-degree
+azimuth. The back and the right side are both visible, the face mostly hidden,
+the same standing pose as the front master.
+```
+
+## south_west
+
+```text
+Three-quarter front view to the left, camera on the south-west, three-hundred-fifteen-degree
+azimuth. The face and the left side are both visible, the right side receding,
+the same standing pose as the front master.
+```
+
+## north_west
+
+```text
+Three-quarter back view to the left, camera on the north-west, two-hundred-twenty-five-degree
+azimuth. The back and the left side are both visible, the face mostly hidden,
+the same standing pose as the front master.
+```

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/view_sheet.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/view_sheet.py
@@ -1,0 +1,44 @@
+"""四向 / 八向立绘 sheet 图生图提示词。
+
+提示词正文在 ``prompts/view_sheet.md``。本模块只做加载与按方向 / 项目视角拼接。
+身份锚是正视图(``south``);东 / 北 / 对角转相机;西 / 西北 / 西南生产路径翻转、不调模型。
+"""
+
+from __future__ import annotations
+
+from windup_common.directions import ActionDirection
+from windup_common.models import CharacterView
+
+from windup_ai_engine.prompt._md import load_section
+
+__all__ = ["VIEW_SHEET_PROMPT_VERSION", "build_view_sheet_prompt"]
+
+_DOC = "view_sheet.md"
+VIEW_SHEET_PROMPT_VERSION = "v1"
+
+
+def build_view_sheet_prompt(
+    direction: ActionDirection | str,
+    *,
+    view: CharacterView | str = CharacterView.TOP_DOWN,
+    extra: str = "",
+) -> str:
+    """拼一条从正视母版转出 ``direction`` 的图生图提示词。
+
+    ``direction`` / ``view`` 都过一遍枚举构造:非法值要炸,不能静默落到某一朝向。
+    ``extra`` 是调用方补的站姿或画风短句,可空;身份与机位以模板为准。
+    """
+
+    azimuth = ActionDirection(direction)
+    perspective = CharacterView(view)
+    parts = [
+        load_section(_DOC, "identity"),
+        load_section(_DOC, "pose"),
+        load_section(_DOC, azimuth.value),
+        load_section(_DOC, f"elevation.{perspective.value}"),
+        load_section(_DOC, "framing"),
+    ]
+    extra_text = extra.strip()
+    if extra_text:
+        parts.append(extra_text)
+    return " ".join(parts)

--- a/backend/packages/app/src/windup_app/bootstrap/worker.py
+++ b/backend/packages/app/src/windup_app/bootstrap/worker.py
@@ -16,6 +16,7 @@ from windup_app.server.orchestrator.executor import (
     run_image_task,
     run_direction_set_task,
 )
+from windup_app.server.orchestrator.view_sheet_executor import run_view_sheet_task
 from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
 from windup_app.worker.consumer import StreamConsumer, start_delayed_loop, start_relay_loop
 from windup_app.worker.pending_timeout import release_stale_pending_tasks
@@ -71,6 +72,7 @@ def main() -> None:
             run_image_task=run_image_task,
             run_action_task=run_action_task,
             run_direction_set_task=run_direction_set_task,
+            run_view_sheet_task=run_view_sheet_task,
             stop_event=stop_event,
         ),
         StreamConsumer(
@@ -78,6 +80,7 @@ def main() -> None:
             run_image_task=run_image_task,
             run_action_task=run_action_task,
             run_direction_set_task=run_direction_set_task,
+            run_view_sheet_task=run_view_sheet_task,
             stop_event=stop_event,
             resume_action_poll=resume_action_poll,
         ),

--- a/backend/packages/app/src/windup_app/server/character/direction_validation.py
+++ b/backend/packages/app/src/windup_app/server/character/direction_validation.py
@@ -7,6 +7,8 @@ from windup_app.server.character.model import (
 )
 from windup_common.directions import (
     ActionDirection,
+    compass_directions_for_movement,
+    derived_direction_pairs_for_movement,
     required_directions_for_movement,
 )
 
@@ -23,6 +25,21 @@ def _real_directions(
 
 def _format_directions(directions: set[ActionDirection]) -> str:
     return "、".join(direction.value for direction in ActionDirection if direction in directions)
+
+
+def _validate_required_mirrors(
+    items: list[CharacterTemplateSequence] | list[CharacterActionSequence],
+    movement: int,
+    *,
+    label: str,
+) -> None:
+    by_direction = {ActionDirection(item.direction): item for item in items}
+    for dst, src in derived_direction_pairs_for_movement(movement):
+        item = by_direction.get(dst)
+        if item is None:
+            raise ValueError(f"{label}缺少镜像方向：{dst.value}")
+        if not item.mirror_x or item.source_direction != src.value:
+            raise ValueError(f"{label}方向 {dst.value} 必须镜像 {src.value}")
 
 
 def _validate_single_derivations(data: CharacterData) -> None:
@@ -66,17 +83,13 @@ def validate_character_directions(
             return
         raise ValueError("旧版镜像资产不能作为完整的多方向资产发布")
 
-    required = set(required_directions_for_movement(movement))
-    allowed = (
-        {ActionDirection.EAST, ActionDirection.WEST}
-        if movement == 1
-        else required
-    )
+    sources = set(required_directions_for_movement(movement))
+    allowed = set(compass_directions_for_movement(movement))
     if movement == 1:
         _validate_single_derivations(data)
 
     real_templates = _real_directions(data.templates)
-    missing_templates = required - real_templates
+    missing_templates = sources - real_templates
     if missing_templates:
         raise ValueError(f"角色母版缺少真实方向：{_format_directions(missing_templates)}")
     unexpected_templates = {
@@ -86,11 +99,13 @@ def validate_character_directions(
         raise ValueError(
             f"角色母版包含规格外方向：{_format_directions(unexpected_templates)}"
         )
+    if movement != 1:
+        _validate_required_mirrors(data.templates, movement, label="角色母版")
 
     for outfit in data.outfits:
         for action in outfit.actions:
             real_sequences = _real_directions(action.sequences)
-            missing_sequences = required - real_sequences
+            missing_sequences = sources - real_sequences
             if missing_sequences:
                 raise ValueError(
                     f"动作 {action.id} 缺少真实方向：{_format_directions(missing_sequences)}"
@@ -102,4 +117,8 @@ def validate_character_directions(
                 raise ValueError(
                     f"动作 {action.id} 包含规格外方向："
                     f"{_format_directions(unexpected_sequences)}"
+                )
+            if movement != 1:
+                _validate_required_mirrors(
+                    action.sequences, movement, label=f"动作 {action.id}"
                 )

--- a/backend/packages/app/src/windup_app/server/mq/catalog.py
+++ b/backend/packages/app/src/windup_app/server/mq/catalog.py
@@ -132,8 +132,13 @@ def types_for_stream(stream: str) -> tuple[TypeSpec, ...]:
 
 def msg_type_for_generation(task_type: str) -> str:
     """PENDING 重入队 / API 投递用的 msg_type。轮询类型没有 recover_as。"""
-    if task_type == "character_direction_set":
-        # 方向集仍是图片工作负载，共用图片池与背压，不另开一倍并发。
+    if task_type in (
+        "character_direction_set",
+        "character_four_view",
+        "character_eight_view",
+    ):
+        # 与单张立绘同一图像并发池。payload.task_type 才是执行器分叉,
+        # 不要另开 TypeSpec,否则会把线程池和信号量再加一倍。
         return MSG_TYPE_CHARACTER_IMAGE
     for spec in type_specs():
         if spec.recover_as == task_type:

--- a/backend/packages/app/src/windup_app/server/orchestrator/billing.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/billing.py
@@ -42,6 +42,8 @@ def prepaid_cost(task_type: GenerationType, model_calls: int) -> int:
     if task_type in (
         GenerationType.CHARACTER_IMAGE,
         GenerationType.CHARACTER_DIRECTION_SET,
+        GenerationType.CHARACTER_FOUR_VIEW,
+        GenerationType.CHARACTER_EIGHT_VIEW,
     ):
         return quota_settings.generate_image_cost * model_calls
     if task_type is GenerationType.CHARACTER_ACTION:

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -1238,3 +1238,6 @@ def bind_matte(matte: MatteProvider) -> None:
     """worker 预热后注入:动作与出图共用同一套 ONNX 会话,不再 warmup 丢一套再 new。"""
     executor._matte = matte
     image_executor._matte = matte
+    from windup_app.server.orchestrator.view_sheet_executor import view_sheet_executor
+
+    view_sheet_executor._matte = matte

--- a/backend/packages/app/src/windup_app/server/orchestrator/interface.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/interface.py
@@ -5,7 +5,8 @@ API 层只依赖本模块定义的抽象。具体实现（AI 引擎调用、任�
 
 调用流程
 --------
-1. 前端调用 ``generate_character_image`` / ``generate_character_action`` 提交任务，
+1. 前端调用 ``generate_character_image`` / ``generate_character_four_view`` /
+   ``generate_character_eight_view`` / ``generate_character_action`` 提交任务，
    拿到 ``task_id``。
 2. 前端通过 SSE 订阅任务状态变更,无需轮询。
    web 层提供 ``GET /generation/tasks/{task_id}/stream`` 端点,
@@ -16,7 +17,9 @@ API 层只依赖本模块定义的抽象。具体实现（AI 引擎调用、任�
 
    .. code-block:: text
 
-       CharacterImageOutput.image_url  → Character.reference_image_url
+       CharacterImageOutput.image_urls[]  → Character.reference_image_url
+       CharacterViewSheetOutput.sheets[]          → 3×3 sheet_url + 各方向 image_url
+                                                    (四向十字、八向八角;确认后源方向回填 templates[])
        CharacterActionOutput.frames[]  → character_data.outfits[].actions[].frames[]
 """
 
@@ -28,6 +31,7 @@ from windup_app.server.orchestrator.model import (
     CharacterActionInput,
     CharacterDirectionSetInput,
     CharacterImageInput,
+    CharacterViewSheetInput,
     GenerationTask,
 )
 
@@ -57,6 +61,35 @@ class GenerationService(ABC):
 
         入参包含角色 ID、动作类型和参考素材；出参为 ``CharacterActionOutput``，
         前端拿到 ``frames[]`` 后回填 ``character_data.outfits[].actions[].frames[]``。
+        """
+
+    @abstractmethod
+    def generate_character_four_view(
+        self,
+        session: Session,
+        *,
+        user_id: int,
+        project_id: int,
+        input: CharacterViewSheetInput,
+    ) -> GenerationTask:
+        """提交四向立绘 sheet。
+
+        必须绑定已确认的正视母版（south）；出参为 ``CharacterViewSheetOutput``
+        （每张候选 = 1 张 3×3 十字 sheet_url + 4 张方向原图 URL）。
+        """
+
+    @abstractmethod
+    def generate_character_eight_view(
+        self,
+        session: Session,
+        *,
+        user_id: int,
+        project_id: int,
+        input: CharacterViewSheetInput,
+    ) -> GenerationTask:
+        """提交八向立绘 sheet。
+
+        入参字段与四向相同；正视母版仍作南向格。每张候选 = 1 张 3×3 罗盘 sheet_url + 8 张方向原图 URL。
         """
 
     @abstractmethod

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -26,6 +26,8 @@ class GenerationType(StrEnum):
 
     CHARACTER_IMAGE = "character_image"  # 角色参考图
     CHARACTER_DIRECTION_SET = "character_direction_set"  # 一次生成项目所需全部母版方向
+    CHARACTER_FOUR_VIEW = "character_four_view"  # 四向立绘 sheet
+    CHARACTER_EIGHT_VIEW = "character_eight_view"  # 八向立绘 sheet
     CHARACTER_ACTION = "character_action"  # 角色动作帧序列
 
 
@@ -117,6 +119,36 @@ class CharacterDirectionSetInput:
                 raise ValueError("已确认母版方向必须属于项目方向集")
         if self.num_images is None:
             self.num_images = 2
+
+
+# 每张 sheet 候选要新生成的源方向数:south 正视复用已确认母版,镜像方向翻转上传不调模型。
+FOUR_VIEW_MODEL_CALLS_PER_SHEET = 2  # east / north
+EIGHT_VIEW_MODEL_CALLS_PER_SHEET = 4  # east / north / north_east / south_east
+
+
+@dataclass
+class CharacterViewSheetInput:
+    """四向 / 八向立绘 sheet 入参。两口字段相同,task_type 由提交方法决定。"""
+
+    character_id: int
+    reference_image_url: str
+    prompt: str = ""
+    negative_prompt: str = ""
+    width: int = 1024
+    height: int = 1024
+    # ``None`` = 调用方没指定。默认 1:sheet 比单张立绘贵,不沿用 image 的默认 3。
+    num_images: int | None = None
+    # 已确认母版必须是正视图,对应南向格。东向是侧视,本任务要图生图。
+    anchor_direction: ActionDirection = ActionDirection.SOUTH
+
+    def __post_init__(self) -> None:
+        self.reference_image_url = (self.reference_image_url or "").strip()
+        if not self.reference_image_url:
+            raise ValueError("立绘 sheet 生成必须绑定已确认角色母版")
+        if self.anchor_direction is not ActionDirection.SOUTH:
+            raise ValueError("立绘 sheet 锚点必须是 south（正视图）")
+        if self.num_images is None:
+            self.num_images = 1
 
 
 @dataclass
@@ -229,6 +261,52 @@ def initial_direction_set_output(
 
 
 @dataclass
+class CharacterViewSheetCell:
+    """sheet 上的一格。生成结果里每个方向都有已上传 URL。
+
+    镜像格是源图水平翻转后重新上传,不是 ``image_url=null``。
+    回填 ``templates[]`` 时镜像行仍只记 ``source_direction`` / ``mirror_x``,
+    不把这张翻转图写成独立母版。
+    """
+
+    direction: ActionDirection
+    image_url: str
+    source_direction: ActionDirection | None = None
+    mirror_x: bool = False
+
+    def __post_init__(self) -> None:
+        self.image_url = (self.image_url or "").strip()
+        if not self.image_url:
+            raise ValueError("立绘格子必须有 image_url")
+        if self.mirror_x != (self.source_direction is not None):
+            raise ValueError("镜像格必须同时给出 source_direction 与 mirror_x")
+        if self.source_direction is not None and self.source_direction == self.direction:
+            raise ValueError("格子不能镜像自身")
+
+
+@dataclass
+class CharacterViewSheetCandidate:
+    """一张 sheet 候选:3×3 罗盘整图 URL + 有朝向的原图 URL(空槽不进 cells)。"""
+
+    sheet_url: str
+    cells: list[CharacterViewSheetCell] = field(default_factory=list)
+
+
+@dataclass
+class CharacterViewSheetOutput:
+    """四向 / 八向立绘 sheet 结果。``type`` 与 ``task_type`` 相同。
+
+    每张候选 = 3×3 ``sheet_url`` + 有朝向的 ``image_url``（镜像格是翻转后上传）。
+    四向只填十字四格;空槽不进 ``cells``。
+    确认后源方向回填 ``character_data.templates[]``；镜像行只记关系。
+    """
+
+    type: str
+    sheets: list[CharacterViewSheetCandidate] = field(default_factory=list)
+    quality: dict | None = None
+
+
+@dataclass
 class CharacterActionFrame:
     """动作帧——前端写入 ``CharacterAction.frames[]``。"""
 
@@ -286,6 +364,7 @@ class GenerationTask:
     result: (
         CharacterImageOutput
         | CharacterDirectionSetOutput
+        | CharacterViewSheetOutput
         | CharacterActionOutput
         | None
     ) = None

--- a/backend/packages/app/src/windup_app/server/orchestrator/service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/service.py
@@ -20,6 +20,9 @@ from windup_app.server.orchestrator.model import (
     CharacterDirectionSetInput,
     CharacterDirectionSetOutput,
     CharacterImageInput,
+    CharacterViewSheetInput,
+    EIGHT_VIEW_MODEL_CALLS_PER_SHEET,
+    FOUR_VIEW_MODEL_CALLS_PER_SHEET,
     GenerationTask,
     GenerationType,
     TaskStatus,
@@ -42,6 +45,66 @@ class AiGenerationService(GenerationService):
         billing.reserve_for_task(
             session, user_id=user_id, task_id=task.id, task_type=task.task_type,
             model_calls=max(1, input.num_images),
+        )
+        return task
+
+    def generate_character_four_view(
+        self,
+        session: Session,
+        *,
+        user_id: int,
+        project_id: int,
+        input: CharacterViewSheetInput,
+    ) -> GenerationTask:
+        return self._submit_view_sheet(
+            session,
+            user_id=user_id,
+            project_id=project_id,
+            input=input,
+            task_type=GenerationType.CHARACTER_FOUR_VIEW,
+            model_calls_per_sheet=FOUR_VIEW_MODEL_CALLS_PER_SHEET,
+        )
+
+    def generate_character_eight_view(
+        self,
+        session: Session,
+        *,
+        user_id: int,
+        project_id: int,
+        input: CharacterViewSheetInput,
+    ) -> GenerationTask:
+        return self._submit_view_sheet(
+            session,
+            user_id=user_id,
+            project_id=project_id,
+            input=input,
+            task_type=GenerationType.CHARACTER_EIGHT_VIEW,
+            model_calls_per_sheet=EIGHT_VIEW_MODEL_CALLS_PER_SHEET,
+        )
+
+    def _submit_view_sheet(
+        self,
+        session: Session,
+        *,
+        user_id: int,
+        project_id: int,
+        input: CharacterViewSheetInput,
+        task_type: GenerationType,
+        model_calls_per_sheet: int,
+    ) -> GenerationTask:
+        task = task_repo.create_task(
+            session,
+            user_id=user_id,
+            project_id=project_id,
+            task_type=task_type,
+            input_payload=dataclasses.asdict(input),
+        )
+        billing.reserve_for_task(
+            session,
+            user_id=user_id,
+            task_id=task.id,
+            task_type=task.task_type,
+            model_calls=max(1, input.num_images or 1) * model_calls_per_sheet,
         )
         return task
 

--- a/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
@@ -21,6 +21,9 @@ from windup_app.server.orchestrator.model import (
     CharacterActionOutput,
     CharacterDirectionSetOutput,
     CharacterImageOutput,
+    CharacterViewSheetCandidate,
+    CharacterViewSheetCell,
+    CharacterViewSheetOutput,
     DirectionImageResult,
     GenerationTask,
     GenerationTaskRecord,
@@ -337,7 +340,13 @@ def _record_to_domain(record: GenerationTaskRecord) -> GenerationTask:
 def _deserialize_result(
     result_type: str | None,
     raw: dict | None,
-) -> CharacterImageOutput | CharacterDirectionSetOutput | CharacterActionOutput | None:
+) -> (
+    CharacterImageOutput
+    | CharacterDirectionSetOutput
+    | CharacterViewSheetOutput
+    | CharacterActionOutput
+    | None
+):
     """根据 ``result_type`` 将 JSON dict 反序列化为对应的 dataclass。"""
     if raw is None or result_type is None:
         return None
@@ -384,5 +393,32 @@ def _deserialize_result(
                 )
                 for item in raw.get("directions", [])
             ],
+        )
+    if result_type in (
+        GenerationType.CHARACTER_FOUR_VIEW.value,
+        GenerationType.CHARACTER_EIGHT_VIEW.value,
+    ):
+        return CharacterViewSheetOutput(
+            type=raw.get("type", result_type),
+            sheets=[
+                CharacterViewSheetCandidate(
+                    sheet_url=item["sheet_url"],
+                    cells=[
+                        CharacterViewSheetCell(
+                            direction=ActionDirection(cell["direction"]),
+                            image_url=cell["image_url"],
+                            source_direction=(
+                                ActionDirection(cell["source_direction"])
+                                if cell.get("source_direction")
+                                else None
+                            ),
+                            mirror_x=bool(cell.get("mirror_x")),
+                        )
+                        for cell in item.get("cells") or []
+                    ],
+                )
+                for item in raw.get("sheets") or []
+            ],
+            quality=raw.get("quality"),
         )
     return None

--- a/backend/packages/app/src/windup_app/server/orchestrator/view_sheet_executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/view_sheet_executor.py
@@ -1,0 +1,372 @@
+"""四向 / 八向立绘 sheet 编排。
+
+从已确认正视母版(south)图生图出源方向,镜像格水平翻转后上传,再拼一张 3×3 罗盘。
+不经过 ``ImageTaskExecutor._produce_image`` / ``DirectionSetTaskExecutor``。
+
+web **不得 import 本模块**(与 ``executor`` 同门禁:会牵出 ai_engine)。
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+import logging
+import threading
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from PIL import Image
+from sqlalchemy.orm import Session
+
+from windup_ai_engine.prompt import build_view_sheet_prompt
+from windup_ai_engine.slicing.quality import subject_blobs
+from windup_common.directions import ActionDirection
+from windup_common.models import CharacterView
+from windup_framework.gateway import bind_call_context, fresh_gateway_request
+
+from windup_app.server.orchestrator import generation_io, task_repo
+from windup_app.server.orchestrator._failure import user_message
+from windup_app.server.orchestrator._fetch import fetch_own_media
+from windup_app.server.orchestrator.executor import (
+    ProjectConstraints,
+    _close_failed,
+    _fit_to,
+    _load_constraints,
+    _require_size,
+    _settle_credit,
+)
+from windup_app.server.orchestrator.model import (
+    CharacterViewSheetCandidate,
+    CharacterViewSheetCell,
+    CharacterViewSheetInput,
+    CharacterViewSheetOutput,
+    GenerationType,
+    TaskStatus,
+)
+
+if TYPE_CHECKING:
+    from windup_framework.providers import MatteProvider
+
+logger = logging.getLogger("windup.generation.view_sheet")
+
+_FOUR_SOURCES = (ActionDirection.EAST, ActionDirection.NORTH)
+_EIGHT_SOURCES = (
+    ActionDirection.EAST,
+    ActionDirection.NORTH,
+    ActionDirection.NORTH_EAST,
+    ActionDirection.SOUTH_EAST,
+)
+_MIRRORS = (
+    (ActionDirection.WEST, ActionDirection.EAST),
+    (ActionDirection.NORTH_WEST, ActionDirection.NORTH_EAST),
+    (ActionDirection.SOUTH_WEST, ActionDirection.SOUTH_EAST),
+)
+# 列、行;中心 (1,1) 不贴。
+_CELL_GRID: dict[ActionDirection, tuple[int, int]] = {
+    ActionDirection.NORTH_WEST: (0, 0),
+    ActionDirection.NORTH: (1, 0),
+    ActionDirection.NORTH_EAST: (2, 0),
+    ActionDirection.WEST: (0, 1),
+    ActionDirection.EAST: (2, 1),
+    ActionDirection.SOUTH_WEST: (0, 2),
+    ActionDirection.SOUTH: (1, 2),
+    ActionDirection.SOUTH_EAST: (2, 2),
+}
+_PERSPECTIVE_TO_VIEW = {
+    1: CharacterView.SIDE,
+    2: CharacterView.TOP_DOWN,
+    3: CharacterView.ISOMETRIC,
+}
+
+
+def source_directions_for(task_type: GenerationType) -> tuple[ActionDirection, ...]:
+    if task_type is GenerationType.CHARACTER_FOUR_VIEW:
+        return _FOUR_SOURCES
+    if task_type is GenerationType.CHARACTER_EIGHT_VIEW:
+        return _EIGHT_SOURCES
+    raise ValueError(f"不是立绘 sheet 任务: {task_type}")
+
+
+def flip_horizontal(png: bytes) -> bytes:
+    """水平翻转后重新编码。镜像格上传前调用;拼 sheet 时不再翻。"""
+    im = Image.open(io.BytesIO(png)).convert("RGBA")
+    buf = io.BytesIO()
+    im.transpose(Image.FLIP_LEFT_RIGHT).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def compose_compass_sheet(
+    cells: dict[ActionDirection, bytes],
+    width: int,
+    height: int,
+) -> bytes:
+    """把已对齐的格子贴进 3×3 罗盘。缺的方向(四向斜角、中心)保持透明。"""
+    sheet = Image.new("RGBA", (3 * width, 3 * height), (0, 0, 0, 0))
+    for direction, png in cells.items():
+        col, row = _CELL_GRID[direction]
+        cell = Image.open(io.BytesIO(png)).convert("RGBA")
+        if cell.size != (width, height):
+            raise ValueError(
+                f"{direction.value} 格尺寸 {cell.size[0]}×{cell.size[1]} "
+                f"与项目精灵 {width}×{height} 不一致,拼装不做二次对齐。"
+            )
+        sheet.alpha_composite(cell, (col * width, row * height))
+    buf = io.BytesIO()
+    sheet.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _mirrors_for(
+    sources: tuple[ActionDirection, ...],
+) -> tuple[tuple[ActionDirection, ActionDirection], ...]:
+    have = set(sources)
+    return tuple((dst, src) for dst, src in _MIRRORS if src in have)
+
+
+class ViewSheetTaskExecutor:
+    """跑四向 / 八向立绘 sheet:图生图源方向 → 翻转镜像 → 拼 3×3 → 回写。"""
+
+    def __init__(
+        self,
+        *,
+        image=None,
+        matte: MatteProvider | None = None,
+        upload: Callable[[bytes], str] | None = None,
+        fetch_ref: Callable[[str], bytes] | None = None,
+        session_factory: Callable[[], Session] | None = None,
+    ) -> None:
+        self._image = image
+        self._matte = matte
+        self._upload = upload
+        self._fetch_ref = fetch_ref
+        self._session_factory = session_factory
+        self._assembly_lock = threading.Lock()
+
+    def run_four_view_task(
+        self,
+        task_id: int,
+        input: CharacterViewSheetInput,
+        project_id: int | None = None,
+        *,
+        session: Session | None = None,
+    ) -> None:
+        self.run_view_sheet_task(
+            task_id,
+            input,
+            GenerationType.CHARACTER_FOUR_VIEW,
+            project_id,
+            session=session,
+        )
+
+    def run_eight_view_task(
+        self,
+        task_id: int,
+        input: CharacterViewSheetInput,
+        project_id: int | None = None,
+        *,
+        session: Session | None = None,
+    ) -> None:
+        self.run_view_sheet_task(
+            task_id,
+            input,
+            GenerationType.CHARACTER_EIGHT_VIEW,
+            project_id,
+            session=session,
+        )
+
+    def run_view_sheet_task(
+        self,
+        task_id: int,
+        input: CharacterViewSheetInput,
+        task_type: GenerationType,
+        project_id: int | None = None,
+        *,
+        session: Session | None = None,
+    ) -> None:
+        reset = None
+        try:
+
+            def _mark_running(s: Session) -> ProjectConstraints:
+                task_repo.update_status(s, task_id, TaskStatus.RUNNING)
+                return _load_constraints(s, project_id)
+
+            cons = generation_io.using_session(session, self._make_session, _mark_running)
+            reset = bind_call_context(task_id=str(task_id))
+            output = self._produce_sheets(input, task_type, cons)
+
+            def _complete(s: Session) -> None:
+                task_repo.update_result(
+                    s,
+                    task_id,
+                    task_type.value,
+                    dataclasses.asdict(output),
+                )
+                _settle_credit(s, task_id, success=True)
+
+            generation_io.using_session(session, self._make_session, _complete)
+        except Exception as exc:  # noqa: BLE001 —— 兜底
+            logger.exception("立绘 sheet 任务 %s 失败", task_id)
+            if session is not None:
+                session.rollback()
+            error_message = user_message(exc)
+
+            def _fail(s: Session) -> None:
+                _close_failed(s, task_id, error_message)
+
+            generation_io.using_session(session, self._make_session, _fail)
+        finally:
+            if reset is not None:
+                reset()
+
+    def _produce_sheets(
+        self,
+        input: CharacterViewSheetInput,
+        task_type: GenerationType,
+        cons: ProjectConstraints,
+    ) -> CharacterViewSheetOutput:
+        sources = source_directions_for(task_type)
+        mirrors = _mirrors_for(sources)
+        fetch = self._fetch_ref or self._download
+        master_png = _require_size(
+            fetch(input.reference_image_url),
+            input.width,
+            input.height,
+        )
+        n_sheets = max(1, input.num_images or 1)
+        from windup_framework.gateway.registry import ModelRegistry, candidate_models
+        from windup_framework.gateway.types import Scene
+
+        spread = candidate_models(
+            ModelRegistry.from_settings().chain(Scene.CHARACTER_IMAGE),
+            n_sheets,
+        )
+        jobs = [(sheet_i, direction) for sheet_i in range(n_sheets) for direction in sources]
+        view = _PERSPECTIVE_TO_VIEW.get(cons.perspective, CharacterView.SIDE)
+        extra = (input.prompt or "").strip()
+        image_gen = self._get_image()
+        matte = self._get_matte()
+        upload = self._upload or self._upload_image
+        refs = [master_png]
+
+        def _gen_one(job: tuple[int, ActionDirection]) -> bytes:
+            sheet_i, direction = job
+            reset_call = fresh_gateway_request(start_from_model=spread[sheet_i])
+            try:
+                prompt = build_view_sheet_prompt(direction, view=view, extra=extra)
+                return image_gen.gen_image(prompt, refs)
+            finally:
+                reset_call()
+
+        raws = generation_io.io_map(_gen_one, jobs)
+        fitted: list[bytes] = []
+        cut_images: list[Image.Image] = []
+        for raw in raws:
+            png = _fit_to(
+                matte.cutout(raw),
+                input.width,
+                input.height,
+                smooth=cons.stylize != "pixel",
+            )
+            cut_images.append(Image.open(io.BytesIO(png)).convert("RGBA"))
+            fitted.append(png)
+
+        sheets: list[CharacterViewSheetCandidate] = []
+        n_sources = len(sources)
+        for sheet_i in range(n_sheets):
+            by_dir: dict[ActionDirection, bytes] = {
+                ActionDirection.SOUTH: master_png,
+            }
+            offset = sheet_i * n_sources
+            for j, direction in enumerate(sources):
+                by_dir[direction] = fitted[offset + j]
+            for dst, src in mirrors:
+                by_dir[dst] = flip_horizontal(by_dir[src])
+
+            upload_dirs = [d for d in by_dir if d is not ActionDirection.SOUTH]
+            urls = generation_io.upload_frames(
+                upload,
+                [by_dir[d] for d in upload_dirs],
+            )
+            url_by_dir = {
+                ActionDirection.SOUTH: input.reference_image_url,
+                **dict(zip(upload_dirs, urls, strict=True)),
+            }
+            sheet_url = upload(compose_compass_sheet(by_dir, input.width, input.height))
+            cells = [
+                CharacterViewSheetCell(
+                    direction=ActionDirection.SOUTH,
+                    image_url=url_by_dir[ActionDirection.SOUTH],
+                ),
+            ]
+            for direction in sources:
+                cells.append(
+                    CharacterViewSheetCell(
+                        direction=direction,
+                        image_url=url_by_dir[direction],
+                    )
+                )
+            for dst, src in mirrors:
+                cells.append(
+                    CharacterViewSheetCell(
+                        direction=dst,
+                        image_url=url_by_dir[dst],
+                        source_direction=src,
+                        mirror_x=True,
+                    )
+                )
+            sheets.append(CharacterViewSheetCandidate(sheet_url=sheet_url, cells=cells))
+
+        south_im = Image.open(io.BytesIO(master_png)).convert("RGBA")
+        return CharacterViewSheetOutput(
+            type=task_type.value,
+            sheets=sheets,
+            quality={"subject_blobs": list(subject_blobs([south_im, *cut_images]))},
+        )
+
+    def _get_image(self):
+        if self._image is not None:
+            return self._image
+        with self._assembly_lock:
+            if self._image is None:
+                from windup_framework.gateway import build_image_gateway
+
+                self._image = build_image_gateway()
+            return self._image
+
+    def _get_matte(self):
+        if self._matte is not None:
+            return self._matte
+        with self._assembly_lock:
+            if self._matte is None:
+                from windup_framework.providers import OnnxU2NetMatteProvider
+
+                self._matte = OnnxU2NetMatteProvider()
+            return self._matte
+
+    def _download(self, url: str) -> bytes:
+        return fetch_own_media(url)
+
+    def _upload_image(self, png: bytes) -> str:
+        from windup_app.server.media.model import MediaCategory, MediaUploadInput
+        from windup_app.server.media.service import service as media_service
+
+        meta = MediaUploadInput(
+            filename="character.png",
+            content_type="image/png",
+            size=len(png),
+            category=MediaCategory.REFERENCE_IMAGE,
+        )
+        return media_service.upload(png, meta).url
+
+    def _make_session(self) -> Session:
+        if self._session_factory is not None:
+            return self._session_factory()
+        from windup_framework.db.session import SessionLocal
+
+        return SessionLocal()
+
+
+view_sheet_executor = ViewSheetTaskExecutor()
+run_four_view_task = view_sheet_executor.run_four_view_task
+run_eight_view_task = view_sheet_executor.run_eight_view_task
+run_view_sheet_task = view_sheet_executor.run_view_sheet_task

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -6,6 +6,8 @@
 端点一览
 --------
 POST /generation/image                     提交角色图片生成任务
+POST /generation/four-view                 提交四向立绘 sheet
+POST /generation/eight-view                提交八向立绘 sheet
 POST /generation/action                    提交角色动作生成任务
 GET  /generation/tasks/{task_id}           查询任务状态
 GET  /generation/tasks/{task_id}/stream    SSE 订阅任务进度
@@ -51,6 +53,7 @@ from windup_app.server.orchestrator.model import (
     CharacterActionInput,
     CharacterDirectionSetInput,
     CharacterImageInput,
+    CharacterViewSheetInput,
     GenerationTask,
 )
 from windup_app.server.project.model import Project
@@ -312,6 +315,20 @@ class CharacterDirectionSetGenerateRequest(BaseModel):
     width: int = Field(default=1024, ge=64, le=2048)
     height: int = Field(default=1024, ge=64, le=2048)
     num_images: int = Field(default=3, ge=1, le=4)
+
+
+class CharacterViewSheetGenerateRequest(BaseModel):
+    """四向 / 八向立绘 sheet。两口字段相同,朝向集合由路径决定。"""
+
+    model_config = ConfigDict(extra="forbid")
+    project_id: int = Field(gt=0)
+    character_id: int = Field(gt=0)
+    prompt: str = ""
+    negative_prompt: str = ""
+    width: int = Field(default=1024, ge=64, le=2048)
+    height: int = Field(default=1024, ge=64, le=2048)
+    # sheet 比单张立绘贵,默认 1,不沿用 image 的 3。
+    num_images: int = Field(default=1, ge=1, le=4)
 
 
 class CharacterActionGenerateRequest(BaseModel):
@@ -599,6 +616,82 @@ def submit_direction_set_generation(
             task_type=task.task_type.value,
         )
     return Response.success(_task_to_out(task), message="方向集任务已提交")
+
+
+def _submit_view_sheet(
+    body: CharacterViewSheetGenerateRequest,
+    request: Request,
+    session: Session,
+    *,
+    expected_movement: int,
+    label: str,
+    submit,
+) -> Response[GenerationTaskOut]:
+    user_id = request.state.current_user.id
+    project = _get_project_or_raise(session, body.project_id, user_id)
+    if project.directional_movement != expected_movement:
+        raise BizException(f"当前项目不是{label}", code=BizCode.BAD_REQUEST)
+    _validate_project_size(project, body.width, body.height)
+    character = _get_character_or_raise(session, body.character_id, body.project_id)
+    confirmed_master = (character.reference_image_url or "").strip()
+    if not confirmed_master:
+        raise BizException("请先选择并确认角色母版", code=BizCode.BAD_REQUEST)
+    input_data = CharacterViewSheetInput(
+        character_id=character.id,
+        reference_image_url=confirmed_master,
+        prompt=body.prompt,
+        negative_prompt=body.negative_prompt,
+        width=body.width,
+        height=body.height,
+        num_images=body.num_images,
+    )
+    task = submit(
+        session,
+        user_id=user_id,
+        project_id=body.project_id,
+        input=input_data,
+    )
+    _publish_generation_after_commit(
+        session,
+        request.app.state.mq_publisher,
+        task_id=task.id,
+        task_type=task.task_type.value,
+    )
+    return Response.success(_task_to_out(session, task), message="任务已提交")
+
+
+@router.post("/four-view", response_model=Response[GenerationTaskOut])
+def submit_four_view_generation(
+    body: CharacterViewSheetGenerateRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> Response[GenerationTaskOut]:
+    """提交四向立绘 sheet:正视母版转出十字四格,斜向留空。"""
+    return _submit_view_sheet(
+        body,
+        request,
+        session,
+        expected_movement=2,
+        label="四向",
+        submit=generation_service.generate_character_four_view,
+    )
+
+
+@router.post("/eight-view", response_model=Response[GenerationTaskOut])
+def submit_eight_view_generation(
+    body: CharacterViewSheetGenerateRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> Response[GenerationTaskOut]:
+    """提交八向立绘 sheet:正视母版转出八角,中心留空。"""
+    return _submit_view_sheet(
+        body,
+        request,
+        session,
+        expected_movement=3,
+        label="八向",
+        submit=generation_service.generate_character_eight_view,
+    )
 
 
 @router.post("/action", response_model=Response[GenerationTaskOut])

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -657,7 +657,7 @@ def _submit_view_sheet(
         task_id=task.id,
         task_type=task.task_type.value,
     )
-    return Response.success(_task_to_out(session, task), message="任务已提交")
+    return Response.success(_task_to_out(task), message="任务已提交")
 
 
 @router.post("/four-view", response_model=Response[GenerationTaskOut])

--- a/backend/packages/app/src/windup_app/worker/consumer.py
+++ b/backend/packages/app/src/windup_app/worker/consumer.py
@@ -60,12 +60,14 @@ class StreamConsumer:
         stop_event: threading.Event,
         resume_action_poll: Callable[..., Any] | None = None,
         run_direction_set_task: Callable[..., Any] | None = None,
+        run_view_sheet_task: Callable[..., Any] | None = None,
     ) -> None:
         self._config = config
         self._run_image_task = run_image_task
         self._run_action_task = run_action_task
         self._resume_action_poll = resume_action_poll
         self._run_direction_set_task = run_direction_set_task
+        self._run_view_sheet_task = run_view_sheet_task
         self._stop = stop_event
         self._consumer_name = f"{socket.gethostname()}-{threading.get_ident()}"
         self._executors: dict[str, ThreadPoolExecutor] = {}
@@ -215,6 +217,7 @@ class StreamConsumer:
                 run_action_task=self._run_action_task,
                 resume_action_poll=self._resume_action_poll,
                 run_direction_set_task=self._run_direction_set_task,
+                run_view_sheet_task=self._run_view_sheet_task,
             )
 
             session = SessionLocal()

--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -20,6 +20,7 @@ from windup_app.server.orchestrator.model import (
     CharacterActionInput,
     CharacterDirectionSetInput,
     CharacterImageInput,
+    CharacterViewSheetInput,
     GenerationType,
     TaskStatus,
 )
@@ -129,12 +130,26 @@ def _direction_set_input(payload: dict) -> CharacterDirectionSetInput:
     )
 
 
+def _view_sheet_input(payload: dict) -> CharacterViewSheetInput:
+    raw_num_images = payload.get("num_images")
+    return CharacterViewSheetInput(
+        character_id=int(payload["character_id"]),
+        reference_image_url=str(payload.get("reference_image_url") or ""),
+        prompt=payload.get("prompt") or "",
+        negative_prompt=payload.get("negative_prompt") or "",
+        width=int(payload.get("width") or 1024),
+        height=int(payload.get("height") or 1024),
+        num_images=int(raw_num_images) if raw_num_images is not None else None,
+    )
+
+
 def handle_generation(
     payload: dict[str, Any],
     *,
     run_image_task: Callable[..., Any],
     run_action_task: Callable[..., Any],
     run_direction_set_task: Callable[..., Any] | None = None,
+    run_view_sheet_task: Callable[..., Any] | None = None,
 ) -> None:
     task_id = int(payload["task_id"])
     task_type = str(payload.get("task_type") or "")
@@ -167,6 +182,18 @@ def handle_generation(
         if run_direction_set_task is None:
             raise RuntimeError("未注入 run_direction_set_task")
         run_direction_set_task(task_id, _direction_set_input(input_payload), project_id)
+    elif task_type in (
+        GenerationType.CHARACTER_FOUR_VIEW.value,
+        GenerationType.CHARACTER_EIGHT_VIEW.value,
+    ):
+        if run_view_sheet_task is None:
+            raise RuntimeError("未注入 run_view_sheet_task")
+        run_view_sheet_task(
+            task_id,
+            _view_sheet_input(input_payload),
+            GenerationType(task_type),
+            project_id,
+        )
     elif task_type == GenerationType.CHARACTER_ACTION.value:
         run_action_task(task_id, _action_input(input_payload), project_id)
     else:
@@ -207,6 +234,7 @@ def dispatch_handler(
     run_action_task: Callable[..., Any],
     resume_action_poll: Callable[..., Any] | None = None,
     run_direction_set_task: Callable[..., Any] | None = None,
+    run_view_sheet_task: Callable[..., Any] | None = None,
 ) -> None:
     handler = HANDLERS.get(msg_type)
     if handler is None:
@@ -217,6 +245,7 @@ def dispatch_handler(
         run_action_task=run_action_task,
         resume_action_poll=resume_action_poll,
         run_direction_set_task=run_direction_set_task,
+        run_view_sheet_task=run_view_sheet_task,
     )
 
 
@@ -230,6 +259,7 @@ def _dispatch_generation(
     run_image_task: Callable[..., Any],
     run_action_task: Callable[..., Any],
     run_direction_set_task: Callable[..., Any] | None = None,
+    run_view_sheet_task: Callable[..., Any] | None = None,
     **_deps: Any,
 ) -> None:
     handle_generation(
@@ -237,6 +267,7 @@ def _dispatch_generation(
         run_image_task=run_image_task,
         run_action_task=run_action_task,
         run_direction_set_task=run_direction_set_task,
+        run_view_sheet_task=run_view_sheet_task,
     )
 
 

--- a/backend/packages/common/src/windup_common/directions.py
+++ b/backend/packages/common/src/windup_common/directions.py
@@ -14,22 +14,56 @@ class ActionDirection(StrEnum):
     SOUTH_WEST = "south_west"
 
 
-_REQUIRED_DIRECTIONS: dict[int, tuple[ActionDirection, ...]] = {
+# 进生成队列、必须有独立资产的源方向。west / NW / SW 是镜像，不在此列。
+_SOURCE_DIRECTIONS: dict[int, tuple[ActionDirection, ...]] = {
     1: (ActionDirection.EAST,),
     2: (
         ActionDirection.EAST,
-        ActionDirection.WEST,
         ActionDirection.NORTH,
         ActionDirection.SOUTH,
     ),
-    3: tuple(ActionDirection),
+    3: (
+        ActionDirection.EAST,
+        ActionDirection.NORTH,
+        ActionDirection.SOUTH,
+        ActionDirection.NORTH_EAST,
+        ActionDirection.SOUTH_EAST,
+    ),
+}
+
+# (派生方向, 源方向)。完整发布时派生行必须是这些镜像。
+_DERIVED_PAIRS: dict[int, tuple[tuple[ActionDirection, ActionDirection], ...]] = {
+    1: ((ActionDirection.WEST, ActionDirection.EAST),),
+    2: ((ActionDirection.WEST, ActionDirection.EAST),),
+    3: (
+        (ActionDirection.WEST, ActionDirection.EAST),
+        (ActionDirection.NORTH_WEST, ActionDirection.NORTH_EAST),
+        (ActionDirection.SOUTH_WEST, ActionDirection.SOUTH_EAST),
+    ),
 }
 
 
 def required_directions_for_movement(movement: int) -> tuple[ActionDirection, ...]:
-    """返回项目必须真实生成的方向；未知项目配置按单向兼容。"""
+    """返回项目必须真实生成、可入队的源方向；未知项目配置按单向兼容。"""
 
-    return _REQUIRED_DIRECTIONS.get(movement, _REQUIRED_DIRECTIONS[1])
+    return _SOURCE_DIRECTIONS.get(movement, _SOURCE_DIRECTIONS[1])
+
+
+def derived_direction_pairs_for_movement(
+    movement: int,
+) -> tuple[tuple[ActionDirection, ActionDirection], ...]:
+    """返回 ``(派生方向, 源方向)``；未知配置按单向兼容。"""
+
+    return _DERIVED_PAIRS.get(movement, _DERIVED_PAIRS[1])
+
+
+def compass_directions_for_movement(movement: int) -> tuple[ActionDirection, ...]:
+    """源方向加派生方向，即 templates / sequences 允许出现的罗盘全集。"""
+
+    wanted = set(required_directions_for_movement(movement)) | {
+        dst for dst, _src in derived_direction_pairs_for_movement(movement)
+    }
+    return tuple(direction for direction in ActionDirection if direction in wanted)
 
 
 def is_required_direction(movement: int, direction: ActionDirection) -> bool:

--- a/backend/tests/test_character_api.py
+++ b/backend/tests/test_character_api.py
@@ -88,24 +88,61 @@ def _payload_with_frames(project_id: int, **overrides):
     return base
 
 
-def _directional_data(directions: list[str]) -> dict:
+def _complete_directional_data(movement: int) -> dict:
+    from windup_common.directions import (
+        compass_directions_for_movement,
+        required_directions_for_movement,
+    )
+
+    sources = {direction.value for direction in required_directions_for_movement(movement)}
+    directions = [
+        direction.value for direction in compass_directions_for_movement(movement)
+    ]
+    return _directional_data(directions, sources=sources)
+
+
+def _directional_data(directions: list[str], *, sources: set[str] | None = None) -> dict:
     def frame(direction: str) -> dict:
         return {
             "index": 0,
             "image_url": f"https://example.com/{direction}-0.png",
         }
 
+    def template(direction: str) -> dict:
+        if sources is not None and direction not in sources:
+            return {
+                "direction": direction,
+                "source_direction": _MIRROR_SOURCES[direction],
+                "mirror_x": True,
+                "image_url": None,
+            }
+        return {
+            "direction": direction,
+            "source_direction": None,
+            "mirror_x": False,
+            "image_url": f"https://example.com/{direction}.png",
+        }
+
+    def sequence(direction: str) -> dict:
+        if sources is not None and direction not in sources:
+            return {
+                "direction": direction,
+                "source_direction": _MIRROR_SOURCES[direction],
+                "mirror_x": True,
+                "frame_count": 1,
+                "frames": [],
+            }
+        return {
+            "direction": direction,
+            "source_direction": None,
+            "mirror_x": False,
+            "frame_count": 1,
+            "frames": [frame(direction)],
+        }
+
     return {
         "version": 2,
-        "templates": [
-            {
-                "direction": direction,
-                "source_direction": None,
-                "mirror_x": False,
-                "image_url": f"https://example.com/{direction}.png",
-            }
-            for direction in directions
-        ],
+        "templates": [template(direction) for direction in directions],
         "outfits": [
             {
                 "id": "outfit-1",
@@ -117,21 +154,19 @@ def _directional_data(directions: list[str]) -> dict:
                         "name": "待机",
                         "frame_count": 1,
                         "frames": [frame("east")],
-                        "sequences": [
-                            {
-                                "direction": direction,
-                                "source_direction": None,
-                                "mirror_x": False,
-                                "frame_count": 1,
-                                "frames": [frame(direction)],
-                            }
-                            for direction in directions
-                        ],
+                        "sequences": [sequence(direction) for direction in directions],
                     }
                 ],
             }
         ],
     }
+
+
+_MIRROR_SOURCES = {
+    "west": "east",
+    "north_west": "north_east",
+    "south_west": "south_east",
+}
 
 
 def test_character_model_defaults_to_draft(db_session):
@@ -921,18 +956,14 @@ def test_update_rejects_published_version_one_asset_in_multi_direction_project(
 
 
 @pytest.mark.parametrize(
-    ("movement", "directions", "missing"),
+    ("movement", "drop", "missing"),
     [
-        (2, ["east", "north", "south"], "west"),
-        (
-            3,
-            ["east", "west", "north", "south", "north_east", "south_east"],
-            "north_west",
-        ),
+        (2, "west", "west"),
+        (3, "north_west", "north_west"),
     ],
 )
 def test_update_rejects_published_version_two_assets_with_missing_real_directions(
-    auth_client, movement, directions, missing
+    auth_client, movement, drop, missing
 ):
     project = _create_project(
         auth_client,
@@ -943,37 +974,31 @@ def test_update_rejects_published_version_two_assets_with_missing_real_direction
         "/characters",
         json=_payload(project["id"]),
     ).json()["data"]
+    character_data = _complete_directional_data(movement)
+    character_data["templates"] = [
+        template
+        for template in character_data["templates"]
+        if template["direction"] != drop
+    ]
+    action = character_data["outfits"][0]["actions"][0]
+    action["sequences"] = [
+        sequence
+        for sequence in action["sequences"]
+        if sequence["direction"] != drop
+    ]
 
     body = auth_client.patch(
         f"/characters/{created['id']}",
-        json={"character_data": _directional_data(directions)},
+        json={"character_data": character_data},
     ).json()
 
     assert body["code"] == 400
     assert missing in body["message"]
 
 
-@pytest.mark.parametrize(
-    ("movement", "directions"),
-    [
-        (2, ["east", "west", "north", "south"]),
-        (
-            3,
-            [
-                "east",
-                "west",
-                "north",
-                "south",
-                "north_east",
-                "north_west",
-                "south_east",
-                "south_west",
-            ],
-        ),
-    ],
-)
+@pytest.mark.parametrize("movement", [2, 3])
 def test_update_accepts_complete_version_two_multi_direction_assets(
-    auth_client, movement, directions
+    auth_client, movement
 ):
     project = _create_project(
         auth_client,
@@ -987,9 +1012,7 @@ def test_update_accepts_complete_version_two_multi_direction_assets(
 
     response = auth_client.patch(
         f"/characters/{created['id']}",
-        json={
-            "character_data": _directional_data(directions)
-        },
+        json={"character_data": _complete_directional_data(movement)},
     )
 
     assert response.status_code == 200

--- a/backend/tests/test_character_direction_contract.py
+++ b/backend/tests/test_character_direction_contract.py
@@ -76,23 +76,61 @@ def _data(version: int, templates: list[dict], sequences: list[dict]) -> Charact
     )
 
 
-def test_version_two_four_way_accepts_real_west_frames():
-    directions = ["east", "west", "north", "south"]
-    data = _data(
+_FOUR_SOURCES = ["east", "north", "south"]
+_EIGHT_SOURCES = ["east", "north", "south", "north_east", "south_east"]
+_EIGHT_MIRRORS = [
+    ("west", "east"),
+    ("north_west", "north_east"),
+    ("south_west", "south_east"),
+]
+
+
+def _four_way_complete() -> CharacterData:
+    return _data(
         2,
-        [_real_template(direction) for direction in directions],
-        [_real_sequence(direction) for direction in directions],
+        [_real_template(direction) for direction in _FOUR_SOURCES]
+        + [_mirror_template("west", "east")],
+        [_real_sequence(direction) for direction in _FOUR_SOURCES]
+        + [_mirror_sequence("west", "east")],
     )
 
+
+def _eight_way_complete() -> CharacterData:
+    return _data(
+        2,
+        [_real_template(direction) for direction in _EIGHT_SOURCES]
+        + [_mirror_template(dst, src) for dst, src in _EIGHT_MIRRORS],
+        [_real_sequence(direction) for direction in _EIGHT_SOURCES]
+        + [_mirror_sequence(dst, src) for dst, src in _EIGHT_MIRRORS],
+    )
+
+
+def test_version_two_four_way_accepts_west_as_east_mirror():
+    data = _four_way_complete()
+
     validate_character_directions(data, movement=2, require_complete=True)
-    west = data.outfits[0].actions[0].sequences[1]
-    assert west.direction == "west"
-    assert west.source_direction is None
-    assert west.mirror_x is False
-    assert west.frames[0].image_url.endswith("west-0.png")
+    west = next(
+        sequence
+        for sequence in data.outfits[0].actions[0].sequences
+        if sequence.direction == "west"
+    )
+    assert west.source_direction == "east"
+    assert west.mirror_x is True
+    assert west.frames == []
 
 
-def test_version_two_four_way_mirror_is_readable_but_not_complete():
+def test_version_two_four_way_rejects_real_west():
+    data = _data(
+        2,
+        [_real_template(direction) for direction in [*_FOUR_SOURCES, "west"]],
+        [_real_sequence(direction) for direction in [*_FOUR_SOURCES, "west"]],
+    )
+
+    with pytest.raises(ValueError, match="west"):
+        validate_character_directions(data, movement=2, require_complete=True)
+
+
+def test_version_two_four_way_mirror_without_sources_is_readable_but_not_complete():
     data = _data(
         2,
         [_real_template("east"), _mirror_template("west", "east")],
@@ -100,8 +138,12 @@ def test_version_two_four_way_mirror_is_readable_but_not_complete():
     )
 
     validate_character_directions(data, movement=2, require_complete=False)
-    with pytest.raises(ValueError, match="west"):
+    with pytest.raises(ValueError, match="north"):
         validate_character_directions(data, movement=2, require_complete=True)
+
+
+def test_version_two_eight_way_accepts_diagonal_mirrors():
+    validate_character_directions(_eight_way_complete(), movement=3, require_complete=True)
 
 
 def test_version_one_west_mirror_round_trips_unchanged():
@@ -127,11 +169,12 @@ def test_version_two_single_keeps_east_to_west_mirror_compatibility():
 
 
 def test_version_two_four_way_rejects_specification_external_real_direction():
-    directions = ["east", "west", "north", "south", "north_east"]
     data = _data(
         2,
-        [_real_template(direction) for direction in directions],
-        [_real_sequence(direction) for direction in directions],
+        [_real_template(direction) for direction in _FOUR_SOURCES]
+        + [_mirror_template("west", "east"), _real_template("north_east")],
+        [_real_sequence(direction) for direction in _FOUR_SOURCES]
+        + [_mirror_sequence("west", "east"), _real_sequence("north_east")],
     )
 
     with pytest.raises(ValueError, match="north_east"):
@@ -190,12 +233,12 @@ def test_version_two_single_rejects_non_west_derived_direction():
         validate_character_directions(data, movement=1, require_complete=True)
 
 
-def test_version_two_four_way_reports_missing_action_direction_after_complete_templates():
-    required = ["east", "west", "north", "south"]
+def test_version_two_four_way_reports_missing_action_mirror_after_complete_templates():
     data = _data(
         2,
-        [_real_template(direction) for direction in required],
-        [_real_sequence(direction) for direction in required if direction != "west"],
+        [_real_template(direction) for direction in _FOUR_SOURCES]
+        + [_mirror_template("west", "east")],
+        [_real_sequence(direction) for direction in _FOUR_SOURCES],
     )
 
     with pytest.raises(ValueError, match="west"):
@@ -203,11 +246,12 @@ def test_version_two_four_way_reports_missing_action_direction_after_complete_te
 
 
 def test_version_two_four_way_rejects_specification_external_action_direction():
-    required = ["east", "west", "north", "south"]
     data = _data(
         2,
-        [_real_template(direction) for direction in required],
-        [_real_sequence(direction) for direction in [*required, "north_east"]],
+        [_real_template(direction) for direction in _FOUR_SOURCES]
+        + [_mirror_template("west", "east")],
+        [_real_sequence(direction) for direction in _FOUR_SOURCES]
+        + [_mirror_sequence("west", "east"), _real_sequence("north_east")],
     )
 
     with pytest.raises(ValueError, match="north_east"):

--- a/backend/tests/test_directional_generation.py
+++ b/backend/tests/test_directional_generation.py
@@ -7,6 +7,8 @@
 from windup_ai_engine.strategy.concrete import VideoFrameStrategy
 from windup_common.directions import (
     ActionDirection,
+    compass_directions_for_movement,
+    derived_direction_pairs_for_movement,
     required_directions_for_movement,
 )
 from windup_common.models import ActionSpec, ActionType, CharacterStance, Facing
@@ -16,17 +18,31 @@ def test_direction_profile_requires_one_four_or_eight_real_tasks():
     assert required_directions_for_movement(1) == (ActionDirection.EAST,)
     assert required_directions_for_movement(2) == (
         ActionDirection.EAST,
+        ActionDirection.NORTH,
+        ActionDirection.SOUTH,
+    )
+    assert required_directions_for_movement(3) == (
+        ActionDirection.EAST,
+        ActionDirection.NORTH,
+        ActionDirection.SOUTH,
+        ActionDirection.NORTH_EAST,
+        ActionDirection.SOUTH_EAST,
+    )
+
+
+def test_west_side_directions_are_mirrors_not_generation_sources():
+    assert ActionDirection.WEST not in required_directions_for_movement(2)
+    assert ActionDirection.NORTH_WEST not in required_directions_for_movement(3)
+    assert ActionDirection.SOUTH_WEST not in required_directions_for_movement(3)
+    assert derived_direction_pairs_for_movement(2) == (
+        (ActionDirection.WEST, ActionDirection.EAST),
+    )
+    assert compass_directions_for_movement(2) == (
+        ActionDirection.EAST,
         ActionDirection.WEST,
         ActionDirection.NORTH,
         ActionDirection.SOUTH,
     )
-    assert required_directions_for_movement(3) == tuple(ActionDirection)
-
-
-def test_west_side_directions_are_real_generation_sources_for_multi_direction_projects():
-    assert ActionDirection.WEST in required_directions_for_movement(2)
-    assert ActionDirection.NORTH_WEST in required_directions_for_movement(3)
-    assert ActionDirection.SOUTH_WEST in required_directions_for_movement(3)
 
 
 def test_every_action_direction_has_an_independent_provider_prompt_lock():

--- a/backend/tests/test_full_direction_integration.py
+++ b/backend/tests/test_full_direction_integration.py
@@ -20,7 +20,7 @@ from windup_app.server.orchestrator.executor import (
 from windup_app.server.orchestrator.model import GenerationTaskRecord, TaskStatus
 from windup_app.server.quota.model import CreditAccount
 from windup_app.worker.handlers import handle_generation
-from windup_common.directions import ActionDirection
+from windup_common.directions import ActionDirection, required_directions_for_movement
 from windup_common.models import CharacterStance
 from windup_framework.config.quota import settings as quota_settings
 
@@ -88,7 +88,7 @@ def test_eight_way_http_tasks_reach_worker_as_eight_real_results_and_settle_each
     engine,
     monkeypatch,
 ):
-    directions = tuple(ActionDirection)
+    directions = required_directions_for_movement(3)
     initial_balance = quota_settings.generate_action_cost * len(directions) + 100
     seed_credit_account(db_session, 1, balance=initial_balance)
     db_session.commit()
@@ -171,7 +171,7 @@ def test_eight_way_image_tasks_call_provider_with_eight_direction_locks_and_sett
     engine,
     monkeypatch,
 ):
-    directions = tuple(ActionDirection)
+    directions = required_directions_for_movement(3)
     initial_balance = quota_settings.generate_image_cost * len(directions) + 100
     seed_credit_account(db_session, 1, balance=initial_balance)
     db_session.commit()

--- a/backend/tests/test_generation_api.py
+++ b/backend/tests/test_generation_api.py
@@ -130,36 +130,32 @@ def test_action_generation_uses_token_user_without_body_user_id(auth_client):
     assert body["data"]["status"] == "pending"
 
 
-def test_image_generation_accepts_real_west_for_four_way_project(auth_client):
+def test_image_generation_rejects_west_for_four_way_project(auth_client):
     project = _create_project(auth_client)
 
-    response = auth_client.post(
+    body = auth_client.post(
         "/generation/image",
         json=_image_payload(project["id"], direction="west"),
-    )
+    ).json()
 
-    body = response.json()
-    assert body["code"] == 200
-    assert body["data"]["status"] == "pending"
-    assert body["data"]["input_payload"]["direction"] == "west"
+    assert body["code"] == 400
+    assert "west" in body["message"]
 
 
-def test_action_generation_accepts_real_west_for_four_way_project(auth_client):
+def test_action_generation_rejects_west_for_four_way_project(auth_client):
     project = _create_project(auth_client)
     character = _create_character(auth_client, project["id"])
 
-    response = auth_client.post(
+    body = auth_client.post(
         "/generation/action",
         json=_action_payload(project["id"], character["id"], direction="west"),
-    )
+    ).json()
 
-    body = response.json()
-    assert body["code"] == 200
-    assert body["data"]["status"] == "pending"
-    assert body["data"]["input_payload"]["direction"] == "west"
+    assert body["code"] == 400
+    assert "west" in body["message"]
 
 
-def test_image_generation_accepts_real_north_west_for_eight_way_project(auth_client):
+def test_image_generation_rejects_north_west_for_eight_way_project(auth_client):
     project = _create_project(
         auth_client,
         name="八向生成项目",
@@ -171,9 +167,8 @@ def test_image_generation_accepts_real_north_west_for_eight_way_project(auth_cli
         json=_image_payload(project["id"], direction="north_west"),
     ).json()
 
-    assert body["code"] == 200
-    assert body["data"]["status"] == "pending"
-    assert body["data"]["input_payload"]["direction"] == "north_west"
+    assert body["code"] == 400
+    assert "north_west" in body["message"]
 
 
 def test_direction_set_generation_derives_all_directions_from_project(auth_client):
@@ -200,13 +195,10 @@ def test_direction_set_generation_derives_all_directions_from_project(auth_clien
     assert body["data"]["input_payload"]["reference_image_url"] == _MASTER_URL
     assert body["data"]["input_payload"]["directions"] == [
         "east",
-        "west",
         "north",
         "south",
         "north_east",
-        "north_west",
         "south_east",
-        "south_west",
     ]
 
 
@@ -342,6 +334,133 @@ def test_direction_set_retry_publishes_a_new_attempt_message(auth_client, engine
     assert publisher.enqueue.call_args.kwargs["dedupe_key"] == (
         f"generation:{submitted['id']}:retry:1"
     )
+
+
+def _view_sheet_payload(project_id: int, character_id: int, **overrides) -> dict:
+    payload = {
+        "project_id": project_id,
+        "character_id": character_id,
+        "width": 64,
+        "height": 64,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_four_view_copies_confirmed_master_and_shares_image_queue(auth_client):
+    project = _create_project(auth_client)
+    character = _create_character(
+        auth_client,
+        project["id"],
+        reference_image_url=_MASTER_URL,
+    )
+    publisher = auth_client.app.state.mq_publisher
+    publisher.reset_mock()
+
+    body = auth_client.post(
+        "/generation/four-view",
+        json=_view_sheet_payload(project["id"], character["id"]),
+    ).json()
+
+    assert body["code"] == 200
+    assert body["data"]["task_type"] == "character_four_view"
+    assert body["data"]["status"] == "pending"
+    assert body["data"]["input_payload"]["reference_image_url"] == _MASTER_URL
+    assert body["data"]["input_payload"]["anchor_direction"] == "south"
+    assert body["data"]["input_payload"]["num_images"] == 1
+    assert "direction" not in body["data"]["input_payload"]
+    assert publisher.enqueue.call_args.kwargs["msg_type"] == "character_image"
+    assert publisher.enqueue.call_args.kwargs["payload"]["task_type"] == "character_four_view"
+
+
+def test_four_view_without_confirmed_master_is_rejected_before_queueing(auth_client):
+    project = _create_project(auth_client)
+    character = _create_character(auth_client, project["id"])
+    publisher = auth_client.app.state.mq_publisher
+    publisher.reset_mock()
+
+    response = auth_client.post(
+        "/generation/four-view",
+        json=_view_sheet_payload(project["id"], character["id"]),
+    )
+
+    assert response.json()["code"] == 400
+    assert "请先选择并确认角色母版" in response.json()["message"]
+    publisher.enqueue.assert_not_called()
+
+
+def test_four_view_rejects_unidirectional_project(auth_client):
+    project = _create_project(auth_client, name="单向", directional_movement=1)
+    character = _create_character(
+        auth_client, project["id"], reference_image_url=_MASTER_URL,
+    )
+    publisher = auth_client.app.state.mq_publisher
+    publisher.reset_mock()
+
+    response = auth_client.post(
+        "/generation/four-view",
+        json=_view_sheet_payload(project["id"], character["id"]),
+    )
+
+    assert response.json()["code"] == 400
+    assert "当前项目不是四向" in response.json()["message"]
+    publisher.enqueue.assert_not_called()
+
+
+def test_eight_view_rejects_four_way_project(auth_client):
+    project = _create_project(auth_client)
+    character = _create_character(
+        auth_client, project["id"], reference_image_url=_MASTER_URL,
+    )
+
+    response = auth_client.post(
+        "/generation/eight-view",
+        json=_view_sheet_payload(project["id"], character["id"]),
+    )
+
+    assert response.json()["code"] == 400
+    assert "当前项目不是八向" in response.json()["message"]
+
+
+def test_eight_view_submits_on_eight_way_project(auth_client):
+    project = _create_project(
+        auth_client, name="八向 sheet", directional_movement=3,
+    )
+    character = _create_character(
+        auth_client, project["id"], reference_image_url=_MASTER_URL,
+    )
+
+    body = auth_client.post(
+        "/generation/eight-view",
+        json=_view_sheet_payload(project["id"], character["id"]),
+    ).json()
+
+    assert body["code"] == 200
+    assert body["data"]["task_type"] == "character_eight_view"
+    assert body["data"]["input_payload"]["anchor_direction"] == "south"
+
+
+def test_view_sheet_rejects_client_supplied_reference_url(auth_client):
+    project = _create_project(auth_client)
+    character = _create_character(
+        auth_client, project["id"], reference_image_url=_MASTER_URL,
+    )
+
+    publisher = auth_client.app.state.mq_publisher
+    publisher.reset_mock()
+    response = auth_client.post(
+        "/generation/four-view",
+        json=_view_sheet_payload(
+            project["id"],
+            character["id"],
+            reference_image_url="https://evil.example/not-the-master.png",
+        ),
+    )
+
+    body = response.json()
+    assert body["code"] == 400
+    assert "reference_image_url" in body["message"] or "Extra" in body["message"]
+    publisher.enqueue.assert_not_called()
 
 
 def test_action_character_must_belong_to_requested_project(auth_client):

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -478,6 +478,8 @@ def test_prepaid_cost_scales_with_model_calls():
     unit = quota_settings.generate_image_cost
     assert billing.prepaid_cost(GenerationType.CHARACTER_IMAGE, 1) == unit
     assert billing.prepaid_cost(GenerationType.CHARACTER_IMAGE, 3) == unit * 3
+    assert billing.prepaid_cost(GenerationType.CHARACTER_FOUR_VIEW, 2) == unit * 2
+    assert billing.prepaid_cost(GenerationType.CHARACTER_EIGHT_VIEW, 4) == unit * 4
     assert billing.prepaid_cost(GenerationType.CHARACTER_ACTION, 1) == quota_settings.generate_action_cost
     with pytest.raises(ValueError, match="model_calls"):
         billing.prepaid_cost(GenerationType.CHARACTER_IMAGE, 0)

--- a/backend/tests/test_mq_catalog.py
+++ b/backend/tests/test_mq_catalog.py
@@ -92,6 +92,8 @@ def test_type_specs_register_pool_limit_and_recover():
 def test_msg_type_for_generation_skips_poll_types():
     assert msg_type_for_generation(MSG_TYPE_CHARACTER_IMAGE) == MSG_TYPE_CHARACTER_IMAGE
     assert msg_type_for_generation("character_direction_set") == MSG_TYPE_CHARACTER_IMAGE
+    assert msg_type_for_generation("character_four_view") == MSG_TYPE_CHARACTER_IMAGE
+    assert msg_type_for_generation("character_eight_view") == MSG_TYPE_CHARACTER_IMAGE
     assert msg_type_for_generation(MSG_TYPE_CHARACTER_ACTION) == MSG_TYPE_CHARACTER_ACTION
     with pytest.raises(ValueError, match="未知任务类型"):
         msg_type_for_generation(MSG_TYPE_CHARACTER_ACTION_POLL)

--- a/backend/tests/test_prompt_assets.py
+++ b/backend/tests/test_prompt_assets.py
@@ -21,6 +21,7 @@ from windup_ai_engine.prompt import (
     build_walk_prompt,
 )
 from windup_ai_engine.prompt._md import PromptAssetError, load_doc, load_section
+from windup_common.directions import ActionDirection
 from windup_common.models import AttackArchetype
 
 BUILDERS = {
@@ -35,6 +36,15 @@ SECTIONS = {
     doc: ["side", "front"] for doc in ("walk.md", "jump.md", "idle.md")
 } | {
     "attack.md": [f"{a.value}.{f}" for a in AttackArchetype for f in ("side", "front")],
+    "view_sheet.md": [
+        "identity",
+        "pose",
+        "framing",
+        "elevation.side",
+        "elevation.top-down",
+        "elevation.isometric",
+        *[direction.value for direction in ActionDirection],
+    ],
 }
 
 
@@ -116,7 +126,7 @@ def test_two_code_fences_in_one_section_raise(tmp_path, monkeypatch):
         md.load_section("inline.md", "side")
 
 
-@pytest.mark.parametrize("doc", ["walk.md", "jump.md", "idle.md", "attack.md", "master_poses.md"])
+@pytest.mark.parametrize("doc", ["walk.md", "jump.md", "idle.md", "attack.md", "master_poses.md", "view_sheet.md"])
 def test_every_shipped_document_keeps_prose_and_data_separated(doc: str):
     """随包发的每一份 md,框内不含中文。"""
     from windup_ai_engine.prompt._md import load_doc
@@ -197,5 +207,5 @@ def test_markdown_assets_are_shipped_in_the_wheel(tmp_path):
     wheels = sorted(tmp_path.glob("*.whl"))
     assert wheels, "没产出 wheel"
     names = set(zipfile.ZipFile(wheels[-1]).namelist())
-    for md in ("walk.md", "jump.md", "idle.md", "attack.md", "master_poses.md"):
+    for md in ("walk.md", "jump.md", "idle.md", "attack.md", "master_poses.md", "view_sheet.md"):
         assert f"windup_ai_engine/prompt/prompts/{md}" in names, f"{md} 没进 wheel"

--- a/backend/tests/test_view_sheet_executor.py
+++ b/backend/tests/test_view_sheet_executor.py
@@ -1,0 +1,298 @@
+"""四向 / 八向立绘 sheet 执行器:图生图次数、翻转、3×3 拼装。"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from windup_app.server.orchestrator.model import (
+    CharacterViewSheetInput,
+    CharacterViewSheetOutput,
+    GenerationType,
+    TaskStatus,
+)
+from windup_app.server.orchestrator.service import AiGenerationService
+from windup_app.server.orchestrator.view_sheet_executor import (
+    ViewSheetTaskExecutor,
+    compose_compass_sheet,
+    flip_horizontal,
+)
+from windup_app.server.quota.model import CreditAccount
+from windup_common.directions import ActionDirection
+from windup_framework.db.base import Base
+
+_MASTER_URL = "https://cdn.example.com/masters/south.png"
+_W, _H = 64, 96
+
+
+@pytest.fixture
+def sheet_session_factory():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    with factory() as session:
+        session.add(
+            CreditAccount(
+                user_id=1,
+                balance=1_000,
+                frozen=0,
+                total_earned=1_000,
+                total_spent=0,
+            )
+        )
+        session.commit()
+    yield factory
+    engine.dispose()
+
+
+def _png(color: tuple[int, int, int, int], *, mark: tuple[int, int, tuple[int, int, int, int]] | None = None) -> bytes:
+    im = Image.new("RGBA", (_W, _H), color)
+    if mark is not None:
+        x, y, mark_color = mark
+        im.putpixel((x, y), mark_color)
+    buf = io.BytesIO()
+    im.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _sheet_input() -> CharacterViewSheetInput:
+    return CharacterViewSheetInput(
+        character_id=42,
+        reference_image_url=_MASTER_URL,
+        prompt="像素风勇者",
+        width=_W,
+        height=_H,
+    )
+
+
+def _open(png: bytes) -> Image.Image:
+    return Image.open(io.BytesIO(png)).convert("RGBA")
+
+
+SOUTH = _png((200, 40, 40, 255))
+EAST = _png((40, 180, 40, 255), mark=(_W - 1, _H // 2, (255, 255, 255, 255)))
+NORTH = _png((40, 40, 200, 255))
+NORTH_EAST = _png((180, 40, 180, 255))
+SOUTH_EAST = _png((40, 180, 180, 255))
+
+_BY_PROMPT = (
+    ("ninety-degree", EAST),
+    ("one-hundred-eighty", NORTH),
+    ("one-hundred-thirty-five", NORTH_EAST),
+    ("forty-five-degree", SOUTH_EAST),
+)
+
+
+class _Matte:
+    def cutout(self, png):
+        return png
+
+
+def _gen(prompts: list[str]):
+    class _Gen:
+        def gen_image(self, prompt, refs):
+            prompts.append(prompt)
+            assert refs == [SOUTH]
+            for needle, png in _BY_PROMPT:
+                if needle in prompt:
+                    return png
+            raise AssertionError(f"未识别朝向提示词: {prompt[:80]!r}")
+
+    return _Gen()
+
+
+def test_flip_horizontal_moves_mark_to_the_opposite_edge():
+    flipped = _open(flip_horizontal(EAST))
+    assert flipped.size == (_W, _H)
+    assert flipped.getpixel((0, _H // 2)) == (255, 255, 255, 255)
+    assert flipped.getpixel((_W - 1, _H // 2)) != (255, 255, 255, 255)
+
+
+def test_four_view_compass_leaves_corners_and_center_empty():
+    west = flip_horizontal(EAST)
+    sheet = _open(
+        compose_compass_sheet(
+            {
+                ActionDirection.NORTH: NORTH,
+                ActionDirection.WEST: west,
+                ActionDirection.EAST: EAST,
+                ActionDirection.SOUTH: SOUTH,
+            },
+            _W,
+            _H,
+        )
+    )
+    assert sheet.size == (3 * _W, 3 * _H)
+    empty = (0, 0, 0, 0)
+    assert sheet.getpixel((0, 0)) == empty
+    assert sheet.getpixel((3 * _W - 1, 0)) == empty
+    assert sheet.getpixel((0, 3 * _H - 1)) == empty
+    assert sheet.getpixel((3 * _W - 1, 3 * _H - 1)) == empty
+    assert sheet.getpixel((_W + _W // 2, _H + _H // 2)) == empty
+    assert sheet.getpixel((_W + _W // 2, 2 * _H + _H // 2)) == (200, 40, 40, 255)
+    assert sheet.getpixel((2 * _W + _W - 1, _H + _H // 2)) == (255, 255, 255, 255)
+    assert sheet.getpixel((0, _H + _H // 2)) == (255, 255, 255, 255)
+
+
+def test_four_view_calls_model_twice_reuses_south_and_uploads_flipped_west(
+    sheet_session_factory,
+):
+    prompts: list[str] = []
+    uploaded: dict[str, bytes] = {}
+    n = 0
+
+    def upload(png: bytes) -> str:
+        nonlocal n
+        n += 1
+        url = f"https://cdn.example.com/{n}-{id(png)}.png"
+        uploaded[url] = png
+        return url
+
+    executor = ViewSheetTaskExecutor(
+        image=_gen(prompts),
+        matte=_Matte(),
+        upload=upload,
+        fetch_ref=lambda url: SOUTH if url == _MASTER_URL else pytest.fail(url),
+        session_factory=sheet_session_factory,
+    )
+    with sheet_session_factory() as session:
+        task = AiGenerationService().generate_character_four_view(
+            session, user_id=1, project_id=7, input=_sheet_input(),
+        )
+        session.commit()
+        task_id = task.id
+
+    executor.run_four_view_task(task_id, _sheet_input(), project_id=None)
+
+    with sheet_session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=7, task_id=task_id)
+
+    assert done.status is TaskStatus.COMPLETED
+    assert isinstance(done.result, CharacterViewSheetOutput)
+    assert done.result.type == GenerationType.CHARACTER_FOUR_VIEW.value
+    assert len(prompts) == 2
+    assert all("ninety-degree" in p or "one-hundred-eighty" in p for p in prompts)
+    assert not any("forty-five-degree" in p for p in prompts)
+    assert not any("two-hundred-seventy" in p for p in prompts)
+
+    sheet = done.result.sheets[0]
+    by_dir = {cell.direction: cell for cell in sheet.cells}
+    assert set(by_dir) == {
+        ActionDirection.SOUTH,
+        ActionDirection.EAST,
+        ActionDirection.NORTH,
+        ActionDirection.WEST,
+    }
+    assert by_dir[ActionDirection.SOUTH].image_url == _MASTER_URL
+    assert by_dir[ActionDirection.WEST].mirror_x is True
+    assert by_dir[ActionDirection.WEST].source_direction is ActionDirection.EAST
+    assert by_dir[ActionDirection.EAST].mirror_x is False
+
+    # south 不重传;东/北/西 + sheet = 4
+    assert len(uploaded) == 4
+    west_png = uploaded[by_dir[ActionDirection.WEST].image_url]
+    assert _open(west_png).getpixel((0, _H // 2)) == (255, 255, 255, 255)
+    composed = _open(uploaded[sheet.sheet_url])
+    assert composed.size == (3 * _W, 3 * _H)
+    assert composed.getpixel((0, 0))[3] == 0
+    assert sheet.sheet_url in uploaded
+
+
+def test_eight_view_generates_diagonals_and_three_mirrors(sheet_session_factory):
+    prompts: list[str] = []
+
+    def upload(png: bytes) -> str:
+        return f"https://cdn.example.com/{id(png)}.png"
+
+    executor = ViewSheetTaskExecutor(
+        image=_gen(prompts),
+        matte=_Matte(),
+        upload=upload,
+        fetch_ref=lambda url: SOUTH,
+        session_factory=sheet_session_factory,
+    )
+    with sheet_session_factory() as session:
+        task = AiGenerationService().generate_character_eight_view(
+            session, user_id=1, project_id=7, input=_sheet_input(),
+        )
+        session.commit()
+        task_id = task.id
+
+    executor.run_eight_view_task(task_id, _sheet_input(), project_id=None)
+
+    with sheet_session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=7, task_id=task_id)
+
+    assert done.status is TaskStatus.COMPLETED
+    assert len(prompts) == 4
+    assert any("one-hundred-thirty-five" in p for p in prompts)
+    assert any("forty-five-degree" in p for p in prompts)
+    cells = done.result.sheets[0].cells
+    assert len(cells) == 8
+    mirrors = {c.direction: c for c in cells if c.mirror_x}
+    assert set(mirrors) == {
+        ActionDirection.WEST,
+        ActionDirection.NORTH_WEST,
+        ActionDirection.SOUTH_WEST,
+    }
+    assert mirrors[ActionDirection.NORTH_WEST].source_direction is ActionDirection.NORTH_EAST
+
+
+def test_view_sheet_failure_fails_the_whole_task(sheet_session_factory):
+    class _Boom:
+        def gen_image(self, prompt, refs):
+            raise RuntimeError("north provider failed")
+
+    executor = ViewSheetTaskExecutor(
+        image=_Boom(),
+        matte=_Matte(),
+        upload=lambda png: "https://cdn.example.com/x.png",
+        fetch_ref=lambda url: SOUTH,
+        session_factory=sheet_session_factory,
+    )
+    with sheet_session_factory() as session:
+        task = AiGenerationService().generate_character_four_view(
+            session, user_id=1, project_id=7, input=_sheet_input(),
+        )
+        session.commit()
+        task_id = task.id
+
+    executor.run_four_view_task(task_id, _sheet_input(), project_id=None)
+
+    with sheet_session_factory() as session:
+        done = AiGenerationService().get_task(session, project_id=7, task_id=task_id)
+        account = session.scalar(select(CreditAccount).where(CreditAccount.user_id == 1))
+
+    assert done.status is TaskStatus.FAILED
+    assert done.result is None
+    assert account.frozen == 0
+
+
+def test_view_sheet_prompt_follows_master_not_project_style():
+    from windup_app.server.orchestrator.executor import ProjectConstraints
+
+    prompts: list[str] = []
+    executor = ViewSheetTaskExecutor(
+        image=_gen(prompts),
+        matte=_Matte(),
+        upload=lambda png: "https://cdn.example.com/x.png",
+        fetch_ref=lambda url: SOUTH,
+    )
+    executor._produce_sheets(
+        _sheet_input(),
+        GenerationType.CHARACTER_FOUR_VIEW,
+        ProjectConstraints(style="中世纪厚涂", perspective=2, stylize="pixel"),
+    )
+    assert prompts
+    assert all("Art style" not in p and "中世纪厚涂" not in p for p in prompts)
+    assert all("thirty to forty-five degrees" in p for p in prompts)
+    assert all("像素风勇者" in p for p in prompts)

--- a/backend/tests/test_view_sheet_orchestration.py
+++ b/backend/tests/test_view_sheet_orchestration.py
@@ -1,0 +1,153 @@
+"""四向 / 八向立绘 sheet：提交任务类型与预付费次数。"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from windup_app.server.orchestrator.model import (
+    CharacterViewSheetInput,
+    GenerationType,
+)
+from windup_app.server.orchestrator.service import AiGenerationService
+from windup_app.server.quota.model import CreditAccount
+from windup_framework.config.quota import settings as quota_settings
+from windup_framework.db.base import Base
+
+
+_MASTER_URL = "https://cdn.example.com/masters/confirmed-east.png"
+
+
+@pytest.fixture
+def sheet_session_factory():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    with factory() as session:
+        session.add(
+            CreditAccount(
+                user_id=1,
+                balance=1_000,
+                frozen=0,
+                total_earned=1_000,
+                total_spent=0,
+            )
+        )
+        session.commit()
+    yield factory
+    engine.dispose()
+
+
+def _sheet_input() -> CharacterViewSheetInput:
+    return CharacterViewSheetInput(
+        character_id=42,
+        reference_image_url=_MASTER_URL,
+        prompt="像素风勇者",
+        width=64,
+        height=96,
+    )
+
+
+def test_four_view_submission_charges_two_calls_and_reuses_master(sheet_session_factory):
+    service = AiGenerationService()
+    with sheet_session_factory() as session:
+        task = service.generate_character_four_view(
+            session, user_id=1, project_id=7, input=_sheet_input(),
+        )
+        account = session.scalar(
+            select(CreditAccount).where(CreditAccount.user_id == 1)
+        )
+
+    assert task.task_type is GenerationType.CHARACTER_FOUR_VIEW
+    assert task.input_payload["reference_image_url"] == _MASTER_URL
+    assert task.input_payload["anchor_direction"] == "south"
+    assert task.input_payload["num_images"] == 1
+    assert account.frozen == 2 * quota_settings.generate_image_cost
+
+
+def test_eight_view_submission_charges_four_calls(sheet_session_factory):
+    service = AiGenerationService()
+    with sheet_session_factory() as session:
+        task = service.generate_character_eight_view(
+            session, user_id=1, project_id=7, input=_sheet_input(),
+        )
+        account = session.scalar(
+            select(CreditAccount).where(CreditAccount.user_id == 1)
+        )
+
+    assert task.task_type is GenerationType.CHARACTER_EIGHT_VIEW
+    assert account.frozen == 4 * quota_settings.generate_image_cost
+
+
+def test_view_sheet_input_rejects_blank_master():
+    with pytest.raises(ValueError, match="已确认角色母版"):
+        CharacterViewSheetInput(character_id=1, reference_image_url="  ")
+
+
+def test_view_sheet_anchor_must_be_south_front_view():
+    from windup_common.directions import ActionDirection
+
+    with pytest.raises(ValueError, match="south"):
+        CharacterViewSheetInput(
+            character_id=1,
+            reference_image_url=_MASTER_URL,
+            anchor_direction=ActionDirection.EAST,
+        )
+
+
+def test_view_sheet_cell_requires_uploaded_url_even_for_mirror():
+    from windup_app.server.orchestrator.model import CharacterViewSheetCell
+    from windup_common.directions import ActionDirection
+
+    west = CharacterViewSheetCell(
+        direction=ActionDirection.WEST,
+        image_url="https://cdn.example.com/west.png",
+        source_direction=ActionDirection.EAST,
+        mirror_x=True,
+    )
+    assert west.image_url.endswith("west.png")
+    with pytest.raises(ValueError, match="image_url"):
+        CharacterViewSheetCell(
+            direction=ActionDirection.WEST,
+            image_url="  ",
+            source_direction=ActionDirection.EAST,
+            mirror_x=True,
+        )
+
+
+def test_worker_dispatches_four_view_to_sheet_executor_not_image(
+    sheet_session_factory,
+    monkeypatch,
+):
+    from windup_app.worker import handlers
+
+    service = AiGenerationService()
+    with sheet_session_factory() as session:
+        task = service.generate_character_four_view(
+            session, user_id=1, project_id=9, input=_sheet_input(),
+        )
+        session.commit()
+        task_id = task.id
+
+    seen: list[tuple] = []
+    monkeypatch.setattr(handlers, "SessionLocal", sheet_session_factory)
+    handlers.handle_generation(
+        {"task_id": task_id, "task_type": "character_four_view"},
+        run_image_task=lambda *_args: pytest.fail("不应走单张立绘执行器"),
+        run_action_task=lambda *_args: pytest.fail("不应走动作执行器"),
+        run_direction_set_task=lambda *_args: pytest.fail("不应走方向集执行器"),
+        run_view_sheet_task=lambda *args: seen.append(args),
+    )
+
+    assert seen[0][0] == task_id
+    assert seen[0][1].character_id == 42
+    assert seen[0][1].reference_image_url == _MASTER_URL
+    assert seen[0][1].anchor_direction.value == "south"
+    assert seen[0][2] is GenerationType.CHARACTER_FOUR_VIEW
+    assert seen[0][3] == 9

--- a/backend/tests/test_view_sheet_prompt.py
+++ b/backend/tests/test_view_sheet_prompt.py
@@ -1,0 +1,67 @@
+"""四向 / 八向立绘 sheet 提示词:每个朝向与项目视角都有正文,非法值要炸。"""
+
+from __future__ import annotations
+
+import pytest
+
+from windup_ai_engine.prompt import build_view_sheet_prompt
+from windup_ai_engine.prompt._md import load_section
+from windup_common.directions import ActionDirection
+from windup_common.models import CharacterView
+
+
+def test_every_compass_direction_has_a_camera_section():
+    for direction in ActionDirection:
+        text = load_section("view_sheet.md", direction.value)
+        assert len(text) > 40, f"{direction.value} 朝向节短得不像正文:{text!r}"
+
+
+@pytest.mark.parametrize("view", list(CharacterView))
+def test_every_project_view_has_an_elevation_section(view: CharacterView):
+    text = load_section("view_sheet.md", f"elevation.{view.value}")
+    assert "orthographic" in text
+
+
+def test_build_locks_identity_then_camera():
+    text = build_view_sheet_prompt(ActionDirection.EAST)
+    assert text.index("FRONT-VIEW character master") < text.index("ninety-degree")
+    assert "true side view" in text
+    assert "Exactly one character" in text
+
+
+def test_south_is_front_view_not_east_profile():
+    south = build_view_sheet_prompt(ActionDirection.SOUTH)
+    east = build_view_sheet_prompt(ActionDirection.EAST)
+    assert "faces the viewer" in south
+    assert "true side view" in east
+    assert south != east
+
+
+def test_top_down_and_side_elevations_differ():
+    top = build_view_sheet_prompt(ActionDirection.NORTH, view=CharacterView.TOP_DOWN)
+    side = build_view_sheet_prompt(ActionDirection.NORTH, view=CharacterView.SIDE)
+    assert "thirty to forty-five degrees" in top
+    assert "Eye-level camera" in side
+    assert top != side
+
+
+def test_extra_clause_appends_without_replacing_identity():
+    text = build_view_sheet_prompt(
+        ActionDirection.NORTH_EAST,
+        extra="pixel art, limited palette",
+    )
+    assert text.endswith("pixel art, limited palette")
+    assert "FRONT-VIEW character master" in text
+
+
+def test_blank_extra_does_not_pad_the_prompt():
+    bare = build_view_sheet_prompt(ActionDirection.NORTH)
+    padded = build_view_sheet_prompt(ActionDirection.NORTH, extra="   ")
+    assert bare == padded
+
+
+def test_illegal_direction_or_view_raises():
+    with pytest.raises(ValueError):
+        build_view_sheet_prompt("eastt")
+    with pytest.raises(ValueError):
+        build_view_sheet_prompt(ActionDirection.EAST, view="topdown")

--- a/docs/superpowers/specs/2026-08-26-four-eight-view-sheet-api.md
+++ b/docs/superpowers/specs/2026-08-26-four-eight-view-sheet-api.md
@@ -1,0 +1,237 @@
+# 四向 / 八向立绘 sheet 接口契约
+
+日期：2026-08-26
+
+状态：后端已落地。发布完整性见 #756：源方向才进模型，west / NW / SW 只记镜像。
+
+相关：前端 3×3 候选拼图见 [direction-sheet-candidate](./2026-08-25-direction-sheet-candidate.md)（那份**不新增后端接口**，只把已有逐方向图拼网格）。本文件是真正的 sheet 生成口，两者不要混用。
+
+## 目标
+
+在 `/generation` 上新增两个提交口，分别跑四向立绘和八向立绘。调度、查任务、SSE 沿用现有 generation 任务信封。执行器、计费次数、失败语义分开，不经过 `POST /generation/image-set`。
+
+正式立绘仍走 `POST /generation/image`，但必须是**正视图**（面对镜头，方向 `south`），确认后写入 `Character.reference_image_url`。本接口把这张图当作南向格，再转出其余朝向。不是把东向侧视母版拿来跳过生成。
+
+## 生产顺序
+
+```
+定妆：正视图（south，面对镜头）→ 确认母版 URL
+        ↓
+图生图出侧视 / 背视：east、north（八向再出 north_east、south_east）
+        ↓
+镜像格水平翻转后上传：west ← east（八向再 NW ← NE、SW ← SE）
+        ↓
+拼成一张 3×3 罗盘 sheet（四向只填十字，斜向留空）→ 上传
+        ↓
+返回：sheet_url + 各方向原图 URL
+```
+
+东向是侧视，必须从图生图出，不能复用正视母版。
+
+## 和现有两个口像什么、不像什么
+
+**信封一样。** 提交立刻返回 `GenerationTaskOut`；进度和终态走：
+
+- `GET /generation/tasks/{task_id}?project_id=`
+- `GET /generation/tasks/{task_id}/stream?project_id=`
+
+`task_type` / `status` / `input_payload` / `result` / `error_message` / `queue_ahead` 字段不改。
+
+**请求体接近 `/generation/image`，外加 `/generation/action` 那种角色绑定。** 只要这些：
+
+| 字段 | 来自 | 本接口 |
+|---|---|---|
+| `project_id` | image / action | 要 |
+| `character_id` | action | 要（母版从角色上取，不另传 URL） |
+| `prompt` / `negative_prompt` | image | 要，可空 |
+| `width` / `height` | image | 要，且必须等于项目 `sprite_width` / `sprite_height`（格子尺寸） |
+| `num_images` | image | 要，表示 **sheet 候选张数**，不是每方向各出几张 |
+
+**不要从 image 抄：** `reference_image_url`、`direction`。母版只认 `character.reference_image_url`；朝向集合由路径决定，调用方再传一个方向等于第二份真相源。
+
+**不要从 action 抄：** `action_type`、`custom_prompt`、`loop`、`ground_contact`、`num_frames`、`video_model`、`outfit_id`、`stance`、`reference_image_urls`、`reference_video_url`。sheet 不是动画。
+
+**`result` 不像 image，也不像 action。** 不是 `image_urls[]`，也不是 `frames[]`。见下方结果形状。
+
+四向和八向 **HTTP 字段相同**，路径和 `task_type` 不同。差别在执行器，不在请求字段再分叉一套。
+
+## 端点
+
+```
+POST /generation/four-view
+POST /generation/eight-view
+```
+
+| | four-view | eight-view |
+|---|---|---|
+| `task_type` | `character_four_view` | `character_eight_view` |
+| 项目规格 | `directional_movement == 2` | `directional_movement == 3` |
+| 身份锚（复用、不生成） | `south` 正视 | `south` 正视 |
+| 图生图源方向 | `east`, `north` | `east`, `north`, `north_east`, `south_east` |
+| 镜像、翻转后上传 | `west ← east` | `west ← east`，`north_west ← north_east`，`south_west ← south_east` |
+| 交付 | 1 张 3×3 sheet + 4 张原图 URL | 1 张 3×3 sheet + 8 张原图 URL |
+| sheet 布局 | 3×3 罗盘，只填北/西/东/南，斜向与中心留空 | 3×3 罗盘，中心留空，八角都填 |
+
+单向项目（`directional_movement == 1`）不要打这两个口：母版本身就是唯一朝向。规格对不上 → `400`。
+
+`POST /generation/image-set` 不再作为产品路径扩能力；旧任务仍可查询/恢复。本接口 **没有** `retry-failed-directions`：sheet 是一张图，失败整单重提，不按格局部重试。
+
+## 请求
+
+两口共用同一请求模型（`extra=forbid`）：
+
+```json
+{
+  "project_id": 12,
+  "character_id": 34,
+  "prompt": "",
+  "negative_prompt": "",
+  "width": 64,
+  "height": 96,
+  "num_images": 1
+}
+```
+
+| 字段 | 类型 | 约束 |
+|---|---|---|
+| `project_id` | int | `> 0`，属于当前用户 |
+| `character_id` | int | `> 0`，属于该项目 |
+| `prompt` | str | 默认 `""`。身份由母版图承载；这里只补站姿/透视等，不复述外貌 |
+| `negative_prompt` | str | 默认 `""` |
+| `width` | int | `64–2048`，必须等于 `project.sprite_width` |
+| `height` | int | `64–2048`，必须等于 `project.sprite_height` |
+| `num_images` | int | `1–4`，默认 **1**（sheet 比单张立绘贵，不沿用 image 的默认 3） |
+
+入口在入队前拒绝：
+
+- 角色没有非空 `reference_image_url` → `400`「请先选择并确认角色母版」
+- 项目规格与路径不一致 → `400`「当前项目不是四向/八向」
+- 宽高与项目精灵尺寸不一致 → `400`（与 `/generation/image` 同一句）
+
+母版 URL **不写进请求体**。落库的 `input_payload.reference_image_url` 由服务端在提交时从角色拷入，执行器只读这一份。调用方另传一张图看起来会生效、实际必须忽略 —— 按本仓惯例直接不收这个字段。
+
+## 提交响应
+
+与 image / action 相同：`Response[GenerationTaskOut]`，`status=pending`，`result=null`。
+
+`input_payload` 最小集（执行器 / 计费 / 前端恢复只读这些）：
+
+```json
+{
+  "character_id": 34,
+  "reference_image_url": "https://…/master.png",
+  "prompt": "",
+  "negative_prompt": "",
+  "width": 64,
+  "height": 96,
+  "num_images": 1,
+  "anchor_direction": "south"
+}
+```
+
+`anchor_direction` 固定 `south`：已确认母版是正视图，对应南向格（面对镜头）。东向是侧视，本任务里要图生图，不复用母版。不让请求体改锚点。
+
+## 完成时 `result`
+
+`result.type` 与 `task_type` 相同。`num_images` 张候选；**每张候选 = 1 个 `sheet_url` + 全部方向的原图 URL**（四向 4 张，八向 8 张）。格子上都有已上传 URL，前端不用自己翻转。
+
+管线见上方「生产顺序」。南向格的 `image_url` 等于已确认正视母版；其余格子是本任务新上传的 URL。
+
+```json
+{
+  "type": "character_four_view",
+  "sheets": [
+    {
+      "sheet_url": "https://…/four-view-0.png",
+      "cells": [
+        { "direction": "south", "image_url": "https://…/master.png", "source_direction": null, "mirror_x": false },
+        { "direction": "east", "image_url": "https://…/east-0.png", "source_direction": null, "mirror_x": false },
+        { "direction": "north", "image_url": "https://…/north-0.png", "source_direction": null, "mirror_x": false },
+        { "direction": "west", "image_url": "https://…/west-0.png", "source_direction": "east", "mirror_x": true }
+      ]
+    }
+  ],
+  "quality": null
+}
+```
+
+八向：`type` 为 `character_eight_view`；`cells` 长度为 8；`sheet_url` 与四向同一张 3×3 罗盘（中心空）；斜向四格也有图；`west` / `north_west` / `south_west` 同样是翻转后上传的 URL，并标 `mirror_x`。
+
+格子规则：
+
+- 每个**有朝向的**格子 `image_url` 都必须非空。缺一格 URL 不能 `completed`。空槽（中心，以及四向的四个对角）不出现在 `cells[]` 里，也不上传假图。
+- 真实源方向：`mirror_x=false`，`source_direction=null`。`south` 的 `image_url` 必须等于提交时拷入的正视母版 URL，不另出一张「几乎一样的正视」。`east` / `north`（八向还有对角）是图生图新图。
+- 镜像方向：`mirror_x=true`，`source_direction` 指向源方向；`image_url` 是把源图水平翻转后**重新上传**得到的 URL。不调模型、不计费。
+- 同一候选内 `direction` 不重复；集合必须恰好是该路径要求的 4 或 8 个方向。
+- `width`×`height` 是单格尺寸。sheet 画布四向八向都是 `3w × 3h`。请求体不收 sheet 宽高。
+
+## sheet 拼装（四向 / 八向同一张罗盘）
+
+上北下南、左西右东，与 [direction-sheet-candidate](./2026-08-25-direction-sheet-candidate.md) 的 3×3 确认卡同一套坐标。单格 `w×h`，缝宽 0，画布 `3w × 3h`。空槽保持透明，不贴占位图。west 等镜像格贴**已经翻转好的 PNG**，拼装时不再翻一次。
+
+```
+列0          列1          列2
+行0  north_west    north     north_east
+行1  west          （空）      east
+行2  south_west    south     south_east
+```
+
+| 格 | 方向 | 左上角 |
+|---|---|---|
+| (1,0) | north | `(w, 0)` |
+| (0,1) | west | `(0, h)` |
+| (2,1) | east | `(2w, h)` |
+| (1,2) | south | `(w, 2h)` |
+| (2,0) | north_east | `(2w, 0)` |
+| (0,0) | north_west | `(0, 0)` |
+| (2,2) | south_east | `(2w, 2h)` |
+| (0,2) | south_west | `(0, 2h)` |
+| (1,1) | 空 | — |
+
+四向只贴 north / west / east / south 四格。八向再贴四个对角。脚底已在各格 `w×h` 内对齐，拼装不再二次对齐。
+
+
+`quality` 与 image 同口径：只记账，不参与前端回填，本层不据此判成败。没有读数时为 `null`。
+
+失败：`status=failed`，`result=null`，`error_message` 给用户可读原因。不引入 `partial`：缺一格就是整张 sheet 不能用。
+
+## 计费与调度
+
+走 generation Stream、与 `character_image` 同一图像并发池（`recover_as` 指向各自的 `task_type`，不要 recover 成 `character_image` 否则 handler 会按单张立绘跑）。
+
+积分：`generate_image_cost × 计划模型调用次数`。
+
+计划次数 = `num_images × 本路径要新生成的源方向数`：
+
+- 四向：每张候选 **2** 次（east、north；south 复用正视母版）
+- 八向：每张候选 **4** 次（east、north、north_east、south_east）
+
+镜像不计费。失败整单解冻；成功按实际上游调用结算，口径与现有 image 预付费相同（提交时冻、终态 capture/release）。
+
+## 确认之后怎么接到动作
+
+本接口 **不写** `character_data.templates`，和 `/generation/image` 不写 `reference_image_url` 同一立场：生成给出候选，用户选一张候选 sheet 后由角色更新接口回填。
+
+选中第 `i` 张后：
+
+1. 源方向格子（有独立生成图或母版）写入 `character_data.templates`，带 `image_url`
+2. 镜像格子写入 `templates` 时**只记** `source_direction` + `mirror_x`，不要把翻转图写成独立母版（`CharacterTemplateSequence` 禁止镜像行存图）
+3. 之后每个**源方向**的动作仍走 `POST /generation/action`；`reference_image_urls[0]` 用该格 `image_url`
+4. 镜像方向不调动作模型，沿用 `sequences[].mirror_x`
+
+生成结果里的翻转 URL 给预览和拼 sheet 用，不是 `templates[]` 的第二份母版。
+
+sheet 是站立立绘，不是 walk 循环。切格只得到各朝向静帧。
+
+## 查询 / SSE
+
+沿用现有任务查询与 stream。终态事件的 `result` 形状即上一节。前端用 `task_type` 区分 `character_four_view` / `character_eight_view`，不要复用 `character_template` 的 `images[]` 映射。
+
+## 明确不做（本契约）
+
+- 不把四向八向收成一个带 `directional_movement` 的通口
+- 不在请求里让调用方声明方向列表或镜像表
+- 不在本口生成动作帧、不调 i2v
+- 不从一张 sheet 里切出 walk / attack
+- 不为 sheet 单独做「失败格重试」
+- 不改 `/generation/action` 的字段。四向/八向项目的定妆应走 `/generation/image` 且 `direction=south`（正视）；单向横版仍用默认 east。

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -316,6 +316,7 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     renderEditor('/workflow-editor/42')
 
     const image = await screen.findByRole('img', { name: '已确认身份母版' })
+    image.addEventListener('load', (event) => event.stopImmediatePropagation())
     fireEvent.error(image)
 
     expect(await screen.findByText('图片加载失败')).toBeTruthy()

--- a/openapi.json
+++ b/openapi.json
@@ -998,6 +998,59 @@
         "title": "CharacterUpdate",
         "type": "object"
       },
+      "CharacterViewSheetGenerateRequest": {
+        "additionalProperties": false,
+        "description": "四向 / 八向立绘 sheet。两口字段相同,朝向集合由路径决定。",
+        "properties": {
+          "character_id": {
+            "exclusiveMinimum": 0.0,
+            "title": "Character Id",
+            "type": "integer"
+          },
+          "height": {
+            "default": 1024,
+            "maximum": 2048.0,
+            "minimum": 64.0,
+            "title": "Height",
+            "type": "integer"
+          },
+          "negative_prompt": {
+            "default": "",
+            "title": "Negative Prompt",
+            "type": "string"
+          },
+          "num_images": {
+            "default": 1,
+            "maximum": 4.0,
+            "minimum": 1.0,
+            "title": "Num Images",
+            "type": "integer"
+          },
+          "project_id": {
+            "exclusiveMinimum": 0.0,
+            "title": "Project Id",
+            "type": "integer"
+          },
+          "prompt": {
+            "default": "",
+            "title": "Prompt",
+            "type": "string"
+          },
+          "width": {
+            "default": 1024,
+            "maximum": 2048.0,
+            "minimum": 64.0,
+            "title": "Width",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "project_id",
+          "character_id"
+        ],
+        "title": "CharacterViewSheetGenerateRequest",
+        "type": "object"
+      },
       "ChatChoiceResponse": {
         "properties": {
           "finish_reason": {
@@ -4347,6 +4400,90 @@
           }
         },
         "summary": "Submit Action Generation",
+        "tags": [
+          "generation"
+        ]
+      }
+    },
+    "/generation/eight-view": {
+      "post": {
+        "description": "提交八向立绘 sheet:正视母版转出八角,中心留空。",
+        "operationId": "submit_eight_view_generation_generation_eight_view_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CharacterViewSheetGenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_GenerationTaskOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Submit Eight View Generation",
+        "tags": [
+          "generation"
+        ]
+      }
+    },
+    "/generation/four-view": {
+      "post": {
+        "description": "提交四向立绘 sheet:正视母版转出十字四格,斜向留空。",
+        "operationId": "submit_four_view_generation_generation_four_view_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CharacterViewSheetGenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_GenerationTaskOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Submit Four View Generation",
         "tags": [
           "generation"
         ]


### PR DESCRIPTION
## Summary

- 新增 `POST /generation/four-view` / `/eight-view`：从已确认正视母版（`Character.reference_image_url`，定妆须 `direction=south`）图生图出源方向，镜像翻转后拼 3×3 罗盘 sheet。不走 `/generation/image-set`。
- 按 [#756](https://github.com/1024XEngineer/Windup/issues/756) 对齐发布完整性：四向真实源 `south/east/north`，`west←east` 只记镜像；八向再加 `NE/SE` 源图和 `NW/SW` 镜像。`required_directions_for_movement` 不再把 west/NW/SW 当生成规格，`/generation/image` 与 `/generation/action` 拒绝派生方向入队。
- 表结构不动。sheet 口不写 `templates[]`；确认后由角色更新接口回填（源方向带图，镜像行 `image_url=null`）。

Related: #755 #756

Close #755 

## Test plan

- [x] 四向项目：`/generation/image` `direction=south` → 确认母版 → `POST /generation/four-view` 出十字 sheet；west 入队 400。
- [x] 八向项目：`POST /generation/eight-view` 出八角 sheet；`north_west` 入队 400。
- [x] 无母版、规格不符、尺寸不符：入队前 400。
- [x] 按镜像回填 `templates[]`（四向 west←east，八向再加 NW/SW）后，带动作帧的角色可以发布；west 写成真实行则 400。
- [x] 单向项目合同不改（真实源仍是 east）。
- [ ] 前端 `generationDirections` 尚未收到源方向集合（#756 前端部分），本 PR 只后端。