### PR TITLE
Restore Agent flow when appending character actions

### DIFF
--- a/frontend/src/features/quick-start-agent/planner.test.ts
+++ b/frontend/src/features/quick-start-agent/planner.test.ts
@@ -37,6 +37,18 @@ describe('quickStartPlannerInstructions', () => {
     expect(laterTurn).toContain('不得再问第二个澄清问题')
     expect(laterTurn).toContain('可继续补充')
   })
+
+  it('keeps an existing character fixed while proposing only a new action', () => {
+    const instructions = quickStartPlannerInstructions(false, undefined, {
+      characterPrompt: '紫发女巫，黑色尖顶帽，手持木质法杖',
+    })
+
+    expect(instructions).toContain('当前任务只为已有角色新增动作')
+    expect(instructions).toContain('紫发女巫，黑色尖顶帽，手持木质法杖')
+    expect(instructions).toContain('不得修改、补写或重新提案角色身份')
+    expect(instructions).toContain('actionPrompt')
+    expect(instructions).toContain('locomotion: true')
+  })
 })
 
 describe('createAiSdkQuickStartPlanner', () => {

--- a/frontend/src/features/quick-start-agent/planner.ts
+++ b/frontend/src/features/quick-start-agent/planner.ts
@@ -244,6 +244,7 @@ function fallbackPlannerResult(
 export function quickStartPlannerInstructions(
   clarificationUsed: boolean,
   artStyle?: string,
+  addActionContext?: { characterPrompt: string },
 ): string {
   const clarificationRule = clarificationUsed
     ? '本草稿已经问过一次必要澄清，不得因为轮数强制生成，也不得再问第二个澄清问题；信息不足时用 reply 说明可继续补充，存在硬冲突时用 blocked。'
@@ -251,9 +252,14 @@ export function quickStartPlannerInstructions(
   const artStyleContext = artStyle
     ? `用户当前选择的画风是「${artStyle}」。这是宿主已经确定的生成约束；拟写提示词时不得使用与它冲突的画风描述，也不要修改或重新选择画风。`
     : ''
+  const addActionRule = addActionContext
+    ? `当前任务只为已有角色新增动作。已有角色的固定约束是：「${addActionContext.characterPrompt}」。不得修改、补写或重新提案角色身份；proposal 的 optimizedPrompt 必须原样返回这份固定约束，只在 actionPrompt 中整理用户要求的新增动作。`
+    : ''
   return `你是 Windup Quick Start 的轻量 Planner。你只理解当前草稿、回复用户，并在合适时给出角色母版提示词提案；你不执行生成，也不参与生成后的流程。
 
 ${artStyleContext}
+
+${addActionRule}
 
 每轮必须调用一次 ${QUICK_START_DECISION_TOOL}，并只返回一个决策：
 - reply：闲聊、回顾历史、评价、比较方案、解释或继续讨论。reply 不消耗澄清额度。
@@ -321,6 +327,7 @@ export function createAiSdkQuickStartPlanner({
     messages,
     clarificationUsed,
     artStyle,
+    addActionContext,
     workflow,
     signal,
   }): Promise<PlannerResult> => {
@@ -331,7 +338,7 @@ export function createAiSdkQuickStartPlanner({
       : { [QUICK_START_DECISION_TOOL]: quickStartDecisionTool }
     const instructions = workflow
       ? quickStartWorkflowInstructions(workflow)
-      : quickStartPlannerInstructions(clarificationUsed, artStyle)
+      : quickStartPlannerInstructions(clarificationUsed, artStyle, addActionContext)
     const history = messages.slice(-MAX_PLANNER_HISTORY_MESSAGES)
     const result = await generateText({
       model,

--- a/frontend/src/features/quick-start-agent/react.test.tsx
+++ b/frontend/src/features/quick-start-agent/react.test.tsx
@@ -75,6 +75,8 @@ describe('useQuickStartAgent', () => {
       prompt: '银发像素骑士，全身像，深蓝斗篷',
       directionalMovement: 'single',
     })
+    expect(result.current.state).toEqual({ status: 'idle' })
+    expect(result.current.busy).toBe(false)
   })
 
   it('lets a new discussion message supersede the visible proposal', async () => {

--- a/frontend/src/features/quick-start-agent/react.ts
+++ b/frontend/src/features/quick-start-agent/react.ts
@@ -69,6 +69,7 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
     planner,
     startCharacterGeneration,
     artStyle,
+    addActionContext,
     initialMessages,
     initialClarificationUsed,
     initialProposal,
@@ -89,19 +90,21 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
       agent.current?.revoke()
       agent.current = null
     }
-  }, [artStyle, initialMessages, planner, startCharacterGeneration])
+  }, [addActionContext, artStyle, initialMessages, planner, startCharacterGeneration])
 
   const ensureAgent = useCallback(() => {
     agent.current ??= createQuickStartAgent({
       planner,
       startCharacterGeneration,
       artStyle,
+      addActionContext,
       initialMessages,
       initialClarificationUsed,
       initialProposal,
     })
     return agent.current
   }, [
+    addActionContext,
     artStyle,
     initialClarificationUsed,
     initialMessages,
@@ -216,7 +219,14 @@ export function useQuickStartAgent(options: UseQuickStartAgentOptions) {
         })
       }
       try {
-        return await ensureAgent().confirmProposal(proposalId, prompt, directionalMovement, options)
+        const result = await ensureAgent().confirmProposal(
+          proposalId,
+          prompt,
+          directionalMovement,
+          options,
+        )
+        if (mounted.current) setState({ status: 'idle' })
+        return result
       } catch (cause) {
         if (mounted.current) {
           logAgentFailure(cause)

--- a/frontend/src/features/quick-start-agent/runtime.test.ts
+++ b/frontend/src/features/quick-start-agent/runtime.test.ts
@@ -299,6 +299,29 @@ describe('createQuickStartAgent', () => {
     })
   })
 
+  it('passes the fixed existing-character context to every add-action planning turn', async () => {
+    const planner = vi.fn<QuickStartPlanner>(async () =>
+      decisionResult({ kind: 'reply', message: '我会只整理新增动作。' }),
+    )
+    const agent = createQuickStartAgent({
+      planner,
+      startCharacterGeneration: vi.fn(),
+      addActionContext: {
+        characterPrompt: '紫发女巫，黑色尖顶帽，手持木质法杖',
+      },
+    })
+
+    await agent.start('让她快速向前翻滚')
+
+    expect(planner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        addActionContext: {
+          characterPrompt: '紫发女巫，黑色尖顶帽，手持木质法杖',
+        },
+      }),
+    )
+  })
+
   it('silently carries explicit pixel-art intent into the confirmed generation', async () => {
     const { agent, startCharacterGeneration } = fixture(
       decisionResult({

--- a/frontend/src/features/quick-start-agent/runtime.ts
+++ b/frontend/src/features/quick-start-agent/runtime.ts
@@ -48,6 +48,7 @@ export interface PlannerInput {
   clarificationUsed: boolean
   /** 用户在宿主中选择的画风；Planner 只把它当作拟写提示词时的既定约束。 */
   artStyle?: string
+  addActionContext?: { characterPrompt: string }
   workflow?: WorkflowAgentContext
   signal?: AbortSignal
 }
@@ -127,6 +128,8 @@ export interface CreateQuickStartAgentOptions {
   planner: QuickStartPlanner
   startCharacterGeneration: StartCharacterGenerationAction
   artStyle?: string
+  /** 已有角色新增动作时的只读角色约束；只交给 Planner，不写入 WorkflowRun。 */
+  addActionContext?: { characterPrompt: string }
   initialMessages?: readonly PlannerMessage[]
   initialClarificationUsed?: boolean
   initialProposal?: CharacterGenerationProposal | null
@@ -319,6 +322,7 @@ export function createQuickStartAgent({
   planner,
   startCharacterGeneration,
   artStyle,
+  addActionContext,
   initialMessages = [],
   initialClarificationUsed = false,
   initialProposal = null,
@@ -364,7 +368,13 @@ export function createQuickStartAgent({
       // runtime 也必须保留同一历史，避免刷新前后得到不同上下文。
       messages = nextMessages
       const decision = validatePlannerTerminal(
-        await planner({ messages: nextMessages, clarificationUsed, artStyle, signal }),
+        await planner({
+          messages: nextMessages,
+          clarificationUsed,
+          artStyle,
+          addActionContext,
+          signal,
+        }),
       )
       if (signal?.aborted) {
         revoked = true

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -427,6 +427,26 @@ function agentFor(
   }
 }
 
+function addActionAgentFor(): CreateQuickStartAgentOptions {
+  return agentFor({
+    planner: vi.fn(async ({ messages, addActionContext }) => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'quick_start_decision',
+          input: {
+            kind: 'proposal',
+            optimizedPrompt: addActionContext?.characterPrompt ?? '',
+            actionPrompt: messages.at(-1)?.content ?? '',
+            optimizationSummary: '我会保留现有角色，只新增这条动作。',
+          },
+        },
+      ],
+    })),
+  })
+}
+
 const existingProject: Project = {
   id: '42',
   workflowId: null,
@@ -3113,10 +3133,30 @@ describe('QuickStartPage', () => {
     expect(composer?.querySelector('[data-layout="quick-start-attachment-row"]')).toBeNull()
   })
 
-  it('adds an action from the existing Quick Start run instead of creating another run', async () => {
+  it('confirms an Agent proposal before appending an action to the existing Run', async () => {
     const run = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'passed' })
     const service = serviceFor(run)
-    renderAt('/quick-start/run-1?intent=add-action&outfitId=outfit-1', service)
+    const planner = vi.fn(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'quick_start_decision',
+          input: {
+            kind: 'proposal',
+            optimizedPrompt: '像素骑士',
+            actionPrompt: '向前翻滚一圈',
+            locomotion: true,
+            optimizationSummary: '我会保留现有骑士，只新增向前翻滚的位移动作。',
+          },
+        },
+      ],
+    }))
+    renderAt(
+      '/quick-start/run-1?intent=add-action&outfitId=outfit-1',
+      service,
+      agentFor({ planner }),
+    )
 
     const input = await screen.findByRole('textbox', { name: '继续描述你的想法' })
     const submit = screen.getByRole('button', { name: '发送' })
@@ -3124,11 +3164,67 @@ describe('QuickStartPage', () => {
     expect(service.addAction).not.toHaveBeenCalled()
     expect((submit as HTMLButtonElement).disabled).toBe(true)
 
-    fireEvent.change(input, { target: { value: '挥手' } })
+    fireEvent.change(input, { target: { value: '让他向前翻滚一圈' } })
     await waitFor(() => expect((submit as HTMLButtonElement).disabled).toBe(false))
     fireEvent.click(submit)
 
-    await waitFor(() => expect(service.addAction).toHaveBeenCalledWith('outfit-1', '挥手'))
+    expect(await screen.findByText('动作：向前翻滚一圈')).toBeTruthy()
+    expect(screen.getAllByText('让他向前翻滚一圈')).toHaveLength(1)
+    expect(service.addAction).not.toHaveBeenCalled()
+    expect(planner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        addActionContext: { characterPrompt: '像素骑士' },
+      }),
+    )
+    await waitFor(() => {
+      const sidecar = window.localStorage.getItem('windup.quick-start.agent-chat.v2:run:7:run-1')
+      expect(sidecar).toContain('"scope":"add-action"')
+      expect(sidecar).toContain('让他向前翻滚一圈')
+    })
+    expect(JSON.stringify(service.getWorkflow())).not.toContain('让他向前翻滚一圈')
+
+    fireEvent.click(screen.getByRole('button', { name: '确认并生成' }))
+
+    await waitFor(() =>
+      expect(service.addAction).toHaveBeenCalledWith('outfit-1', '向前翻滚一圈', {
+        locomotion: true,
+      }),
+    )
+    await waitFor(() => expect((input as HTMLTextAreaElement).disabled).toBe(false))
+    expect(service.start).not.toHaveBeenCalled()
+  })
+
+  it('keeps add-action clarification in Agent conversation without touching the Run', async () => {
+    const run = actionWorkflow({ fullStatus: 'passed', reviewStatus: 'passed' })
+    const service = serviceFor(run)
+    const planner = vi.fn(async () => ({
+      text: '',
+      finishReason: 'tool-calls',
+      toolCalls: [
+        {
+          toolName: 'quick_start_decision',
+          input: {
+            kind: 'clarification',
+            message: '这个翻滚需要向前位移，还是原地完成？',
+          },
+        },
+      ],
+    }))
+    renderAt(
+      '/quick-start/run-1?intent=add-action&outfitId=outfit-1',
+      service,
+      agentFor({ planner }),
+    )
+
+    fireEvent.change(await screen.findByRole('textbox', { name: '继续描述你的想法' }), {
+      target: { value: '让他翻滚' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+
+    expect(await screen.findByText('这个翻滚需要向前位移，还是原地完成？')).toBeTruthy()
+    expect(service.addAction).not.toHaveBeenCalled()
+    expect(service.start).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: '确认并生成' })).toBeNull()
   })
 
   it('adds an action when an older action branch failed', async () => {
@@ -3144,7 +3240,7 @@ describe('QuickStartPage', () => {
       ...current.nodes.slice(2),
     ])
     const service = serviceFor(run)
-    renderAt('/quick-start/run-1?intent=add-action&outfitId=outfit-1', service)
+    renderAt('/quick-start/run-1?intent=add-action&outfitId=outfit-1', service, addActionAgentFor())
 
     const input = await screen.findByRole('textbox', { name: '继续描述你的想法' })
     fireEvent.change(input, { target: { value: '跳跃' } })
@@ -3152,7 +3248,8 @@ describe('QuickStartPage', () => {
     const submit = screen.getByRole('button', { name: '发送' })
     await waitFor(() => expect((submit as HTMLButtonElement).disabled).toBe(false))
     fireEvent.click(submit)
-    await waitFor(() => expect(service.addAction).toHaveBeenCalledWith('outfit-1', '跳跃'))
+    fireEvent.click(await screen.findByRole('button', { name: '确认并生成' }))
+    await waitFor(() => expect(service.addAction).toHaveBeenCalledWith('outfit-1', '跳跃', {}))
   })
 
   it('reports add-action failures inside the existing Quick Start run', async () => {
@@ -3160,12 +3257,13 @@ describe('QuickStartPage', () => {
     const service = serviceFor(run, {
       addAction: vi.fn(async () => Promise.reject(new Error('动作生成暂时不可用'))),
     })
-    renderAt('/quick-start/run-1?intent=add-action&outfitId=outfit-1', service)
+    renderAt('/quick-start/run-1?intent=add-action&outfitId=outfit-1', service, addActionAgentFor())
 
     fireEvent.change(await screen.findByRole('textbox', { name: '继续描述你的想法' }), {
       target: { value: '挥手' },
     })
     fireEvent.click(screen.getByRole('button', { name: '发送' }))
+    fireEvent.click(await screen.findByRole('button', { name: '确认并生成' }))
 
     expect((await screen.findByRole('alert')).textContent).toContain('动作生成暂时不可用')
   })

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -199,13 +199,20 @@ const AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v2'
 const LEGACY_AGENT_CONVERSATION_STORAGE_KEY = 'windup.quick-start.agent-chat.v1'
 const AGENT_DRAFT_HISTORY_STATE_KEY = 'windupQuickStartAgentDraftId'
 
+type AgentConversationScope = 'workflow' | 'add-action'
+
 type AgentConversationTurn =
-  | { role: 'user'; content: string; referenceMedia?: readonly string[]; scope?: 'workflow' }
+  | {
+      role: 'user'
+      content: string
+      referenceMedia?: readonly string[]
+      scope?: AgentConversationScope
+    }
   | {
       role: 'assistant'
       content: string
       kind: 'reply' | 'clarification' | 'blocked'
-      scope?: 'workflow'
+      scope?: AgentConversationScope
     }
   | {
       role: 'assistant'
@@ -220,7 +227,7 @@ type AgentConversationTurn =
       suggestPixelPerfect?: boolean
       referenceMedia?: readonly string[]
       proposalStatus: 'pending' | 'superseded' | 'adopted' | 'confirmed'
-      scope?: 'workflow'
+      scope?: AgentConversationScope
     }
 
 type AgentConversationRecord = {
@@ -336,7 +343,10 @@ function readAgentConversation(
       ) {
         return []
       }
-      const scope = 'scope' in turn && turn.scope === 'workflow' ? 'workflow' : undefined
+      const scope =
+        'scope' in turn && (turn.scope === 'workflow' || turn.scope === 'add-action')
+          ? turn.scope
+          : undefined
       if (turn.role === 'user') {
         const referenceMedia =
           'referenceMedia' in turn &&
@@ -2626,6 +2636,7 @@ function QuickStartRun({
   const location = useLocation()
   const [searchParams] = useSearchParams()
   const addActionIntent = searchParams.get('intent') === 'add-action'
+  const requestedOutfitId = searchParams.get('outfitId')
   const [session, setSession] = useState<QuickStartSession | null>(null)
   const [run, setRun] = useState<WorkflowRun | null>(null)
   const [restoring, setRestoring] = useState(true)
@@ -2661,7 +2672,12 @@ function QuickStartRun({
   const initialAgentConversation = useRef(readAgentRunConversation(activeRunUserId, runId)).current
   const [agentConversationTurns, setAgentConversationTurns] = useState(initialAgentConversation)
   const agentConversationTurnsRef = useRef(agentConversationTurns)
-  const initialWorkflowAgentSeed = useRef(createAgentSeed(initialAgentConversation)).current
+  const initialWorkflowAgentSeed = useRef(
+    createAgentSeed(initialAgentConversation.filter((turn) => turn.scope !== 'add-action')),
+  ).current
+  const initialAddActionAgentSeed = useRef(
+    createAgentSeed(initialAgentConversation.filter((turn) => turn.scope === 'add-action')),
+  ).current
   const automaticPublishAttempt = useRef<string | null>(null)
   const transcriptScrollRegion = useRef<HTMLElement>(null)
   const promptCopyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -2711,6 +2727,45 @@ function QuickStartRun({
     planner: agent.planner,
     actions: workflowAgentActions,
     initialMessages: initialWorkflowAgentSeed.messages,
+  })
+  const appendActionToCurrentRun = useCallback(
+    async (input: {
+      prompt: string
+      actionPrompt?: string
+      actionType?: 'idle' | 'walk' | 'attack' | 'jump'
+      locomotion?: true
+    }) => {
+      const target = activeSessionRef.current
+      if (!target) throw new Error('当前生成会话尚未恢复')
+      let outfitId = requestedOutfitId
+      if (!outfitId) {
+        const info = target.getCharacterInfo() ?? (await target.resolveCharacterInfo())
+        outfitId = info?.outfitId ?? null
+      }
+      if (!outfitId) throw new Error('没有找到要追加动作的角色造型')
+      const actionPrompt = input.actionPrompt?.trim()
+      if (!actionPrompt) throw new Error('Agent 提案缺少新增动作')
+      const updated = await target.addAction(outfitId, actionPrompt, {
+        ...(input.actionType ? { actionType: input.actionType } : {}),
+        ...(input.locomotion ? { locomotion: input.locomotion } : {}),
+      })
+      if (mountedRef.current && activeSessionRef.current === target) setRun(updated)
+      return { runId: target.runId }
+    },
+    [requestedOutfitId],
+  )
+  const addActionCharacterPrompt = run ? workflowPrompt(run) : ''
+  const addActionContext = useMemo(
+    () => ({ characterPrompt: addActionCharacterPrompt }),
+    [addActionCharacterPrompt],
+  )
+  const addActionAgentSession = useQuickStartAgent({
+    planner: agent.planner,
+    startCharacterGeneration: appendActionToCurrentRun,
+    addActionContext,
+    initialMessages: initialAddActionAgentSeed.messages,
+    initialClarificationUsed: initialAddActionAgentSeed.clarificationUsed,
+    initialProposal: initialAddActionAgentSeed.pendingProposal,
   })
   const reportWorkflowError = useCallback((cause: unknown, fallback: string) => {
     const presented = presentWorkflowError(cause, fallback)
@@ -3200,7 +3255,6 @@ function QuickStartRun({
       : allDirectionsSelected(firstFrameCandidates, firstFrameSelections)
   const firstFrameConfirmLabel =
     firstFrameSheets.length > 0 ? '确认候选帧，生成完整动作' : '确认首帧，生成完整动作'
-  const requestedOutfitId = searchParams.get('outfitId')
   const canAddAction =
     addActionIntent &&
     !workflowHasActiveNode &&
@@ -3360,6 +3414,44 @@ function QuickStartRun({
     )
   }
 
+  function updateAddActionProposalStatus(
+    proposalId: string,
+    proposalStatus: Extract<AgentConversationTurn, { kind: 'proposal' }>['proposalStatus'],
+  ) {
+    const next = agentConversationTurnsRef.current.map((turn) =>
+      turn.role === 'assistant' &&
+      turn.kind === 'proposal' &&
+      turn.scope === 'add-action' &&
+      turn.proposalId === proposalId
+        ? { ...turn, proposalStatus }
+        : turn,
+    )
+    agentConversationTurnsRef.current = next
+    setAgentConversationTurns(next)
+    writeAgentConversation('localStorage', agentRunConversationStorageKey(activeRunUserId, runId), {
+      turns: next,
+    })
+  }
+
+  async function confirmAddActionProposal(proposalId: string) {
+    const state = addActionAgentSession.state
+    if (state.status !== 'proposal' || state.proposalId !== proposalId || addingAction) return
+    setAddingAction(true)
+    clearWorkflowError()
+    try {
+      await addActionAgentSession.confirmProposal(
+        state.optimizedPrompt,
+        session?.getDirectionalMovement?.() ?? 'single',
+      )
+      updateAddActionProposalStatus(proposalId, 'confirmed')
+      setActionDescription('')
+    } catch (cause) {
+      reportWorkflowError(cause, '新增动作失败，请稍后重试')
+    } finally {
+      if (mountedRef.current) setAddingAction(false)
+    }
+  }
+
   async function continueConversation(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     if (workflowConflictRef.current) return
@@ -3374,24 +3466,37 @@ function QuickStartRun({
     const message = actionDescription.trim()
     if (addActionIntent) {
       if (!canAddAction || !message || !session || addingAction) return
-      setAddingAction(true)
       clearWorkflowError()
+      appendRunConversationTurn({ role: 'user', content: message, scope: 'add-action' })
+      setActionDescription('')
       try {
-        let outfitId = requestedOutfitId
-        if (!outfitId) {
-          const info = session.getCharacterInfo() ?? (await session.resolveCharacterInfo())
-          outfitId = info?.outfitId ?? null
+        const result = await addActionAgentSession.submit(message)
+        if (result.kind === 'message') {
+          appendRunConversationTurn({
+            role: 'assistant',
+            content: result.message,
+            kind: result.messageKind,
+            scope: 'add-action',
+          })
+        } else if (result.kind === 'proposal') {
+          appendRunConversationTurn({
+            role: 'assistant',
+            content: `${result.optimizationSummary}\n\n角色：${result.optimizedPrompt}${result.actionPrompt ? `\n动作：${result.actionPrompt}` : ''}`,
+            kind: 'proposal',
+            proposalId: result.proposalId,
+            optimizedPrompt: result.optimizedPrompt,
+            ...(result.actionPrompt ? { actionPrompt: result.actionPrompt } : {}),
+            ...(result.actionType ? { actionType: result.actionType } : {}),
+            ...(result.locomotion ? { locomotion: result.locomotion } : {}),
+            optimizationSummary: result.optimizationSummary,
+            suggestPixelPerfect: result.suggestPixelPerfect,
+            proposalStatus: 'pending',
+            scope: 'add-action',
+          })
         }
-        if (!outfitId) throw new Error('没有找到要追加动作的角色造型')
-        const updated = await session.addAction(outfitId, message)
-        if (!mountedRef.current || activeSessionRef.current !== session) return
-        setRun(updated)
-        setActionDescription('')
       } catch (cause) {
         if (!mountedRef.current || activeSessionRef.current !== session) return
-        reportWorkflowError(cause, '新增动作失败，请稍后重试')
-      } finally {
-        if (mountedRef.current && activeSessionRef.current === session) setAddingAction(false)
+        reportWorkflowError(cause, 'Agent 暂时无法整理新增动作')
       }
       return
     }
@@ -3447,10 +3552,13 @@ function QuickStartRun({
       templateSelectionComplete &&
       (!isDirectionSetSelecting || Boolean(actionDescription.trim()))) ||
     (isFirstFrameSelecting && firstFrameSelectionComplete) ||
-    (canAddAction && Boolean(actionDescription.trim()) && !addingAction) ||
+    (canAddAction &&
+      Boolean(actionDescription.trim()) &&
+      !addingAction &&
+      !addActionAgentSession.busy) ||
     (workflowAgentMode && workflowAgentAvailable && Boolean(actionDescription.trim()))
   const workflowComposerDisabled = addActionIntent
-    ? !canAddAction || addingAction || workflowConflict
+    ? !canAddAction || addingAction || addActionAgentSession.busy || workflowConflict
     : workflowAgentMode &&
       ((workflowIsActive && !candidateAgentMode) ||
         !workflowAgentAvailable ||
@@ -3475,11 +3583,12 @@ function QuickStartRun({
     actionStep?.id,
     new Map(pixelPerfectReplacementEntries),
   )
-  const entryAgentConversationTurns = agentConversationTurns.filter(
-    (turn) => turn.scope !== 'workflow',
-  )
+  const entryAgentConversationTurns = agentConversationTurns.filter((turn) => !turn.scope)
   const workflowAgentConversationTurns = agentConversationTurns.filter(
     (turn) => turn.scope === 'workflow',
+  )
+  const addActionAgentConversationTurns = agentConversationTurns.filter(
+    (turn) => turn.scope === 'add-action',
   )
   const workflowAgentConversation = workflowAgentConversationTurns.map((turn, index) => (
     <div
@@ -3498,6 +3607,32 @@ function QuickStartRun({
     workflowAgentSession.state.status === 'action' &&
     (workflowAgentSession.state.action === 'regenerate_character_template' ||
       workflowAgentSession.state.action === 'refine_character_template')
+  const addActionAgentConversation = addActionAgentConversationTurns.map((turn, index) => (
+    <div
+      key={`${turn.role}:add-action:${index}:${turn.content}`}
+      data-conversation-kind="agent"
+      className="min-w-0"
+    >
+      {turn.role === 'user' ? (
+        <UserTurn>{turn.content}</UserTurn>
+      ) : turn.kind === 'proposal' ? (
+        <PromptProposal
+          summary={turn.optimizationSummary}
+          prompt={turn.optimizedPrompt}
+          actionPrompt={turn.actionPrompt}
+          status={turn.proposalStatus}
+          disabled={addingAction || addActionAgentSession.busy || workflowConflict}
+          onConfirm={() => void confirmAddActionProposal(turn.proposalId)}
+          onFill={() => {
+            updateAddActionProposalStatus(turn.proposalId, 'adopted')
+            setActionDescription(turn.actionPrompt ?? '')
+          }}
+        />
+      ) : (
+        <AgentCopy lines={turn.content.split('\n')} />
+      )}
+    </div>
+  ))
 
   return (
     <section className="relative min-h-screen overflow-hidden bg-app-canvas pt-14 text-app-ink">
@@ -3657,6 +3792,8 @@ function QuickStartRun({
                 />
               ) : null}
             </AgentTurn>
+
+            {addActionAgentConversation}
 
             {firstFrameStep ? (
               <>

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -2814,6 +2814,42 @@ describe('createQuickStartService', () => {
     })
   })
 
+  it('uses confirmed Agent semantics when appending an action to the current Run', async () => {
+    const run: WorkflowRun = {
+      id: 'old-run',
+      projectId: 'project-1',
+      version: 1,
+      storageStatus: 'active',
+      nodes: setupNodes(),
+    }
+    const generationApis = pendingGenerationApis()
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis([run]),
+      generationApis,
+      projectApis: projectReader(),
+      prepareProject: vi.fn(),
+    })
+
+    const session = await service.open(run.id)
+    await session.addAction('outfit-existing', '向前翻滚一圈', {
+      locomotion: true,
+    })
+
+    expect(session.getWorkflow().id).toBe(run.id)
+    expect(
+      session.getWorkflow().nodes.find((node) => node.type === 'action-first-frame'),
+    ).toMatchObject({
+      input: {
+        prompt: '向前翻滚一圈',
+        type: 'custom',
+        locomotion: true,
+      },
+    })
+    expect(generationApis.create).toHaveBeenCalledWith(
+      expect.objectContaining({ actionType: 'custom', prompt: '向前翻滚一圈' }),
+    )
+  })
+
   it('Character 写入失败时重新打开已确认的母版节点', async () => {
     const character = characterFixture({
       id: 'orphan-character',

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -99,7 +99,14 @@ export interface QuickStartSession {
     signal?: AbortSignal,
   ): Promise<WorkflowRun>
   /** 在当前 WorkflowRun 的角色母版后追加动作，不创建新的 Run。 */
-  addAction(outfitId: string, actionDescription: string): Promise<WorkflowRun>
+  addAction(
+    outfitId: string,
+    actionDescription: string,
+    semantics?: {
+      actionType?: 'idle' | 'walk' | 'attack' | 'jump'
+      locomotion?: true
+    },
+  ): Promise<WorkflowRun>
   confirmCandidate(
     selectedImages: QuickStartTemplateSelection,
     actionDescription?: string,
@@ -1027,7 +1034,7 @@ export function createQuickStartService({
             .map((generation) => generation.queueAhead ?? 0),
         )
       },
-      async addAction(outfitId, actionDescription) {
+      async addAction(outfitId, actionDescription, semantics) {
         const prompt = actionDescription.trim()
         if (!prompt) throw new Error('请先描述要新增的动作')
         const run = controller.getWorkflow()
@@ -1042,7 +1049,7 @@ export function createQuickStartService({
           }
         }
         const spriteSize = knownSpriteSize ?? (await resolveProjectSpriteSize(run.projectId))
-        await prepareAction(controller, outfitId, prompt, spriteSize)
+        await prepareAction(controller, outfitId, prompt, spriteSize, semantics)
         ensureAutomaticAdvance()
         return controller.getWorkflow()
       },


### PR DESCRIPTION
## 变更说明

- 已有角色新增动作恢复完整 Agent 对话、澄清、提案与确认流程
- 确认后复用当前 `QuickStartSession.addAction`，保留原 WorkflowRun 与角色提示词约束
- Agent 对话继续保存在 localStorage sidecar，不写入 WorkflowRun；新增动作语义只传给现有 Controller
- 隔离新增动作与工作流 Agent 的会话种子，并修正同页 dispatch 完成后的输入状态

## 验证

- `npm test -- --run src/pages/quick-start/index.test.tsx src/pages/quick-start/service.test.ts src/features/quick-start-agent/runtime.test.ts src/features/quick-start-agent/react.test.tsx src/features/quick-start-agent/planner.test.ts`
- `npm run typecheck`
- touched files `oxfmt --check` / `oxlint`
- 本次无视觉样式变更；本地真实页面受登录门禁限制，未使用生产页面补验

Closes #786
