### PR TITLE
feat(export): 导出资产包支持 GIF 动画预览

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@phosphor-icons/react": "^2.1.10",
         "@xyflow/react": "^12.11.2",
         "ai": "^7.0.68",
+        "gifenc": "^1.0.3",
         "markdown-to-jsx": "^9.10.2",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -2876,6 +2877,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
+      "license": "MIT"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@xyflow/react": "^12.11.2",
     "ai": "^7.0.68",
+    "gifenc": "^1.0.3",
     "markdown-to-jsx": "^9.10.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/frontend/src/features/export-package/README.md
+++ b/frontend/src/features/export-package/README.md
@@ -17,7 +17,7 @@
 2. `validateExportPackageModel` 检查角色、画布、生成记录、帧数、质量状态、锚点和脚底线。
 3. `createAssetExportPlan` 为每个动作方向生成稳定目录与三位连续帧名。
 4. `exportGameAssets` 读取透明 PNG，并检查图片尺寸是否与统一画布一致。
-5. 浏览器生成 Sprite Sheet，最后写入动画 `meta.json`、`schema.json`、README 与 ZIP。
+5. 浏览器生成 Sprite Sheet 与逐动作方向 GIF 预览，最后写入动画 `meta.json`、`schema.json`、README 与 ZIP。
 6. 可选 target 只在 `targets/<target-id>/` 下追加引擎文件，不修改通用层。
 
 ## 导出结构
@@ -31,11 +31,14 @@ Aster-character-1-Explorer-outfit-1/
   README.md
   frames/Walk/Walk_000.png
   atlas/Walk.png
+  preview/Walk.gif
   playtest.json
   targets/<target-id>/...
 ```
 
 `meta.json` 的坐标原点在左上角，y 轴向下。`anchor` 是 0-1 归一化坐标，`foot_y` 是从画布顶部开始计算的像素值。
+
+`preview/*.gif` 使用动作的逐帧时长和循环设置，只用于快速查看。GIF 最多 256 色且只支持一位透明度，游戏引擎仍应读取 `frames/*.png` 或 `atlas/*.png`。
 
 ## 为什么缺一帧就全部失败
 

--- a/frontend/src/features/export-package/asset-export.test.ts
+++ b/frontend/src/features/export-package/asset-export.test.ts
@@ -190,7 +190,7 @@ describe('asset export', () => {
       new TextDecoder().decode(playtestEntries.get(`${root}/playtest.json`)),
     )
     expect(playtest).toEqual({
-      schema_version: '1.1.0',
+      schema_version: '1.2.0',
       initial_action_id: 'walk-abcdef12',
       action_ids: ['walk-abcdef12'],
     })
@@ -226,7 +226,7 @@ describe('asset export', () => {
     expect(plan[0]?.frames[8]?.filename).toBe('Walk-Forward-south_008.png')
   })
 
-  it('生成通用目录、透明 PNG、图集、README、Schema 和可校验的动画 meta.json', async () => {
+  it('为每个动作方向生成可识别的 GIF 预览，并在 meta.json 中声明路径', async () => {
     const phases: string[] = []
     const result = await exportGameAssets(model, {
       runtime: runtime(),
@@ -242,14 +242,18 @@ describe('asset export', () => {
     expect(names).toContain(`${root}/schema.json`)
     expect(names).toContain(`${root}/README.md`)
     expect(names).toContain(`${root}/atlas/Walk-Forward-south.png`)
+    expect(names).toContain(`${root}/preview/Walk-Forward-south.gif`)
     expect(names.filter((name) => name.includes('/frames/'))).toHaveLength(9)
+
+    const gif = entries.get(`${root}/preview/Walk-Forward-south.gif`)
+    expect(new TextDecoder().decode(gif?.slice(0, 6))).toBe('GIF89a')
 
     const meta = JSON.parse(new TextDecoder().decode(entries.get(`${root}/meta.json`)))
     const schema = JSON.parse(EXPORT_PACKAGE_JSON_SCHEMA_TEXT)
     const validate = new Ajv2020().compile(schema)
     expect(validate(meta), JSON.stringify(validate.errors)).toBe(true)
     expect(meta).toMatchObject({
-      schema_version: '1.1.0',
+      schema_version: '1.2.0',
       character: { id: 'character-1', name: 'Aster' },
       canvas: { w: 32, h: 40 },
       source: { workflow_run_id: 'run-1', generation_ids: ['generation-1'] },
@@ -260,9 +264,9 @@ describe('asset export', () => {
       loop: true,
       anchor: { x: 0.5, y: 0.9 },
       foot_y: 36,
+      preview_gif: 'preview/Walk-Forward-south.gif',
       atlas: { cols: 8, rows: 2, cell: { w: 32, h: 40 } },
     })
-    expect(names.some((name) => name.endsWith('.gif'))).toBe(false)
   })
 
   it('把 Outfit 标识写入包名，避免同一 Character 的不同造型互相覆盖', async () => {
@@ -446,6 +450,47 @@ describe('asset export', () => {
     await expect(exportGameAssets(model, { runtime: testRuntime })).rejects.toThrow(
       'atlas: PNG 编码失败',
     )
+  })
+
+  it('GIF 编码失败时指出预览路径并释放动作帧', async () => {
+    const closes: Array<ReturnType<typeof vi.fn>> = []
+    const testRuntime: AssetExportRuntime = {
+      ...runtime(),
+      decodeFrame: vi.fn(async () => {
+        const close = vi.fn()
+        closes.push(close)
+        return {
+          source: {} as CanvasImageSource,
+          width: 32,
+          height: 40,
+          close,
+        }
+      }),
+      createCanvas: vi.fn((width, height) => {
+        const canvas = document.createElement('canvas')
+        canvas.width = width
+        canvas.height = height
+        Object.defineProperty(canvas, 'getContext', {
+          value: () => ({
+            clearRect: vi.fn(),
+            drawImage: vi.fn(),
+            getImageData: vi.fn(() => {
+              throw new Error('pixel access denied')
+            }),
+          }),
+        })
+        Object.defineProperty(canvas, 'toBlob', {
+          value: (callback: BlobCallback) => callback(new Blob(['atlas'], { type: 'image/png' })),
+        })
+        return canvas
+      }),
+    }
+
+    await expect(exportGameAssets(model, { runtime: testRuntime })).rejects.toThrow(
+      'preview/Walk-Forward-south.gif: GIF 编码失败（pixel access denied）',
+    )
+    expect(closes).toHaveLength(11)
+    expect(closes.every((close) => close.mock.calls.length === 1)).toBe(true)
   })
 
   it('target 只能写入安全且不重复的相对路径', async () => {

--- a/frontend/src/features/export-package/asset-export.ts
+++ b/frontend/src/features/export-package/asset-export.ts
@@ -1,3 +1,5 @@
+import { applyPalette, GIFEncoder, quantize } from 'gifenc'
+
 import {
   EXPORT_PACKAGE_JSON_SCHEMA_TEXT,
   EXPORT_PACKAGE_SCHEMA_VERSION,
@@ -39,6 +41,7 @@ export interface PlannedSequence {
   exportName: string
   framesFolder: string
   atlasFile: string
+  previewGifFile: string
   columns: number
   rows: number
   frames: readonly PlannedFrame[]
@@ -139,6 +142,7 @@ export function createAssetExportPlan(model: ExportPackageModel): readonly Plann
           exportName,
           framesFolder: `frames/${exportName}`,
           atlasFile: `atlas/${exportName}.png`,
+          previewGifFile: `preview/${exportName}.gif`,
           columns,
           rows: Math.ceil(sequence.frames.length / columns),
           frames: sequence.frames.map((currentFrame) => {
@@ -360,6 +364,40 @@ async function renderAtlas(
   return canvasPng(canvas)
 }
 
+function renderGif(
+  loaded: LoadedSequence,
+  model: ExportPackageModel,
+  runtime: AssetExportRuntime,
+): Uint8Array {
+  try {
+    const canvas = runtime.createCanvas(model.canvas.width, model.canvas.height)
+    const context = context2d(canvas, loaded.item.previewGifFile)
+    const gif = GIFEncoder()
+
+    for (const frame of loaded.frames) {
+      context.clearRect(0, 0, canvas.width, canvas.height)
+      context.drawImage(frame.decoded.source, 0, 0)
+      const rgba = context.getImageData(0, 0, canvas.width, canvas.height).data
+      const palette = quantize(rgba, 256, { format: 'rgba4444', oneBitAlpha: true })
+      const indexed = applyPalette(rgba, palette, 'rgba4444')
+      const transparentIndex = palette.findIndex((color) => color[3] === 0)
+      gif.writeFrame(indexed, canvas.width, canvas.height, {
+        palette,
+        delay: frame.frame.durationMs,
+        repeat: loaded.item.sequence.loop ? 0 : -1,
+        transparent: transparentIndex >= 0,
+        transparentIndex,
+      })
+    }
+
+    gif.finish()
+    return gif.bytes()
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : '未知错误'
+    throw new Error(`${loaded.item.previewGifFile}: GIF 编码失败（${reason}）`)
+  }
+}
+
 function createMetadata(
   model: ExportPackageModel,
   plan: readonly PlannedSequence[],
@@ -390,6 +428,7 @@ function createMetadata(
       frames: item.frames.map((frame) => ({ index: frame.index, file: frame.filename })),
       anchor: { ...item.sequence.anchor },
       foot_y: item.sequence.footY,
+      preview_gif: item.previewGifFile,
       atlas: {
         file: item.atlasFile,
         cols: item.columns,
@@ -419,6 +458,7 @@ function createReadme(model: ExportPackageModel): string {
 - \`meta.json\`: 动作、帧率、循环、画布、锚点、脚底线、图集与生成记录。
 - \`frames/<action>/\`: 连续编号的透明 PNG 原始帧。
 - \`atlas/<action>.png\`: 按 \`meta.json\` 中 cols、rows 和 cell 切分的图集。
+- \`preview/<action>.gif\`: 按逐帧时长生成的 GIF 快速预览；PNG 原始帧仍是无损源。
 - \`schema.json\`: 校验 \`meta.json\` 的 JSON Schema。
 - \`targets/<target>/\`: 可选引擎适配器产生的原生文件。
 
@@ -570,6 +610,10 @@ export async function exportGameAssets(
       entries.push({
         name: `${root}/${current.item.atlasFile}`,
         data: await bytes(await renderAtlas(current, model, runtime)),
+      })
+      entries.push({
+        name: `${root}/${current.item.previewGifFile}`,
+        data: renderGif(current, model, runtime),
       })
     } finally {
       current.frames.forEach((frame) => frame.decoded.close())

--- a/frontend/src/features/export-package/contract.ts
+++ b/frontend/src/features/export-package/contract.ts
@@ -2,7 +2,7 @@ import exportSchemaText from './export-package.schema.json?raw'
 import { EXPORT_STAGES } from './model'
 import type { ExportPackageModel } from './model'
 
-export const EXPORT_PACKAGE_SCHEMA_VERSION = '1.1.0'
+export const EXPORT_PACKAGE_SCHEMA_VERSION = '1.2.0'
 export const EXPORT_PACKAGE_JSON_SCHEMA_TEXT = exportSchemaText
 
 export interface GenericExportFrame {
@@ -19,6 +19,7 @@ export interface GenericExportAction {
   frames: readonly GenericExportFrame[]
   anchor: { x: number; y: number }
   foot_y: number
+  preview_gif: string
   atlas: {
     file: string
     cols: number

--- a/frontend/src/features/export-package/export-package.schema.json
+++ b/frontend/src/features/export-package/export-package.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://windup.local/schemas/export-package-1.1.0.json",
+  "$id": "https://windup.local/schemas/export-package-1.2.0.json",
   "title": "Windup Generic Export Package",
   "type": "object",
   "additionalProperties": false,
@@ -16,7 +16,7 @@
     "source"
   ],
   "properties": {
-    "schema_version": { "const": "1.1.0" },
+    "schema_version": { "const": "1.2.0" },
     "stage": { "enum": ["character", "first-frame", "action-assets", "playtest"] },
     "character": {
       "type": "object",
@@ -60,6 +60,7 @@
           "frames",
           "anchor",
           "foot_y",
+          "preview_gif",
           "atlas"
         ],
         "properties": {
@@ -91,6 +92,7 @@
             }
           },
           "foot_y": { "type": "integer", "minimum": 0 },
+          "preview_gif": { "type": "string", "pattern": "^preview/.+\\.gif$" },
           "atlas": {
             "type": "object",
             "additionalProperties": false,

--- a/frontend/src/pages/guide/content.ts
+++ b/frontend/src/pages/guide/content.ts
@@ -177,7 +177,7 @@ export const guideChapters: readonly GuideChapter[] = [
       {
         title: '资源包包含什么',
         description:
-          '根据角色完成情况，资源包会包含母版、首帧、透明 PNG、Sprite Sheet 和动画说明文件。',
+          '根据角色完成情况，资源包会包含母版、首帧、透明 PNG、Sprite Sheet、逐动作方向 GIF 预览和动画说明文件。',
       },
       {
         title: '导出失败怎么办',

--- a/frontend/src/types/gifenc.d.ts
+++ b/frontend/src/types/gifenc.d.ts
@@ -1,0 +1,32 @@
+declare module 'gifenc' {
+  export type GifPalette = number[][]
+
+  export interface GifEncoder {
+    writeFrame(
+      index: Uint8Array,
+      width: number,
+      height: number,
+      options: {
+        palette: GifPalette
+        delay?: number
+        repeat?: number
+        transparent?: boolean
+        transparentIndex?: number
+      },
+    ): void
+    finish(): void
+    bytes(): Uint8Array
+  }
+
+  export function GIFEncoder(options?: { auto?: boolean; initialCapacity?: number }): GifEncoder
+  export function quantize(
+    rgba: Uint8Array | Uint8ClampedArray,
+    maxColors: number,
+    options?: { format?: 'rgb565' | 'rgb444' | 'rgba4444'; oneBitAlpha?: boolean | number },
+  ): GifPalette
+  export function applyPalette(
+    rgba: Uint8Array | Uint8ClampedArray,
+    palette: GifPalette,
+    format?: 'rgb565' | 'rgb444' | 'rgba4444',
+  ): Uint8Array
+}


### PR DESCRIPTION
## 改动说明

- 在导出 ZIP 的 `preview/` 目录中，为每个动作方向生成独立 GIF 动画预览。
- 使用原有逐帧 `durationMs`、循环设置和一位透明度，不替代透明 PNG 与 Sprite Sheet。
- 在 `meta.json` 增加 `preview_gif`，导出 Schema 升级至 `1.2.0`。
- GIF 编码失败时返回具体预览路径，并确保动作帧资源正常释放。
- 更新包内 README、模块说明和产品使用手册。

## 验证

- `npm test -- src/features/export-package`：48 项通过
- `npm run typecheck`：通过
- `npm run lint`：通过
- `npm run build`：通过
- `npm audit --omit=dev`：0 个生产依赖漏洞

Closes #769