### PR TITLE
feat(quick-start): select existing characters for new actions

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -14,7 +14,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { QuickStartCandidate, QuickStartEntryService, QuickStartSession } from './service'
 import {
+  CHARACTER_STATUS,
   WorkflowRunConflictError,
+  type Character,
+  type CharacterApis,
+  type CharacterSummaryApis,
   type Project,
   type ProjectApis,
   type WorkflowRun,
@@ -410,18 +414,116 @@ function projectReader(project: Project = existingProject): Pick<ProjectApis, 'l
   }
 }
 
+const existingCharacter: Character = {
+  id: '7',
+  projectId: existingProject.id,
+  workflowRunId: '77',
+  name: '星光法师',
+  description: '银发、蓝色斗篷的像素法师',
+  referenceImageUrl: 'https://cdn.windup.test/star-mage.png',
+  templates: [
+    {
+      direction: 'east',
+      sourceDirection: null,
+      mirrorX: false,
+      imageUrl: 'https://cdn.windup.test/star-mage.png',
+    },
+  ],
+  dataVersion: 1,
+  status: CHARACTER_STATUS.PUBLISHED,
+  outfits: [
+    {
+      id: 'outfit-default',
+      characterId: '7',
+      name: '默认造型',
+      description: null,
+      previewUrl: 'https://cdn.windup.test/star-mage.png',
+      model3dUrl: null,
+      actions: [
+        {
+          id: 'idle',
+          outfitId: 'outfit-default',
+          name: '待机',
+          type: 'idle',
+          loop: true,
+          fps: 12,
+          frameCount: 1,
+          frames: [],
+        },
+        {
+          id: 'walk',
+          outfitId: 'outfit-default',
+          name: '行走',
+          type: 'walk',
+          loop: true,
+          fps: 12,
+          frameCount: 1,
+          frames: [],
+        },
+        {
+          id: 'wave',
+          outfitId: 'outfit-default',
+          name: '挥手',
+          type: 'custom',
+          loop: false,
+          fps: 12,
+          frameCount: 1,
+          frames: [],
+        },
+      ],
+    },
+  ],
+}
+
+function characterReader(
+  character: Character = existingCharacter,
+): Pick<CharacterApis & CharacterSummaryApis, 'get' | 'listSummariesByProject'> {
+  return {
+    get: vi.fn(async () => character),
+    listSummariesByProject: vi.fn(async () => ({
+      items: [
+        {
+          id: character.id,
+          projectId: character.projectId,
+          name: character.name,
+          status: character.status,
+          previewUrl: character.outfits[0]?.previewUrl ?? null,
+          outfitName: character.outfits[0]?.name ?? null,
+          outfitCount: character.outfits.length,
+          actionCount: character.outfits.reduce(
+            (total, outfit) => total + outfit.actions.length,
+            0,
+          ),
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 8,
+    })),
+  }
+}
+
 function renderAt(
   path: string,
   service: QuickStartEntryService,
   agent: CreateQuickStartAgentOptions = agentFor(),
   projects: Pick<ProjectApis, 'list' | 'get'> = projectReader(),
+  characters: Pick<
+    CharacterApis & CharacterSummaryApis,
+    'get' | 'listSummariesByProject'
+  > = characterReader(),
 ) {
   function PlaytestLocation() {
     const location = useLocation()
     return <h1>{`${location.pathname}${location.search}`}</h1>
   }
+  function LocationProbe() {
+    const location = useLocation()
+    return <output data-testid="location-probe">{`${location.pathname}${location.search}`}</output>
+  }
   return render(
     <MemoryRouter initialEntries={[path]}>
+      <LocationProbe />
       <Routes>
         <Route
           path="/quick-start"
@@ -431,6 +533,7 @@ function renderAt(
               activeRunUserId="7"
               agent={agent}
               projectApis={projects}
+              characterApis={characters}
             />
           }
         />
@@ -442,6 +545,7 @@ function renderAt(
               activeRunUserId="7"
               agent={agent}
               projectApis={projects}
+              characterApis={characters}
             />
           }
         />
@@ -981,7 +1085,8 @@ describe('QuickStartPage', () => {
     expect(screen.getByRole('menuitem', { name: '新建项目' }).getAttribute('href')).toBe(
       '/projects/new?entry=quick-start',
     )
-    fireEvent.click(await screen.findByRole('menuitemradio', { name: '星海计划' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: '星海计划' }))
+    fireEvent.click(await screen.findByRole('menuitemradio', { name: '在此项目中新建角色' }))
 
     expect(screen.getByRole('button', { name: '选择项目，当前星海计划' })).toBeTruthy()
     expect(screen.getByRole('button', { name: '生成方向，当前四向' })).toBeTruthy()
@@ -1003,6 +1108,47 @@ describe('QuickStartPage', () => {
         automaticDelivery: true,
         projectId: '42',
       }),
+    )
+  })
+
+  it('drills from a project into new-character and existing-character choices', async () => {
+    const characters = characterReader()
+    renderAt('/quick-start', serviceFor(null), agentFor(), projectReader(), characters)
+
+    fireEvent.click(screen.getByRole('button', { name: '选择项目，当前自动创建' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: '星海计划' }))
+
+    expect(await screen.findByRole('menu', { name: '选择星海计划中的角色' })).toBeTruthy()
+    expect(screen.getByRole('menuitemradio', { name: '在此项目中新建角色' })).toBeTruthy()
+    expect(screen.getByText('或为已有角色新增动作')).toBeTruthy()
+    const characterItem = screen.getByRole('menuitem', {
+      name: '为星光法师新增动作，已有 3 个动作',
+    })
+    expect(characterItem).toBeTruthy()
+    expect(characterItem.querySelector('img')).toBeNull()
+    expect(characters.listSummariesByProject).toHaveBeenCalledWith('42', {
+      page: 1,
+      pageSize: 8,
+      status: CHARACTER_STATUS.PUBLISHED,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '返回项目列表' }))
+    expect(screen.getByRole('menu', { name: '选择项目' })).toBeTruthy()
+  })
+
+  it('opens the existing character workflow when choosing it for a new action', async () => {
+    renderAt('/quick-start', serviceFor(null))
+
+    fireEvent.click(screen.getByRole('button', { name: '选择项目，当前自动创建' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: '星海计划' }))
+    fireEvent.click(
+      await screen.findByRole('menuitem', { name: '为星光法师新增动作，已有 3 个动作' }),
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location-probe').textContent).toBe(
+        '/quick-start/77?intent=add-action&outfitId=outfit-default',
+      ),
     )
   })
 

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1128,12 +1128,40 @@ describe('QuickStartPage', () => {
     expect(characterItem.querySelector('img')).toBeNull()
     expect(characters.listSummariesByProject).toHaveBeenCalledWith('42', {
       page: 1,
-      pageSize: 8,
+      pageSize: 100,
       status: CHARACTER_STATUS.PUBLISHED,
     })
 
     fireEvent.click(screen.getByRole('button', { name: '返回项目列表' }))
     expect(screen.getByRole('menu', { name: '选择项目' })).toBeTruthy()
+  })
+
+  it('tells the user when a project has more characters than one page', async () => {
+    const characters = characterReader()
+    characters.listSummariesByProject = vi.fn(async () => ({
+      items: [
+        {
+          id: '77',
+          projectId: '42',
+          name: '星光法师',
+          status: CHARACTER_STATUS.PUBLISHED,
+          previewUrl: null,
+          outfitName: '默认造型',
+          outfitCount: 1,
+          actionCount: 3,
+          updatedAt: '2026-08-26T00:00:00Z',
+        },
+      ],
+      total: 137,
+      page: 1,
+      pageSize: 100,
+    }))
+    renderAt('/quick-start', serviceFor(null), agentFor(), projectReader(), characters)
+
+    fireEvent.click(screen.getByRole('button', { name: '选择项目，当前自动创建' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: '星海计划' }))
+
+    expect(await screen.findByText('仅显示前 1 个角色，其余请在资产库中打开')).toBeTruthy()
   })
 
   it('opens the existing character workflow when choosing it for a new action', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -18,6 +18,8 @@ import {
   ArrowClockwise,
   ArrowUp,
   CaretDown,
+  CaretLeft,
+  CaretRight,
   Check,
   CopySimple,
   FolderOpen,
@@ -36,11 +38,16 @@ import { PixelPerfectVersionSwitch, type PixelPerfectVersion } from './pixel-per
 import {
   ART_STYLE,
   ART_STYLE_OPTIONS,
+  CHARACTER_STATUS,
   DIRECTIONAL_MOVEMENT,
+  characterApis as defaultCharacterApis,
   isArtStyle,
   type ActionDirection,
   type ActionFirstFrameWorkflowNode,
   type ArtStyle,
+  type CharacterApis,
+  type CharacterSummary,
+  type CharacterSummaryApis,
   type CharacterTemplateWorkflowNode,
   type DirectionalMovement,
   type WorkflowRun,
@@ -505,6 +512,7 @@ export interface QuickStartPageProps {
   /** app 组合层注入 Planner 与绑定到现有 WorkflowController 的唯一写 action。 */
   agent: CreateQuickStartAgentOptions
   projectApis?: Pick<ProjectApis, 'list' | 'get'>
+  characterApis?: Pick<CharacterApis & CharacterSummaryApis, 'get' | 'listSummariesByProject'>
 }
 
 /** Quick Start 独立完成 AI 入口；它不跳转 Workflow Editor。 */
@@ -513,6 +521,7 @@ export function QuickStartPage({
   activeRunUserId: providedActiveRunUserId,
   agent,
   projectApis = defaultProjectApis,
+  characterApis = defaultCharacterApis,
 }: QuickStartPageProps) {
   const { runId } = useParams()
   const location = useLocation()
@@ -546,6 +555,7 @@ export function QuickStartPage({
       agent={agent}
       activeRunUserId={activeRunUserId}
       projectApis={projectApis}
+      characterApis={characterApis}
     />
   )
 }
@@ -733,11 +743,13 @@ function QuickStartInput({
   agent,
   activeRunUserId,
   projectApis,
+  characterApis,
 }: {
   service: QuickStartEntryService
   agent: CreateQuickStartAgentOptions
   activeRunUserId: string | null
   projectApis: Pick<ProjectApis, 'list' | 'get'>
+  characterApis: Pick<CharacterApis & CharacterSummaryApis, 'get' | 'listSummariesByProject'>
 }) {
   const navigate = useNavigate()
   const [entrySearchParams] = useSearchParams()
@@ -770,6 +782,13 @@ function QuickStartInput({
   const [selectedProject, setSelectedProject] = useState<Project | null>(null)
   const [projects, setProjects] = useState<readonly Project[]>([])
   const [projectMenuOpen, setProjectMenuOpen] = useState(false)
+  const [projectMenuProject, setProjectMenuProject] = useState<Project | null>(null)
+  const [projectCharacters, setProjectCharacters] = useState<readonly CharacterSummary[] | null>(
+    null,
+  )
+  const [projectCharactersError, setProjectCharactersError] = useState<string | null>(null)
+  const [openingCharacterId, setOpeningCharacterId] = useState<string | null>(null)
+  const projectCharactersRequest = useRef(0)
   const projectIdRef = useRef(projectId)
   projectIdRef.current = projectId
   const gameStyleRef = useRef(gameStyle)
@@ -896,6 +915,54 @@ function QuickStartInput({
       directionalMovement: project?.directionalMovement ?? directionalMovementRef.current,
       projectId: nextProjectId,
     })
+  }
+
+  async function openProjectCharacters(project: Project) {
+    const request = projectCharactersRequest.current + 1
+    projectCharactersRequest.current = request
+    setProjectMenuProject(project)
+    setProjectCharacters(null)
+    setProjectCharactersError(null)
+    try {
+      const result = await characterApis.listSummariesByProject(project.id, {
+        page: 1,
+        pageSize: 8,
+        status: CHARACTER_STATUS.PUBLISHED,
+      })
+      if (projectCharactersRequest.current === request) setProjectCharacters(result.items)
+    } catch {
+      if (projectCharactersRequest.current === request) {
+        setProjectCharacters([])
+        setProjectCharactersError('角色列表暂时无法读取')
+      }
+    }
+  }
+
+  function returnToProjects() {
+    projectCharactersRequest.current += 1
+    setProjectMenuProject(null)
+    setProjectCharacters(null)
+    setProjectCharactersError(null)
+  }
+
+  async function openCharacterForAction(summary: CharacterSummary) {
+    if (openingCharacterId) return
+    setOpeningCharacterId(summary.id)
+    setProjectCharactersError(null)
+    try {
+      const character = await characterApis.get(summary.id)
+      const outfit = character.outfits[0]
+      if (!outfit) throw new Error('这个角色还没有可用造型')
+      navigate(
+        `/quick-start/${encodeURIComponent(character.workflowRunId)}?${new URLSearchParams({
+          intent: 'add-action',
+          outfitId: outfit.id,
+        })}`,
+      )
+    } catch (cause) {
+      setProjectCharactersError(cause instanceof Error ? cause.message : '角色暂时无法读取')
+      setOpeningCharacterId(null)
+    }
   }
 
   const persistRunConversation = useCallback(
@@ -1513,7 +1580,12 @@ function QuickStartInput({
                     onClick={() => {
                       styleMenu.close()
                       directionMenu.close()
-                      setProjectMenuOpen((open) => !open)
+                      if (projectMenuOpen) {
+                        setProjectMenuOpen(false)
+                      } else {
+                        returnToProjects()
+                        setProjectMenuOpen(true)
+                      }
                     }}
                     className={`inline-flex h-10 max-w-44 items-center gap-1 rounded-app-control px-3 text-sm font-medium text-app-ink-soft transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ${hasConversation ? 'pointer-events-none disabled:opacity-100' : 'hover:bg-app-surface-muted hover:text-app-ink disabled:opacity-45'}`}
                   >
@@ -1530,50 +1602,113 @@ function QuickStartInput({
                   {projectMenuOpen && !hasConversation ? (
                     <div
                       role="menu"
-                      aria-label="选择项目"
-                      className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid min-w-40 gap-1 p-1.5 opacity-100`}
+                      aria-label={
+                        projectMenuProject ? `选择${projectMenuProject.name}中的角色` : '选择项目'
+                      }
+                      className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid w-[19rem] max-w-[calc(100vw-2rem)] gap-1 p-1.5 opacity-100`}
                     >
-                      {projects.map((project) => (
-                        <button
-                          key={project.id}
-                          type="button"
-                          role="menuitemradio"
-                          aria-checked={projectId === project.id}
-                          onClick={() => chooseProject(project)}
-                          className={`flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === project.id ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
-                        >
-                          <FolderOpen aria-hidden="true" size={15} weight="regular" />
-                          <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                          {projectId === project.id ? (
-                            <Check aria-hidden="true" size={14} weight="bold" />
+                      {projectMenuProject ? (
+                        <>
+                          <button
+                            type="button"
+                            aria-label="返回项目列表"
+                            onClick={returnToProjects}
+                            className="flex min-w-0 items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs font-semibold text-app-ink transition hover:bg-app-surface-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+                          >
+                            <CaretLeft aria-hidden="true" size={15} weight="bold" />
+                            <span className="truncate">{projectMenuProject.name}</span>
+                          </button>
+                          <button
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={projectId === projectMenuProject.id}
+                            onClick={() => chooseProject(projectMenuProject)}
+                            className={`flex items-center gap-2 rounded-app-compact px-3 py-2.5 text-left text-xs transition ${projectId === projectMenuProject.id ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
+                          >
+                            <Plus aria-hidden="true" size={15} weight="bold" />
+                            <span className="min-w-0 flex-1">在此项目中新建角色</span>
+                            {projectId === projectMenuProject.id ? (
+                              <Check aria-hidden="true" size={14} weight="bold" />
+                            ) : null}
+                          </button>
+                          <div className="px-3 pt-1">
+                            <p className="text-[0.68rem] font-medium text-app-faint">
+                              或为已有角色新增动作
+                            </p>
+                          </div>
+                          {projectCharacters === null ? (
+                            <p role="status" className="px-3 py-3 text-xs text-app-muted">
+                              正在读取角色…
+                            </p>
+                          ) : projectCharacters.length === 0 && !projectCharactersError ? (
+                            <p className="px-3 py-3 text-xs text-app-muted">此项目还没有角色</p>
+                          ) : (
+                            projectCharacters.map((character) => {
+                              const name = character.name ?? '未命名角色'
+                              return (
+                                <button
+                                  key={character.id}
+                                  type="button"
+                                  role="menuitem"
+                                  aria-label={`为${name}新增动作，${character.actionCount === 0 ? '暂无动作' : `已有 ${character.actionCount} 个动作`}`}
+                                  disabled={openingCharacterId !== null}
+                                  onClick={() => void openCharacterForAction(character)}
+                                  className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs text-app-ink-soft transition hover:bg-app-surface-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-45"
+                                >
+                                  <span className="min-w-0 flex-1 truncate">{name}</span>
+                                  <CaretRight aria-hidden="true" size={14} weight="bold" />
+                                </button>
+                              )
+                            })
+                          )}
+                          {projectCharactersError ? (
+                            <p role="alert" className="px-3 py-2 text-xs text-app-danger">
+                              {projectCharactersError}
+                            </p>
                           ) : null}
-                        </button>
-                      ))}
-                      <div className="my-1 border-t border-app-line" />
-                      <Link
-                        to="/projects/new?entry=quick-start"
-                        role="menuitem"
-                        onClick={() => setProjectMenuOpen(false)}
-                        className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-xs text-app-ink-soft transition hover:bg-app-surface-muted"
-                      >
-                        <Plus aria-hidden="true" size={15} weight="bold" />
-                        新建项目
-                      </Link>
-                      <button
-                        type="button"
-                        role="menuitemradio"
-                        aria-checked={projectId === null}
-                        onClick={() => chooseProject(null)}
-                        className={`flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === null ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
-                      >
-                        <span aria-hidden="true" className="w-[15px] text-center">
-                          ×
-                        </span>
-                        <span className="flex-1">自动创建</span>
-                        {projectId === null ? (
-                          <Check aria-hidden="true" size={14} weight="bold" />
-                        ) : null}
-                      </button>
+                        </>
+                      ) : (
+                        <>
+                          {projects.map((project) => (
+                            <button
+                              key={project.id}
+                              type="button"
+                              role="menuitem"
+                              onClick={() => void openProjectCharacters(project)}
+                              className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs text-app-ink-soft transition hover:bg-app-surface-muted"
+                            >
+                              <FolderOpen aria-hidden="true" size={15} weight="regular" />
+                              <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                              <CaretRight aria-hidden="true" size={14} weight="bold" />
+                            </button>
+                          ))}
+                          <div className="my-1 border-t border-app-line" />
+                          <Link
+                            to="/projects/new?entry=quick-start"
+                            role="menuitem"
+                            onClick={() => setProjectMenuOpen(false)}
+                            className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-xs text-app-ink-soft transition hover:bg-app-surface-muted"
+                          >
+                            <Plus aria-hidden="true" size={15} weight="bold" />
+                            新建项目
+                          </Link>
+                          <button
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={projectId === null}
+                            onClick={() => chooseProject(null)}
+                            className={`flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs transition ${projectId === null ? 'bg-app-accent-soft text-app-accent' : 'text-app-ink-soft hover:bg-app-surface-muted'}`}
+                          >
+                            <span aria-hidden="true" className="w-[15px] text-center">
+                              ×
+                            </span>
+                            <span className="flex-1">自动创建</span>
+                            {projectId === null ? (
+                              <Check aria-hidden="true" size={14} weight="bold" />
+                            ) : null}
+                          </button>
+                        </>
+                      )}
                     </div>
                   ) : null}
                 </div>

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -170,6 +170,8 @@ const ROLE_DEFAULT_MESSAGE: readonly KineticCopyMessage[] = [
   { lines: ['用文字塑造你的角色……'], className: 'text-app-ink' },
 ]
 
+/** 角色选择菜单一次取满后端允许的最大一页；再多的项目在菜单里给出明确提示而不是静默截断。 */
+const CHARACTER_MENU_PAGE_SIZE = 100
 const ENTRY_HANDOFF_MS = 460
 const PROMPT_REWRITE_MS = 760
 const AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v2'
@@ -786,6 +788,7 @@ function QuickStartInput({
   const [projectCharacters, setProjectCharacters] = useState<readonly CharacterSummary[] | null>(
     null,
   )
+  const [projectCharactersTotal, setProjectCharactersTotal] = useState(0)
   const [projectCharactersError, setProjectCharactersError] = useState<string | null>(null)
   const [openingCharacterId, setOpeningCharacterId] = useState<string | null>(null)
   const projectCharactersRequest = useRef(0)
@@ -926,13 +929,17 @@ function QuickStartInput({
     try {
       const result = await characterApis.listSummariesByProject(project.id, {
         page: 1,
-        pageSize: 8,
+        pageSize: CHARACTER_MENU_PAGE_SIZE,
         status: CHARACTER_STATUS.PUBLISHED,
       })
-      if (projectCharactersRequest.current === request) setProjectCharacters(result.items)
+      if (projectCharactersRequest.current === request) {
+        setProjectCharacters(result.items)
+        setProjectCharactersTotal(result.total)
+      }
     } catch {
       if (projectCharactersRequest.current === request) {
         setProjectCharacters([])
+        setProjectCharactersTotal(0)
         setProjectCharactersError('角色列表暂时无法读取')
       }
     }
@@ -942,6 +949,7 @@ function QuickStartInput({
     projectCharactersRequest.current += 1
     setProjectMenuProject(null)
     setProjectCharacters(null)
+    setProjectCharactersTotal(0)
     setProjectCharactersError(null)
   }
 
@@ -1643,24 +1651,32 @@ function QuickStartInput({
                           ) : projectCharacters.length === 0 && !projectCharactersError ? (
                             <p className="px-3 py-3 text-xs text-app-muted">此项目还没有角色</p>
                           ) : (
-                            projectCharacters.map((character) => {
-                              const name = character.name ?? '未命名角色'
-                              return (
-                                <button
-                                  key={character.id}
-                                  type="button"
-                                  role="menuitem"
-                                  aria-label={`为${name}新增动作，${character.actionCount === 0 ? '暂无动作' : `已有 ${character.actionCount} 个动作`}`}
-                                  disabled={openingCharacterId !== null}
-                                  onClick={() => void openCharacterForAction(character)}
-                                  className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs text-app-ink-soft transition hover:bg-app-surface-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-45"
-                                >
-                                  <span className="min-w-0 flex-1 truncate">{name}</span>
-                                  <CaretRight aria-hidden="true" size={14} weight="bold" />
-                                </button>
-                              )
-                            })
+                            <div className="grid max-h-56 gap-1 overflow-y-auto">
+                              {projectCharacters.map((character) => {
+                                const name = character.name ?? '未命名角色'
+                                return (
+                                  <button
+                                    key={character.id}
+                                    type="button"
+                                    role="menuitem"
+                                    aria-label={`为${name}新增动作，${character.actionCount === 0 ? '暂无动作' : `已有 ${character.actionCount} 个动作`}`}
+                                    disabled={openingCharacterId !== null}
+                                    onClick={() => void openCharacterForAction(character)}
+                                    className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs text-app-ink-soft transition hover:bg-app-surface-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-45"
+                                  >
+                                    <span className="min-w-0 flex-1 truncate">{name}</span>
+                                    <CaretRight aria-hidden="true" size={14} weight="bold" />
+                                  </button>
+                                )
+                              })}
+                            </div>
                           )}
+                          {projectCharacters !== null &&
+                          projectCharactersTotal > projectCharacters.length ? (
+                            <p className="px-3 pb-2 text-[0.68rem] text-app-faint">
+                              仅显示前 {projectCharacters.length} 个角色，其余请在资产库中打开
+                            </p>
+                          ) : null}
                           {projectCharactersError ? (
                             <p role="alert" className="px-3 py-2 text-xs text-app-danger">
                               {projectCharactersError}


### PR DESCRIPTION
Quick Start 的项目选择菜单现在可继续进入项目内角色列表，用户可选择已有角色并直接进入既有的新增动作流程。

## Why

已有项目只能从 Quick Start 创建新角色，已有角色虽然具备新增动作能力，但缺少同入口下的选择路径。

## Changes

- 点击项目后进入项目内二级菜单，保留“在此项目中新建角色”。
- 加载项目下已发布角色，并以与项目列表一致的单行菜单展示。
- 选择角色后进入其既有 WorkflowRun 的 Quick Start 新增动作流程。

## Implementation

- 复用 `characterApis.listSummariesByProject` 与 `characterApis.get` 读取角色和默认造型。
- 复用 `/quick-start/:workflowRunId?intent=add-action&outfitId=:outfitId` 路由，不新增 Agent Tool、后端接口或数据模型。
- 加入请求失效保护、加载态、空态与读取错误反馈。

## Verification

- [x] `npm test -- --run src/pages/quick-start/index.test.tsx`：122/122 通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run typecheck`：通过。

## Screenshots

### Desktop

<img width="1707" height="960" alt="Quick Start 项目内角色选择菜单" src="https://github.com/user-attachments/assets/b2df5489-b236-45fd-9947-5fbf98884056" />

## Scope

- 本 PR 不包含：Agent 上下文结构、Agent Tool、后端接口、数据模型或既有新增动作工作流变更。
- mock 预览文件与 mock 数据未进入提交。

## Related Issues

Closes #762
Refs #374
