### PR TITLE
feat(render3d): 前端接回 3D 资产创建入口

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/_failure.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/_failure.py
@@ -39,6 +39,10 @@ def user_message(exc: BaseException) -> str:
         return f"动作描述没通过检查：{detail}" if detail else "动作描述没通过检查，换一种说法再试。"
     if name == "FetchNotAllowed":
         return "参考图地址不被接受，请重新上传图片后再试。"
+    if name == "StanceNotRiggable":
+        # 体型不在绑骨能力范围内。这条**不能抹成通用文案**：通用那句让用户去重试，
+        # 而重试一万次也不会变 —— 四足永远绑不了。原文里只有体型和路线名，无内部信息。
+        return str(exc)
     if name == "QualityBlocked":
         # 判官给的是产品级原因,不是基础设施信息 —— 翻成人话交给用户,
         # 抹成"没通过检查"会让用户不知道改什么,那是脱敏脱过头。

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -662,7 +662,7 @@ class ActionTaskExecutor:
                 start_from_model=_resolve_video_model(input.video_model),
             )
             card, action, canvas = self._action_spec(input, cons)
-            progress: ProgressPort = _LogProgress()
+            progress: ProgressPort = _TaskProgress(task_id=task_id, project_id=project_id)
             generated = self._get_generator(
                 _resolve_video_model(input.video_model), cons.directions
             ).finish_rendered(frames, card, action, progress, canvas=canvas)

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -29,6 +29,7 @@ from windup_ai_engine.master_check import check_master
 from windup_ai_engine.ports import MasterRejected
 
 from windup_app.server.orchestrator._fetch import FetchNotAllowed, fetch_own_media
+from windup_common.models import CharacterStance
 from windup_app.server.orchestrator.render3d_assets import (
     AUTORIG_CREDITS,
     BUILD_CREDITS,
@@ -45,11 +46,19 @@ from windup_app.server.orchestrator.render3d_assets import (
 
 logger = logging.getLogger("windup.render3d.service")
 
+# 拒绝文案里用得着的中文名。放这里而不是塞进枚举:枚举是给措辞门禁用的,
+# 这几个字只服务于这一条拒绝理由。
+_STANCE_LABEL = {
+    CharacterStance.QUADRUPED: "四足",
+    CharacterStance.SERPENTINE: "无肢(蛇形)",
+}
+
 __all__ = [
     "PHASE_BUILDING", "PHASE_FAILED", "PHASE_RIGGING",
     "FetchNotAllowed", "MasterPrecheckFailed", "Render3DAssetOperations",
     "SpendNotAuthorized", "default_operations", "precheck_master",
     "precheck_master_bytes",
+    "StanceNotRiggable",
 ]
 
 # 落点里存"绑骨模型的公网 URL"用的键前缀。与模型 bytes 同一个 store,是因为两者的
@@ -94,6 +103,19 @@ def precheck_master_bytes(master: bytes, canvas: tuple[int, int] | None = None) 
 def precheck_master(master_url: str, canvas: tuple[int, int] | None = None) -> dict:
     """:func:`precheck_master_bytes` 的 URL 版。取图受限于自家对象存储,见 ``_fetch``。"""
     return precheck_master_bytes(fetch_own_media(master_url), canvas)
+
+
+class StanceNotRiggable(ValueError):
+    """体型不在自动绑骨的能力范围内 —— **在花钱之前**拒。
+
+    为什么按声明拦而不是从模型几何判:实测拿全部归档 GLB 量过,四足与人形的包围盒比例
+    完全重叠(狼 Z/Y=1.47,而混元人形原始产物 3.19~4.47,比狼还大),因为管线不同阶段的
+    模型量纲不一样。几何上判不出来,只能让调用方声明。
+
+    为什么必须拦而不是"建了再说":自动绑骨对非双足**不报错**,它会漏认被遮挡的肢体,
+    那条肢体在每一帧保持同一姿势,而 ``motion_scale``、死帧数、``loop_seam``、帧数时长
+    成色**全部正常**,一道闸都不会红。用户拿到的是"有条腿是根柱子"的动画且不知情。
+    """
 
 
 class MasterPrecheckFailed(ValueError):
@@ -172,13 +194,21 @@ class Render3DAssetOperations:
         }
 
     # ── 三个动作 ─────────────────────────────────────────────────────────
-    def build(self, outfit_key: str, master_url: str) -> dict:
-        """① 图生 3D。**这一步开始花钱**,所以只在两个前提都成立时才起:
-        该造型确实还什么都没有,且母版过得了零成本预检。
+    def build(self, outfit_key: str, master_url: str, stance: CharacterStance) -> dict:
+        """① 图生 3D。**这一步开始花钱**,所以只在三个前提都成立时才起:
+        该造型确实还什么都没有、体型能绑骨、且母版过得了零成本预检。
 
         预检不过就在这里拒:母版不合格 → 模型必然不合格,而模型改不动只能重生成。
         警告不拦 —— 它们已经在母版确认闸上给人看过,人点了"就用这张"就是他的决定。
+
+        ``stance`` **无默认值**:替调用方兜成双足的话,"没给"与"明确给了双足"从这里起
+        就分不开,而分不开的代价是四足角色照样被放行去绑骨(见 :class:`StanceNotRiggable`)。
         """
+        if stance is not CharacterStance.BIPED:
+            raise StanceNotRiggable(
+                f"{_STANCE_LABEL.get(stance, stance.value)}角色目前无法绑定骨骼,三渲二这条"
+                "路线只支持双足人形。这一步没有扣费,可以改走视频路线。"
+            )
         if not self._builder.may_build_assets:
             raise SpendNotAuthorized(
                 f"本部署未开启建 3D 资产(需 WINDUP_RENDER3D_ALLOW_SPEND)。建一次 "
@@ -376,8 +406,8 @@ class _LazyOperations:
     def view(self, outfit_key: str) -> dict:
         return self._ops().view(outfit_key)
 
-    def build(self, outfit_key: str, master_url: str) -> dict:
-        return self._ops().build(outfit_key, master_url)
+    def build(self, outfit_key: str, master_url: str, stance: CharacterStance) -> dict:
+        return self._ops().build(outfit_key, master_url, stance)
 
     def approve(self, outfit_key: str, master_url: str) -> dict:
         return self._ops().approve(outfit_key, master_url)

--- a/backend/packages/app/src/windup_app/web/api/render3d.py
+++ b/backend/packages/app/src/windup_app/web/api/render3d.py
@@ -13,6 +13,7 @@ import logging
 
 from fastapi import APIRouter, Depends, File, Request, UploadFile
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from windup_common.enums.biz_code import BizCode
@@ -21,6 +22,8 @@ from windup_common.result import Response
 from windup_framework.db import get_session
 
 from windup_app.server.character.model import Character, CharacterData
+from windup_app.server.project.model import Project
+from windup_common.models import CharacterStance
 from windup_app.server.orchestrator import client_bake, task_repo
 from windup_app.server.orchestrator._failure import user_message
 from windup_app.server.character.service import service as character_service
@@ -29,6 +32,16 @@ from windup_app.web.api.character import get_character_with_auth
 logger = logging.getLogger("windup.render3d.api")
 
 router = APIRouter(prefix="/render3d", tags=["render3d"])
+
+
+class BuildAssetRequest(BaseModel):
+    """建 3D 资产的入参。
+
+    ``stance`` 必填、无默认:自动绑骨只支持双足,而四足/无肢从模型几何判不出来
+    (实测归档模型的包围盒比例完全重叠)。给默认值等于把「没声明」当成「双足」放行。
+    """
+
+    stance: CharacterStance
 
 
 class MasterPrecheckRequest(BaseModel):
@@ -53,6 +66,36 @@ def _precheck(request: Request):
     if precheck is None:
         raise BizException("母版预检服务未装配", code=BizCode.INTERNAL_ERROR)
     return precheck
+
+
+#: 每个用户最多同时持有的 3D 资产数。
+#:
+#: 这条是**产品限额**不是技术限制:一个 3D 资产 = 图生 3D 20 积分 + 绑骨 10 积分,
+#: 且后续动作全部复用它,所以它是这条路线上唯一的重成本点。
+MAX_ASSETS_PER_USER = 2
+
+
+def _owned_asset_count(session: Session, user_id: int) -> int:
+    """该用户名下已经建成的 3D 资产数。
+
+    数的是**当前持有**而不是历史建过多少次 —— 弃掉一个就释放一个名额。理由是混元的
+    模型生成即最终、改不动,不合格只能弃掉重建;名额若不释放,两个坏模型就把用户永久
+    卡死在这条路线外面。
+
+    只数已落 ``model_3d_url`` 的。建造中的不计入:那需要逐造型去问资产存储,而并发建多个
+    的代价本来就由积分挡着(每个都真金白银扣),不值得为它多打一圈存储。
+    """
+    rows = session.execute(
+        select(Character.character_data)
+        .join(Project, Character.project_id == Project.id)
+        .where(Project.user_id == user_id)
+    ).scalars().all()
+    owned = 0
+    for data in rows:
+        for outfit in (data or {}).get("outfits", []):
+            if outfit.get("model_3d_url"):
+                owned += 1
+    return owned
 
 
 def _asset_key(character_id: int, outfit_id: str) -> str:
@@ -142,6 +185,7 @@ def get_outfit_asset(
 def build_outfit_asset(
     character_id: int,
     outfit_id: str,
+    body: BuildAssetRequest,
     request: Request,
     session: Session = Depends(get_session),
 ) -> Response[dict]:
@@ -149,11 +193,18 @@ def build_outfit_asset(
     user_id = request.state.current_user.id
     character = get_character_with_auth(session, character_id, user_id)
     outfit = _outfit_or_raise(character, outfit_id)
+    owned = _owned_asset_count(session, user_id)
+    if owned >= MAX_ASSETS_PER_USER:
+        raise BizException(
+            f"每个账号最多同时持有 {MAX_ASSETS_PER_USER} 个 3D 角色，你已经有 {owned} 个。"
+            "弃掉其中一个就能再建。",
+            code=BizCode.BAD_REQUEST,
+        )
     operations = _operations(request)
     try:
         return Response.success(
             operations.build(_asset_key(character_id, outfit_id),
-                             _master_url_or_raise(outfit)),
+                             _master_url_or_raise(outfit), body.stance),
             message="已开始生成 3D 模型",
         )
     except ValueError as exc:

--- a/backend/packages/framework/src/windup_framework/providers/render3d/checks.py
+++ b/backend/packages/framework/src/windup_framework/providers/render3d/checks.py
@@ -319,8 +319,10 @@ def check_model(
         if ratio > arm_span_max:
             raise ModelRejected(
                 ModelRejectCode.NOT_A_POSE,
-                f"臂展/身高 = {ratio:.2f},高于上限 {arm_span_max};人形 A/T-Pose 不会这么宽 —— "
-                "多半是模型躺着或轴向约定不对(glTF 规范是 Y-up)。包围盒 "
+                f"臂展/身高 = {ratio:.2f},高于上限 {arm_span_max};人形 A/T-Pose 不会这么宽。"
+                "最常见的原因是**角色手里拿着东西**:剑、法杖、弓这类延展物会把包围盒横向"
+                "撑开,而它们本身也绑不了骨(会被当成肢体绑上权重、动画里乱甩)。"
+                "其次才是模型躺着或轴向约定不对(glTF 规范是 Y-up)。包围盒 "
                 f"{facts.bbox[0]:.3f}×{facts.bbox[1]:.3f}×{facts.bbox[2]:.3f}。",
             )
     return facts

--- a/backend/tests/test_render3d_asset_endpoints.py
+++ b/backend/tests/test_render3d_asset_endpoints.py
@@ -26,6 +26,8 @@ from windup_app.server.character.model import Character
 from windup_app.server.project.model import Project
 
 MASTER_URL = "https://cdn.windup.test/media/reference-image/master.png"
+# 建资产必填体型：自动绑骨只支持双足，且几何上判不出来，只能声明。
+BIPED = {"stance": "biped"}
 OUTFIT_ID = "outfit-default"
 
 
@@ -180,7 +182,7 @@ def test_cost_numbers_come_from_the_billing_implementation(api):
 
 def test_build_stops_at_the_review_gate_without_rigging(api, render3d):
     """建完 ① 就停。**绑骨一次都不许调** —— 这道闸的全部价值就在这里。"""
-    data = _data(api.post(f"{_base()}/build"))
+    data = _data(api.post(f"{_base()}/build", json=BIPED))
     assert data["state"] == "awaiting_review"
     assert render3d.test_model3d.calls == 1
     assert render3d.test_autorig.calls == 0
@@ -190,7 +192,7 @@ def test_build_stops_at_the_review_gate_without_rigging(api, render3d):
 def test_waiting_at_the_gate_forever_never_auto_approves(api, render3d):
     """反复查状态不会把闸熬开。超时自动放行的闸等于没有闸,只是把"没人看"伪装成
     "看过了"。"""
-    api.post(f"{_base()}/build")
+    api.post(f"{_base()}/build", json=BIPED)
     for _ in range(10):
         assert _data(api.get(_base()))["state"] == "awaiting_review"
     assert render3d.test_autorig.calls == 0
@@ -199,18 +201,18 @@ def test_waiting_at_the_gate_forever_never_auto_approves(api, render3d):
 def test_awaiting_review_hands_out_a_link_to_the_model(api):
     """待审模型必须能取到。只躺在服务器磁盘上的话,人点"通过"时其实一眼都没看到,
     闸就退化成一个必须点的按钮 —— 比没有闸更糟,它制造了"已经审过"的假象。"""
-    data = _data(api.post(f"{_base()}/build"))
+    data = _data(api.post(f"{_base()}/build", json=BIPED))
     assert data["review_model_url"], "待审模型没有可打开的地址"
     assert data["model_3d_url"] is None, "还没绑骨,不该有可用的绑骨模型"
 
 
 def test_discarding_also_drops_the_review_link(api):
-    api.post(f"{_base()}/build")
+    api.post(f"{_base()}/build", json=BIPED)
     assert _data(api.post(f"{_base()}/discard"))["review_model_url"] is None
 
 
 def test_approve_is_what_starts_rigging(api, render3d):
-    api.post(f"{_base()}/build")
+    api.post(f"{_base()}/build", json=BIPED)
     data = _data(api.post(f"{_base()}/approve"))
     assert data["state"] == "ready"
     assert render3d.test_autorig.calls == 1
@@ -225,11 +227,11 @@ def test_approving_before_there_is_a_model_is_refused(api, render3d):
 
 def test_discard_sends_it_back_to_absent_and_the_next_build_regenerates(api, render3d):
     """不合格 → 丢弃 → 重新生成。混元的模型改不动,这是唯一的补救。"""
-    api.post(f"{_base()}/build")
+    api.post(f"{_base()}/build", json=BIPED)
     assert _data(api.post(f"{_base()}/discard"))["state"] == "absent"
     assert render3d.test_autorig.calls == 0
 
-    assert _data(api.post(f"{_base()}/build"))["state"] == "awaiting_review"
+    assert _data(api.post(f"{_base()}/build", json=BIPED))["state"] == "awaiting_review"
     assert render3d.test_model3d.calls == 2      # 重新生成要再付一次图生 3D
 
 
@@ -240,14 +242,14 @@ def test_discard_after_a_failed_rig_clears_the_approval_marker(api, render3d):
         render3d.test_autorig.calls += 1
         raise RuntimeError("绑骨服务 500")
 
-    api.post(f"{_base()}/build")
+    api.post(f"{_base()}/build", json=BIPED)
     render3d.test_autorig.rig = _boom
     api.post(f"{_base()}/approve")
     assert render3d.test_autorig.calls == 1
 
     assert _data(api.post(f"{_base()}/discard"))["state"] == "absent"
     render3d.test_autorig.rig = _FakeAutoRig().rig.__get__(render3d.test_autorig)
-    assert _data(api.post(f"{_base()}/build"))["state"] == "awaiting_review", (
+    assert _data(api.post(f"{_base()}/build", json=BIPED))["state"] == "awaiting_review", (
         "新模型被旧的批准标记放行了"
     )
 
@@ -256,15 +258,15 @@ def test_discard_after_a_failed_rig_clears_the_approval_marker(api, render3d):
 
 
 def test_building_twice_is_refused_instead_of_paying_again(api, render3d):
-    api.post(f"{_base()}/build")
-    assert api.post(f"{_base()}/build").json()["code"] == 400
+    api.post(f"{_base()}/build", json=BIPED)
+    assert api.post(f"{_base()}/build", json=BIPED).json()["code"] == 400
     assert render3d.test_model3d.calls == 1
 
 
 def test_ready_asset_is_not_rebuilt(api, render3d):
-    api.post(f"{_base()}/build")
+    api.post(f"{_base()}/build", json=BIPED)
     api.post(f"{_base()}/approve")
-    assert api.post(f"{_base()}/build").json()["code"] == 400
+    assert api.post(f"{_base()}/build", json=BIPED).json()["code"] == 400
     assert render3d.test_model3d.calls == 1
     assert render3d.test_autorig.calls == 1
 
@@ -272,7 +274,7 @@ def test_ready_asset_is_not_rebuilt(api, render3d):
 def test_ready_asset_writes_the_url_back_onto_the_outfit(api, engine):
     """不回写的话,三渲二的判据(``outfits[].model_3d_url``)永远是 None ——
     资产建好了,前端依旧显示"该造型暂无绑骨 3D 模型",钱白花。"""
-    api.post(f"{_base()}/build")
+    api.post(f"{_base()}/build", json=BIPED)
     api.post(f"{_base()}/approve")
     api.get(_base())                              # 回写发生在读状态这一步
 
@@ -295,7 +297,7 @@ def test_unusable_master_is_refused_before_any_paid_call(api, render3d):
     blank.save(buf, "PNG")
     render3d.test_source["master"] = buf.getvalue()
 
-    assert api.post(f"{_base()}/build").json()["code"] == 400
+    assert api.post(f"{_base()}/build", json=BIPED).json()["code"] == 400
     assert render3d.test_model3d.calls == 0
 
 
@@ -303,7 +305,7 @@ def test_a_warned_but_usable_master_still_builds(api, render3d):
     """警告不拦路:两条警告判据都会在合法母版上误报(侧视角色两腿必然重叠),
     拿它们挡路等于把误报变成挡住用户的钱。"""
     render3d.test_source["master"] = _master_png(legs_apart=False)
-    assert _data(api.post(f"{_base()}/build"))["state"] == "awaiting_review"
+    assert _data(api.post(f"{_base()}/build", json=BIPED))["state"] == "awaiting_review"
     assert render3d.test_model3d.calls == 1
 
 
@@ -355,7 +357,7 @@ def test_other_users_character_is_not_reachable(auth_client_b, api):
 def test_asset_key_is_namespaced_by_character(api, render3d, engine):
     """``outfit-default`` 是工作流写死给首个造型的 id。只用它当落点键的话,
     全站每个角色的默认造型会共用同一个 3D 模型,且没有任何报错。"""
-    api.post(f"{_base()}/build")
+    api.post(f"{_base()}/build", json=BIPED)
     from sqlalchemy.orm import sessionmaker
 
     session = sessionmaker(bind=engine)()
@@ -372,3 +374,102 @@ def test_asset_key_is_namespaced_by_character(api, render3d, engine):
 
     other = api.get(f"/render3d/characters/8/outfits/{OUTFIT_ID}")
     assert _data(other)["state"] == "absent", "另一个角色的默认造型不该套用这一个的模型"
+
+
+# ── 体型闸:非双足不给建 ────────────────────────────────────────────────────
+
+
+def test_quadruped_is_refused_before_any_spend(api, render3d):
+    """四足角色在**花钱之前**就被拦下,且拒绝理由说得出改法。
+
+    为什么必须拦而不是建了再说:自动绑骨对非双足**不报错**,它漏认被遮挡的肢体,那条
+    肢体每帧同姿势,而 motion_scale、死帧数、loop_seam、帧数时长成色全部正常 ——
+    一道闸都不会红,用户拿到"有条腿是柱子"的动画且不知情。
+    """
+    body = api.post(f"{_base()}/build", json={"stance": "quadruped"}).json()
+    assert body["code"] == 400, body
+    assert "无法绑定骨骼" in body["message"]
+    assert render3d.test_model3d.calls == 0, "四足被拦下却已经调过图生 3D"
+
+
+def test_serpentine_is_refused_too(api, render3d):
+    body = api.post(f"{_base()}/build", json={"stance": "serpentine"}).json()
+    assert body["code"] == 400, body
+    assert render3d.test_model3d.calls == 0
+
+
+def test_stance_has_no_default(api, render3d):
+    """不带 stance 直接拒。给默认值等于把「没声明」当成「双足」放行 —— 而这条链路上
+    「没声明」最可能出现在非双足角色上(调用方没意识到有这个字段)。"""
+    body = api.post(f"{_base()}/build", json={}).json()
+    assert body["code"] != 200, body
+    assert render3d.test_model3d.calls == 0
+
+
+def test_biped_still_builds(api, render3d):
+    """闸不能把正常路径也挡了 —— 控制样本。"""
+    data = _data(api.post(f"{_base()}/build", json=BIPED))
+    assert data["state"] in {"building", "awaiting_review"}
+    assert render3d.test_model3d.calls == 1
+
+
+# ── 每用户限额 ────────────────────────────────────────────────────────────
+
+
+def _give_user_assets(engine, count: int) -> None:
+    """给 user 1 名下塞 count 个已建成的 3D 资产（另起角色，不碰被测那个造型）。"""
+    from sqlalchemy.orm import sessionmaker
+
+    session = sessionmaker(bind=engine)()
+    for index in range(count):
+        session.add(Character(
+            id=100 + index, project_id=1, workflow_run_id=100 + index, name=f"已有{index}",
+            character_data={"version": 1, "outfits": [
+                {"id": "outfit-default", "name": "常态", "description": None,
+                 "preview_url": MASTER_URL,
+                 "model_3d_url": f"https://cdn.windup.test/media/model-3d/{index}.glb",
+                 "actions": []},
+            ]},
+            status=0,
+        ))
+    session.commit()
+    session.close()
+
+
+def test_third_asset_is_refused(api, engine, render3d):
+    """名额用满就不给建，且**在花钱之前**拒。"""
+    _give_user_assets(engine, 2)
+    body = api.post(f"{_base()}/build", json=BIPED).json()
+    assert body["code"] == 400, body
+    assert "最多同时持有 2 个" in body["message"]
+    assert render3d.test_model3d.calls == 0, "名额满了却已经调过图生 3D"
+
+
+def test_second_asset_still_allowed(api, engine, render3d):
+    """闸不能把正常路径挡了 —— 控制样本：已有 1 个时第 2 个必须能建。"""
+    _give_user_assets(engine, 1)
+    data = _data(api.post(f"{_base()}/build", json=BIPED))
+    assert data["state"] in {"building", "awaiting_review"}
+    assert render3d.test_model3d.calls == 1
+
+
+def test_discarding_frees_a_slot(api, engine, render3d):
+    """弃掉一个要能再建。
+
+    混元的模型生成即最终、改不动，不合格只能弃掉重建；名额若不释放，两个坏模型就把
+    用户永久卡死在这条路线外面。
+    """
+    _give_user_assets(engine, 2)
+    assert api.post(f"{_base()}/build", json=BIPED).json()["code"] == 400
+
+    from sqlalchemy.orm import sessionmaker
+    session = sessionmaker(bind=engine)()
+    stale = session.get(Character, 100)
+    data = dict(stale.character_data)
+    data["outfits"] = [{**o, "model_3d_url": None} for o in data["outfits"]]
+    stale.character_data = data
+    session.commit()
+    session.close()
+
+    data = _data(api.post(f"{_base()}/build", json=BIPED))
+    assert data["state"] in {"building", "awaiting_review"}

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -119,6 +119,7 @@ export { createRender3DApis, render3DApis, Render3DContractError } from './rende
 export type {
   BakeCompletion,
   BakeJob,
+  CharacterStance,
   MasterFacts,
   MasterPrecheckReport,
   MasterRejectCode,

--- a/frontend/src/entities/render3d/api.test.ts
+++ b/frontend/src/entities/render3d/api.test.ts
@@ -60,7 +60,7 @@ describe('三渲二资产适配器', () => {
     const { client, calls } = clientReturning(ASSET)
     const apis = createRender3DApis(client)
     await apis.getOutfitAsset('7', 'outfit-default')
-    await apis.buildOutfitAsset('7', 'outfit-default')
+    await apis.buildOutfitAsset('7', 'outfit-default', 'biped')
     await apis.approveOutfitAsset('7', 'outfit-default')
     await apis.discardOutfitAsset('7', 'outfit-default')
 
@@ -220,7 +220,7 @@ describe('render3DApis 单例', () => {
 
     await render3DApis.precheckMaster('https://cdn.test/master.png')
     await render3DApis.getOutfitAsset('7', 'outfit-default')
-    await render3DApis.buildOutfitAsset('7', 'outfit-default')
+    await render3DApis.buildOutfitAsset('7', 'outfit-default', 'biped')
     await render3DApis.approveOutfitAsset('7', 'outfit-default')
     await render3DApis.discardOutfitAsset('7', 'outfit-default')
 

--- a/frontend/src/entities/render3d/api.ts
+++ b/frontend/src/entities/render3d/api.ts
@@ -202,10 +202,11 @@ export function createRender3DApis(client: ApiClient = defaultClient()): Render3
       return parseAsset(await client.request<unknown>(outfitPath(characterId, outfitId)))
     },
 
-    async buildOutfitAsset(characterId, outfitId) {
+    async buildOutfitAsset(characterId, outfitId, stance) {
       return parseAsset(
         await client.request<unknown>(`${outfitPath(characterId, outfitId)}/build`, {
           method: 'POST',
+          json: { stance },
         }),
       )
     },
@@ -274,8 +275,8 @@ export const render3DApis: Render3DApis = {
   precheckMaster: (imageUrl, canvas) => createRender3DApis().precheckMaster(imageUrl, canvas),
   getOutfitAsset: (characterId, outfitId) =>
     createRender3DApis().getOutfitAsset(characterId, outfitId),
-  buildOutfitAsset: (characterId, outfitId) =>
-    createRender3DApis().buildOutfitAsset(characterId, outfitId),
+  buildOutfitAsset: (characterId, outfitId, stance) =>
+    createRender3DApis().buildOutfitAsset(characterId, outfitId, stance),
   approveOutfitAsset: (characterId, outfitId) =>
     createRender3DApis().approveOutfitAsset(characterId, outfitId),
   discardOutfitAsset: (characterId, outfitId) =>

--- a/frontend/src/entities/render3d/bake-api.test.ts
+++ b/frontend/src/entities/render3d/bake-api.test.ts
@@ -106,3 +106,25 @@ describe('出帧任务的网络边界', () => {
     expect(calls[0].json).toEqual({ reason: 'WebGL 起不来' })
   })
 })
+
+describe('建 3D 资产的体型入参', () => {
+  it('把 stance 放进请求体 —— 后端必填，前端不能省', async () => {
+    const { api, calls } = client(() => ({
+      state: 'building',
+      model_3d_url: null,
+      review_model_url: null,
+      error: null,
+      cost: {
+        model3d_credits: 20,
+        autorig_credits: 10,
+        total_credits: 30,
+        billing: 'postpaid',
+        scope: 'per_outfit_once',
+      },
+    }))
+    await createRender3DApis(api).buildOutfitAsset('7', 'outfit-default', 'quadruped')
+    expect(calls[0].path).toBe('/render3d/characters/7/outfits/outfit-default/build')
+    expect(calls[0].method).toBe('POST')
+    expect(calls[0].json).toEqual({ stance: 'quadruped' })
+  })
+})

--- a/frontend/src/entities/render3d/index.ts
+++ b/frontend/src/entities/render3d/index.ts
@@ -109,6 +109,9 @@ export interface BakeCompletion {
   sampleTimes: number[]
 }
 
+/** 角色体型。决定这条路线能不能给它绑骨；与后端 `CharacterStance` 同一取值域。 */
+export type CharacterStance = 'biped' | 'quadruped' | 'serpentine'
+
 export interface Render3DApis {
   /** 零成本母版预检。**不触发任何按次计费调用**,确认闸上可以随便调。 */
   precheckMaster(
@@ -116,8 +119,17 @@ export interface Render3DApis {
     canvas?: { width: number; height: number },
   ): Promise<MasterPrecheckReport>
   getOutfitAsset(characterId: string, outfitId: string): Promise<Render3DAsset>
-  /** 触发图生 3D。**按次计费**,只能由用户的显式操作调用。 */
-  buildOutfitAsset(characterId: string, outfitId: string): Promise<Render3DAsset>
+  /**
+   * 触发图生 3D。**按次计费**,只能由用户的显式操作调用。
+   *
+   * ``stance`` 必填、无默认:自动绑骨只支持双足,而四足/无肢从模型几何判不出来
+   * (实测归档模型的包围盒比例完全重叠)。给默认值等于把"没声明"当成"双足"。
+   */
+  buildOutfitAsset(
+    characterId: string,
+    outfitId: string,
+    stance: CharacterStance,
+  ): Promise<Render3DAsset>
   /** 人看过模型点头 → 继续绑骨。 */
   approveOutfitAsset(characterId: string, outfitId: string): Promise<Render3DAsset>
   /** 模型不合格 → 丢弃重来。 */

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -93,7 +93,7 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe('WorkflowEditorPage real runtime boundary', () => {
-  it('身份母版只展示现有操作，并让加号菜单专注于生成动作', async () => {
+  it('身份母版展示导出、调整与 3D 资产入口，加号菜单专注于生成动作', async () => {
     const character = characterFixture()
     character.outfits[0] = {
       ...character.outfits[0]!,
@@ -112,7 +112,9 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     })
     expect(within(secondaryActions).getByRole('button', { name: '重新生成角色母版' })).toBeTruthy()
     expect(within(secondaryActions).getByRole('button', { name: '微调角色母版' })).toBeTruthy()
-    expect(screen.queryByText(/3D 资产/)).toBeNull()
+    // #486 当时把 3D 入口撤了，理由是 worker 镜像缺 node/playwright、点进去必然抛错；
+    // 依赖在 #517 补齐、出帧又在 #717 改到浏览器之后，那条理由不成立了（#518）。
+    expect(await within(primaryActions).findByRole('group', { name: '3D 资产' })).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: '添加动作分支' }))
     const actionMenu = screen.getByRole('menu', { name: '新增节点' })

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -40,6 +40,7 @@ import {
   type ExportPackageModel,
 } from '@/features/export-package'
 import { FrameAnimationPlayer, GenerationPreviewCard, GenerationProgressCopy } from '@/shared/ui'
+import { Render3DAssetPanel } from './render3d-panel'
 import { loadDefaultActionPresets, type WorkflowEditorSession } from './runtime'
 import { useWorkflowEditorSession } from './use-workflow-editor-session'
 import { WorkflowEditorView, type WorkflowCardNode } from './workflow-editor-view'
@@ -837,6 +838,14 @@ function CharacterTemplateContent({
         <span className="text-center text-[11px] text-[var(--color-app-muted)]">身份已锁定</span>
         <div className="grid gap-2" role="group" aria-label="角色母版操作">
           {outfit ? <NodeExportButton model={input.exportModels.get(outfit.id)} /> : null}
+          {outfit ? (
+            <Render3DAssetPanelHost
+              input={input}
+              outfitId={outfit.id}
+              masterUrl={node.selectedImageUrl}
+              disabled={branchBusy}
+            />
+          ) : null}
           <div className="grid grid-cols-2 gap-2" role="group" aria-label="调整角色母版">
             <button
               type="button"
@@ -1044,6 +1053,32 @@ function useMasterPrecheck(input: ProjectionInput, imageUrl: string): MasterPrec
   }, [height, imageUrl, render3d, width])
 
   return state
+}
+
+/** 把母版预检接到面板上。面板只吃结果，不知道预检怎么来的。 */
+function Render3DAssetPanelHost({
+  input,
+  outfitId,
+  masterUrl,
+  disabled,
+}: {
+  input: ProjectionInput
+  outfitId: string
+  masterUrl: string
+  disabled: boolean
+}) {
+  const precheck = useMasterPrecheck(input, masterUrl)
+  const characterId = input.character?.id
+  if (!characterId) return null
+  return (
+    <Render3DAssetPanel
+      render3d={input.render3d}
+      characterId={characterId}
+      outfitId={outfitId}
+      precheck={precheck.status === 'done' ? precheck.report : null}
+      disabled={disabled}
+    />
+  )
 }
 
 const WARNING_TITLE: Record<MasterWarning['code'], string> = {

--- a/frontend/src/pages/workflow-editor/render3d-panel.test.tsx
+++ b/frontend/src/pages/workflow-editor/render3d-panel.test.tsx
@@ -1,0 +1,127 @@
+/** @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { MasterPrecheckReport, Render3DApis, Render3DAsset } from '@/entities'
+import { Render3DAssetPanel } from './render3d-panel'
+
+const COST: Render3DAsset['cost'] = {
+  model3dCredits: 20,
+  autorigCredits: 10,
+  totalCredits: 30,
+  billing: 'postpaid',
+  scope: 'per_outfit_once',
+}
+
+function asset(overrides: Partial<Render3DAsset> = {}): Render3DAsset {
+  return {
+    state: 'absent',
+    model3dUrl: null,
+    reviewModelUrl: null,
+    error: null,
+    cost: COST,
+    ...overrides,
+  }
+}
+
+function apis(current: Render3DAsset, overrides: Partial<Render3DApis> = {}): Render3DApis {
+  return {
+    precheckMaster: async () => ({}) as MasterPrecheckReport,
+    getOutfitAsset: async () => current,
+    buildOutfitAsset: async () => current,
+    approveOutfitAsset: async () => current,
+    discardOutfitAsset: async () => current,
+    getBakeJob: async () => null,
+    putBakeFrame: async () => 1,
+    completeBake: async () => undefined,
+    failBake: async () => undefined,
+    ...overrides,
+  }
+}
+
+function mount(current: Render3DAsset, extra: Partial<Render3DApis> = {}, precheck = null) {
+  return render(
+    <Render3DAssetPanel
+      render3d={apis(current, extra)}
+      characterId="7"
+      outfitId="outfit-default"
+      precheck={precheck}
+      disabled={false}
+    />,
+  )
+}
+
+// 这个套件里多条用例渲同一个组件，不清干净会出现「找到多个同名元素」。
+afterEach(cleanup)
+
+describe('3D 资产面板', () => {
+  it('金额与「只收一次」都从后端 cost 读，前端不硬编码', async () => {
+    mount(asset())
+    const build = await screen.findByRole('button', { name: '建 3D 资产' })
+    expect(build.textContent).toContain('30 积分')
+    fireEvent.click(build)
+    const confirm = await screen.findByRole('group', { name: '确认建 3D 资产' })
+    expect(confirm.textContent).toContain('图生 3D 20')
+    expect(confirm.textContent).toContain('绑骨 10')
+    expect(confirm.textContent).toContain('同一造型只收一次')
+    expect(confirm.textContent).toContain('最多同时持有 2 个')
+  })
+
+  it('非双足不给点确认，并说明改法', async () => {
+    const build = vi.fn(async () => asset())
+    mount(asset(), { buildOutfitAsset: build })
+    fireEvent.click(await screen.findByRole('button', { name: '建 3D 资产' }))
+    fireEvent.click(await screen.findByDisplayValue('quadruped'))
+    const confirm = screen.getByRole('button', { name: '确认扣费并建 3D 资产' })
+    expect(confirm.hasAttribute('disabled')).toBe(true)
+    expect(screen.getByText(/无法绑定骨骼/)).toBeTruthy()
+    expect(build).not.toHaveBeenCalled()
+  })
+
+  it('双足才把 stance 发出去', async () => {
+    const build = vi.fn(async () => asset({ state: 'building' }))
+    mount(asset(), { buildOutfitAsset: build })
+    fireEvent.click(await screen.findByRole('button', { name: '建 3D 资产' }))
+    fireEvent.click(screen.getByRole('button', { name: '确认扣费并建 3D 资产' }))
+    await waitFor(() => expect(build).toHaveBeenCalledWith('7', 'outfit-default', 'biped'))
+  })
+
+  it('预检不过就不给建，并展示后端给的原因', async () => {
+    const report: MasterPrecheckReport = {
+      accepted: false,
+      rejectCode: 'subject_too_small',
+      detail: '主体只占画幅 3.1%，换一张再试。',
+      facts: null,
+      warnings: [],
+    }
+    render(
+      <Render3DAssetPanel
+        render3d={apis(asset())}
+        characterId="7"
+        outfitId="outfit-default"
+        precheck={report}
+        disabled={false}
+      />,
+    )
+    const build = await screen.findByRole('button', { name: '建 3D 资产' })
+    expect(build.hasAttribute('disabled')).toBe(true)
+    expect(screen.getByText(/主体只占画幅 3.1%/)).toBeTruthy()
+  })
+
+  it('awaiting_review 是人工闸：只有放行与弃掉，没有自动路径', async () => {
+    const approve = vi.fn(async () => asset({ state: 'rigging' }))
+    mount(asset({ state: 'awaiting_review', reviewModelUrl: 'https://cdn.test/x.glb' }), {
+      approveOutfitAsset: approve,
+    })
+    expect(await screen.findByRole('button', { name: '放行并开始绑骨' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: '弃掉待审模型' })).toBeTruthy()
+    expect(approve).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: '放行并开始绑骨' }))
+    await waitFor(() => expect(approve).toHaveBeenCalledWith('7', 'outfit-default'))
+  })
+
+  it('失败时展示后端文案，不在前端重拼', async () => {
+    mount(asset({ state: 'failed', error: '模型含武器配件，绑骨会把剑一起绑上权重。' }))
+    expect(await screen.findByText(/模型含武器配件/)).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/workflow-editor/render3d-panel.tsx
+++ b/frontend/src/pages/workflow-editor/render3d-panel.tsx
@@ -1,0 +1,288 @@
+/**
+ * 造型级 3D 资产的建 / 审 / 弃（Refs #518）。
+ *
+ * 三条约束：金额只从后端 `cost` 读（档位会变，前端抄一份就会分叉）；`awaiting_review`
+ * 是人工闸，不提供任何自动放行路径；`error` 直接展示后端文案，不在前端重拼。
+ */
+import { useEffect, useState } from 'react'
+
+import type { CharacterStance, MasterPrecheckReport, Render3DApis, Render3DAsset } from '@/entities'
+import { KineticCopyCycle } from '@/shared/ui'
+
+const PANEL_BUTTON =
+  'inline-flex w-full items-center justify-center rounded-lg border border-transparent bg-app-accent px-3 py-2 text-[11px] font-medium text-app-on-accent transition-colors hover:bg-app-accent-strong disabled:cursor-not-allowed disabled:opacity-50'
+const PANEL_BUTTON_SECONDARY =
+  'inline-flex w-full items-center justify-center rounded-lg border border-[var(--color-app-line)] bg-app-surface-raised px-3 py-2 text-[11px] font-medium text-[var(--color-app-ink)] transition-colors hover:border-app-accent disabled:cursor-not-allowed disabled:opacity-50'
+const PANEL_SUMMARY = 'm-0 text-[11px] font-medium leading-[1.6] text-[var(--color-app-ink)]'
+const PANEL_TEXT = 'm-0 text-[11px] leading-[1.6] text-[var(--color-app-muted)]'
+
+/** 只有这两个状态在动，需要轮询；其余是稳态，停下来别空转。 */
+const IN_FLIGHT = new Set<Render3DAsset['state']>(['building', 'rigging'])
+const POLL_MS = 4000
+
+/**
+ * 建模 40~60 秒、绑骨再一段，中间后端只给状态不给百分比。
+ * 一句不动的「正在绑骨…」在这个时长上读起来像卡死了，所以复用产品里已有的轮播文案
+ * 表示它还活着。**这不是进度条** —— 没有真实百分比就不假装有。
+ */
+const BUILDING_COPY = [
+  { lines: ['正在把母版立成 3D'] },
+  { lines: ['估算体积与朝向'] },
+  { lines: ['生成网格与贴图'] },
+] as const
+
+const RIGGING_COPY = [
+  { lines: ['正在给模型绑骨'] },
+  { lines: ['识别四肢与躯干'] },
+  { lines: ['蒙皮权重收敛中'] },
+] as const
+
+const STATE_TEXT: Record<Render3DAsset['state'], string> = {
+  absent: '尚未建 3D 资产',
+  building: '正在生成 3D 模型…',
+  awaiting_review: '模型已出，等你确认',
+  rigging: '正在绑骨…',
+  ready: '3D 资产已就绪',
+  failed: '建 3D 资产失败',
+}
+
+/** 让用户声明体型。三个取值与后端 ``CharacterStance`` 一一对应。 */
+const STANCE_CHOICES: ReadonlyArray<{ value: CharacterStance; label: string; hint?: string }> = [
+  { value: 'biped', label: '双足人形', hint: '两条腿站立、一对上肢' },
+  { value: 'quadruped', label: '四足', hint: '暂不支持绑骨' },
+  { value: 'serpentine', label: '无肢 / 蛇形', hint: '暂不支持绑骨' },
+]
+
+type AssetState =
+  | { status: 'loading' }
+  | { status: 'done'; asset: Render3DAsset }
+  | { status: 'error'; message: string }
+
+function message(cause: unknown, fallback: string): string {
+  return cause instanceof Error && cause.message ? cause.message : fallback
+}
+
+function useRender3DAsset(
+  render3d: Render3DApis,
+  characterId: string,
+  outfitId: string,
+  refreshKey: number,
+): AssetState {
+  const [state, setState] = useState<AssetState>({ status: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const tick = () => {
+      void render3d
+        .getOutfitAsset(characterId, outfitId)
+        .then((asset) => {
+          if (cancelled) return
+          setState({ status: 'done', asset })
+          if (IN_FLIGHT.has(asset.state)) timer = setTimeout(tick, POLL_MS)
+        })
+        .catch((cause: unknown) => {
+          if (!cancelled)
+            setState({ status: 'error', message: message(cause, '读取 3D 资产状态失败') })
+        })
+    }
+    tick()
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [characterId, outfitId, refreshKey, render3d])
+
+  return state
+}
+
+export interface Render3DAssetPanelProps {
+  render3d: Render3DApis
+  characterId: string
+  outfitId: string
+  /** 母版预检结果。不过检就不给建 —— 重出母版比重建模型便宜一个量级。 */
+  precheck: MasterPrecheckReport | null
+  disabled: boolean
+}
+
+export function Render3DAssetPanel({
+  render3d,
+  characterId,
+  outfitId,
+  precheck,
+  disabled,
+}: Render3DAssetPanelProps) {
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [confirming, setConfirming] = useState(false)
+  const [stance, setStance] = useState<CharacterStance>('biped')
+  const state = useRender3DAsset(render3d, characterId, outfitId, refreshKey)
+
+  if (state.status === 'loading') {
+    return (
+      <p className={PANEL_SUMMARY} role="status">
+        正在读取 3D 资产状态…
+      </p>
+    )
+  }
+  if (state.status === 'error') return <p className={PANEL_TEXT}>{state.message}</p>
+
+  const { asset } = state
+  const run = (work: () => Promise<Render3DAsset>) => {
+    setBusy(true)
+    setActionError(null)
+    void work()
+      .then(() => {
+        setConfirming(false)
+        setRefreshKey((key) => key + 1)
+      })
+      .catch((cause: unknown) => setActionError(message(cause, '操作失败')))
+      .finally(() => setBusy(false))
+  }
+
+  const blocked = precheck !== null && !precheck.accepted
+  const locked = disabled || busy
+  const cost = asset.cost
+
+  return (
+    <div className="grid gap-2" role="group" aria-label="3D 资产">
+      {asset.state === 'building' || asset.state === 'rigging' ? (
+        <KineticCopyCycle
+          messages={asset.state === 'building' ? BUILDING_COPY : RIGGING_COPY}
+          ariaLabel={STATE_TEXT[asset.state]}
+          className={PANEL_SUMMARY}
+        />
+      ) : (
+        <p className={PANEL_SUMMARY} role="status">
+          {STATE_TEXT[asset.state]}
+        </p>
+      )}
+      {asset.error ? <p className={PANEL_TEXT}>{asset.error}</p> : null}
+      {actionError ? <p className={PANEL_TEXT}>{actionError}</p> : null}
+
+      {asset.state === 'absent' && !confirming ? (
+        <>
+          <button
+            type="button"
+            className={PANEL_BUTTON}
+            aria-label="建 3D 资产"
+            disabled={locked || blocked}
+            onClick={() => setConfirming(true)}
+          >
+            建 3D 资产 · {cost.totalCredits} 积分
+          </button>
+          {blocked && precheck ? <p className={PANEL_TEXT}>{precheck.detail}</p> : null}
+        </>
+      ) : null}
+
+      {asset.state === 'absent' && confirming ? (
+        <div className="grid gap-2" role="group" aria-label="确认建 3D 资产">
+          <p className={PANEL_TEXT}>
+            将扣 {cost.totalCredits} 积分（图生 3D {cost.model3dCredits} + 绑骨{' '}
+            {cost.autorigCredits}）。
+            {cost.scope === 'per_outfit_once' ? '同一造型只收一次，后续动作不再计费。' : null}
+            每个账号最多同时持有 2 个 3D 角色，弃掉一个就能再建。
+          </p>
+          <fieldset className="grid gap-1.5 border-0 p-0">
+            {/* 体型必须由用户声明：四足与人形的包围盒比例完全重叠，几何上判不出来，
+                而自动绑骨对非双足不报错，只会漏认被遮挡的肢体。 */}
+            <legend className={PANEL_TEXT}>这个角色是——</legend>
+            {STANCE_CHOICES.map(({ value, label, hint }) => (
+              <label key={value} className="flex items-start gap-2 text-[11px] leading-[1.5]">
+                <input
+                  type="radio"
+                  name={`stance-${outfitId}`}
+                  value={value}
+                  checked={stance === value}
+                  disabled={busy}
+                  onChange={() => setStance(value)}
+                  className="mt-0.5"
+                />
+                <span>
+                  <span className="text-[var(--color-app-ink)]">{label}</span>
+                  {hint ? <span className="text-[var(--color-app-muted)]">　{hint}</span> : null}
+                </span>
+              </label>
+            ))}
+          </fieldset>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              className={PANEL_BUTTON_SECONDARY}
+              disabled={busy}
+              onClick={() => setConfirming(false)}
+            >
+              取消
+            </button>
+            <button
+              type="button"
+              className={PANEL_BUTTON}
+              aria-label="确认扣费并建 3D 资产"
+              disabled={busy || stance !== 'biped'}
+              onClick={() => run(() => render3d.buildOutfitAsset(characterId, outfitId, stance))}
+            >
+              确认扣费
+            </button>
+          </div>
+          {stance !== 'biped' ? (
+            <p className={PANEL_TEXT}>
+              {STANCE_CHOICES.find((choice) => choice.value === stance)?.label}
+              角色目前无法绑定骨骼，三渲二只支持双足人形。这一步没有扣费，可以改走视频路线。
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {asset.state === 'awaiting_review' ? (
+        <div className="grid gap-2" role="group" aria-label="确认 3D 模型">
+          {asset.reviewModelUrl ? (
+            <a
+              className={PANEL_BUTTON_SECONDARY}
+              href={asset.reviewModelUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              下载模型看一眼
+            </a>
+          ) : null}
+          <p className={PANEL_TEXT}>
+            模型生成即最终、改不动；不合格只能弃掉重建。放行会再扣 {cost.autorigCredits} 积分绑骨。
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              className={PANEL_BUTTON_SECONDARY}
+              aria-label="弃掉待审模型"
+              disabled={locked}
+              onClick={() => run(() => render3d.discardOutfitAsset(characterId, outfitId))}
+            >
+              弃掉重建
+            </button>
+            <button
+              type="button"
+              className={PANEL_BUTTON}
+              aria-label="放行并开始绑骨"
+              disabled={locked}
+              onClick={() => run(() => render3d.approveOutfitAsset(characterId, outfitId))}
+            >
+              放行绑骨
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {asset.state === 'failed' ? (
+        <button
+          type="button"
+          className={PANEL_BUTTON_SECONDARY}
+          aria-label="清掉重来"
+          disabled={locked}
+          onClick={() => run(() => render3d.discardOutfitAsset(characterId, outfitId))}
+        >
+          清掉重来
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/openapi.json
+++ b/openapi.json
@@ -200,6 +200,19 @@
         "title": "Body_upload_media_media_upload_post",
         "type": "object"
       },
+      "BuildAssetRequest": {
+        "description": "建 3D 资产的入参。\n\n``stance`` 必填、无默认:自动绑骨只支持双足,而四足/无肢从模型几何判不出来\n(实测归档模型的包围盒比例完全重叠)。给默认值等于把「没声明」当成「双足」放行。",
+        "properties": {
+          "stance": {
+            "$ref": "#/components/schemas/CharacterStance"
+          }
+        },
+        "required": [
+          "stance"
+        ],
+        "title": "BuildAssetRequest",
+        "type": "object"
+      },
       "ChangePasswordRequest": {
         "description": "修改密码请求。",
         "properties": {
@@ -5633,6 +5646,16 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BuildAssetRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {


### PR DESCRIPTION
## Summary

母版卡片上接回 3D 资产入口：`absent` 给建、`awaiting_review` 给放行/弃掉、`building`/`rigging` 给在跑的反馈、`failed` 展示后端文案。面板抽成 `render3d-panel.tsx`（`index.tsx` 已经 1900 行，且抽出来才能单独挂起来看渲染结果）。

后端加两道闸，都在**花钱之前**：体型不可绑骨、每账号资产数上限。

## 三条约束的落法

**金额只从后端 `cost` 读。** 建按钮上的 30 积分、确认里的 20+10 拆分、`per_outfit_once` 的说明，全部来自 `GET` 的返回。前端 grep 不到硬编码的积分数——档位会变，抄一份就会分叉。

**`awaiting_review` 是人工闸。** 只有「放行绑骨」和「弃掉重建」两个动作，没有任何自动放行路径。文案写明模型生成即最终、改不动，以及放行会再扣绑骨那 10 积分。

**`error` 原样展示。** 不在前端重拼文案。

## 体型闸：为什么是声明而不是检测

自动绑骨对非双足**不报错**——它漏认被遮挡的肢体，那条肢体每帧同姿势，而 `motion_scale`、死帧数、`loop_seam`、帧数时长成色全部正常，一道闸都不会红。用户拿到「有条腿是柱子」的动画且不知情。

原本想从包围盒判。量了全部 25 份归档 GLB：

| | X/Y 臂展 | Z/Y 体长 |
|---|---|---|
| 狼（四足） | 0.72 | 1.47 |
| 混元人形原始产物 | 2.11 ~ 2.62 | 3.19 ~ 4.47 |
| 减面后的人形 | 0.72 | 0.28 |

四足与人形完全重叠，且人形原始产物比狼更「长」——管线不同阶段的模型量纲不一样，几何上判不出来。所以 `stance` 由调用方声明，且**必填无默认**：给默认值等于把「没声明」当成「双足」放行，而「没声明」最可能出现在非双足角色上。

`user_message()` 原本把这条脱敏成通用的「生成没能完成，请稍后重试」。这条不能抹——重试一万次也不会变，四足永远绑不了；原文里只有体型与路线名，无内部信息，已加进白名单原样透出。

## 每账号上限

`MAX_ASSETS_PER_USER = 2`。数的是**当前持有**而不是历史建过多少次，弃掉一个释放一个名额：混元的模型生成即最终、不合格只能弃掉重建，名额若不释放，两个坏模型会把用户永久卡死在这条路线外面。

建造中的不计入。那需要逐造型去问资产存储，而并发建多个的代价本来就由积分挡着。

## 顺带修的一处

`not_a_pose` 超上限时的文案原本写「多半是模型躺着或轴向约定不对」。实测拦下带武器模型的正是这条闸（臂展/身高 4.10），而 `has_accessory` 一次都没触发——它靠 node/mesh 名里的武器词，真实产物的部件名是 `node_0` / `Material.001`。原文案把用户往轴向上引，改成把手持物列在首位。

## 一处既有测试的断言方向被改了

`身份母版只展示现有操作` 里有 `expect(screen.queryByText(/3D 资产/)).toBeNull()`，是 #486 撤掉入口时锁进去的。#486 的理由是 worker 镜像缺 node/playwright、点进去必然抛错；依赖在 #517 补齐、出帧又在 #717 改到浏览器之后，那条理由不成立。断言改成要求该分组存在，并在代码里注明了原委。

## 不包含

- Quick Start 里的入口。那块 huyanxius 正在高频改动（#763 开着），另开 issue 对齐后再动。
- 骨架规范与挂点的落点（#761 第二条）。
- 多朝向出参的 UI。

## Test plan

- [x] 后端 `uv run ruff check .` / `export_openapi` 无漂移 / `uv run lint-imports` / `uv run pytest -q`：**1773 passed, 14 skipped**
- [x] 前端 `format:check` / `lint` / `typecheck` / `test:coverage` / `build`：**1213 passed, 81 files**
- [x] 新增用例：后端 7 条（体型闸 4 条含双足控制样本、账号上限 3 条含「已有 1 个仍可建」与「弃掉释放名额」），前端 6 条面板 + 1 条 stance 传输
- [x] 六个状态在真浏览器里逐个渲过并看图确认（含扣费确认与选中四足后的拒绝态）

两侧命令都跑在最后一次编辑之后。

Closes #518
