### PR TITLE
fix(video): preserve character fidelity in action frames

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/impl/character_generator.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/impl/character_generator.py
@@ -12,14 +12,16 @@ MVP 边界(与作者对齐):**只出帧 bytes + 逐帧时长**,不打包 sprite 
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 from PIL import Image
 
-from windup_common.models import ActionSpec, CharacterCard, GenRoute
+from windup_common.models import ActionSpec, CharacterCard, GenRoute, Stylize
 
 from windup_ai_engine._imgio import from_png as _img
 from windup_ai_engine._imgio import to_png as _png
-from windup_ai_engine.master_check import check_master
+from windup_ai_engine.master_check import MasterFacts, check_master
 from windup_ai_engine.ports import (
     ActionQuality,
     CharacterGeneratorPort,
@@ -28,7 +30,9 @@ from windup_ai_engine.ports import (
     RenderPlan,
     SequenceGeometry,
 )
-from windup_ai_engine.postprocess import FOOT_LINE, align_bottom_center, frame_durations
+from windup_ai_engine.postprocess import (
+    FOOT_LINE, align_bottom_center, detect_pixel_size, frame_durations,
+)
 from windup_ai_engine.postprocess.pack import ANCHOR_CENTROID, FILL_H
 from windup_ai_engine.prompt import PROMPT_VERSION
 from windup_ai_engine.slicing import (
@@ -61,6 +65,14 @@ _TICK_ROUTE = 1
 _DERIVE_FROM, _DERIVE_TO = 2, 7       # strategy 的 0..sub_total 映射到 [2, 7]
 _TICK_LASTMILE = 8
 _TICK_PACKAGE = 9
+
+
+@dataclass(frozen=True)
+class _LastMileRenderSpec:
+    """视频帧收口时从确认母版继承的两项视觉事实。"""
+
+    fill_h: float = FILL_H
+    resample: Image.Resampling = Image.Resampling.NEAREST
 
 
 class _BandProgress(ProgressPort):
@@ -127,7 +139,11 @@ class CharacterGenerator(CharacterGeneratorPort):
         frames = strategy.derive(
             card, action, master, _BandProgress(progress, _DERIVE_FROM, _DERIVE_TO)
         )
-        return self._finish(frames, action, route, progress, canvas)
+        render_spec = (
+            _video_render_spec(master, facts, action)
+            if route is GenRoute.VIDEO_I2V else None
+        )
+        return self._finish(frames, action, route, progress, canvas, render_spec)
 
     def can_defer_i2v(self) -> bool:
         strategy = self._by_route.get(GenRoute.VIDEO_I2V)
@@ -175,6 +191,9 @@ class CharacterGenerator(CharacterGeneratorPort):
         canvas: tuple[int, int] | None = None,
     ) -> GeneratedAction:
         """成片到位后走抽帧 / 抠图 / 最后一公里。"""
+        # 异步提交与收口可能落在不同进程,不能依赖 start_video 当时的内存事实。
+        # 母版仍是这次交付尺度的唯一来源,在此重新量一次再进入最后一公里。
+        facts = check_master(master, canvas)
         route = ROUTE_MATRIX[action.action]
         progress.step("route", _TICK_ROUTE, _TOTAL, f"{action.action.value} → {route.value}")
         strategy = self._pick(route, action)
@@ -184,7 +203,8 @@ class CharacterGenerator(CharacterGeneratorPort):
         frames = frames_from(
             video, card, action, master, _BandProgress(progress, _DERIVE_FROM, _DERIVE_TO)
         )
-        return self._finish(frames, action, route, progress, canvas)
+        render_spec = _video_render_spec(master, facts, action)
+        return self._finish(frames, action, route, progress, canvas, render_spec)
 
     def generate_rendered(
         self,
@@ -253,6 +273,7 @@ class CharacterGenerator(CharacterGeneratorPort):
         route: GenRoute,
         progress: ProgressPort,
         canvas: tuple[int, int] | None,
+        render_spec: _LastMileRenderSpec | None = None,
     ) -> GeneratedAction:
         """出帧之后的公共尾段:帧数对账 → 脚线对齐 → 量成色 → 出参。
 
@@ -273,7 +294,8 @@ class CharacterGenerator(CharacterGeneratorPort):
             )
 
         # 最后一公里:对齐成原地序列帧(直接对齐到调用方要的画布尺寸)
-        aligned = self._lastmile(frames, action, progress, canvas)
+        spec = render_spec or _LastMileRenderSpec()
+        aligned = self._lastmile(frames, action, progress, canvas, spec)
 
         # 量交付成色。在**对齐之后**量,量的是用户真正会看到的那组帧:抠图 / 像素化 /
         # 对齐都会改像素,在中间任何一步量出来的数都描述不了交付物。
@@ -287,7 +309,9 @@ class CharacterGenerator(CharacterGeneratorPort):
         return GeneratedAction(
             frames=[_png(im) for im in aligned],
             durations=frame_durations(action.action.value, len(aligned)),
-            geometry=_geometry_of(aligned[0], canvas, vertical_anchor(action)),
+            geometry=_geometry_of(
+                aligned[0], canvas, vertical_anchor(action), fill_h=spec.fill_h,
+            ),
             quality=quality,
             prompt_version=PROMPT_VERSION,
         )
@@ -318,6 +342,7 @@ class CharacterGenerator(CharacterGeneratorPort):
         action: ActionSpec,
         progress: ProgressPort,
         canvas: tuple[int, int] | None = None,
+        render_spec: _LastMileRenderSpec | None = None,
     ) -> list[Image.Image]:
         """对齐成原地序列帧(消除逐帧画布漂移,Issue #21);锚点随动作有无地面接触。
 
@@ -345,23 +370,48 @@ class CharacterGenerator(CharacterGeneratorPort):
         if bad:
             raise ValueError(f"strategy 产出了 {len(bad)}/{len(frames)} 个空帧，索引 {bad[:8]}")
         imgs = [_img(f) for f in frames]
+        spec = render_spec or _LastMileRenderSpec()
         # 参考姿态高 = 各帧包围盒高的中位数:比"最高帧"稳(不被举过头顶的武器带偏),
         # 各动作都以自身中位姿态定标,本体尺寸跨动作一致。
         hs = []
         for im in imgs:
             ys, _ = np.where(np.asarray(im)[:, :, 3] > 128)
             if len(ys):
-                hs.append(float(ys.max() - ys.min()))
+                hs.append(float(ys.max() - ys.min() + 1))
         # TODO(dev, #21): tail_match 循环闭合(净位移动作先锚点再匹配帧)
         ref = float(np.median(hs)) if hs else None
         if canvas is None:
-            return align_bottom_center(imgs, ref_height=ref, anchor=anchor)
+            return align_bottom_center(
+                imgs, ref_height=ref, anchor=anchor,
+                fill_h=spec.fill_h, resample=spec.resample,
+            )
         cw, ch = canvas
-        return align_bottom_center(imgs, cell=cw, cell_h=ch, ref_height=ref, anchor=anchor)
+        return align_bottom_center(
+            imgs, cell=cw, cell_h=ch, ref_height=ref, anchor=anchor,
+            fill_h=spec.fill_h, resample=spec.resample,
+        )
+
+
+def _video_render_spec(
+    master: bytes, facts: MasterFacts, action: ActionSpec,
+) -> _LastMileRenderSpec:
+    """把母版占幅与帧的像素语义带到视频交付收口。"""
+    _x0, y0, _x1, y1 = facts.subject_box
+    _master_w, master_h = facts.size
+    fill_h = min(FOOT_LINE, (y1 - y0) / master_h)
+
+    # 显式像素化后的帧必须按像素网格放大。原生分支只在母版能量出真实像素块时保留
+    # NEAREST;高分辨率伪像素/插画的检测值是 1,缩到交付尺寸时用 LANCZOS 保住纹理。
+    pixel_output = action.stylize is Stylize.PIXEL
+    if not pixel_output:
+        pixel_output = detect_pixel_size(_img(master)) > 1
+    resample = Image.Resampling.NEAREST if pixel_output else Image.Resampling.LANCZOS
+    return _LastMileRenderSpec(fill_h=fill_h, resample=resample)
 
 
 def _geometry_of(
-    frame: Image.Image, canvas: tuple[int, int] | None, anchor: str
+    frame: Image.Image, canvas: tuple[int, int] | None, anchor: str,
+    fill_h: float = FILL_H,
 ) -> SequenceGeometry:
     """交付帧的落位几何。取自对齐那一步用的同一组常量,不另立一份。
 
@@ -372,7 +422,7 @@ def _geometry_of(
     帧是按质心摆的、几何说的是脚线,消费方按它落位就会错开半个身高。
     """
     w, h = canvas if canvas else frame.size
-    y = FOOT_LINE - FILL_H / 2 if anchor == ANCHOR_CENTROID else FOOT_LINE
+    y = FOOT_LINE - fill_h / 2 if anchor == ANCHOR_CENTROID else FOOT_LINE
     return SequenceGeometry(
         canvas_w=w,
         canvas_h=h,

--- a/backend/packages/ai_engine/src/windup_ai_engine/postprocess/pack.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/postprocess/pack.py
@@ -157,6 +157,7 @@ def align_bottom_center(
     ref_height: float | None = None,
     cell_h: int | None = None,
     anchor: str = ANCHOR_FOOT,
+    resample: Image.Resampling = Image.Resampling.NEAREST,
 ) -> list[Image.Image]:
     """按脚线对齐到统一画布,消除逐帧画布漂移(Issue #21)。
 
@@ -189,6 +190,9 @@ def align_bottom_center(
     几何按"比例"而不是"像素"表达(``foot_line``/``fill_h``/``fill_w`` 都是比例),所以
     换画布尺寸不改变构图,母版入口预检(``master_check.REJECT_ASPECT`` = 2*FILL_W/FILL_H)
     与出帧仍共用同一套几何 —— 那条阈值里没有 cell,本来就与画布像素尺寸无关。
+
+    ``resample``:最后一次尺寸变换的采样方式。默认 NEAREST 保持已有像素资产逐像素兼容;
+    连续色调的原生视频帧应显式传 LANCZOS,避免缩小时把纹理抽成无意义硬色块。
     """
     import numpy as np
 
@@ -301,7 +305,7 @@ def align_bottom_center(
         else:
             lift = round((ground - box[3]) * fs) if preserve_lift else 0
             top = int(ch * foot_line) - h - lift
-        crop = crop.resize((w, h), Image.NEAREST)
+        crop = crop.resize((w, h), resample)
         canvas = Image.new("RGBA", (cw, ch), (0, 0, 0, 0))
         canvas.alpha_composite(crop, (cw // 2 - w // 2, top))
         out.append(canvas)

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
@@ -10,7 +10,7 @@ from .walk import build_walk_prompt
 # 改动本包任何一个 build_*_prompt 的输出(包括 prompts/*.md 模板)都必须连带把这个
 # 常量加一:落库的 GeneratedAction.prompt_version 就靠它,分不清新旧模板的产出，
 # 改完提示词也没法与改前的成色对比。
-PROMPT_VERSION = "v1"
+PROMPT_VERSION = "v2"
 
 __all__ = [
     "build_walk_prompt",

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/_framing.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/_framing.py
@@ -33,7 +33,9 @@ REFERENCE_FIDELITY_LOCK = (
 
 def with_framing(body: str) -> str:
     """给一段动作正文接上构图与视频保真约束。"""
-    return f"{body} {SINGLE_SUBJECT_FRAMING} {REFERENCE_FIDELITY_LOCK}"
+    # SINGLE_SUBJECT_FRAMING 保持最终收口句:提示词适配器的契约会用它确认公共构图约束
+    # 没被自定义动作分支绕过。新增约束插在它之前,不改变这个既有边界。
+    return f"{body} {REFERENCE_FIDELITY_LOCK} {SINGLE_SUBJECT_FRAMING}"
 
 
 def with_direction_lock(body: str, direction: ActionDirection | None) -> str:

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/_framing.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/_framing.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 from windup_common.directions import ActionDirection, direction_prompt
 
-__all__ = ["SINGLE_SUBJECT_FRAMING", "with_framing", "with_direction_lock"]
+__all__ = [
+    "REFERENCE_FIDELITY_LOCK",
+    "SINGLE_SUBJECT_FRAMING",
+    "with_framing",
+    "with_direction_lock",
+]
 
 # 攻击的两处留白(母版姿态要求 + 母版补边)让画面空得足以容下第二个主体。
 SINGLE_SUBJECT_FRAMING = (
@@ -18,10 +23,17 @@ SINGLE_SUBJECT_FRAMING = (
     "and the whole body stays inside the frame."
 )
 
+REFERENCE_FIDELITY_LOCK = (
+    "Preserve the reference character's exact face, hairstyle, clothing, accessories, "
+    "color palette, linework, silhouette, textures, and local details throughout every frame. "
+    "Use a locked camera with unchanged projection, framing, character scale, and canvas "
+    "occupancy throughout the video."
+)
+
 
 def with_framing(body: str) -> str:
-    """给一段动作正文接上构图约束。"""
-    return f"{body} {SINGLE_SUBJECT_FRAMING}"
+    """给一段动作正文接上构图与视频保真约束。"""
+    return f"{body} {SINGLE_SUBJECT_FRAMING} {REFERENCE_FIDELITY_LOCK}"
 
 
 def with_direction_lock(body: str, direction: ActionDirection | None) -> str:

--- a/backend/tests/test_ai_engine_skeleton.py
+++ b/backend/tests/test_ai_engine_skeleton.py
@@ -39,6 +39,17 @@ def _tiny_png(color=(200, 60, 60, 255), shift=0) -> bytes:
     return buf.getvalue()
 
 
+def _large_subject_master() -> bytes:
+    """256 画布上 198px 高的确认母版,与 Issue #793 的生产样本占幅一致。"""
+    img = Image.new("RGBA", (256, 256), (0, 0, 0, 0))
+    for y in range(29, 227):
+        for x in range(100, 156):
+            img.putpixel((x, y), (30, 80, 180, 255))
+    buf = io.BytesIO()
+    img.save(buf, "PNG")
+    return buf.getvalue()
+
+
 class _NullProgress:
     def step(self, stage: str, i: int, total: int, note: str = "") -> None:
         pass
@@ -81,6 +92,45 @@ def test_generate_walk_is_wired_end_to_end():
     assert all(d > 0 for d in out.durations)
     assert set(out.durations) == {DEFAULT_FPS_MS["walk"]}
     assert all(f and f[:8] == b"\x89PNG\r\n\x1a\n" for f in out.frames)  # 真 PNG
+
+
+def _delivered_subject_height(frame: bytes) -> int:
+    rgba = Image.open(io.BytesIO(frame)).convert("RGBA")
+    box = rgba.getchannel("A").getbbox()
+    assert box is not None
+    return box[3] - box[1]
+
+
+def test_video_delivery_inherits_master_occupancy_for_native_and_pixel_outputs():
+    """原生与像素分支必须继承确认母版占幅,不能再统一压回 62%。"""
+    gen = _make_generator()
+    heights = []
+    for stylize in (Stylize.NONE, Stylize.PIXEL):
+        out = gen.generate(
+            CharacterCard(name="rogue", desc=""),
+            ActionSpec(action=ActionType.WALK, n_frames=4, stylize=stylize),
+            master=_large_subject_master(), progress=_NullProgress(),
+        )
+        heights.append(_delivered_subject_height(out.frames[0]))
+
+    assert all(abs(height - 198) <= 2 for height in heights), heights
+    assert abs(heights[0] - heights[1]) <= 2, heights
+
+
+class _DeferredWalkStrategy(_MockWalkStrategy):
+    def frames_from_video(self, video, card, action, master, progress) -> list[bytes]:
+        return [_tiny_png() for _ in range(action.n_frames)]
+
+
+def test_deferred_video_finish_reloads_master_occupancy():
+    """异步收口跨进程,仍要从母版重建占幅事实,不能退回固定 62%。"""
+    gen = CharacterGenerator({GenRoute.VIDEO_I2V: _DeferredWalkStrategy()})
+    out = gen.finish_video(
+        b"video", CharacterCard(name="rogue", desc=""),
+        ActionSpec(action=ActionType.WALK, n_frames=4, stylize=Stylize.NONE),
+        master=_large_subject_master(), progress=_NullProgress(),
+    )
+    assert abs(_delivered_subject_height(out.frames[0]) - 198) <= 2
 
 
 def test_action_spec_stylize_defaults_and_toggle():

--- a/backend/tests/test_attack_archetypes.py
+++ b/backend/tests/test_attack_archetypes.py
@@ -181,6 +181,21 @@ def test_every_action_prompt_carries_the_framing_clause():
     assert not missing, f"这些提示词没带构图约束: {missing}"
 
 
+def test_every_action_prompt_locks_reference_fidelity_and_camera():
+    """预设与自定义动作要共用同一份 i2v 保真约束,否则不同动作会各自重画角色。"""
+    required = (
+        "exact face", "hairstyle", "clothing", "accessories", "color palette",
+        "linework", "local details", "locked camera", "character scale",
+        "canvas occupancy",
+    )
+    missing = {
+        name: [clause for clause in required if clause not in prompt.lower()]
+        for name, prompt in _all_prompts().items()
+        if any(clause not in prompt.lower() for clause in required)
+    }
+    assert not missing, f"这些提示词缺少保真约束: {missing}"
+
+
 def test_the_framing_clause_is_appended_by_code_not_copied_into_the_markdown():
     """抄进每份 md 会各自漂移;md 正文里出现它就说明有人开始抄了。"""
     from windup_ai_engine.prompt._md import load_doc

--- a/backend/tests/test_pack_align.py
+++ b/backend/tests/test_pack_align.py
@@ -55,6 +55,29 @@ def test_omitting_cell_h_is_pixel_identical_to_square_cell():
         assert np.array_equal(np.asarray(x), np.asarray(y))
 
 
+def test_resample_defaults_to_nearest_but_accepts_lanczos_for_continuous_art():
+    """最后一公里要按帧的实际像素语义选采样,而不是所有画风一律 NEAREST。"""
+    arr = np.zeros((64, 64, 4), dtype=np.uint8)
+    arr[:, :, 3] = 255
+    arr[:, 1::2, :3] = 255
+    src = [Image.fromarray(arr, "RGBA")]
+
+    default = align_bottom_center(src, cell=32, fill_h=0.5, ref_height=64.0)[0]
+    nearest = align_bottom_center(
+        src, cell=32, fill_h=0.5, ref_height=64.0,
+        resample=Image.Resampling.NEAREST,
+    )[0]
+    lanczos = align_bottom_center(
+        src, cell=32, fill_h=0.5, ref_height=64.0,
+        resample=Image.Resampling.LANCZOS,
+    )[0]
+
+    assert np.array_equal(np.asarray(default), np.asarray(nearest))
+    rgba = np.asarray(lanczos)
+    lanczos_rgb = rgba[:, :, :3][rgba[:, :, 3] > 128]
+    assert any(0 < int(v) < 255 for v in np.unique(lanczos_rgb))
+
+
 def test_doubling_cell_doubles_subject_height():
     """指定 512 时交付帧主体高度翻倍 —— 这正是"交付帧太小"的修法。"""
     src = _frames()

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -3293,7 +3293,7 @@ describe('QuickStartPage', () => {
       resume: vi.fn(() => resumed.promise),
       addAction: vi.fn(async () => Promise.reject(new Error('动作生成暂时不可用'))),
     })
-    renderAt('/quick-start/run-1?intent=add-action&outfitId=outfit-1', service)
+    renderAt('/quick-start/run-1?intent=add-action&outfitId=outfit-1', service, addActionAgentFor())
 
     const input = await screen.findByRole('textbox', { name: '继续描述你的想法' })
     await waitFor(() =>
@@ -3301,8 +3301,9 @@ describe('QuickStartPage', () => {
     )
     fireEvent.change(input, { target: { value: '挥手' } })
     fireEvent.click(screen.getByRole('button', { name: '发送' }))
+    fireEvent.click(await screen.findByRole('button', { name: '确认并生成' }))
 
-    await waitFor(() => expect(service.addAction).toHaveBeenCalledWith('outfit-1', '挥手'))
+    await waitFor(() => expect(service.addAction).toHaveBeenCalledWith('outfit-1', '挥手', {}))
     expect((await screen.findByRole('alert')).textContent).toContain('动作生成暂时不可用')
 
     await act(async () => {


### PR DESCRIPTION
修复视频动作帧相较确认母版的尺度与细节退化：交付帧现在继承母版主体占幅，并按原生/像素输出选择缩放采样，同时强化所有 i2v 动作的身份与镜头保真约束。

## Why

生产任务 360 的原始视频与 U2Net 抠图没有制造同等级的新损坏，主要退化发生在最后一公里：256×256 母版主体约占画布 78%，动作帧却被固定压到 62%，有效高度额外损失约 20%。原生帧继续使用 NEAREST 缩小时，也会把连续纹理抽成无意义硬色块。与此同时，现有 i2v 提示词没有统一锁定角色身份、局部细节、镜头与主体占幅。

## Changes

- 让直接生成与异步视频收口都从确认母版重建主体占幅，并传入最后一公里。
- 显式像素化或可检测到真实像素块的输出保留 NEAREST；其他原生输出使用 LANCZOS。
- 为 walk、idle、jump、attack 与 custom 共用一份角色身份、色板、线稿、局部细节、镜头和占幅约束。
- 将动作提示词版本升级为 `v2`，便于区分修复前后的生成结果。

## Implementation

- `CharacterGenerator` 通过内部渲染规格携带母版 `fill_h` 与重采样策略；异步 `finish_video` 不依赖提交进程内存，重新执行只读母版检查。
- `align_bottom_center` 新增默认兼容的 `resample` 参数；未传时仍保持 NEAREST。
- 公共保真句由 `_framing.py` 统一装配，避免动作模板之间漂移。

## Verification

- [x] `uv run ruff check <本次变更的 7 个 Python 文件>`：通过。
- [x] `uv run pytest -q tests/test_ai_engine_skeleton.py tests/test_pack_align.py tests/test_attack_archetypes.py tests/test_custom_action.py tests/test_directional_generation.py tests/test_ground_contact_anchor.py tests/test_master_check_and_quality.py tests/test_master_resample.py tests/test_prompt_assets.py tests/test_character_contract.py`：300 passed。
- [x] 使用生产任务 360 的母版与抠图帧复跑最后一公里：母版主体 200/256，交付主体 199px，原生分支选择 LANCZOS。
- [ ] 浏览器验收：按用户要求不执行，本次无前端改动。

## Scope

- 本 PR 不包含：修改完美像素化算法、更换视频供应商、增加逐帧图生图恢复、部署预发或生产。
- 后续事项：合并后由用户用同一角色重新生成视频动作，比较人物边缘、局部纹理与杂色色块。

## Related Issues

Closes #793
