### PR TITLE
refactor(guide): present the manual as an article

### DIFF
--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -72,6 +72,12 @@ describe('AppRoutes authentication boundary', () => {
     expect(await screen.findByRole('heading', { name: 'Windup 使用指南', level: 1 })).toBeTruthy()
     expect(screen.getByRole('article', { name: 'Windup 使用指南' })).toBeTruthy()
     expect(screen.getByRole('navigation', { name: '使用指南章节' })).toBeTruthy()
+    expect(screen.getByRole('article').querySelectorAll('section ul')).toHaveLength(0)
+    expect(screen.getByRole('article').querySelectorAll('section ol')).toHaveLength(0)
+    expect(screen.getByRole('textbox', { name: '创作指令示例' })).toBeTruthy()
+    expect(screen.getByRole('link', { name: '打开 Quick Start' }).getAttribute('href')).toBe(
+      '/quick-start',
+    )
     expect(screen.getByRole('link', { name: 'Quick Start' }).getAttribute('href')).toBe(
       '#quick-start',
     )

--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -69,9 +69,9 @@ describe('AppRoutes authentication boundary', () => {
       </GuestAuthSession>,
     )
 
-    expect(await screen.findByRole('heading', { name: 'Windup 使用手册', level: 1 })).toBeTruthy()
-    expect(screen.getByRole('article', { name: 'Windup 使用手册' })).toBeTruthy()
-    expect(screen.getByRole('navigation', { name: '使用手册目录' })).toBeTruthy()
+    expect(await screen.findByRole('heading', { name: 'Windup 使用指南', level: 1 })).toBeTruthy()
+    expect(screen.getByRole('article', { name: 'Windup 使用指南' })).toBeTruthy()
+    expect(screen.getByRole('navigation', { name: '使用指南章节' })).toBeTruthy()
     expect(screen.getByRole('link', { name: 'Quick Start' }).getAttribute('href')).toBe(
       '#quick-start',
     )

--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -70,6 +70,7 @@ describe('AppRoutes authentication boundary', () => {
     )
 
     expect(await screen.findByRole('heading', { name: 'Windup 使用手册', level: 1 })).toBeTruthy()
+    expect(screen.getByRole('article', { name: 'Windup 使用手册' })).toBeTruthy()
     expect(screen.getByRole('navigation', { name: '使用手册目录' })).toBeTruthy()
     expect(screen.getByRole('link', { name: 'Quick Start' }).getAttribute('href')).toBe(
       '#quick-start',

--- a/frontend/src/pages/guide/index.tsx
+++ b/frontend/src/pages/guide/index.tsx
@@ -18,7 +18,12 @@ interface Journey {
   description: string
   label: string
   to: string
-  icon: ComponentType<{ 'aria-hidden'?: boolean; size?: number; weight?: 'duotone' }>
+  icon: ComponentType<{
+    'aria-hidden'?: boolean
+    className?: string
+    size?: number
+    weight?: 'duotone'
+  }>
 }
 
 const journeys: readonly Journey[] = [
@@ -59,22 +64,28 @@ export function GuidePage() {
     <>
       <MarketingHeader />
       <main className="min-h-[100dvh] bg-app-canvas pb-24 pt-32 text-app-ink sm:pt-36">
-        <div className="mx-auto w-full max-w-[1560px] px-4 sm:px-6 xl:px-8">
-          <section className="border-b border-app-line pb-10 sm:pb-12">
+        <article
+          aria-labelledby="guide-title"
+          className="mx-auto w-full max-w-[82rem] px-5 sm:px-8 lg:px-12"
+        >
+          <header className="border-b border-app-line pb-14 sm:pb-16">
             <p className="font-mono text-[0.68rem] font-semibold tracking-[0.16em] text-app-faint uppercase">
               使用说明
             </p>
-            <div className="mt-4 grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.65fr)] lg:items-end">
+            <div className="mt-5 grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.46fr)] lg:items-end">
               <div>
-                <h1 className="max-w-3xl font-serif text-[clamp(2.5rem,6vw,5rem)] leading-[0.98] font-medium tracking-[-0.055em] text-app-ink">
+                <h1
+                  id="guide-title"
+                  className="max-w-4xl font-serif text-[clamp(3rem,6.4vw,5.25rem)] leading-[1.06] font-semibold tracking-[-0.055em] text-app-ink"
+                >
                   Windup 使用手册
                 </h1>
-                <p className="mt-5 max-w-2xl text-sm leading-7 text-app-muted sm:text-base">
+                <p className="mt-6 max-w-2xl text-base leading-8 text-app-muted sm:text-lg">
                   告诉 Windup
                   你想做什么，选择满意的角色和方向，然后把动作带进游戏。你可以从下面的目标直接开始，也可以按章节了解完整流程。
                 </p>
               </div>
-              <div className="flex flex-wrap gap-3 lg:justify-end">
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-4 lg:justify-end">
                 <Link
                   to="/quick-start"
                   className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-app-accent px-5 text-sm font-semibold text-app-on-accent transition-colors hover:bg-app-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
@@ -84,74 +95,80 @@ export function GuidePage() {
                 </Link>
                 <Link
                   to="/workspace"
-                  className="inline-flex min-h-11 items-center rounded-lg border border-app-line-strong bg-app-surface-raised px-5 text-sm font-semibold text-app-ink-soft transition-colors hover:border-app-accent hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+                  className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-app-ink-soft underline decoration-app-line-strong underline-offset-4 transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
                 >
                   返回工作台
+                  <ArrowRight aria-hidden="true" size={14} weight="bold" />
                 </Link>
               </div>
             </div>
-          </section>
+          </header>
 
-          <section aria-labelledby="guide-goals-title" className="py-10 sm:py-12">
-            <div className="mb-5 flex items-end justify-between gap-4">
+          <section aria-labelledby="guide-goals-title" className="py-14 sm:py-16">
+            <div className="grid gap-5 lg:grid-cols-[15rem_minmax(0,1fr)]">
               <div>
-                <p className="text-xs font-medium text-app-faint">按你的目标开始</p>
+                <p className="font-mono text-[0.68rem] font-semibold tracking-[0.14em] text-app-faint uppercase">
+                  按你的目标开始
+                </p>
                 <h2
                   id="guide-goals-title"
-                  className="mt-1 font-serif text-2xl font-medium tracking-[-0.035em] text-app-ink sm:text-3xl"
+                  className="mt-3 text-2xl font-extrabold tracking-[-0.025em] text-app-ink sm:text-3xl"
                 >
                   你现在想做什么？
                 </h2>
               </div>
-              <span className="hidden text-xs text-app-faint sm:block">点击后进入对应功能</span>
-            </div>
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-              {journeys.map((journey) => {
-                const Icon = journey.icon
-                return (
-                  <Link
-                    key={journey.title}
-                    to={journey.to}
-                    aria-label={journey.label}
-                    className="group flex min-h-48 flex-col rounded-[1.25rem] border border-app-line bg-app-surface-raised p-5 transition hover:-translate-y-0.5 hover:border-app-line-strong focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-                  >
-                    <Icon aria-hidden={true} size={28} weight="duotone" />
-                    <strong className="mt-auto font-serif text-xl font-medium tracking-[-0.025em] text-app-ink">
-                      {journey.title}
-                    </strong>
-                    <span className="mt-2 text-xs leading-5 text-app-muted">
-                      {journey.description}
-                    </span>
-                    <span className="mt-4 inline-flex items-center gap-1.5 text-xs font-semibold text-app-accent">
-                      {journey.label}
-                      <ArrowRight
-                        aria-hidden="true"
-                        className="transition-transform group-hover:translate-x-0.5"
-                        size={14}
-                        weight="bold"
+              <div className="grid md:grid-cols-2">
+                {journeys.map((journey) => {
+                  const Icon = journey.icon
+                  return (
+                    <Link
+                      key={journey.title}
+                      to={journey.to}
+                      aria-label={journey.label}
+                      className="group grid min-h-44 grid-cols-[2rem_minmax(0,1fr)] gap-x-4 border-t border-app-line py-6 md:px-6 md:first:pl-0 md:nth-[2]:pr-0 md:nth-[3]:pl-0 md:nth-[4]:pr-0"
+                    >
+                      <Icon
+                        aria-hidden={true}
+                        className="mt-0.5 text-app-accent"
+                        size={24}
+                        weight="duotone"
                       />
-                    </span>
-                  </Link>
-                )
-              })}
+                      <span className="flex min-w-0 flex-col">
+                        <strong className="text-lg font-bold tracking-[-0.015em] text-app-ink">
+                          {journey.title}
+                        </strong>
+                        <span className="mt-2 text-sm leading-6 text-app-muted">
+                          {journey.description}
+                        </span>
+                        <span className="mt-auto inline-flex items-center gap-1.5 pt-5 text-xs font-semibold text-app-accent">
+                          {journey.label}
+                          <ArrowRight
+                            aria-hidden="true"
+                            className="transition-transform group-hover:translate-x-1"
+                            size={14}
+                            weight="bold"
+                          />
+                        </span>
+                      </span>
+                    </Link>
+                  )
+                })}
+              </div>
             </div>
           </section>
 
-          <div className="grid gap-6 lg:grid-cols-[15rem_minmax(0,1fr)] xl:gap-10">
-            <aside className="lg:sticky lg:top-24 lg:self-start">
-              <nav
-                aria-label="使用手册目录"
-                className="rounded-[1.25rem] border border-app-line bg-app-surface p-3"
-              >
-                <p className="px-3 pb-2 pt-1 text-[0.68rem] font-semibold tracking-[0.12em] text-app-faint uppercase">
+          <div className="grid gap-12 border-t border-app-line pt-10 lg:grid-cols-[15rem_minmax(0,1fr)] lg:gap-16">
+            <aside className="lg:sticky lg:top-28 lg:self-start">
+              <nav aria-label="使用手册目录" className="border-l border-app-line pl-5">
+                <p className="font-mono text-[0.68rem] font-semibold tracking-[0.14em] text-app-faint uppercase">
                   完整流程
                 </p>
-                <ol className="grid grid-cols-2 gap-1 sm:grid-cols-4 lg:grid-cols-1">
+                <ol className="mt-5 grid grid-cols-2 gap-x-5 gap-y-1 sm:grid-cols-4 lg:grid-cols-1">
                   {guideChapters.map((chapter) => (
                     <li key={chapter.id}>
                       <a
                         href={`#${chapter.id}`}
-                        className="group flex min-h-10 items-center gap-3 rounded-lg px-3 py-2 text-sm text-app-muted transition-colors hover:bg-app-accent-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                        className="group flex min-h-10 items-center gap-3 py-2 text-sm text-app-muted transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
                       >
                         <span
                           aria-hidden="true"
@@ -167,97 +184,119 @@ export function GuidePage() {
               </nav>
             </aside>
 
-            <article className="min-w-0 space-y-5">
+            <div className="min-w-0">
               {guideChapters.map((chapter) => (
                 <section
                   key={chapter.id}
                   id={chapter.id}
                   aria-labelledby={`${chapter.id}-title`}
-                  className="scroll-mt-24 overflow-hidden rounded-[1.25rem] border border-app-line bg-app-surface-raised"
+                  className="scroll-mt-28 border-b border-app-line py-14 first:pt-0 sm:py-20"
                 >
-                  <header className="grid gap-4 border-b border-app-line px-5 py-6 sm:grid-cols-[3.5rem_minmax(0,1fr)_auto] sm:items-start sm:px-7">
-                    <span aria-hidden="true" className="font-mono text-sm text-app-faint">
+                  <header className="grid gap-5 sm:grid-cols-[3.5rem_minmax(0,1fr)]">
+                    <span
+                      aria-hidden="true"
+                      className="font-mono text-sm tracking-[0.08em] text-app-faint"
+                    >
                       {chapter.index}
                     </span>
                     <div>
-                      <p className="text-xs font-medium text-app-faint">{chapter.navLabel}</p>
+                      <p className="text-xs font-semibold tracking-[0.08em] text-app-faint uppercase">
+                        {chapter.navLabel}
+                      </p>
                       <h2
                         id={`${chapter.id}-title`}
-                        className="mt-1 font-serif text-2xl font-medium tracking-[-0.035em] text-app-ink"
+                        className="mt-3 max-w-4xl text-[clamp(1.85rem,3.6vw,3.15rem)] leading-[1.18] font-extrabold tracking-[-0.035em] text-app-ink"
                       >
                         {chapter.title}
                       </h2>
-                      <p className="mt-3 max-w-3xl text-sm leading-6 text-app-muted">
+                      <p className="mt-5 max-w-3xl text-base leading-8 text-app-muted">
                         {chapter.summary}
                       </p>
+                      {chapter.action ? (
+                        <Link
+                          to={chapter.action.to}
+                          className="mt-6 inline-flex min-h-10 items-center gap-2 text-sm font-semibold text-app-accent underline decoration-app-line-strong underline-offset-4 transition-colors hover:text-app-accent-hover focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+                        >
+                          {chapter.action.label}
+                          <ArrowRight aria-hidden="true" size={14} weight="bold" />
+                        </Link>
+                      ) : null}
                     </div>
-                    {chapter.action ? (
-                      <Link
-                        to={chapter.action.to}
-                        className="inline-flex min-h-10 items-center gap-1.5 self-start rounded-lg border border-app-line-strong px-3 text-xs font-semibold text-app-ink-soft transition-colors hover:border-app-accent hover:bg-app-accent-muted hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent sm:ml-4"
-                      >
-                        {chapter.action.label}
-                        <ArrowRight aria-hidden="true" size={13} weight="bold" />
-                      </Link>
-                    ) : null}
                   </header>
 
-                  <div className="grid gap-px bg-app-line sm:grid-cols-2">
-                    {chapter.topics.map((topic) => (
-                      <div key={topic.title} className="bg-app-surface-raised p-5 sm:p-7">
-                        <h3 className="font-serif text-lg font-medium text-app-ink-soft">
-                          {topic.title}
-                        </h3>
-                        <p className="mt-2 text-sm leading-6 text-app-muted">{topic.description}</p>
-                        {topic.bullets ? (
-                          <ul className="mt-4 space-y-2">
-                            {topic.bullets.map((bullet) => (
-                              <li
-                                key={bullet}
-                                className="flex gap-2 text-xs leading-5 text-app-ink-soft"
-                              >
-                                <CheckCircle
-                                  aria-hidden="true"
-                                  className="mt-0.5 shrink-0 text-app-accent"
-                                  size={15}
-                                  weight="fill"
-                                />
-                                <span>{bullet}</span>
-                              </li>
-                            ))}
-                          </ul>
-                        ) : null}
-                        {topic.example ? (
-                          <p className="mt-4 rounded-lg border border-app-line bg-app-surface-muted px-3 py-2.5 font-mono text-xs leading-5 text-app-ink-soft">
-                            {topic.example}
-                          </p>
-                        ) : null}
-                      </div>
-                    ))}
-                  </div>
-
-                  {chapter.tip ? (
-                    <div className="flex gap-3 border-t border-app-line bg-app-accent-muted px-5 py-4 text-xs leading-5 text-app-ink-soft sm:px-7">
-                      <Lifebuoy
-                        aria-hidden="true"
-                        className="mt-0.5 shrink-0 text-app-accent"
-                        size={18}
-                        weight="duotone"
-                      />
-                      <p>{chapter.tip}</p>
+                  <div className="mt-10 sm:ml-[5.5rem] sm:mt-12">
+                    <div className="max-w-3xl divide-y divide-app-line">
+                      {chapter.topics.map((topic, topicIndex) => (
+                        <div
+                          key={topic.title}
+                          className="grid gap-4 py-8 first:pt-0 sm:grid-cols-[2rem_minmax(0,1fr)] sm:gap-6"
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="font-mono text-[0.68rem] text-app-faint"
+                          >
+                            {String(topicIndex + 1).padStart(2, '0')}
+                          </span>
+                          <div>
+                            <h3 className="text-lg font-bold tracking-[-0.015em] text-app-ink-soft sm:text-xl">
+                              {topic.title}
+                            </h3>
+                            <p className="mt-3 text-sm leading-7 text-app-muted sm:text-base">
+                              {topic.description}
+                            </p>
+                            {topic.bullets ? (
+                              <ul className="mt-5 space-y-3">
+                                {topic.bullets.map((bullet) => (
+                                  <li
+                                    key={bullet}
+                                    className="flex gap-3 text-sm leading-6 text-app-ink-soft"
+                                  >
+                                    <CheckCircle
+                                      aria-hidden="true"
+                                      className="mt-1 shrink-0 text-app-accent"
+                                      size={16}
+                                      weight="fill"
+                                    />
+                                    <span>{bullet}</span>
+                                  </li>
+                                ))}
+                              </ul>
+                            ) : null}
+                            {topic.example ? (
+                              <blockquote className="mt-5 border-l-2 border-app-line-strong pl-4 font-mono text-xs leading-6 text-app-ink-soft sm:text-sm">
+                                {topic.example}
+                              </blockquote>
+                            ) : null}
+                          </div>
+                        </div>
+                      ))}
                     </div>
-                  ) : null}
+
+                    {chapter.tip ? (
+                      <div className="mt-4 flex max-w-3xl gap-3 border-l-2 border-app-accent bg-app-accent-muted px-5 py-4 text-sm leading-6 text-app-ink-soft">
+                        <Lifebuoy
+                          aria-hidden="true"
+                          className="mt-0.5 shrink-0 text-app-accent"
+                          size={18}
+                          weight="duotone"
+                        />
+                        <p>{chapter.tip}</p>
+                      </div>
+                    ) : null}
+                  </div>
                 </section>
               ))}
 
-              <section className="rounded-[1.25rem] bg-app-ink px-5 py-7 text-app-on-accent sm:px-7">
-                <p className="text-xs text-app-surface-strong">没有找到答案？</p>
-                <div className="mt-2 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+              <footer className="border-b border-app-line py-14 sm:py-20">
+                <p className="font-mono text-[0.68rem] font-semibold tracking-[0.14em] text-app-faint uppercase">
+                  没有找到答案？
+                </p>
+                <div className="mt-4 grid gap-8 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
                   <div>
-                    <h2 className="font-serif text-2xl font-medium">
+                    <h2 className="max-w-3xl text-2xl font-extrabold tracking-[-0.025em] text-app-ink sm:text-3xl">
                       把页面提示和操作步骤告诉我们
                     </h2>
-                    <p className="mt-2 max-w-2xl text-xs leading-5 text-app-surface-strong">
+                    <p className="mt-4 max-w-2xl text-sm leading-7 text-app-muted">
                       附上所在页面、刚刚执行的操作、页面显示的错误信息和截图，可以更快定位问题。
                     </p>
                   </div>
@@ -265,16 +304,16 @@ export function GuidePage() {
                     href={githubIssues}
                     target="_blank"
                     rel="noreferrer"
-                    className="inline-flex min-h-10 shrink-0 items-center justify-center gap-2 rounded-lg bg-app-surface-raised px-4 text-xs font-semibold text-app-ink transition hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-surface-raised"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-app-ink px-5 text-sm font-semibold text-app-on-accent transition-colors hover:bg-app-ink-soft focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
                   >
                     提交问题
                     <ArrowRight aria-hidden="true" size={14} weight="bold" />
                   </a>
                 </div>
-              </section>
-            </article>
+              </footer>
+            </div>
           </div>
-        </div>
+        </article>
       </main>
     </>
   )

--- a/frontend/src/pages/guide/index.tsx
+++ b/frontend/src/pages/guide/index.tsx
@@ -72,14 +72,14 @@ export function GuidePage() {
           <header className="grid border-b border-app-line pb-9 md:grid-cols-[13.5rem_minmax(0,1fr)] md:gap-12 xl:gap-16">
             <div className="hidden md:block" aria-hidden="true" />
             <div>
-              <p className="text-xs font-semibold tracking-[0.08em] text-app-faint">使用指南</p>
+              <p className="text-meta font-semibold text-app-faint">使用指南</p>
               <h1
                 id="guide-title"
-                className="mt-3 text-[2.25rem] leading-[1.16] font-extrabold tracking-[-0.035em] text-app-ink sm:text-[2.75rem]"
+                className="mt-3 font-serif text-[2.4rem] leading-[1.18] font-semibold tracking-[-0.04em] text-app-ink sm:text-[2.8rem]"
               >
                 Windup 使用指南
               </h1>
-              <p className="mt-4 max-w-4xl text-base leading-7 text-app-muted">
+              <p className="mt-4 max-w-4xl text-lead text-app-muted">
                 从建立项目开始，完成角色母版、方向首帧和动作，再到预览与导出。这份指南按实际制作顺序说明每一步。
               </p>
               <div className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-3">
@@ -103,13 +103,13 @@ export function GuidePage() {
           <div className="grid gap-10 pt-8 md:grid-cols-[13.5rem_minmax(0,1fr)] md:gap-12 xl:gap-16">
             <aside className="md:sticky md:top-28 md:self-start md:border-r md:border-app-line md:pr-7 xl:pr-8">
               <nav aria-label="使用指南章节">
-                <p className="text-xs font-semibold text-app-ink-soft">本页内容</p>
+                <p className="text-meta font-semibold text-app-ink-soft">本页内容</p>
                 <ol className="mt-3 grid grid-cols-2 gap-x-4 gap-y-0.5 sm:grid-cols-4 md:grid-cols-1">
                   {guideChapters.map((chapter) => (
                     <li key={chapter.id}>
                       <a
                         href={`#${chapter.id}`}
-                        className="group flex min-h-9 items-center gap-2.5 py-1.5 text-[13px] leading-5 text-app-muted transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                        className="group flex min-h-9 items-center gap-2.5 py-1.5 text-body text-app-muted transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
                       >
                         <span aria-hidden="true" className="font-mono text-[10px] text-app-faint">
                           {chapter.index}
@@ -122,13 +122,13 @@ export function GuidePage() {
               </nav>
 
               <div className="mt-7 hidden border-t border-app-line pt-5 md:block">
-                <p className="text-xs font-semibold text-app-ink-soft">快速入口</p>
+                <p className="text-meta font-semibold text-app-ink-soft">快速入口</p>
                 <ul className="mt-2 space-y-0.5">
                   {quickLinks.map((link) => (
                     <li key={link.to}>
                       <Link
                         to={link.to}
-                        className="inline-flex min-h-8 items-center gap-1.5 text-[13px] text-app-muted transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                        className="inline-flex min-h-8 items-center gap-1.5 text-body text-app-muted transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
                       >
                         {link.label}
                         <ArrowRight aria-hidden="true" size={12} />
@@ -152,13 +152,11 @@ export function GuidePage() {
                   </p>
                   <h2
                     id={`${chapter.id}-title`}
-                    className="mt-2 text-[1.65rem] leading-tight font-bold tracking-[-0.025em] text-app-ink sm:text-[1.85rem]"
+                    className="mt-2 font-serif text-[1.75rem] leading-[1.35] font-semibold tracking-[-0.03em] text-app-ink sm:text-[2rem]"
                   >
                     {chapter.title}
                   </h2>
-                  <p className="mt-3 max-w-[52rem] text-[15px] leading-7 text-app-muted">
-                    {chapter.summary}
-                  </p>
+                  <p className="mt-3 max-w-[52rem] text-body text-app-muted">{chapter.summary}</p>
 
                   {chapter.id === 'quick-start' ? <QuickStartComposerPreview /> : null}
 
@@ -193,12 +191,12 @@ export function GuidePage() {
                         id={`${chapter.id}-${topicIndex + 1}`}
                         className="space-y-2"
                       >
-                        <h3 className="text-base font-bold leading-6 text-app-ink-soft">
+                        <h3 className="text-subtitle font-semibold text-app-ink-soft">
                           {topic.title}
                         </h3>
-                        <p className="text-sm leading-7 text-app-muted">{topic.description}</p>
+                        <p className="text-body text-app-muted">{topic.description}</p>
                         {topic.bullets?.map((bullet) => (
-                          <p key={bullet} className="text-sm leading-7 text-app-ink-soft">
+                          <p key={bullet} className="text-body text-app-ink-soft">
                             {bullet}
                           </p>
                         ))}

--- a/frontend/src/pages/guide/index.tsx
+++ b/frontend/src/pages/guide/index.tsx
@@ -68,35 +68,35 @@ export function GuidePage() {
     <>
       <MarketingHeader />
       <main className="min-h-[100dvh] bg-app-canvas pb-20 pt-28 text-app-ink sm:pt-32">
-        <article
-          aria-labelledby="guide-title"
-          className="mx-auto w-full max-w-[78rem] px-5 sm:px-8 lg:px-10"
-        >
-          <header className="border-b border-app-line pb-9">
-            <p className="text-xs font-semibold tracking-[0.08em] text-app-faint">使用指南</p>
-            <h1
-              id="guide-title"
-              className="mt-3 text-[2.25rem] leading-[1.16] font-extrabold tracking-[-0.035em] text-app-ink sm:text-[2.75rem]"
-            >
-              Windup 使用指南
-            </h1>
-            <p className="mt-4 max-w-3xl text-base leading-7 text-app-muted">
-              从建立项目开始，完成角色母版、方向首帧和动作，再到预览与导出。这份指南按实际制作顺序说明每一步。
-            </p>
-            <div className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-3">
-              <Link
-                to="/quick-start"
-                className="inline-flex min-h-10 items-center gap-2 rounded-app-control bg-app-accent px-4 text-sm font-semibold text-app-on-accent transition-colors hover:bg-app-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+        <article aria-labelledby="guide-title" className="w-full px-5 sm:px-8 lg:px-12 xl:px-16">
+          <header className="grid border-b border-app-line pb-9 md:grid-cols-[13.5rem_minmax(0,1fr)] md:gap-12 xl:gap-16">
+            <div className="hidden md:block" aria-hidden="true" />
+            <div>
+              <p className="text-xs font-semibold tracking-[0.08em] text-app-faint">使用指南</p>
+              <h1
+                id="guide-title"
+                className="mt-3 text-[2.25rem] leading-[1.16] font-extrabold tracking-[-0.035em] text-app-ink sm:text-[2.75rem]"
               >
-                开始创建角色
-                <ArrowRight aria-hidden="true" size={15} weight="bold" />
-              </Link>
-              <Link
-                to="/workspace"
-                className="inline-flex min-h-10 items-center text-sm font-medium text-app-muted underline decoration-app-line-strong underline-offset-4 transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-              >
-                返回工作台
-              </Link>
+                Windup 使用指南
+              </h1>
+              <p className="mt-4 max-w-4xl text-base leading-7 text-app-muted">
+                从建立项目开始，完成角色母版、方向首帧和动作，再到预览与导出。这份指南按实际制作顺序说明每一步。
+              </p>
+              <div className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-3">
+                <Link
+                  to="/quick-start"
+                  className="inline-flex min-h-10 items-center gap-2 rounded-app-control bg-app-accent px-4 text-sm font-semibold text-app-on-accent transition-colors hover:bg-app-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+                >
+                  开始创建角色
+                  <ArrowRight aria-hidden="true" size={15} weight="bold" />
+                </Link>
+                <Link
+                  to="/workspace"
+                  className="inline-flex min-h-10 items-center text-sm font-medium text-app-muted underline decoration-app-line-strong underline-offset-4 transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+                >
+                  返回工作台
+                </Link>
+              </div>
             </div>
           </header>
 

--- a/frontend/src/pages/guide/index.tsx
+++ b/frontend/src/pages/guide/index.tsx
@@ -1,179 +1,66 @@
-import {
-  ArrowRight,
-  ChatCircleText,
-  CheckCircle,
-  FolderOpen,
-  GameController,
-  Lifebuoy,
-  Package,
-} from '@phosphor-icons/react'
-import type { ComponentType } from 'react'
+import { ArrowRight, CheckCircle, Lifebuoy } from '@phosphor-icons/react'
 import { Link } from 'react-router'
 
 import { MarketingHeader } from '@/pages/landing/marketing-header'
 import { guideChapters } from './content'
 
-interface Journey {
-  title: string
-  description: string
-  label: string
-  to: string
-  icon: ComponentType<{
-    'aria-hidden'?: boolean
-    className?: string
-    size?: number
-    weight?: 'duotone'
-  }>
-}
-
-const journeys: readonly Journey[] = [
-  {
-    title: '创建一个新角色',
-    description: '用自然语言完成角色母版、方向首帧和第一个动作。',
-    label: '开始创建角色',
-    to: '/quick-start',
-    icon: ChatCircleText,
-  },
-  {
-    title: '继续管理角色',
-    description: '查看已有项目，为角色增加动作或整理逐帧素材。',
-    label: '查看项目资产',
-    to: '/projects',
-    icon: FolderOpen,
-  },
-  {
-    title: '试玩已有动作',
-    description: '在浏览器里控制角色，检查移动方向与动画衔接。',
-    label: '进入预览台',
-    to: '/playtest',
-    icon: GameController,
-  },
-  {
-    title: '导出游戏素材',
-    description: '从角色详情下载透明帧、Sprite Sheet 和完整资源包。',
-    label: '选择角色并导出',
-    to: '/projects',
-    icon: Package,
-  },
-]
-
 const githubIssues = 'https://github.com/1024XEngineer/Windup/issues'
+
+const quickLinks = [
+  { label: '开始创建角色', to: '/quick-start' },
+  { label: '查看项目资产', to: '/projects' },
+  { label: '进入预览台', to: '/playtest' },
+] as const
 
 export function GuidePage() {
   return (
     <>
       <MarketingHeader />
-      <main className="min-h-[100dvh] bg-app-canvas pb-24 pt-32 text-app-ink sm:pt-36">
+      <main className="min-h-[100dvh] bg-app-canvas pb-20 pt-28 text-app-ink sm:pt-32">
         <article
           aria-labelledby="guide-title"
-          className="mx-auto w-full max-w-[82rem] px-5 sm:px-8 lg:px-12"
+          className="mx-auto w-full max-w-[78rem] px-5 sm:px-8 lg:px-10"
         >
-          <header className="border-b border-app-line pb-14 sm:pb-16">
-            <p className="font-mono text-[0.68rem] font-semibold tracking-[0.16em] text-app-faint uppercase">
-              使用说明
+          <header className="border-b border-app-line pb-9">
+            <p className="text-xs font-semibold tracking-[0.08em] text-app-faint">使用指南</p>
+            <h1
+              id="guide-title"
+              className="mt-3 text-[2.25rem] leading-[1.16] font-extrabold tracking-[-0.035em] text-app-ink sm:text-[2.75rem]"
+            >
+              Windup 使用指南
+            </h1>
+            <p className="mt-4 max-w-3xl text-base leading-7 text-app-muted">
+              从建立项目开始，完成角色母版、方向首帧和动作，再到预览与导出。这份指南按实际制作顺序说明每一步。
             </p>
-            <div className="mt-5 grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.46fr)] lg:items-end">
-              <div>
-                <h1
-                  id="guide-title"
-                  className="max-w-4xl font-serif text-[clamp(3rem,6.4vw,5.25rem)] leading-[1.06] font-semibold tracking-[-0.055em] text-app-ink"
-                >
-                  Windup 使用手册
-                </h1>
-                <p className="mt-6 max-w-2xl text-base leading-8 text-app-muted sm:text-lg">
-                  告诉 Windup
-                  你想做什么，选择满意的角色和方向，然后把动作带进游戏。你可以从下面的目标直接开始，也可以按章节了解完整流程。
-                </p>
-              </div>
-              <div className="flex flex-wrap items-center gap-x-6 gap-y-4 lg:justify-end">
-                <Link
-                  to="/quick-start"
-                  className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-app-accent px-5 text-sm font-semibold text-app-on-accent transition-colors hover:bg-app-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-                >
-                  开始创建角色
-                  <ArrowRight aria-hidden="true" size={16} weight="bold" />
-                </Link>
-                <Link
-                  to="/workspace"
-                  className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-app-ink-soft underline decoration-app-line-strong underline-offset-4 transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-                >
-                  返回工作台
-                  <ArrowRight aria-hidden="true" size={14} weight="bold" />
-                </Link>
-              </div>
+            <div className="mt-6 flex flex-wrap items-center gap-x-5 gap-y-3">
+              <Link
+                to="/quick-start"
+                className="inline-flex min-h-10 items-center gap-2 rounded-app-control bg-app-accent px-4 text-sm font-semibold text-app-on-accent transition-colors hover:bg-app-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+              >
+                开始创建角色
+                <ArrowRight aria-hidden="true" size={15} weight="bold" />
+              </Link>
+              <Link
+                to="/workspace"
+                className="inline-flex min-h-10 items-center text-sm font-medium text-app-muted underline decoration-app-line-strong underline-offset-4 transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+              >
+                返回工作台
+              </Link>
             </div>
           </header>
 
-          <section aria-labelledby="guide-goals-title" className="py-14 sm:py-16">
-            <div className="grid gap-5 lg:grid-cols-[15rem_minmax(0,1fr)]">
-              <div>
-                <p className="font-mono text-[0.68rem] font-semibold tracking-[0.14em] text-app-faint uppercase">
-                  按你的目标开始
-                </p>
-                <h2
-                  id="guide-goals-title"
-                  className="mt-3 text-2xl font-extrabold tracking-[-0.025em] text-app-ink sm:text-3xl"
-                >
-                  你现在想做什么？
-                </h2>
-              </div>
-              <div className="grid md:grid-cols-2">
-                {journeys.map((journey) => {
-                  const Icon = journey.icon
-                  return (
-                    <Link
-                      key={journey.title}
-                      to={journey.to}
-                      aria-label={journey.label}
-                      className="group grid min-h-44 grid-cols-[2rem_minmax(0,1fr)] gap-x-4 border-t border-app-line py-6 md:px-6 md:first:pl-0 md:nth-[2]:pr-0 md:nth-[3]:pl-0 md:nth-[4]:pr-0"
-                    >
-                      <Icon
-                        aria-hidden={true}
-                        className="mt-0.5 text-app-accent"
-                        size={24}
-                        weight="duotone"
-                      />
-                      <span className="flex min-w-0 flex-col">
-                        <strong className="text-lg font-bold tracking-[-0.015em] text-app-ink">
-                          {journey.title}
-                        </strong>
-                        <span className="mt-2 text-sm leading-6 text-app-muted">
-                          {journey.description}
-                        </span>
-                        <span className="mt-auto inline-flex items-center gap-1.5 pt-5 text-xs font-semibold text-app-accent">
-                          {journey.label}
-                          <ArrowRight
-                            aria-hidden="true"
-                            className="transition-transform group-hover:translate-x-1"
-                            size={14}
-                            weight="bold"
-                          />
-                        </span>
-                      </span>
-                    </Link>
-                  )
-                })}
-              </div>
-            </div>
-          </section>
-
-          <div className="grid gap-12 border-t border-app-line pt-10 lg:grid-cols-[15rem_minmax(0,1fr)] lg:gap-16">
-            <aside className="lg:sticky lg:top-28 lg:self-start">
-              <nav aria-label="使用手册目录" className="border-l border-app-line pl-5">
-                <p className="font-mono text-[0.68rem] font-semibold tracking-[0.14em] text-app-faint uppercase">
-                  完整流程
-                </p>
-                <ol className="mt-5 grid grid-cols-2 gap-x-5 gap-y-1 sm:grid-cols-4 lg:grid-cols-1">
+          <div className="grid gap-10 pt-8 md:grid-cols-[12.5rem_minmax(0,45rem)] md:justify-center md:gap-10 xl:grid-cols-[13.5rem_minmax(0,45rem)] xl:gap-16">
+            <aside className="md:sticky md:top-28 md:self-start md:border-r md:border-app-line md:pr-7 xl:pr-8">
+              <nav aria-label="使用指南章节">
+                <p className="text-xs font-semibold text-app-ink-soft">本页内容</p>
+                <ol className="mt-3 grid grid-cols-2 gap-x-4 gap-y-0.5 sm:grid-cols-4 md:grid-cols-1">
                   {guideChapters.map((chapter) => (
                     <li key={chapter.id}>
                       <a
                         href={`#${chapter.id}`}
-                        className="group flex min-h-10 items-center gap-3 py-2 text-sm text-app-muted transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+                        className="group flex min-h-9 items-center gap-2.5 py-1.5 text-[13px] leading-5 text-app-muted transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
                       >
-                        <span
-                          aria-hidden="true"
-                          className="font-mono text-[0.65rem] text-app-faint"
-                        >
+                        <span aria-hidden="true" className="font-mono text-[10px] text-app-faint">
                           {chapter.index}
                         </span>
                         <span>{chapter.navLabel}</span>
@@ -182,6 +69,23 @@ export function GuidePage() {
                   ))}
                 </ol>
               </nav>
+
+              <div className="mt-7 hidden border-t border-app-line pt-5 md:block">
+                <p className="text-xs font-semibold text-app-ink-soft">快速入口</p>
+                <ul className="mt-2 space-y-0.5">
+                  {quickLinks.map((link) => (
+                    <li key={link.to}>
+                      <Link
+                        to={link.to}
+                        className="inline-flex min-h-8 items-center gap-1.5 text-[13px] text-app-muted transition-colors hover:text-app-accent focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-app-accent"
+                      >
+                        {link.label}
+                        <ArrowRight aria-hidden="true" size={12} />
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </aside>
 
             <div className="min-w-0">
@@ -190,126 +94,112 @@ export function GuidePage() {
                   key={chapter.id}
                   id={chapter.id}
                   aria-labelledby={`${chapter.id}-title`}
-                  className="scroll-mt-28 border-b border-app-line py-14 first:pt-0 sm:py-20"
+                  className="scroll-mt-28 border-b border-app-line py-10 first:pt-0"
                 >
-                  <header className="grid gap-5 sm:grid-cols-[3.5rem_minmax(0,1fr)]">
-                    <span
-                      aria-hidden="true"
-                      className="font-mono text-sm tracking-[0.08em] text-app-faint"
+                  <p className="font-mono text-[11px] font-medium tracking-[0.06em] text-app-faint">
+                    {chapter.index}
+                  </p>
+                  <h2
+                    id={`${chapter.id}-title`}
+                    className="mt-2 text-[1.65rem] leading-tight font-bold tracking-[-0.025em] text-app-ink sm:text-[1.85rem]"
+                  >
+                    {chapter.title}
+                  </h2>
+                  <p className="mt-3 max-w-[42rem] text-[15px] leading-7 text-app-muted">
+                    {chapter.summary}
+                  </p>
+
+                  {chapter.action ? (
+                    <Link
+                      to={chapter.action.to}
+                      className="mt-4 inline-flex min-h-9 items-center gap-1.5 text-sm font-semibold text-app-accent underline decoration-app-line-strong underline-offset-4 transition-colors hover:text-app-accent-hover focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
                     >
-                      {chapter.index}
-                    </span>
-                    <div>
-                      <p className="text-xs font-semibold tracking-[0.08em] text-app-faint uppercase">
-                        {chapter.navLabel}
-                      </p>
-                      <h2
-                        id={`${chapter.id}-title`}
-                        className="mt-3 max-w-4xl text-[clamp(1.85rem,3.6vw,3.15rem)] leading-[1.18] font-extrabold tracking-[-0.035em] text-app-ink"
+                      {chapter.action.label}
+                      <ArrowRight aria-hidden="true" size={13} weight="bold" />
+                    </Link>
+                  ) : null}
+
+                  <ol className="mt-7 space-y-7">
+                    {chapter.topics.map((topic, topicIndex) => (
+                      <li
+                        key={topic.title}
+                        className="grid grid-cols-[1.75rem_minmax(0,1fr)] gap-3"
                       >
-                        {chapter.title}
-                      </h2>
-                      <p className="mt-5 max-w-3xl text-base leading-8 text-app-muted">
-                        {chapter.summary}
-                      </p>
-                      {chapter.action ? (
-                        <Link
-                          to={chapter.action.to}
-                          className="mt-6 inline-flex min-h-10 items-center gap-2 text-sm font-semibold text-app-accent underline decoration-app-line-strong underline-offset-4 transition-colors hover:text-app-accent-hover focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-                        >
-                          {chapter.action.label}
-                          <ArrowRight aria-hidden="true" size={14} weight="bold" />
-                        </Link>
-                      ) : null}
-                    </div>
-                  </header>
-
-                  <div className="mt-10 sm:ml-[5.5rem] sm:mt-12">
-                    <div className="max-w-3xl divide-y divide-app-line">
-                      {chapter.topics.map((topic, topicIndex) => (
-                        <div
-                          key={topic.title}
-                          className="grid gap-4 py-8 first:pt-0 sm:grid-cols-[2rem_minmax(0,1fr)] sm:gap-6"
-                        >
-                          <span
-                            aria-hidden="true"
-                            className="font-mono text-[0.68rem] text-app-faint"
-                          >
-                            {String(topicIndex + 1).padStart(2, '0')}
-                          </span>
-                          <div>
-                            <h3 className="text-lg font-bold tracking-[-0.015em] text-app-ink-soft sm:text-xl">
-                              {topic.title}
-                            </h3>
-                            <p className="mt-3 text-sm leading-7 text-app-muted sm:text-base">
-                              {topic.description}
-                            </p>
-                            {topic.bullets ? (
-                              <ul className="mt-5 space-y-3">
-                                {topic.bullets.map((bullet) => (
-                                  <li
-                                    key={bullet}
-                                    className="flex gap-3 text-sm leading-6 text-app-ink-soft"
-                                  >
-                                    <CheckCircle
-                                      aria-hidden="true"
-                                      className="mt-1 shrink-0 text-app-accent"
-                                      size={16}
-                                      weight="fill"
-                                    />
-                                    <span>{bullet}</span>
-                                  </li>
-                                ))}
-                              </ul>
-                            ) : null}
-                            {topic.example ? (
-                              <blockquote className="mt-5 border-l-2 border-app-line-strong pl-4 font-mono text-xs leading-6 text-app-ink-soft sm:text-sm">
-                                {topic.example}
-                              </blockquote>
-                            ) : null}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-
-                    {chapter.tip ? (
-                      <div className="mt-4 flex max-w-3xl gap-3 border-l-2 border-app-accent bg-app-accent-muted px-5 py-4 text-sm leading-6 text-app-ink-soft">
-                        <Lifebuoy
+                        <span
                           aria-hidden="true"
-                          className="mt-0.5 shrink-0 text-app-accent"
-                          size={18}
-                          weight="duotone"
-                        />
-                        <p>{chapter.tip}</p>
-                      </div>
-                    ) : null}
-                  </div>
+                          className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full border border-app-line-strong font-mono text-[10px] text-app-faint"
+                        >
+                          {topicIndex + 1}
+                        </span>
+                        <div>
+                          <h3 className="text-base font-bold leading-6 text-app-ink-soft">
+                            {topic.title}
+                          </h3>
+                          <p className="mt-1.5 text-sm leading-6 text-app-muted">
+                            {topic.description}
+                          </p>
+                          {topic.bullets ? (
+                            <ul className="mt-3 space-y-2">
+                              {topic.bullets.map((bullet) => (
+                                <li
+                                  key={bullet}
+                                  className="flex gap-2.5 text-sm leading-6 text-app-ink-soft"
+                                >
+                                  <CheckCircle
+                                    aria-hidden="true"
+                                    className="mt-1 shrink-0 text-app-accent"
+                                    size={15}
+                                    weight="fill"
+                                  />
+                                  <span>{bullet}</span>
+                                </li>
+                              ))}
+                            </ul>
+                          ) : null}
+                          {topic.example ? (
+                            <div className="mt-3 border-l-2 border-app-line-strong pl-3">
+                              <p className="text-[13px] leading-6 text-app-ink-soft">
+                                <span className="mr-2 font-semibold text-app-faint">示例</span>
+                                {topic.example}
+                              </p>
+                            </div>
+                          ) : null}
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+
+                  {chapter.tip ? (
+                    <div className="mt-7 flex gap-3 border-l-2 border-app-accent bg-app-accent-muted px-4 py-3 text-sm leading-6 text-app-ink-soft">
+                      <Lifebuoy
+                        aria-hidden="true"
+                        className="mt-0.5 shrink-0 text-app-accent"
+                        size={17}
+                        weight="duotone"
+                      />
+                      <p>
+                        <span className="mr-2 font-semibold text-app-accent">注意</span>
+                        {chapter.tip}
+                      </p>
+                    </div>
+                  ) : null}
                 </section>
               ))}
 
-              <footer className="border-b border-app-line py-14 sm:py-20">
-                <p className="font-mono text-[0.68rem] font-semibold tracking-[0.14em] text-app-faint uppercase">
-                  没有找到答案？
+              <footer className="py-10">
+                <h2 className="text-xl font-bold tracking-[-0.02em] text-app-ink">还没有解决？</h2>
+                <p className="mt-2 max-w-[40rem] text-sm leading-6 text-app-muted">
+                  提交问题时附上所在页面、刚刚执行的操作、错误提示和截图，我们会更快定位原因。
                 </p>
-                <div className="mt-4 grid gap-8 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
-                  <div>
-                    <h2 className="max-w-3xl text-2xl font-extrabold tracking-[-0.025em] text-app-ink sm:text-3xl">
-                      把页面提示和操作步骤告诉我们
-                    </h2>
-                    <p className="mt-4 max-w-2xl text-sm leading-7 text-app-muted">
-                      附上所在页面、刚刚执行的操作、页面显示的错误信息和截图，可以更快定位问题。
-                    </p>
-                  </div>
-                  <a
-                    href={githubIssues}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-app-ink px-5 text-sm font-semibold text-app-on-accent transition-colors hover:bg-app-ink-soft focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
-                  >
-                    提交问题
-                    <ArrowRight aria-hidden="true" size={14} weight="bold" />
-                  </a>
-                </div>
+                <a
+                  href={githubIssues}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-4 inline-flex min-h-10 items-center gap-2 rounded-app-control border border-app-line-strong bg-app-surface-raised px-4 text-sm font-semibold text-app-ink-soft transition-colors hover:border-app-accent hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent"
+                >
+                  提交问题
+                  <ArrowRight aria-hidden="true" size={13} weight="bold" />
+                </a>
               </footer>
             </div>
           </div>

--- a/frontend/src/pages/guide/index.tsx
+++ b/frontend/src/pages/guide/index.tsx
@@ -1,6 +1,9 @@
-import { ArrowRight, CheckCircle, Lifebuoy } from '@phosphor-icons/react'
+import { ArrowRight, Lifebuoy, PaperPlaneTilt } from '@phosphor-icons/react'
 import { Link } from 'react-router'
 
+import assetLibraryArtwork from '@/assets/workspace/asset-library.png'
+import playtestArtwork from '@/assets/workspace/playtest.png'
+import workflowArtwork from '@/assets/workspace/workflow.png'
 import { MarketingHeader } from '@/pages/landing/marketing-header'
 import { guideChapters } from './content'
 
@@ -11,6 +14,54 @@ const quickLinks = [
   { label: '查看项目资产', to: '/projects' },
   { label: '进入预览台', to: '/playtest' },
 ] as const
+
+const chapterArtwork: Partial<Record<string, { src: string; alt: string; caption: string }>> = {
+  'workflow-editor': {
+    src: workflowArtwork,
+    alt: '工作流编辑器对应的织机像素画',
+    caption: '工作流把角色母版、动作首帧、完整动画和审核结果留在同一条制作线上。',
+  },
+  assets: {
+    src: assetLibraryArtwork,
+    alt: '项目资产对应的素材册像素画',
+    caption: '项目资产保存角色、造型、动作和每一帧，之后可以继续制作或导出。',
+  },
+  playtest: {
+    src: playtestArtwork,
+    alt: '预览台对应的逐帧播放器像素画',
+    caption: '预览台读取项目中真实保存的动作帧，用来检查移动方向和播放衔接。',
+  },
+}
+
+function QuickStartComposerPreview() {
+  return (
+    <div className="my-7">
+      <p className="mb-3 text-xs font-semibold text-app-faint">Quick Start 输入示例</p>
+      <div className="relative rounded-app-surface border border-app-line-strong bg-app-surface-raised shadow-app-panel transition-[border-color,box-shadow] focus-within:border-app-accent focus-within:shadow-[var(--shadow-app-composer-focus)]">
+        <label className="relative block min-h-[52px] min-w-0 overflow-hidden">
+          <span className="sr-only">创作指令示例</span>
+          <textarea
+            rows={2}
+            readOnly
+            aria-label="创作指令示例"
+            value="年轻的港口信使，短银发，深蓝短外套和红围巾，全身像，适合 2D RPG。"
+            className="block min-h-[76px] w-full min-w-0 resize-none border-0 bg-transparent py-[14px] pr-16 pl-4 text-[15px] leading-6 text-app-ink outline-none"
+          />
+        </label>
+        <Link
+          to="/quick-start"
+          aria-label="打开 Quick Start"
+          className="absolute right-[8px] bottom-[8px] grid size-10 place-items-center rounded-full border-0 bg-app-accent text-app-canvas transition-[transform,background] duration-150 hover:-translate-y-px hover:bg-app-accent-hover active:scale-95"
+        >
+          <PaperPlaneTilt aria-hidden="true" size={17} weight="fill" />
+        </Link>
+      </div>
+      <p className="mt-2 text-xs leading-5 text-app-faint">
+        写清身份、外形、服装、配色和整体气质，再发送给 Windup。
+      </p>
+    </div>
+  )
+}
 
 export function GuidePage() {
   return (
@@ -49,7 +100,7 @@ export function GuidePage() {
             </div>
           </header>
 
-          <div className="grid gap-10 pt-8 md:grid-cols-[12.5rem_minmax(0,45rem)] md:justify-center md:gap-10 xl:grid-cols-[13.5rem_minmax(0,45rem)] xl:gap-16">
+          <div className="grid gap-10 pt-8 md:grid-cols-[13.5rem_minmax(0,1fr)] md:gap-12 xl:gap-16">
             <aside className="md:sticky md:top-28 md:self-start md:border-r md:border-app-line md:pr-7 xl:pr-8">
               <nav aria-label="使用指南章节">
                 <p className="text-xs font-semibold text-app-ink-soft">本页内容</p>
@@ -105,9 +156,25 @@ export function GuidePage() {
                   >
                     {chapter.title}
                   </h2>
-                  <p className="mt-3 max-w-[42rem] text-[15px] leading-7 text-app-muted">
+                  <p className="mt-3 max-w-[52rem] text-[15px] leading-7 text-app-muted">
                     {chapter.summary}
                   </p>
+
+                  {chapter.id === 'quick-start' ? <QuickStartComposerPreview /> : null}
+
+                  {chapterArtwork[chapter.id] ? (
+                    <figure className="my-7 grid items-center gap-5 border-y border-app-line py-5 sm:grid-cols-[11rem_minmax(0,1fr)]">
+                      <img
+                        src={chapterArtwork[chapter.id]?.src}
+                        alt={chapterArtwork[chapter.id]?.alt}
+                        className="mx-auto h-36 w-36 object-contain"
+                        style={{ imageRendering: 'pixelated' }}
+                      />
+                      <figcaption className="text-sm leading-7 text-app-muted">
+                        {chapterArtwork[chapter.id]?.caption}
+                      </figcaption>
+                    </figure>
+                  ) : null}
 
                   {chapter.action ? (
                     <Link
@@ -119,55 +186,31 @@ export function GuidePage() {
                     </Link>
                   ) : null}
 
-                  <ol className="mt-7 space-y-7">
+                  <div className="mt-7 space-y-7">
                     {chapter.topics.map((topic, topicIndex) => (
-                      <li
+                      <div
                         key={topic.title}
-                        className="grid grid-cols-[1.75rem_minmax(0,1fr)] gap-3"
+                        id={`${chapter.id}-${topicIndex + 1}`}
+                        className="space-y-2"
                       >
-                        <span
-                          aria-hidden="true"
-                          className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full border border-app-line-strong font-mono text-[10px] text-app-faint"
-                        >
-                          {topicIndex + 1}
-                        </span>
-                        <div>
-                          <h3 className="text-base font-bold leading-6 text-app-ink-soft">
-                            {topic.title}
-                          </h3>
-                          <p className="mt-1.5 text-sm leading-6 text-app-muted">
-                            {topic.description}
+                        <h3 className="text-base font-bold leading-6 text-app-ink-soft">
+                          {topic.title}
+                        </h3>
+                        <p className="text-sm leading-7 text-app-muted">{topic.description}</p>
+                        {topic.bullets?.map((bullet) => (
+                          <p key={bullet} className="text-sm leading-7 text-app-ink-soft">
+                            {bullet}
                           </p>
-                          {topic.bullets ? (
-                            <ul className="mt-3 space-y-2">
-                              {topic.bullets.map((bullet) => (
-                                <li
-                                  key={bullet}
-                                  className="flex gap-2.5 text-sm leading-6 text-app-ink-soft"
-                                >
-                                  <CheckCircle
-                                    aria-hidden="true"
-                                    className="mt-1 shrink-0 text-app-accent"
-                                    size={15}
-                                    weight="fill"
-                                  />
-                                  <span>{bullet}</span>
-                                </li>
-                              ))}
-                            </ul>
-                          ) : null}
-                          {topic.example ? (
-                            <div className="mt-3 border-l-2 border-app-line-strong pl-3">
-                              <p className="text-[13px] leading-6 text-app-ink-soft">
-                                <span className="mr-2 font-semibold text-app-faint">示例</span>
-                                {topic.example}
-                              </p>
-                            </div>
-                          ) : null}
-                        </div>
-                      </li>
+                        ))}
+                        {topic.example ? (
+                          <p className="border-l-2 border-app-line-strong pl-3 text-[13px] leading-6 text-app-ink-soft">
+                            <span className="mr-2 font-semibold text-app-faint">例如</span>
+                            {topic.example}
+                          </p>
+                        ) : null}
+                      </div>
                     ))}
-                  </ol>
+                  </div>
 
                   {chapter.tip ? (
                     <div className="mt-7 flex gap-3 border-l-2 border-app-accent bg-app-accent-muted px-4 py-3 text-sm leading-6 text-app-ink-soft">


### PR DESCRIPTION
将 `/guide` 重做为紧凑的 Windup 图文使用指南，正文可以连续阅读，同时在关键流程中直接展示用户会操作的产品界面。

## Why

此前版本仍用编号和勾选项切碎内容，读起来像组件清单；左右两栏又把中间正文限制得过窄。用户需要的是接近 Claude Support 的文档定位，但保留 Windup 自己的产品视觉与真实操作对象。

## Changes

- 正文改为标题、导语和连续自然段，不再使用步骤圆圈或勾选清单。
- 删除右侧本页目录，只保留左侧章节栏，并让中央正文占据剩余宽度。
- Quick Start 章节复用现有输入栏的边界、表面、文字与发送按钮语义，提供可点击的真实入口。
- 工作流、项目资产和预览台章节复用仓库现有产品视觉资源，形成图文说明。
- 保留纸色底、深绿强调、8px 控件与 12px 表面圆角，不恢复卡片网格。

## Implementation

- 文章主体继续使用具名 `article` landmark，并由页面主标题提供可访问名称。
- 桌面端使用 216px 左目录与自适应正文列；窄屏目录回落为可换行索引。
- Quick Start 输入示例沿用生产输入栏的 textarea、surface、focus 和圆形发送按钮样式。
- 章节锚点、Quick Start、项目资产、预览台、问题反馈等原有入口保持不变。

## Verification

- [x] `npm test -- src/app/app.test.tsx`：12/12 通过。
- [x] `npm run build`：TypeScript 与 Vite 构建通过。
- [x] `npx oxfmt src/pages/guide/index.tsx src/app/app.test.tsx`：通过。
- [x] `npx oxlint src/pages/guide/index.tsx src/app/app.test.tsx`：通过。
- [x] 本地真实浏览器：宽版正文、左侧目录和 Quick Start 输入示例已检查，无水平溢出。

## Screenshots

### Desktop

最终状态已留在本地浏览器，供当前任务直接视觉验收。

## Scope

- 本 PR 不包含：产品流程、接口、权限、路由及其他页面改动。
- 后续事项：无。

## Related Issues

Closes #778