### PR TITLE
feat(quick-start): make automatic pixelation optional

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -153,7 +153,7 @@ def _load_constraints(session: Session, project_id: int | None) -> ProjectConstr
         sprite_w=p.sprite_width,
         sprite_h=p.sprite_height,
         style=ArtStyle.phrase_from_stored(p.game_style),
-        stylize="pixel" if art_style.wants_pixelation else "none",
+        stylize="pixel" if art_style.wants_pixelation and p.auto_pixelate else "none",
         sprite_sample_url=p.sprite_sample_url or "",
     )
 

--- a/backend/packages/app/src/windup_app/server/project/interface.py
+++ b/backend/packages/app/src/windup_app/server/project/interface.py
@@ -72,6 +72,7 @@ class ProjectService(ABC):
         *,
         project_name: str | None = None,
         game_style: str | None | UnsetType = UNSET,
+        auto_pixelate: bool | UnsetType = UNSET,
     ) -> Project:
         """改已完成归属校验的项目。
 

--- a/backend/packages/app/src/windup_app/server/project/model.py
+++ b/backend/packages/app/src/windup_app/server/project/model.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 
-from sqlalchemy import BigInteger, DateTime, Integer, SmallInteger, String, Text, UniqueConstraint
+from sqlalchemy import BigInteger, Boolean, DateTime, Integer, SmallInteger, String, Text, UniqueConstraint, true
 from sqlalchemy.orm import Mapped, mapped_column
 
 from windup_framework.db import Base
@@ -31,6 +31,9 @@ class Project(Base):
     sprite_width: Mapped[int] = mapped_column(SmallInteger, nullable=False)
     sprite_height: Mapped[int] = mapped_column(SmallInteger, nullable=False)
     game_style: Mapped[str | None] = mapped_column(Text, nullable=True)
+    auto_pixelate: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=true()
+    )
     sprite_sample_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     create_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc)

--- a/backend/packages/app/src/windup_app/server/project/service.py
+++ b/backend/packages/app/src/windup_app/server/project/service.py
@@ -137,11 +137,14 @@ class SqlAlchemyProjectService(ProjectService):
         *,
         project_name: str | None = None,
         game_style: str | None | UnsetType = UNSET,
+        auto_pixelate: bool | UnsetType = UNSET,
     ) -> Project:
         if project_name is not None:
             project.project_name = project_name
         if not isinstance(game_style, UnsetType):
             project.game_style = game_style
+        if not isinstance(auto_pixelate, UnsetType):
+            project.auto_pixelate = auto_pixelate
         session.flush()
         return project
 

--- a/backend/packages/app/src/windup_app/web/api/project.py
+++ b/backend/packages/app/src/windup_app/web/api/project.py
@@ -63,6 +63,7 @@ class ProjectCreate(BaseModel):
     sprite_width: int = Field(ge=32, le=2048)
     sprite_height: int = Field(ge=32, le=2048)
     game_style: ArtStyle | str = ArtStyle.UNSPECIFIED
+    auto_pixelate: bool = True
     sprite_sample_url: str | None = None
 
     @field_validator("game_style", mode="before")
@@ -77,6 +78,7 @@ class ProjectPatch(BaseModel):
 
     project_name: str | None = Field(default=None, min_length=1, max_length=20)
     game_style: ArtStyle | str | None = None
+    auto_pixelate: bool | None = None
 
     _accept_legacy = field_validator("game_style", mode="before")(
         _legacy_style_or_none
@@ -84,7 +86,11 @@ class ProjectPatch(BaseModel):
 
     @model_validator(mode="after")
     def _at_least_one(self) -> "ProjectPatch":
-        if self.project_name is None and self.game_style is None:
+        if (
+            self.project_name is None
+            and self.game_style is None
+            and self.auto_pixelate is None
+        ):
             raise ValueError("至少要改一个字段")
         return self
 
@@ -102,6 +108,7 @@ class ProjectOut(BaseModel):
     sprite_width: int
     sprite_height: int
     game_style: ArtStyle | str
+    auto_pixelate: bool
     sprite_sample_url: str | None
     create_at: datetime
     update_at: datetime
@@ -238,6 +245,7 @@ def update_project(
             game_style=(
                 UNSET if body.game_style is None else _stored_style(body.game_style)
             ),
+            auto_pixelate=(UNSET if body.auto_pixelate is None else body.auto_pixelate),
         )
     except IntegrityError:
         session.rollback()

--- a/backend/tests/test_art_style.py
+++ b/backend/tests/test_art_style.py
@@ -80,6 +80,20 @@ def test_created_project_reports_the_chosen_style(auth_client):
     assert created["game_style"] == "pixel"
 
 
+def test_pixel_project_can_disable_automatic_pixelation(auth_client, db_session):
+    """关闭后仍保留 pixel art 提示词，但生成后处理必须走原生分支。"""
+    from windup_app.server.orchestrator.executor import _load_constraints
+
+    created = auth_client.post(
+        "/projects", json=_payload(game_style="pixel", auto_pixelate=False)
+    ).json()["data"]
+
+    assert created["auto_pixelate"] is False
+    constraints = _load_constraints(db_session, created["id"])
+    assert constraints.style == "pixel art"
+    assert constraints.stylize == "none"
+
+
 def test_unspecified_is_stored_as_null(auth_client, db_session):
     """库里存 NULL 而不是字面量;响应侧再归一成枚举交给前端。"""
     from windup_app.server.project.model import Project

--- a/frontend/src/entities/project/index.test.ts
+++ b/frontend/src/entities/project/index.test.ts
@@ -9,6 +9,7 @@ const projectDto = {
   sprite_width: 64,
   sprite_height: 96,
   game_style: null,
+  auto_pixelate: true,
   sprite_sample_url: 'https://cdn.windup.test/style.png',
   preview_url: 'https://cdn.windup.test/project-preview.png',
   create_at: '2026-08-01T08:00:00Z',
@@ -61,6 +62,7 @@ describe('projectApis', () => {
           directionalMovement: 'four-way',
           spriteSize: { width: 64, height: 96 },
           gameStyle: 'unspecified',
+          autoPixelate: true,
           sampleImageUrl: 'https://cdn.windup.test/style.png',
           previewUrl: 'https://cdn.windup.test/project-preview.png',
           createdAt: '2026-08-01T08:00:00Z',
@@ -88,6 +90,7 @@ describe('projectApis', () => {
       directionalMovement: 'four-way',
       spriteSize: { width: 64, height: 96 },
       gameStyle: 'unspecified',
+      autoPixelate: false,
       sampleImageUrl: 'https://cdn.windup.test/style.png',
     })
 
@@ -101,6 +104,7 @@ describe('projectApis', () => {
       sprite_width: 64,
       sprite_height: 96,
       game_style: 'unspecified',
+      auto_pixelate: false,
       sprite_sample_url: 'https://cdn.windup.test/style.png',
     })
   })

--- a/frontend/src/entities/project/index.ts
+++ b/frontend/src/entities/project/index.ts
@@ -10,6 +10,8 @@ export interface Project {
   directionalMovement: DirectionalMovement
   spriteSize: { width: number; height: number }
   gameStyle: ArtStyle
+  /** 像素风仍进提示词；此开关只决定生成管线是否自动做像素后处理。 */
+  autoPixelate?: boolean
   sampleImageUrl: string | null
   /** 项目列表已经解析好的卡片预览；详情响应不承诺提供。 */
   previewUrl?: string | null
@@ -30,6 +32,7 @@ export interface CreateProjectInput {
   directionalMovement: DirectionalMovement
   spriteSize: { width: number; height: number }
   gameStyle?: ArtStyle
+  autoPixelate?: boolean
   sampleImageUrl?: string | null
 }
 
@@ -112,6 +115,7 @@ export interface ProjectApis {
   create(input: CreateProjectInput): Promise<Project>
   rename(id: Project['id'], name: string): Promise<Project>
   setGameStyle(id: Project['id'], gameStyle: ArtStyle): Promise<Project>
+  setAutoPixelate(id: Project['id'], enabled: boolean): Promise<Project>
   remove(id: Project['id']): Promise<void>
 }
 
@@ -124,6 +128,7 @@ interface ProjectDto {
   sprite_width: number
   sprite_height: number
   game_style: string | null
+  auto_pixelate: boolean
   sprite_sample_url: string | null
   preview_url?: string | null
   create_at: string
@@ -195,6 +200,7 @@ function mapProject(dto: ProjectDto): Project {
     ),
     spriteSize: { width: dto.sprite_width, height: dto.sprite_height },
     gameStyle: artStyleFromDto(dto.game_style),
+    autoPixelate: dto.auto_pixelate,
     sampleImageUrl: dto.sprite_sample_url,
     previewUrl: dto.preview_url ?? dto.sprite_sample_url,
     createdAt: dto.create_at,
@@ -241,6 +247,7 @@ export const projectApis: ProjectApis = {
           sprite_width: input.spriteSize.width,
           sprite_height: input.spriteSize.height,
           game_style: input.gameStyle,
+          auto_pixelate: input.autoPixelate,
           sprite_sample_url: input.sampleImageUrl,
         },
       })
@@ -286,6 +293,15 @@ export const projectApis: ProjectApis = {
       await getApiClient().request<ProjectDto>(`/projects/${encodeURIComponent(id)}`, {
         method: 'PATCH',
         json: { game_style: gameStyle },
+      }),
+    )
+  },
+
+  async setAutoPixelate(id, enabled) {
+    return mapProject(
+      await getApiClient().request<ProjectDto>(`/projects/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        json: { auto_pixelate: enabled },
       }),
     )
   },

--- a/frontend/src/features/quick-start-agent/production.ts
+++ b/frontend/src/features/quick-start-agent/production.ts
@@ -149,6 +149,7 @@ export function createProductionQuickStartAgentDependencies(
           referenceMedia: input.referenceMedia as readonly MediaReference[] | undefined,
           directionalMovement: input.directionalMovement,
           gameStyle,
+          autoPixelate: input.autoPixelate,
           projectId: input.projectId,
           ...(input.suggestPixelPerfect ? { suggestPixelPerfect: true } : {}),
           ...(input.automaticDelivery

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -187,7 +187,12 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
     async (
       prompt: string,
       directionalMovement: QuickStartDirectionalMovement = 'single',
-      options?: { gameStyle?: string; projectId?: string; automaticDelivery?: boolean },
+      options?: {
+        gameStyle?: string
+        autoPixelate?: boolean
+        projectId?: string
+        automaticDelivery?: boolean
+      },
     ): Promise<QuickStartAgentResult> => {
       if (running.current) throw new Error('Planner 正在处理上一条输入')
       if (state.status !== 'proposal') throw new Error('提示词提案已失效')

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -91,6 +91,7 @@ export interface QuickStartAgentTurnOptions {
 export interface ConfirmProposalOptions {
   /** 画风原样透传给宿主；取值范围由宿主定义，本模块不认识业务对象。 */
   gameStyle?: string
+  autoPixelate?: boolean
   /** 宿主选择的已有项目；缺省时继续自动创建项目。 */
   projectId?: string
   /** 用户选择确认后由 Controller 自动交付，不再暴露中间候选选择。 */
@@ -117,6 +118,7 @@ export type StartCharacterGenerationAction = (input: {
   locomotion?: true
   directionalMovement?: QuickStartDirectionalMovement
   gameStyle?: string
+  autoPixelate?: boolean
   projectId?: string
   automaticDelivery?: boolean
   suggestPixelPerfect?: boolean
@@ -399,7 +401,7 @@ export function createQuickStartAgent({
     proposalId: string,
     prompt: string,
     directionalMovement: QuickStartDirectionalMovement = 'single',
-    { gameStyle, projectId, automaticDelivery }: ConfirmProposalOptions = {},
+    { gameStyle, autoPixelate, projectId, automaticDelivery }: ConfirmProposalOptions = {},
   ): Promise<QuickStartAgentResult> {
     assertAuthorized()
     if (running) throw new Error('Planner 正在处理上一条输入')
@@ -423,6 +425,7 @@ export function createQuickStartAgent({
         ...(proposal.locomotion ? { locomotion: proposal.locomotion } : {}),
         directionalMovement,
         gameStyle,
+        ...(autoPixelate === undefined ? {} : { autoPixelate }),
         projectId,
         ...(automaticDelivery ? { automaticDelivery: true } : {}),
         ...(proposal.suggestPixelPerfect ? { suggestPixelPerfect: true } : {}),

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -322,6 +322,42 @@ describe('WorkflowController', () => {
     })
   })
 
+  it('keeps pixel style while opting out of automatic pixelation', async () => {
+    const workflow = createWorkflowApis()
+    const generation = createGenerationHarness()
+    const prepareProject = vi.fn(async () => ({
+      id: 'project-native-pixel',
+      spriteSize: { width: 256, height: 256 },
+    }))
+    const controller = createWorkflowController({
+      workflowRunApis: workflow.apis,
+      generationApis: generation.apis,
+      prepareProject,
+      onAsyncError: () => undefined,
+    })
+
+    await controller.startCharacterGeneration({
+      prompt: '银发像素骑士',
+      gameStyle: 'pixel',
+      autoPixelate: false,
+    })
+
+    expect(prepareProject).toHaveBeenCalledWith('银发像素骑士', 'single', {
+      gameStyle: 'pixel',
+      autoPixelate: false,
+    })
+    expect(workflow.apis.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodes: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'character-setup',
+            pixelPerfectSuggested: true,
+          }),
+        ]),
+      }),
+    )
+  })
+
   it('uses the uploaded reference when Agent starts character generation', async () => {
     const workflow = createWorkflowApis()
     const generation = createGenerationHarness()

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -120,6 +120,7 @@ export interface ApplyGenerationResultInput {
 
 export interface PrepareQuickStartProjectOptions {
   gameStyle?: ArtStyle
+  autoPixelate?: boolean
   /** 传入时复用已有项目；缺省时保持 Quick Start 自动建项目。 */
   projectId?: Project['id']
 }
@@ -136,6 +137,7 @@ export interface StartCharacterGenerationInput {
   referenceMedia?: readonly MediaReference[]
   directionalMovement?: DirectionalMovement
   gameStyle?: ArtStyle
+  autoPixelate?: boolean
   projectId?: Project['id']
   automaticDelivery?: {
     actionPrompt?: string
@@ -284,11 +286,17 @@ interface PendingGenerationAttachment {
 }
 
 export function createAutoPrepareProject(
-  projectApis: Pick<ProjectApis, 'create' | 'get'>,
+  projectApis: Pick<ProjectApis, 'create' | 'get' | 'setAutoPixelate'>,
 ): PrepareQuickStartProject {
   return async (prompt, directionalMovement = 'single', options) => {
     if (options?.projectId) {
-      const project = await projectApis.get(options.projectId)
+      let project = await projectApis.get(options.projectId)
+      if (
+        options.autoPixelate !== undefined &&
+        (project.autoPixelate ?? true) !== options.autoPixelate
+      ) {
+        project = await projectApis.setAutoPixelate(project.id, options.autoPixelate)
+      }
       return {
         id: project.id,
         spriteSize: project.spriteSize,
@@ -301,6 +309,7 @@ export function createAutoPrepareProject(
       directionalMovement,
       spriteSize: { width: 256, height: 256 },
       gameStyle: options?.gameStyle,
+      autoPixelate: options?.autoPixelate,
     })
     return {
       id: project.id,
@@ -437,6 +446,7 @@ export function createWorkflowController({
     referenceMedia = [],
     directionalMovement: selectedDirectionalMovement = 'single',
     gameStyle,
+    autoPixelate,
     projectId,
     automaticDelivery,
     suggestPixelPerfect = false,
@@ -451,6 +461,7 @@ export function createWorkflowController({
     const locomotion = actionPrompt ? automaticDelivery?.locomotion : undefined
     const project = await prepareProject(normalizedPrompt, selectedDirectionalMovement, {
       gameStyle,
+      ...(autoPixelate === undefined ? {} : { autoPixelate }),
       projectId,
     })
     generationDirections = getDirectionProfile(
@@ -469,7 +480,7 @@ export function createWorkflowController({
           generations: [],
           error: null,
           input: { prompt: normalizedPrompt, referenceMedia: [...referenceMedia] },
-          ...(suggestPixelPerfect ? { pixelPerfectSuggested: true } : {}),
+          ...(suggestPixelPerfect || autoPixelate === false ? { pixelPerfectSuggested: true } : {}),
           ...(automaticDelivery
             ? {
                 automation: {

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -3188,6 +3188,32 @@ describe('QuickStartPage', () => {
     expect((await screen.findByRole('alert')).textContent).toContain('动作生成暂时不可用')
   })
 
+  it('keeps an add-action error visible when run restoration finishes late', async () => {
+    const run = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'passed' })
+    const resumed = deferred<WorkflowRun>()
+    const service = serviceFor(run, {
+      resume: vi.fn(() => resumed.promise),
+      addAction: vi.fn(async () => Promise.reject(new Error('动作生成暂时不可用'))),
+    })
+    renderAt('/quick-start/run-1?intent=add-action&outfitId=outfit-1', service)
+
+    const input = await screen.findByRole('textbox', { name: '继续描述你的想法' })
+    await waitFor(() =>
+      expect(service.resume).toHaveBeenCalledWith({ automaticActionAdvance: false }),
+    )
+    fireEvent.change(input, { target: { value: '挥手' } })
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+
+    await waitFor(() => expect(service.addAction).toHaveBeenCalledWith('outfit-1', '挥手'))
+    expect((await screen.findByRole('alert')).textContent).toContain('动作生成暂时不可用')
+
+    await act(async () => {
+      resumed.resolve(run)
+      await resumed.promise
+    })
+    expect(screen.getByRole('alert').textContent).toContain('动作生成暂时不可用')
+  })
+
   it('recovers missing runs and returns to the creation entry', async () => {
     const service = serviceFor(null)
     renderAt('/quick-start/missing', service)

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -1138,6 +1138,7 @@ describe('QuickStartPage', () => {
         actionType: 'walk',
         directionalMovement: 'four-way',
         gameStyle: 'pixel',
+        autoPixelate: true,
         automaticDelivery: true,
         projectId: '42',
       }),
@@ -1614,6 +1615,23 @@ describe('QuickStartPage', () => {
     expect(JSON.parse(window.sessionStorage.getItem(key) ?? '{}')).toMatchObject({
       gameStyle: 'pixel',
       directionalMovement: 'eight-way',
+    })
+  })
+
+  it('lets a pixel-style draft turn off automatic perfect pixelation', () => {
+    renderAt('/quick-start', serviceFor(null), agentFor())
+
+    fireEvent.click(screen.getByRole('button', { name: '选择画风，当前不指定' }))
+    fireEvent.click(screen.getByRole('menuitemradio', { name: '像素' }))
+    const toggle = screen.getByRole('button', { name: '自动完美像素化：已开启' })
+    fireEvent.click(toggle)
+
+    expect(screen.getByRole('button', { name: '自动完美像素化：已关闭' })).toBeTruthy()
+    const draftId = window.history.state?.windupQuickStartAgentDraftId
+    const key = `windup.quick-start.agent-chat.v2:draft:7:${draftId}`
+    expect(JSON.parse(window.sessionStorage.getItem(key) ?? '{}')).toMatchObject({
+      gameStyle: 'pixel',
+      autoPixelate: false,
     })
   })
 

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -2738,6 +2738,8 @@ function QuickStartRun({
   } | null>(null)
   const mountedRef = useRef(true)
   const pixelPerfectUrlsRef = useRef<readonly string[]>([])
+  // 恢复会先展示旧快照再等待 resume；用序号避免迟到的成功清理抹掉期间产生的用户错误。
+  const workflowErrorEpochRef = useRef(0)
   const workflowAgentActions = useMemo<WorkflowAgentActions>(
     () => ({
       getContext: () =>
@@ -2779,12 +2781,14 @@ function QuickStartRun({
   const reportWorkflowError = useCallback((cause: unknown, fallback: string) => {
     const presented = presentWorkflowError(cause, fallback)
     if (workflowConflictRef.current && !presented.conflict) return
+    workflowErrorEpochRef.current += 1
     workflowConflictRef.current ||= presented.conflict
     setError(presented.message)
     setWorkflowConflict(workflowConflictRef.current)
   }, [])
   const clearWorkflowError = useCallback(() => {
     if (workflowConflictRef.current) return
+    workflowErrorEpochRef.current += 1
     setError(null)
     setWorkflowConflict(false)
   }, [])
@@ -2932,8 +2936,10 @@ function QuickStartRun({
     setPixelPerfectStatus('idle')
     setActionVersion('original')
     workflowConflictRef.current = false
+    workflowErrorEpochRef.current += 1
     setError(null)
     setWorkflowConflict(false)
+    const restoreErrorEpoch = workflowErrorEpochRef.current
 
     void (async () => {
       const providedSession = initialSessionRef.current
@@ -2965,7 +2971,7 @@ function QuickStartRun({
         : await nextSession.resume()
       if (active) {
         setRun(resumed)
-        clearWorkflowError()
+        if (workflowErrorEpochRef.current === restoreErrorEpoch) clearWorkflowError()
         setRestoring(false)
       }
     })().catch((cause) => {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -23,6 +23,7 @@ import {
   Check,
   CopySimple,
   FolderOpen,
+  GridFour,
   MagnifyingGlass,
   Play,
   Plus,
@@ -227,6 +228,8 @@ type AgentConversationRecord = {
   turns: readonly AgentConversationTurn[]
   /** 入口处选的画风；不随草稿存住的话，刷新后画风选择器已隐藏而值悄悄回到不指定。 */
   gameStyle?: ArtStyle
+  /** 默认开启；关闭时保留像素风提示词，只跳过自动像素后处理。 */
+  autoPixelate?: boolean
   /** 入口滑块选的方向；进入对话后控件锁定，刷新时必须恢复原值。 */
   directionalMovement?: DirectionalMovement
   projectId?: string | null
@@ -270,6 +273,22 @@ function readAgentDraftGameStyle(key: string): ArtStyle {
     return isArtStyle(parsed.gameStyle) ? parsed.gameStyle : 'unspecified'
   } catch {
     return 'unspecified'
+  }
+}
+
+function readAgentDraftAutoPixelate(key: string): boolean {
+  try {
+    const stored = window.sessionStorage.getItem(key)
+    if (!stored) return true
+    const parsed: unknown = JSON.parse(stored)
+    return !(
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'autoPixelate' in parsed &&
+      parsed.autoPixelate === false
+    )
+  } catch {
+    return true
   }
 }
 
@@ -591,6 +610,7 @@ function IconActionButton({
   type = 'button',
   className = '',
   expanded,
+  pressed,
   children,
 }: {
   label: string
@@ -600,6 +620,7 @@ function IconActionButton({
   type?: 'button' | 'submit'
   className?: string
   expanded?: boolean
+  pressed?: boolean
   children: ReactNode
 }) {
   const tooltipId = useId()
@@ -610,6 +631,7 @@ function IconActionButton({
       aria-label={label}
       aria-describedby={tooltipId}
       aria-expanded={expanded}
+      aria-pressed={pressed}
       disabled={disabled}
       onClick={onClick}
       data-icon-action
@@ -794,6 +816,12 @@ function QuickStartInput({
       ? readAgentDraftGameStyle(agentDraftConversationStorageKey(activeRunUserId, draftId))
       : 'unspecified'
   })
+  const [autoPixelate, setAutoPixelate] = useState(() => {
+    const draftId = readAgentDraftId()
+    return draftId
+      ? readAgentDraftAutoPixelate(agentDraftConversationStorageKey(activeRunUserId, draftId))
+      : true
+  })
   const [projectId, setProjectId] = useState<string | null>(() => {
     const requestedProjectId = entrySearchParams.get('projectId')
     if (requestedProjectId) return requestedProjectId
@@ -817,6 +845,8 @@ function QuickStartInput({
   projectIdRef.current = projectId
   const gameStyleRef = useRef(gameStyle)
   gameStyleRef.current = gameStyle
+  const autoPixelateRef = useRef(autoPixelate)
+  autoPixelateRef.current = autoPixelate
   const [submitting, setSubmitting] = useState(false)
   const [revealingFirstAgentTurn, setRevealingFirstAgentTurn] = useState(false)
   const [entryTransition, setEntryTransition] = useState<'idle' | 'leaving'>('idle')
@@ -891,6 +921,7 @@ function QuickStartInput({
         {
           turns,
           gameStyle: updates.gameStyle ?? gameStyleRef.current,
+          autoPixelate: updates.autoPixelate ?? autoPixelateRef.current,
           directionalMovement: updates.directionalMovement ?? directionalMovementRef.current,
           projectId: updates.projectId === undefined ? projectIdRef.current : updates.projectId,
         },
@@ -913,6 +944,7 @@ function QuickStartInput({
           setSelectedProject(restoredProject)
           setDirectionalMovement(restoredProject.directionalMovement)
           setGameStyle(restoredProject.gameStyle)
+          setAutoPixelate(restoredProject.autoPixelate ?? true)
         }
       },
       () => {
@@ -939,9 +971,12 @@ function QuickStartInput({
       gameStyleRef.current = project.gameStyle
       setDirectionalMovement(project.directionalMovement)
       setGameStyle(project.gameStyle)
+      autoPixelateRef.current = project.autoPixelate ?? true
+      setAutoPixelate(project.autoPixelate ?? true)
     }
     persistAgentDraft({
       gameStyle: project?.gameStyle ?? gameStyleRef.current,
+      autoPixelate: project?.autoPixelate ?? autoPixelateRef.current,
       directionalMovement: project?.directionalMovement ?? directionalMovementRef.current,
       projectId: nextProjectId,
     })
@@ -1124,7 +1159,12 @@ function QuickStartInput({
       const result = await agentSession.confirmProposal(
         state.optimizedPrompt,
         directionalMovement,
-        { gameStyle, automaticDelivery: true, ...(projectId ? { projectId } : {}) },
+        {
+          gameStyle,
+          ...(gameStyle === 'pixel' ? { autoPixelate } : {}),
+          automaticDelivery: true,
+          ...(projectId ? { projectId } : {}),
+        },
       )
       if (result.kind === 'generated') await handoffGenerated(result)
     } catch {
@@ -1149,6 +1189,13 @@ function QuickStartInput({
     setGameStyle(next)
     styleMenu.close()
     persistAgentDraft({ gameStyle: next })
+  }
+
+  function toggleAutoPixelate() {
+    const next = !autoPixelateRef.current
+    autoPixelateRef.current = next
+    setAutoPixelate(next)
+    persistAgentDraft({ autoPixelate: next })
   }
 
   function chooseDirectionalMovement(next: DirectionalMovement) {
@@ -1210,6 +1257,7 @@ function QuickStartInput({
       try {
         const result = await agentSession.confirmProposal(normalizedPrompt, directionalMovement, {
           gameStyle,
+          ...(gameStyle === 'pixel' ? { autoPixelate } : {}),
           ...(projectId ? { projectId } : {}),
         })
         if (result.kind === 'generated') await handoffGenerated(result)
@@ -1603,6 +1651,22 @@ function QuickStartInput({
                         </div>
                       ) : null}
                     </div>
+                    {gameStyle === 'pixel' ? (
+                      <IconActionButton
+                        label={`自动完美像素化：${autoPixelate ? '已开启' : '已关闭'}`}
+                        disabled={entryBusy}
+                        pressed={autoPixelate}
+                        onClick={toggleAutoPixelate}
+                        className={autoPixelate ? 'text-app-accent' : ''}
+                      >
+                        <GridFour
+                          data-icon="auto-pixelate"
+                          aria-hidden="true"
+                          size={21}
+                          weight={autoPixelate ? 'fill' : 'regular'}
+                        />
+                      </IconActionButton>
+                    ) : null}
                   </>
                 ) : null}
                 <div ref={projectMenuRoot} className="relative order-first">

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -1293,6 +1293,25 @@ describe('createQuickStartService', () => {
     )
   })
 
+  it('creates a pixel project without automatic pixelation when the user turns it off', async () => {
+    const create = vi.fn(async (input) => ({
+      id: 'project-native-pixel',
+      ...input,
+      createdAt: '2026-08-27T00:00:00Z',
+      updatedAt: '2026-08-27T00:00:00Z',
+    }))
+    const prepare = createAutoPrepareProject({ create } as unknown as ProjectApis)
+
+    await prepare('原生像素角色', 'single', {
+      gameStyle: 'pixel',
+      autoPixelate: false,
+    })
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ gameStyle: 'pixel', autoPixelate: false }),
+    )
+  })
+
   it('reuses an existing project instead of creating another one', async () => {
     const existingProject = {
       id: 'project-existing',

--- a/openapi.json
+++ b/openapi.json
@@ -2230,6 +2230,11 @@
       "ProjectCreate": {
         "description": "创建项目请求。",
         "properties": {
+          "auto_pixelate": {
+            "default": true,
+            "title": "Auto Pixelate",
+            "type": "boolean"
+          },
           "character_perspective": {
             "maximum": 3.0,
             "minimum": 1.0,
@@ -2325,6 +2330,10 @@
       "ProjectListOut": {
         "description": "项目列表项；预览是读取投影，不写回 Project。",
         "properties": {
+          "auto_pixelate": {
+            "title": "Auto Pixelate",
+            "type": "boolean"
+          },
           "character_perspective": {
             "title": "Character Perspective",
             "type": "integer"
@@ -2413,6 +2422,7 @@
           "sprite_width",
           "sprite_height",
           "game_style",
+          "auto_pixelate",
           "sprite_sample_url",
           "create_at",
           "update_at",
@@ -2424,6 +2434,10 @@
       "ProjectOut": {
         "description": "项目响应。",
         "properties": {
+          "auto_pixelate": {
+            "title": "Auto Pixelate",
+            "type": "boolean"
+          },
           "character_perspective": {
             "title": "Character Perspective",
             "type": "integer"
@@ -2501,6 +2515,7 @@
           "sprite_width",
           "sprite_height",
           "game_style",
+          "auto_pixelate",
           "sprite_sample_url",
           "create_at",
           "update_at"
@@ -2511,6 +2526,17 @@
       "ProjectPatch": {
         "description": "改项目请求;只改传上来的那些字段。",
         "properties": {
+          "auto_pixelate": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Pixelate"
+          },
           "game_style": {
             "anyOf": [
               {


### PR DESCRIPTION
像素风现在保留模型风格约束，同时允许用户在生成前关闭自动完美像素化；默认行为不变，关闭后交付原生结果，并在完成阶段保留手动处理入口。

## Why

当前 `game_style=pixel` 同时控制提示词和后处理，用户无法排除母版、首帧及视频抽帧自动像素化对质量实验的影响。

## Changes

- 在快速开始的像素风控件旁增加默认开启的“自动完美像素化”按钮，并将选择保存在草稿中。
- 新增项目级 `auto_pixelate` 约束，自动创建和复用已有项目都按用户选择持久化。
- 关闭时仍使用 `pixel art` 提示词，但母版、首帧和视频动作统一走 `stylize=none` 原生分支。
- 关闭自动处理时，WorkflowRun 会保留完成后的手动完美像素化入口。

## Implementation

- `game_style` 继续只描述模型画风；`auto_pixelate` 单独控制 NEAREST 像素适配与 `pixelate_frames` 后处理。
- 字段使用 `server_default=true`，存量项目在补列后默认维持现有自动处理行为。
- 部署已有数据库前需执行 `backend/scripts/schema_sync.py --apply` 补充加法列。

## Verification

- [x] `npm test -- --run src/entities/project/index.test.ts src/pages/quick-start/service.test.ts src/features/workflow-controller/controller.test.ts src/pages/quick-start/index.test.tsx src/features/quick-start-agent/runtime.test.ts src/features/quick-start-agent/production.test.ts src/features/quick-start-agent/react.test.tsx`：355 passed
- [x] `npm run typecheck`：通过
- [x] `npx oxfmt --check <touched frontend files>`：通过
- [x] `npx oxlint <touched frontend files>`：通过
- [x] `uv run pytest -q tests/test_art_style.py tests/test_project_api.py tests/test_schema_sync.py tests/test_ai_engine_skeleton.py`：85 passed
- [x] `uv run ruff check <touched backend files>`：通过
- [ ] 浏览器验收：按用户要求不执行

## Scope

- 本 PR 不修改完美像素化算法、视频缩放/48 色策略或模型供应商。
- 本 PR 不改变非像素风项目，也不覆盖手动生成的完美像素版本。

## Related Issues

Closes #784