### PR TITLE
fix(quick-start): continue candidate regeneration inline

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -232,6 +232,51 @@ describe('Quick Start workflow Agent', () => {
     expect(service.confirmCandidate).not.toHaveBeenCalled()
   })
 
+  it('continues character regeneration below the Agent acknowledgement', async () => {
+    const selectingRun = workflow(setupAndTemplate())
+    const generatingRun = workflow(
+      setupAndTemplate({
+        phase: 'generating',
+        generations: [{ taskId: 'replacement-task', role: 'character_template' }],
+      }),
+    )
+    const planner = vi.fn(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [{ toolName: 'regenerate_character_template', input: {} }],
+    }))
+    const service = serviceFor(selectingRun, {
+      getTemplateCandidates: vi.fn(async () =>
+        eastCandidates(
+          'https://example.test/character-1.png',
+          'https://example.test/character-2.png',
+          'https://example.test/character-3.png',
+        ),
+      ),
+      getWorkflowAgentContext: vi.fn(() => ({
+        availableTools: ['regenerate_character_template', 'refine_character_template'] as const,
+      })),
+      regenerateCharacterTemplate: vi.fn(async () => generatingRun),
+    })
+    renderAt(`/quick-start/${selectingRun.id}`, service, agentFor({ planner }))
+
+    await screen.findAllByRole('button', { name: /选择角色方案/u })
+    fireEvent.change(screen.getByLabelText('继续描述你的想法'), {
+      target: { value: '重新换一批吧' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+
+    const acknowledgement = await screen.findByText('已提交角色母版重新生成。')
+    const progress = await waitFor(() => {
+      const element = document.querySelector<HTMLElement>('[data-generation-progress]')
+      expect(element).toBeTruthy()
+      return element!
+    })
+    expect(
+      acknowledgement.compareDocumentPosition(progress) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
   it('routes a completed-run refinement through the current Controller session', async () => {
     const run = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'passed' })
     const planner = vi.fn(async () => ({

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -3226,6 +3226,23 @@ function QuickStartRun({
   const workflowAgentConversationTurns = agentConversationTurns.filter(
     (turn) => turn.scope === 'workflow',
   )
+  const workflowAgentConversation = workflowAgentConversationTurns.map((turn, index) => (
+    <div
+      key={`${turn.role}:workflow:${index}:${turn.content}`}
+      data-conversation-kind="agent"
+      className="min-w-0"
+    >
+      {turn.role === 'user' ? (
+        <UserTurn>{turn.content}</UserTurn>
+      ) : (
+        <AgentCopy lines={turn.content.split('\n')} />
+      )}
+    </div>
+  ))
+  const characterAgentContinuation =
+    workflowAgentSession.state.status === 'action' &&
+    (workflowAgentSession.state.action === 'regenerate_character_template' ||
+      workflowAgentSession.state.action === 'refine_character_template')
 
   return (
     <section className="relative min-h-screen overflow-hidden bg-app-canvas pt-14 text-app-ink">
@@ -3265,6 +3282,7 @@ function QuickStartRun({
               <UserTurn>{workflowPrompt(run) || '未命名角色创作'}</UserTurn>
             </div>
 
+            {characterAgentContinuation ? workflowAgentConversation : null}
             <AgentTurn step="character-template" current={characterTurnIsCurrent}>
               {isTemplateSelecting && templateStep?.selectedImageUrl ? (
                 <>
@@ -3653,19 +3671,7 @@ function QuickStartRun({
                 ) : null}
               </div>
             ) : null}
-            {workflowAgentConversationTurns.map((turn, index) => (
-              <div
-                key={`${turn.role}:workflow:${index}:${turn.content}`}
-                data-conversation-kind="agent"
-                className="min-w-0"
-              >
-                {turn.role === 'user' ? (
-                  <UserTurn>{turn.content}</UserTurn>
-                ) : (
-                  <AgentCopy lines={turn.content.split('\n')} />
-                )}
-              </div>
-            ))}
+            {characterAgentContinuation ? null : workflowAgentConversation}
             {workflowAgentSession.state.status === 'planning' ? (
               <div
                 data-conversation-kind="agent"


### PR DESCRIPTION
修复角色母版全部不采纳后，Agent 确认消息与重新生成进度在对话流中断开的问题，使后续进度与候选结果紧跟本次讨论显示。

## Why

原有页面把工作流 Agent 消息固定追加在对话底部，而角色母版生成进度仍渲染在前面的母版阶段。用户提交重新生成后，自动滚动停在确认消息处，新的生成进度和候选结果实际更新在上方，视觉上表现为“没有下文”。

## Changes

- 角色母版重新生成或细化时，将当前工作流 Agent 对话移到角色母版阶段内。
- 确认消息之后继续显示既有生成进度与替换候选。
- 其他工作流 Agent 对话保持原有渲染位置。
- 增加对话顺序回归测试。

## Implementation

- 复用既有 workflow Agent conversation nodes，仅根据当前 action 调整渲染位置。
- 不复制候选网格，不修改 WorkflowRun、Controller、生成任务或接口契约。

## Verification

- [x] `npm test -- --run src/pages/quick-start/index.test.tsx`：121 项测试通过。
- [x] `npm run typecheck`：通过。
- [x] `npm run lint -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run format:check -- src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run build`：通过；仅保留既有 chunk size warning。

## Scope

- 本 PR 不修改生成逻辑、后端接口、候选选择状态或其他 Agent action。
- 按本次工程验收范围，不附视觉截图。

## Related Issues

Closes #759
