### PR TITLE
fix(generation): 浏览器出帧续跑引用了已改名的进度类

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -662,7 +662,7 @@ class ActionTaskExecutor:
                 start_from_model=_resolve_video_model(input.video_model),
             )
             card, action, canvas = self._action_spec(input, cons)
-            progress: ProgressPort = _LogProgress()
+            progress: ProgressPort = _TaskProgress(task_id=task_id, project_id=project_id)
             generated = self._get_generator(
                 _resolve_video_model(input.video_model), cons.directions
             ).finish_rendered(frames, card, action, progress, canvas=canvas)


### PR DESCRIPTION
## Summary

main 上 `executor.py:665` 引用 `_LogProgress`，该类已被改名为 `_TaskProgress`，Backend CI 在 `c781a8e` 上 ruff F821 未定义名。

两边文本不冲突，所以合并没拦住，#717 自己的 CI 也是绿的——它的基点上旧名还在。改名与新增调用点分别落在两个 PR 里，合并顺序造成的语义冲突。

## 影响

`resume_action_client_bake` 是浏览器交完帧之后 worker 续跑后处理的入口。任务在此之前一路正常（建单、挂给浏览器、逐帧上传、报交齐都不碰这一行），到最后一步才 NameError。

顺带修回一处能力：原先那个类只打日志，`_TaskProgress` 会同时把进度送进任务 SSE 桥，所以三渲二出帧的进度现在能推到前端。

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run python -m scripts.export_openapi` 后 `openapi.json` 无漂移
- [x] `uv run lint-imports`
- [x] `uv run pytest -q`：1766 passed, 14 skipped

四条都跑在最后一次编辑之后。

Closes #766
