### PR TITLE
feat(quick-start): search and scroll selector lists

### DIFF
--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1078,7 +1078,7 @@ describe('QuickStartPage', () => {
     const projects = projectReader()
     renderAt('/quick-start', serviceFor(null), { planner, startCharacterGeneration }, projects)
 
-    await waitFor(() => expect(projects.list).toHaveBeenCalledWith({ page: 1, pageSize: 3 }))
+    await waitFor(() => expect(projects.list).toHaveBeenCalledWith({ page: 1, pageSize: 100 }))
 
     const project = screen.getByRole('button', { name: '选择项目，当前自动创建' })
     fireEvent.click(project)
@@ -1136,24 +1136,74 @@ describe('QuickStartPage', () => {
     expect(screen.getByRole('menu', { name: '选择项目' })).toBeTruthy()
   })
 
-  it('tells the user when a project has more characters than one page', async () => {
+  it('loads every project page and filters the visible project list', async () => {
+    const secondProject: Project = {
+      ...existingProject,
+      id: '43',
+      name: '测试项目',
+    }
+    const projects = projectReader()
+    projects.list = vi.fn(async ({ page = 1 }) =>
+      page === 1
+        ? {
+            items: Array.from({ length: 100 }, (_, index) => ({
+              ...existingProject,
+              id: String(index + 1),
+              name: index === 0 ? existingProject.name : `项目 ${index + 1}`,
+            })),
+            total: 101,
+            page: 1,
+            pageSize: 100,
+          }
+        : { items: [secondProject], total: 101, page: 2, pageSize: 100 },
+    )
+    renderAt('/quick-start', serviceFor(null), agentFor(), projects)
+
+    fireEvent.click(screen.getByRole('button', { name: '选择项目，当前自动创建' }))
+
+    expect(await screen.findByRole('menuitem', { name: '测试项目' })).toBeTruthy()
+    expect(projects.list).toHaveBeenNthCalledWith(2, { page: 2, pageSize: 100 })
+
+    fireEvent.change(screen.getByRole('searchbox', { name: '搜索项目' }), {
+      target: { value: '测试' },
+    })
+
+    expect(screen.getByRole('menuitem', { name: '测试项目' })).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: '星海计划' })).toBeNull()
+    expect(screen.getByRole('menuitem', { name: '新建项目' })).toBeTruthy()
+  })
+
+  it('loads every character page into the scrollable character list', async () => {
     const characters = characterReader()
-    characters.listSummariesByProject = vi.fn(async () => ({
-      items: [
-        {
-          id: '77',
-          projectId: '42',
-          name: '星光法师',
-          status: CHARACTER_STATUS.PUBLISHED,
-          previewUrl: null,
-          outfitName: '默认造型',
-          outfitCount: 1,
-          actionCount: 3,
-          updatedAt: '2026-08-26T00:00:00Z',
-        },
-      ],
-      total: 137,
-      page: 1,
+    characters.listSummariesByProject = vi.fn(async (_projectId, { page = 1 }) => ({
+      items:
+        page === 1
+          ? Array.from({ length: 100 }, (_, index) => ({
+              id: String(index + 1),
+              projectId: '42',
+              name: index === 0 ? '星光法师' : `角色 ${index + 1}`,
+              status: CHARACTER_STATUS.PUBLISHED,
+              previewUrl: null,
+              outfitName: '默认造型',
+              outfitCount: 1,
+              actionCount: 3,
+              updatedAt: '2026-08-26T00:00:00Z',
+            }))
+          : [
+              {
+                id: '101',
+                projectId: '42',
+                name: '森林邮差',
+                status: CHARACTER_STATUS.PUBLISHED,
+                previewUrl: null,
+                outfitName: '默认造型',
+                outfitCount: 1,
+                actionCount: 3,
+                updatedAt: '2026-08-26T00:00:00Z',
+              },
+            ],
+      total: 101,
+      page,
       pageSize: 100,
     }))
     renderAt('/quick-start', serviceFor(null), agentFor(), projectReader(), characters)
@@ -1161,7 +1211,15 @@ describe('QuickStartPage', () => {
     fireEvent.click(screen.getByRole('button', { name: '选择项目，当前自动创建' }))
     fireEvent.click(await screen.findByRole('menuitem', { name: '星海计划' }))
 
-    expect(await screen.findByText('仅显示前 1 个角色，其余请在资产库中打开')).toBeTruthy()
+    expect(
+      await screen.findByRole('menuitem', { name: '为森林邮差新增动作，已有 3 个动作' }),
+    ).toBeTruthy()
+    expect(characters.listSummariesByProject).toHaveBeenNthCalledWith(2, '42', {
+      page: 2,
+      pageSize: 100,
+      status: CHARACTER_STATUS.PUBLISHED,
+    })
+    expect(screen.queryByText(/仅显示前/)).toBeNull()
   })
 
   it('opens the existing character workflow when choosing it for a new action', async () => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -23,6 +23,7 @@ import {
   Check,
   CopySimple,
   FolderOpen,
+  MagnifyingGlass,
   Play,
   Plus,
   PlusCircle,
@@ -171,7 +172,24 @@ const ROLE_DEFAULT_MESSAGE: readonly KineticCopyMessage[] = [
 ]
 
 /** 角色选择菜单一次取满后端允许的最大一页；再多的项目在菜单里给出明确提示而不是静默截断。 */
-const CHARACTER_MENU_PAGE_SIZE = 100
+const SELECTOR_PAGE_SIZE = 100
+
+async function readAllSelectorPages<T>(
+  readPage: (
+    page: number,
+    pageSize: number,
+  ) => Promise<{
+    items: readonly T[]
+    total: number
+  }>,
+): Promise<readonly T[]> {
+  const items: T[] = []
+  for (let page = 1; ; page += 1) {
+    const result = await readPage(page, SELECTOR_PAGE_SIZE)
+    items.push(...result.items)
+    if (items.length >= result.total || result.items.length === 0) return items
+  }
+}
 const ENTRY_HANDOFF_MS = 460
 const PROMPT_REWRITE_MS = 760
 const AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v2'
@@ -783,12 +801,12 @@ function QuickStartInput({
   })
   const [selectedProject, setSelectedProject] = useState<Project | null>(null)
   const [projects, setProjects] = useState<readonly Project[]>([])
+  const [projectSearch, setProjectSearch] = useState('')
   const [projectMenuOpen, setProjectMenuOpen] = useState(false)
   const [projectMenuProject, setProjectMenuProject] = useState<Project | null>(null)
   const [projectCharacters, setProjectCharacters] = useState<readonly CharacterSummary[] | null>(
     null,
   )
-  const [projectCharactersTotal, setProjectCharactersTotal] = useState(0)
   const [projectCharactersError, setProjectCharactersError] = useState<string | null>(null)
   const [openingCharacterId, setOpeningCharacterId] = useState<string | null>(null)
   const projectCharactersRequest = useRef(0)
@@ -844,6 +862,12 @@ function QuickStartInput({
     () => [{ lines: [prompt] }],
     [prompt],
   )
+  const filteredProjects = useMemo(() => {
+    const query = projectSearch.trim().toLocaleLowerCase()
+    return query
+      ? projects.filter((project) => project.name.toLocaleLowerCase().includes(query))
+      : projects
+  }, [projectSearch, projects])
 
   const ensureDraftId = useCallback(() => {
     const current = draftIdRef.current
@@ -876,12 +900,12 @@ function QuickStartInput({
     let cancelled = false
     const restoredId = projectIdRef.current
     void Promise.all([
-      projectApis.list({ page: 1, pageSize: 3 }),
+      readAllSelectorPages((page, pageSize) => projectApis.list({ page, pageSize })),
       restoredId ? projectApis.get(restoredId) : Promise.resolve(null),
     ]).then(
-      ([result, restoredProject]) => {
+      ([loadedProjects, restoredProject]) => {
         if (cancelled) return
-        setProjects(result.items)
+        setProjects(loadedProjects)
         if (restoredId && restoredProject && projectIdRef.current === restoredId) {
           setSelectedProject(restoredProject)
           setDirectionalMovement(restoredProject.directionalMovement)
@@ -927,19 +951,19 @@ function QuickStartInput({
     setProjectCharacters(null)
     setProjectCharactersError(null)
     try {
-      const result = await characterApis.listSummariesByProject(project.id, {
-        page: 1,
-        pageSize: CHARACTER_MENU_PAGE_SIZE,
-        status: CHARACTER_STATUS.PUBLISHED,
-      })
+      const characters = await readAllSelectorPages((page, pageSize) =>
+        characterApis.listSummariesByProject(project.id, {
+          page,
+          pageSize,
+          status: CHARACTER_STATUS.PUBLISHED,
+        }),
+      )
       if (projectCharactersRequest.current === request) {
-        setProjectCharacters(result.items)
-        setProjectCharactersTotal(result.total)
+        setProjectCharacters(characters)
       }
     } catch {
       if (projectCharactersRequest.current === request) {
         setProjectCharacters([])
-        setProjectCharactersTotal(0)
         setProjectCharactersError('角色列表暂时无法读取')
       }
     }
@@ -949,7 +973,6 @@ function QuickStartInput({
     projectCharactersRequest.current += 1
     setProjectMenuProject(null)
     setProjectCharacters(null)
-    setProjectCharactersTotal(0)
     setProjectCharactersError(null)
   }
 
@@ -1592,6 +1615,7 @@ function QuickStartInput({
                         setProjectMenuOpen(false)
                       } else {
                         returnToProjects()
+                        setProjectSearch('')
                         setProjectMenuOpen(true)
                       }
                     }}
@@ -1613,7 +1637,7 @@ function QuickStartInput({
                       aria-label={
                         projectMenuProject ? `选择${projectMenuProject.name}中的角色` : '选择项目'
                       }
-                      className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-3 grid w-[19rem] max-w-[calc(100vw-2rem)] gap-1 p-1.5 opacity-100`}
+                      className={`${productPopoverClass} quick-start-control-popover absolute bottom-full left-0 z-30 mb-5 grid w-[19rem] max-w-[calc(100vw-2rem)] gap-1 p-1.5 opacity-100`}
                     >
                       {projectMenuProject ? (
                         <>
@@ -1651,7 +1675,7 @@ function QuickStartInput({
                           ) : projectCharacters.length === 0 && !projectCharactersError ? (
                             <p className="px-3 py-3 text-xs text-app-muted">此项目还没有角色</p>
                           ) : (
-                            <div className="grid max-h-56 gap-1 overflow-y-auto">
+                            <div className="grid max-h-[7.75rem] gap-1 overflow-y-auto">
                               {projectCharacters.map((character) => {
                                 const name = character.name ?? '未命名角色'
                                 return (
@@ -1671,12 +1695,6 @@ function QuickStartInput({
                               })}
                             </div>
                           )}
-                          {projectCharacters !== null &&
-                          projectCharactersTotal > projectCharacters.length ? (
-                            <p className="px-3 pb-2 text-[0.68rem] text-app-faint">
-                              仅显示前 {projectCharacters.length} 个角色，其余请在资产库中打开
-                            </p>
-                          ) : null}
                           {projectCharactersError ? (
                             <p role="alert" className="px-3 py-2 text-xs text-app-danger">
                               {projectCharactersError}
@@ -1685,20 +1703,37 @@ function QuickStartInput({
                         </>
                       ) : (
                         <>
-                          {projects.map((project) => (
-                            <button
-                              key={project.id}
-                              type="button"
-                              role="menuitem"
-                              onClick={() => void openProjectCharacters(project)}
-                              className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs text-app-ink-soft transition hover:bg-app-surface-muted"
-                            >
-                              <FolderOpen aria-hidden="true" size={15} weight="regular" />
-                              <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                              <CaretRight aria-hidden="true" size={14} weight="bold" />
-                            </button>
-                          ))}
-                          <div className="my-1 border-t border-app-line" />
+                          <label className="flex items-center gap-2 px-3 py-2 text-app-muted">
+                            <MagnifyingGlass aria-hidden="true" size={14} weight="regular" />
+                            <input
+                              type="search"
+                              aria-label="搜索项目"
+                              value={projectSearch}
+                              onChange={(event) => setProjectSearch(event.target.value)}
+                              placeholder="搜索项目"
+                              className="min-w-0 flex-1 bg-transparent text-xs text-app-ink outline-none placeholder:text-app-faint"
+                            />
+                          </label>
+                          <div className="grid max-h-[7.75rem] gap-1 overflow-y-auto">
+                            {filteredProjects.length === 0 ? (
+                              <p className="px-3 py-3 text-xs text-app-muted">未找到项目</p>
+                            ) : (
+                              filteredProjects.map((project) => (
+                                <button
+                                  key={project.id}
+                                  type="button"
+                                  role="menuitem"
+                                  onClick={() => void openProjectCharacters(project)}
+                                  className="flex items-center gap-2 rounded-app-compact px-3 py-2 text-left text-xs text-app-ink-soft transition hover:bg-app-surface-muted"
+                                >
+                                  <FolderOpen aria-hidden="true" size={15} weight="regular" />
+                                  <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                                  <CaretRight aria-hidden="true" size={14} weight="bold" />
+                                </button>
+                              ))
+                            )}
+                          </div>
+                          <div className="-mt-1 border-t border-app-line" />
                           <Link
                             to="/projects/new?entry=quick-start"
                             role="menuitem"


### PR DESCRIPTION
Quick Start 的项目选择弹层新增项目搜索，并完整加载可滚动的项目与角色列表，同时保持固定操作入口始终可见。

## Why

原弹层只加载 3 个项目，角色也受单页上限约束，项目较多时无法在 Quick Start 内找到目标对象。

## Changes

- 在项目列表顶部增加名称搜索。
- 项目与角色按 100 条一页持续读取到完整 `total`。
- 列表限制为约 3.5 行高度并支持滚动，下一行部分露出提示仍有内容。
- 底部新建项目、自动创建及角色层的新建角色入口不随列表滚动。

## Implementation

- 使用同一分页读取函数组合既有 Project 与 Character 列表接口。
- 搜索仅过滤已完整加载的项目数据，不增加后端查询参数。
- 不修改 Agent Tool、后端接口或数据模型。

## Verification

- [x] `npm test -- --run src/pages/quick-start/index.test.tsx`：124/124 通过。
- [x] `npx oxlint src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxfmt --check src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run typecheck`：通过。

## Scope

- 本 PR 不包含：后端搜索、Agent Tool、数据模型或其他页面改动。
- 临时预览文件与 mock 数据未进入提交。

## Related Issues

Closes #775
