### PR TITLE
fix(video): i2v 首帧放大倍数取整，避免把像素母版打成不规则块

### DIFF
--- a/backend/packages/framework/src/windup_framework/providers/protocol/openai_video.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/openai_video.py
@@ -62,6 +62,13 @@ def fit_first_frame(
         im = im.convert("RGB")
         pad = im.getpixel((0, 0))     # 不透明输入沿用角点色,补边与画面自身背景连成一片
     scale = min(w/im.width, h/im.height)
+    if scale > 1:
+        # **放大倍数必须取整。** NEAREST 是把一个源像素铺成一块,倍数非整数时那"一块"的
+        # 宽度会在相邻整数之间不规则跳变(×2.8125 → 2px/3px 交替),块边长为 1 的像素母版
+        # 每个像素都是独立信息,硬边因此被打成马赛克 —— 而这张图正是喂给 i2v 的输入。
+        # 选 NEAREST 本就是为了不造出源图没有的中间色,取整是这条意图的另一半(#797)。
+        # 实测:256x256 母版进 1280x720,倍数被横屏的 720 卡在 2.8125。
+        scale = float(int(scale))
     tw, th = max(1, round(im.width*scale)), max(1, round(im.height*scale))
     fitted = im.resize((tw, th), Image.NEAREST if scale > 1 else Image.LANCZOS)
     canvas = Image.new("RGB", (w, h), pad)

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -977,6 +977,16 @@ def _submitted_first_frame(frame: bytes, size: str = "1280x720"):
     return _Image.open(_io.BytesIO(_b64.b64decode(uri.split(",", 1)[1])))
 
 
+def _fitted_scale(src_w: int, src_h: int, W: int = 1280, H: int = 720) -> int | float:
+    """``fit_first_frame`` 实际会用的倍数：放大取整，缩小不取整（#797）。
+
+    三条用例都从这里推导而不是各自写死数字 —— 当年 #509 的期望值是按非整数倍数算的，
+    倍数规则一改就要同时改三处，写死必然漏。
+    """
+    scale = min(W / src_w, H / src_h)
+    return int(scale) if scale > 1 else scale
+
+
 def _subject_height(im) -> int:
     """暗色主体在成品里的高度（像素）。JPEG 会糊边，阈值取宽一点。"""
     import numpy as _np
@@ -999,7 +1009,7 @@ def test_small_first_frame_is_enlarged_instead_of_pasted_at_source_size(src_w, s
     im = _submitted_first_frame(_sprite(src_w, src_h, alpha=alpha, subject_ratio=ratio))
     assert im.size == (W, H)
 
-    scale = min(W / src_w, H / src_h)
+    scale = _fitted_scale(src_w, src_h, W, H)
     content_h = round(src_h * scale)
     got = _subject_height(im)
     assert abs(got - ratio * content_h) <= 0.08 * content_h, (
@@ -1008,6 +1018,11 @@ def test_small_first_frame_is_enlarged_instead_of_pasted_at_source_size(src_w, s
     )
     # 与"不拉伸"是两条独立约束：放大到了也可能是拉伸放大的。
     assert scale > 1, "本用例的输入都小于画布，否则测不到放大"
+    # #509 的本意是"别原尺寸贴进去"。取整会让倍数比铺满画布时小一点（256x256 由
+    # x2.8125 变 x2），这条独立断言把那个本意钉住，免得将来倍数再降时无人发觉。
+    assert got >= 1.5 * ratio * src_h, (
+        f"{src_w}x{src_h}: 主体 {got}px，几乎等于原尺寸 {ratio * src_h:.0f}px，放大没生效"
+    )
 
 
 def test_transparent_first_frame_background_does_not_depend_on_undefined_rgb():
@@ -1040,8 +1055,11 @@ def test_opaque_first_frame_keeps_sampling_its_own_corner_for_padding():
     assert _np.allclose(corner, (200, 200, 200), atol=12), f"补边色 {corner}，应沿用源图角点色"
 
 
-def test_square_first_frame_forms_a_720x720_content_region_in_a_1280x720_canvas():
-    """方形输入在 1280x720 里应是 720x720 的等比内容区，左右各补 280px。
+def test_square_first_frame_forms_a_centered_square_content_region():
+    """方形输入在 1280x720 里应是居中的等比方形内容区，左右补边相等。
+
+    尺寸由整数倍数决定：256x256 的倍数 ``min(5.0, 2.8125)`` 取整为 2，内容区 512x512，
+    左右各补 384px（#797 之前是非整数 x2.8125、内容区 720x720、左右各 280px）。
 
     与"主体占幅"是两条判据:主体占幅对了也可能是内容区偏了(比如贴在角上)。
     源图最外一圈填成不透明亮色,内容区边界才量得到 —— 补边色与合成底色相同,
@@ -1058,13 +1076,15 @@ def test_square_first_frame_forms_a_720x720_content_region_in_a_1280x720_canvas(
     buf = _io.BytesIO()
     src.save(buf, "PNG")
 
+    side = round(256 * _fitted_scale(256, 256))
+    pad = (1280 - side) // 2
     im = _submitted_first_frame(buf.getvalue())
     a = _np.asarray(im.convert("L"))
     cols = _np.where((a > 200).any(axis=0))[0]
     rows = _np.where((a > 200).any(axis=1))[0]
-    assert 715 <= cols.max()-cols.min()+1 <= 725, f"内容区宽 {cols.max()-cols.min()+1}，应≈720"
-    assert 715 <= rows.max()-rows.min()+1 <= 725, f"内容区高 {rows.max()-rows.min()+1}，应≈720"
-    assert abs(cols.min() - 280) <= 4, f"内容区左边界 {cols.min()}，应≈280（左右各补 280）"
+    assert abs(cols.max()-cols.min()+1 - side) <= 5, f"内容区宽 {cols.max()-cols.min()+1}，应≈{side}"
+    assert abs(rows.max()-rows.min()+1 - side) <= 5, f"内容区高 {rows.max()-rows.min()+1}，应≈{side}"
+    assert abs(cols.min() - pad) <= 4, f"内容区左边界 {cols.min()}，应≈{pad}（左右各补 {pad}）"
 
 
 def test_upscaling_a_small_sprite_keeps_hard_edges_instead_of_interpolating_them():
@@ -1092,8 +1112,10 @@ def test_upscaling_a_small_sprite_keeps_hard_edges_instead_of_interpolating_them
     _Image.fromarray(src, "RGBA").save(buf, "PNG")
 
     im = _submitted_first_frame(buf.getvalue())
-    # 只取内容区：1280 宽的画布里，720x720 的内容区居中，两侧各 280px 是补边
-    row = _np.asarray(im.convert("RGB"))[360].astype(int)[280:1000]
+    # 只取内容区：内容区边长由整数倍数决定（64x64 的 11.25 取整为 11 → 704），居中放置
+    side = round(64 * _fitted_scale(64, 64))
+    pad = (1280 - side) // 2
+    row = _np.asarray(im.convert("RGB"))[360].astype(int)[pad:pad + side]
     far_from_left = _np.abs(row - _np.array(left)).sum(1) > 40
     far_from_right = _np.abs(row - _np.array(right)).sum(1) > 40
     width = int((far_from_left & far_from_right).sum())

--- a/backend/tests/test_video_protocol.py
+++ b/backend/tests/test_video_protocol.py
@@ -140,3 +140,55 @@ def test_a_2xx_that_is_not_a_json_object_is_invalid_not_a_crash(body):
 
     assert p.parse_submit(resp).error_type is ModelErrorType.INVALID_RESPONSE
     assert p.parse_poll(resp, "job-9").error_type is ModelErrorType.INVALID_RESPONSE
+
+
+def _pixel_master(side: int = 100) -> bytes:
+    """一张纯色方块的「像素母版」。
+
+    必须带 alpha:不透明输入会让 ``fit_first_frame`` 用**源图角点色**当补边色,主体与补边
+    同色就量不出贴进去的那块有多宽。带 alpha 时补边走 ``FIRST_FRAME_BG``,两者才有对比。
+    """
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGBA", (side, side), (12, 180, 90, 255)).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _pasted_width(jpg: bytes, pad_tol: int = 60) -> int:
+    """量 JPEG 画布里非补边那块的宽度。JPEG 会软化边界,故用容差判色而非精确相等。"""
+    import numpy as np
+    from PIL import Image
+
+    a = np.asarray(Image.open(io.BytesIO(jpg)).convert("RGB")).astype(int)
+    pad = a[0, 0]
+    cols = np.where((np.abs(a - pad).sum(axis=2) > pad_tol).any(axis=0))[0]
+    return int(cols.max() - cols.min() + 1) if len(cols) else 0
+
+
+def test_fit_first_frame_upscales_by_an_integer_factor():
+    """放大倍数取整。
+
+    NEAREST 是把一个源像素铺成一块;倍数非整数时那块的宽度在相邻整数之间不规则跳变,
+    块边长为 1 的像素母版会被打成马赛克,而这张图正是喂给 i2v 的输入(#797)。
+
+    100x100 进 1280x720:``min(12.8, 7.2) = 7.2``。取整前贴进去的是 720px(每个源像素
+    7.2px,实际 7px/8px 交替),取整后是 700px(恒 7px)。断言的是后者。
+    """
+    from windup_framework.providers.protocol.openai_video import fit_first_frame
+
+    width = _pasted_width(fit_first_frame(_pixel_master(100), "1280x720"))
+    assert abs(width - 700) <= 2, f"期望 700(=100x7),实得 {width}"
+    assert width % 100 <= 2 or width % 100 >= 98, f"{width} 不是 100 的整数倍"
+
+
+def test_fit_first_frame_keeps_shrink_path_unchanged():
+    """缩小路径不受影响 —— 取整只加在放大那一支上。
+
+    2000x2000 进 1280x720 的倍数是 0.36,取整会把它压成 0(整张图消失),
+    所以这条断言的是「缩小时不取整」这个边界,不是顺手写的冗余用例。
+    """
+    from windup_framework.providers.protocol.openai_video import fit_first_frame
+
+    width = _pasted_width(fit_first_frame(_pixel_master(2000), "1280x720"))
+    assert abs(width - 720) <= 2, f"缩小应仍填满高度方向的 720,实得 {width}"


### PR DESCRIPTION
让 `fit_first_frame` 在放大时使用整数倍，避免把像素母版打成不规则块。

## Why

`fit_first_frame` 按 `min(w/iw, h/ih)` 算放大倍数，该倍数通常不是整数。NEAREST 是把一个源像素铺成一块，倍数非整数时那块的宽度会在相邻整数之间不规则跳变——256×256 母版进 1280×720 的倍数是 2.8125，落地是 2px/3px 交替。块边长为 1 的像素母版每个像素都是独立信息，硬边因此被打成马赛克，而这张图正是喂给 i2v 的输入。

选 NEAREST 本就是为了不造出源图没有的中间色（函数注释已写明），取整是这条意图的另一半。

## 证据

用生产 task 323 的真实首帧与真实提示词、并由 `fit_first_frame` 自己产出请求体重跑一条 i2v：**返回视频的头发在抠图之前已经是噪点**，与线上产物的退化形态一致。同一张母版改为整数 ×2 放大送 i2v，返回视频的头发是清晰发丝。两条视频再过**完全相同**的后处理（同抠图、同目标高、同 48 色母版色板），前者仍是噪点、后者仍然清晰。

已用对照实验排除的其他嫌疑：256×256 画布尺寸、目标逻辑高、母版 48 色色板、U2Net 抠图。

## Changes

- 放大（`scale > 1`）时取不超过原倍数的最大整数；缩小路径不变，仍用 LANCZOS。
- #509 的三条用例把当年那个非整数结果的数字焊死了（`720x720 内容区`、`左边界 280`、`[280:1000]` 取样区间），改为从取整规则推导，意图不变。
- 放大用例补一条独立断言把 #509 的本意「别原尺寸贴进去」钉住，免得将来倍数再降时无人发觉。

## Verification

- [x] 新增 `test_fit_first_frame_upscales_by_an_integer_factor`：在 `origin/main` 上跑是 **failed（实得 720，期望 700）**，本分支 passed —— 它确实拦住了这个缺陷。
- [x] 新增 `test_fit_first_frame_keeps_shrink_path_unchanged`：缩小倍数 0.36 取整会变 0（整张图消失），这条守住那个边界。
- [x] `uv run ruff check .`：All checks passed。
- [x] `uv run python -m scripts.export_openapi`：rc=0，`openapi.json` 无漂移。
- [x] `uv run lint-imports`：Contracts: 2 kept, 0 broken。
- [x] `uv run pytest -q --cov=packages`：1768 passed, 14 skipped, 2 failed。这 2 条（`test_generation_api.py` 的 four_view / eight_view）在**纯 `origin/main` 上同样失败**，与本 PR 无关。

## Scope

不含：最后一公里的主体占幅与重采样选择（#793 / #794 已覆盖）、完美像素化算法、视频供应商。

后续另开：默认画布 `1280x720` 为横屏，装竖长角色时缩放系数被高度卡死；首帧上传编码 JPEG q90 实测把 9707 色母版打成 21817 色。两条都写在 #797 的「后续」一节。

Closes #797
