### PR TITLE
feat(workflow-editor): 接入四向八向首帧节点

### DIFF
--- a/frontend/src/entities/workflow-run/api.test.ts
+++ b/frontend/src/entities/workflow-run/api.test.ts
@@ -362,6 +362,44 @@ describe('workflowRunApis', () => {
     })
   })
 
+  it('拒绝为镜像方向持久化独立动作首帧描述', async () => {
+    const invalidNodes = structuredClone(nodes)
+    const firstFrame = invalidNodes.find((node) => node.type === 'action-first-frame')
+    if (!firstFrame || firstFrame.type !== 'action-first-frame') {
+      throw new Error('测试缺少动作首帧节点')
+    }
+    Object.assign(firstFrame.input, { directionPrompts: { west: '向左行走' } })
+    const apis = await loadWorkflowRunApis(async () =>
+      jsonResponse({ ...workflowRunDto, nodes: invalidNodes }),
+    )
+
+    await expect(apis.get('17')).rejects.toMatchObject({
+      name: 'ApiError',
+      kind: 'invalid-response',
+    })
+  })
+
+  it('恢复真实源方向各自持久化的动作首帧描述', async () => {
+    const directionalNodes = structuredClone(nodes)
+    const firstFrame = directionalNodes.find((node) => node.type === 'action-first-frame')
+    if (!firstFrame || firstFrame.type !== 'action-first-frame') {
+      throw new Error('测试缺少动作首帧节点')
+    }
+    firstFrame.input.directionPrompts = {
+      east: '向右行走',
+      north: '背向镜头行走',
+      south: '面向镜头行走',
+    }
+    const apis = await loadWorkflowRunApis(async () =>
+      jsonResponse({ ...workflowRunDto, nodes: directionalNodes }),
+    )
+
+    const restored = await apis.get('17')
+    expect(restored.nodes.find((node) => node.id === firstFrame.id)).toMatchObject({
+      input: { directionPrompts: firstFrame.input.directionPrompts },
+    })
+  })
+
   it('rejects a dependency that points outside the persisted graph', async () => {
     const apis = await loadWorkflowRunApis(async () =>
       jsonResponse({

--- a/frontend/src/entities/workflow-run/api.ts
+++ b/frontend/src/entities/workflow-run/api.ts
@@ -46,6 +46,21 @@ function isNullableString(value: unknown): value is string | null {
   return value === null || typeof value === 'string'
 }
 
+const ACTION_SOURCE_DIRECTIONS = ['east', 'north', 'south', 'north_east', 'south_east'] as const
+
+function isDirectionPromptMap(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (isRecord(value) &&
+      Object.entries(value).every(
+        ([direction, prompt]) =>
+          isMember(direction, ACTION_SOURCE_DIRECTIONS) &&
+          typeof prompt === 'string' &&
+          prompt.trim().length > 0,
+      ))
+  )
+}
+
 function isGenerationRef(value: unknown): boolean {
   return (
     isRecord(value) &&
@@ -156,6 +171,7 @@ function hasValidActionInput(value: unknown): boolean {
     typeof value.type === 'string' &&
     value.type.length > 0 &&
     isNullableString(value.prompt) &&
+    isDirectionPromptMap(value.directionPrompts) &&
     typeof value.fps === 'number' &&
     Number.isFinite(value.fps) &&
     value.fps > 0 &&

--- a/frontend/src/entities/workflow-run/index.ts
+++ b/frontend/src/entities/workflow-run/index.ts
@@ -96,6 +96,8 @@ export interface WorkflowActionInput {
   name: string
   type: ActionType
   prompt: string | null
+  /** 多方向项目的真实源方向首帧描述；镜像方向始终继承源方向，不单独保存。 */
+  directionPrompts?: Partial<Record<ActionDirection, string>>
   fps: number
   /** 生成类型与试玩位移解耦；例如向前翻滚仍是 custom，但可以发生位移。 */
   locomotion?: true

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -1449,6 +1449,52 @@ describe('WorkflowController', () => {
     })
   })
 
+  it('四向动作首帧为每个真实源方向使用各自保存的提示词', async () => {
+    const actions = actionNodes()
+    const firstFrame = actions.find((node) => node.type === 'action-first-frame')
+    if (!firstFrame || firstFrame.type !== 'action-first-frame') throw new Error('missing frame')
+    Object.assign(firstFrame.input, {
+      directionPrompts: {
+        east: '向右行走，保持侧面轮廓',
+        north: '背向镜头向上行走',
+        south: '面向镜头向下行走',
+      },
+    })
+    const run = createRun([
+      setupNode({ status: 'passed', phase: 'completed' }),
+      templateNode({
+        status: 'passed',
+        phase: 'completed',
+        selectedImageUrl: 'https://img/east.png',
+        selectedImages: {
+          east: 'https://img/east.png',
+          north: 'https://img/north.png',
+          south: 'https://img/south.png',
+        },
+      }),
+      ...actions,
+    ])
+    const { controller, generation } = createController(run, 'four-way')
+
+    await controller.generateFirstFrame(firstFrame.id, {
+      spriteWidth: 64,
+      spriteHeight: 64,
+    })
+
+    expect(generation.apis.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ direction: 'east', prompt: '向右行走，保持侧面轮廓' }),
+    )
+    expect(generation.apis.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ direction: 'north', prompt: '背向镜头向上行走' }),
+    )
+    expect(generation.apis.create).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ direction: 'south', prompt: '面向镜头向下行走' }),
+    )
+  })
+
   it('非东向确认优先沿用方向选择表中的东向兼容值', async () => {
     const template = createController(
       createRun([
@@ -1963,6 +2009,11 @@ describe('WorkflowController', () => {
       firstFrameNode({
         status: 'failed',
         phase: 'generating',
+        input: actionInput({
+          directionPrompts: {
+            north: '背向镜头向上行走',
+          },
+        }),
         generations: [
           { taskId: 'task-east', role: 'first_frame' },
           { taskId: 'task-north', role: 'first_frame', direction: 'north' },
@@ -2006,7 +2057,7 @@ describe('WorkflowController', () => {
       type: 'first_frame',
       projectId: '1',
       actionType: 'walk',
-      prompt: '行走',
+      prompt: '背向镜头向上行走',
       spriteWidth: 64,
       spriteHeight: 64,
       referenceMedia: ['north-template.png'],
@@ -3970,6 +4021,13 @@ describe('WorkflowController', () => {
       firstFrameNode({
         status: 'passed',
         phase: 'completed',
+        input: actionInput({
+          directionPrompts: {
+            east: '向右行走',
+            north: '背向镜头行走',
+            south: '面向镜头行走',
+          },
+        }),
         selectedFirstFrameUrl: 'east-frame.png',
         selectedFirstFrameUrls: {
           east: 'east-frame.png',
@@ -3993,12 +4051,25 @@ describe('WorkflowController', () => {
     expect(
       vi.mocked(generation.apis.create).mock.calls.map(([input]) => ({
         direction: input.direction,
+        prompt: input.prompt,
         referenceMedia: input.referenceMedia,
       })),
     ).toEqual([
-      { direction: 'east', referenceMedia: ['east-frame.png'] },
-      { direction: 'north', referenceMedia: ['north-frame.png'] },
-      { direction: 'south', referenceMedia: ['south-frame.png'] },
+      {
+        direction: 'east',
+        prompt: '向右行走\n增加轮廓光',
+        referenceMedia: ['east-frame.png'],
+      },
+      {
+        direction: 'north',
+        prompt: '背向镜头行走\n增加轮廓光',
+        referenceMedia: ['north-frame.png'],
+      },
+      {
+        direction: 'south',
+        prompt: '面向镜头行走\n增加轮廓光',
+        referenceMedia: ['south-frame.png'],
+      },
     ])
   })
 

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -89,6 +89,8 @@ export interface GenerateFirstFrameOptions {
   sourceImageUrls?: Partial<Record<ActionDirection, GeneratedImage['url']>>
   /** 只影响本次请求的 prompt 覆盖值；不改写动作节点的原始输入。 */
   prompt?: string
+  /** 多方向重生成时分别覆盖各真实源方向，避免退回共享动作描述。 */
+  directionPrompts?: Partial<Record<ActionDirection, string>>
   /** 本阶段每个方向的候选数；自动交付固定为一张。 */
   candidateCount?: ImageCandidateCount
 }
@@ -227,6 +229,11 @@ export interface WorkflowController {
   generateFirstFrame(
     nodeId: ActionFirstFrameWorkflowNode['id'],
     options: GenerateFirstFrameOptions,
+  ): Promise<void>
+  /** 在生成前保存各真实源方向的首帧描述；镜像方向没有独立提示词。 */
+  updateFirstFrameDirectionPrompts(
+    nodeId: ActionFirstFrameWorkflowNode['id'],
+    prompts: Partial<Record<ActionDirection, string>>,
   ): Promise<void>
   regenerateFirstFrame(
     nodeId: ActionFirstFrameWorkflowNode['id'],
@@ -1002,9 +1009,13 @@ export function createWorkflowController({
           projectId: run.projectId,
           actionType: node.input.type,
           prompt:
-            options.prompt === undefined
-              ? node.input.prompt?.trim() || node.input.name
-              : nonEmpty(options.prompt, 'prompt'),
+            options.directionPrompts?.[direction] !== undefined
+              ? nonEmpty(options.directionPrompts[direction] ?? '', 'directionPrompt')
+              : options.prompt === undefined
+                ? node.input.directionPrompts?.[direction]?.trim() ||
+                  node.input.prompt?.trim() ||
+                  node.input.name
+                : nonEmpty(options.prompt, 'prompt'),
           spriteWidth: options.spriteWidth,
           spriteHeight: options.spriteHeight,
           referenceMedia: [sourceImage ?? (characterTemplateReference as MediaReference)],
@@ -1016,6 +1027,40 @@ export function createWorkflowController({
         return input
       },
       generationDirections,
+    )
+  }
+
+  function updateFirstFrameDirectionPrompts(
+    nodeId: ActionFirstFrameWorkflowNode['id'],
+    prompts: Partial<Record<ActionDirection, string>>,
+  ) {
+    ensureRunning()
+    const invalidDirection = Object.keys(prompts).find(
+      (direction) => !generationDirections.includes(direction as ActionDirection),
+    )
+    if (invalidDirection) {
+      throw new Error(`方向 ${invalidDirection} 是镜像方向，不能保存独立提示词`)
+    }
+    const normalized = Object.fromEntries(
+      generationDirections.flatMap((direction) => {
+        const prompt = prompts[direction]?.trim()
+        return prompt ? [[direction, prompt]] : []
+      }),
+    ) as Partial<Record<ActionDirection, string>>
+    return persist((run) =>
+      updateNode(run, nodeId, (node) => {
+        if (node.type !== 'action-first-frame') throw new Error('目标节点不是动作首帧')
+        if (node.phase !== 'configuring') throw new Error('动作首帧已开始生成，不能修改方向提示词')
+        return replaceNode(run, {
+          ...node,
+          input: {
+            ...node.input,
+            ...(Object.keys(normalized).length > 0
+              ? { directionPrompts: normalized }
+              : { directionPrompts: undefined }),
+          },
+        })
+      }),
     )
   }
 
@@ -1095,7 +1140,15 @@ export function createWorkflowController({
       throw new Error('动作首帧当前不能重新生成')
     }
     const basePrompt = firstFrameNode.input.prompt?.trim() || firstFrameNode.input.name
-    const prompt = adjustedPrompt(basePrompt, options)
+    const directionPrompts = Object.fromEntries(
+      generationDirections.map((direction) => [
+        direction,
+        adjustedPrompt(
+          firstFrameNode.input.directionPrompts?.[direction]?.trim() || basePrompt,
+          options,
+        ),
+      ]),
+    ) as Partial<Record<ActionDirection, string>>
     const sourceImageUrls =
       options.mode === 'refine'
         ? Object.fromEntries(
@@ -1123,7 +1176,7 @@ export function createWorkflowController({
         spriteWidth: options.spriteWidth,
         spriteHeight: options.spriteHeight,
         sourceImageUrls,
-        prompt,
+        directionPrompts,
       })
     })
   }
@@ -1320,7 +1373,10 @@ export function createWorkflowController({
               type: 'first_frame',
               projectId: run.projectId,
               actionType: node.input.type,
-              prompt: node.input.prompt?.trim() || node.input.name,
+              prompt:
+                node.input.directionPrompts?.[retryDirection]?.trim() ||
+                node.input.prompt?.trim() ||
+                node.input.name,
               spriteWidth: options.spriteWidth,
               spriteHeight: options.spriteHeight,
               referenceMedia: [templateUrl as MediaReference],
@@ -2012,6 +2068,7 @@ export function createWorkflowController({
     confirmCharacterTemplate: asCommand(confirmCharacterTemplate),
     generateCharacterViewSheet: asCommand(generateCharacterViewSheet),
     confirmCharacterViewSheet: asCommand(confirmCharacterViewSheet),
+    updateFirstFrameDirectionPrompts: asCommand(updateFirstFrameDirectionPrompts),
     generateFirstFrame: asCommand(generateFirstFrame),
     regenerateFirstFrame: asCommand(regenerateFirstFrame),
     confirmFirstFrame: asCommand(confirmFirstFrame),

--- a/frontend/src/font-delivery.test.ts
+++ b/frontend/src/font-delivery.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { afterEach, describe, expect, it } from 'vitest'
 import { build } from 'vite'
@@ -20,9 +21,9 @@ describe('production serif font delivery', () => {
 
     await build({
       build: { emptyOutDir: true, outDir },
-      configFile: new URL('../vite.config.ts', import.meta.url).pathname,
+      configFile: fileURLToPath(new URL('../vite.config.ts', import.meta.url)),
       logLevel: 'silent',
-      root: new URL('..', import.meta.url).pathname,
+      root: fileURLToPath(new URL('..', import.meta.url)),
     })
 
     const assetNames = await readdir(join(outDir, 'assets'))

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -844,10 +844,10 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     expect(group.className).toContain('grid-cols-3')
     expect(group.className).toContain('aspect-square')
     expect(within(group).getAllByRole('img')).toHaveLength(8)
-    expect(within(group).getByLabelText('八向宫格中心留空')).toBeTruthy()
+    expect(within(group).getByLabelText('八向宫格空位')).toBeTruthy()
   })
 
-  it('四向角色母版完成态展示四张独立图片', async () => {
+  it('四向角色母版完成态按九宫方位展示四张独立图片并隐藏空位痕迹', async () => {
     const workflow = completedTemplateWorkflow('42')
     workflow.nodes[1] = {
       ...(workflow.nodes[1] as CharacterTemplateWorkflowNode),
@@ -868,7 +868,9 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     renderEditor('/workflow-editor/42')
 
     const group = await screen.findByRole('group', { name: '四向角色母版集合' })
-    expect(group.className).toContain('grid-cols-2')
+    expect(group.className).toContain('grid-cols-3')
+    expect(group.children).toHaveLength(9)
+    expect(within(group).getAllByLabelText('四向宫格空位')).toHaveLength(5)
     expect(within(group).getAllByRole('img')).toHaveLength(4)
     expect(
       within(group)
@@ -1295,7 +1297,12 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     defaultSessionLoader.mockResolvedValue(session)
     renderEditor('/workflow-editor/42')
 
-    fireEvent.click(await screen.findByRole('button', { name: '重做北方向' }))
+    fireEvent.click(await screen.findByRole('button', { name: '选择北动作首帧候选 1' }))
+    const confirmNorth = screen.getByRole('button', { name: '确认北向首帧' })
+    expect((confirmNorth as HTMLButtonElement).disabled).toBe(false)
+
+    const retryNorth = screen.getByRole('button', { name: '重做北方向' })
+    fireEvent.click(retryNorth)
 
     await waitFor(() =>
       expect(retry).toHaveBeenCalledWith(firstFrame.id, 'north', {
@@ -1304,11 +1311,168 @@ describe('WorkflowEditorPage real runtime boundary', () => {
         referenceMedia: [],
       }),
     )
+    await waitFor(() => expect((retryNorth as HTMLButtonElement).disabled).toBe(false))
+    expect((confirmNorth as HTMLButtonElement).disabled).toBe(true)
     expect(screen.getByRole('img', { name: '北动作首帧候选 1' })).toBeTruthy()
     expect(screen.queryByRole('img', { name: '西动作首帧候选 1' })).toBeNull()
   })
 
-  it('八向动作首帧完成态展示八张独立图片并将中心留空', async () => {
+  it('四向动作首帧只在失败的真实源方向卡片提供重试', async () => {
+    const workflow = reviewingActionWorkflow()
+    const firstFrame = workflow.nodes.find((node) => node.type === 'action-first-frame')
+    if (!firstFrame || firstFrame.type !== 'action-first-frame') throw new Error('missing frame')
+    Object.assign(firstFrame, {
+      status: 'failed',
+      phase: 'generating',
+      error: 'north provider failed',
+      generations: (['east', 'north', 'south'] as const).map((direction) => ({
+        taskId: `first-${direction}`,
+        role: 'first_frame' as const,
+        direction,
+      })),
+      selectedFirstFrameUrl: null,
+    })
+    const project = { ...projectFixture(), directionalMovement: 'four-way' as const }
+    const session = createSession(workflow, {
+      project,
+      generationApis: generationApisFixture({
+        get: vi.fn(async (_projectId: string, taskId: string) => {
+          const direction = taskId.replace('first-', '') as 'east' | 'north' | 'south'
+          return {
+            id: taskId,
+            projectId: '1',
+            type: 'first_frame' as const,
+            status: direction === 'north' ? ('failed' as const) : ('completed' as const),
+            result:
+              direction === 'north'
+                ? null
+                : {
+                    type: 'first_frame' as const,
+                    direction,
+                    images: [{ url: `${direction}-1.png` }, { url: `${direction}-2.png` }],
+                  },
+            error: direction === 'north' ? 'north provider failed' : null,
+          }
+        }) as GenerationApis['get'],
+      }),
+    })
+    const retry = vi.spyOn(session.controller, 'retryGenerationDirection').mockResolvedValue()
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    expect(await screen.findByRole('img', { name: '东动作首帧候选 1' })).toBeTruthy()
+    expect(screen.getByRole('img', { name: '南动作首帧候选 1' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: '重试东方向' })).toBeNull()
+    expect(screen.queryByRole('button', { name: '重试南方向' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: '重试北方向' }))
+
+    expect(retry).toHaveBeenCalledWith(firstFrame.id, 'north', {
+      spriteWidth: 64,
+      spriteHeight: 64,
+      referenceMedia: [],
+    })
+  })
+
+  it('四向配置态展开四张方向卡片并只让真实源方向填写提示词', async () => {
+    const workflow = reviewingActionWorkflow()
+    const firstFrame = workflow.nodes.find((node) => node.type === 'action-first-frame')
+    if (!firstFrame || firstFrame.type !== 'action-first-frame') throw new Error('missing frame')
+    Object.assign(firstFrame, {
+      status: 'active',
+      phase: 'configuring',
+      generations: [],
+      selectedFirstFrameUrl: null,
+      selectedFirstFrameUrls: undefined,
+    })
+    for (const node of workflow.nodes) {
+      if (node.type === 'action-generation-method') node.status = 'locked'
+      if (node.type === 'action-full-frame' || node.type === 'review') node.status = 'locked'
+    }
+    const session = createSession(workflow, {
+      project: { ...projectFixture(), directionalMovement: 'four-way' },
+    })
+    defaultSessionLoader.mockResolvedValue(session)
+
+    renderEditor('/workflow-editor/42')
+
+    expect(await screen.findByRole('article', { name: '北向动作首帧' })).toBeTruthy()
+    expect(screen.getByRole('article', { name: '南向动作首帧' })).toBeTruthy()
+    expect(screen.getByRole('article', { name: '东向动作首帧' })).toBeTruthy()
+    const west = screen.getByRole('article', { name: '西向动作首帧' })
+    expect(within(west).getByText('由东向结果水平镜像，不单独调用模型')).toBeTruthy()
+    expect(within(west).queryByRole('textbox')).toBeNull()
+    expect(screen.getByRole('textbox', { name: '东向动作描述' })).toBeTruthy()
+    expect(screen.getByRole('textbox', { name: '北向动作描述' })).toBeTruthy()
+    expect(screen.getByRole('textbox', { name: '南向动作描述' })).toBeTruthy()
+    expect(screen.getAllByRole('button', { name: '生成全部真实方向首帧' })).toHaveLength(1)
+
+    const directionNodes = Object.fromEntries(
+      latestFlowProps()
+        .nodes.filter((node) => node.id.startsWith(`${firstFrame.id}:direction:`))
+        .map((node) => [node.id.split(':').at(-1), node]),
+    )
+    expect(directionNodes.north!.position.x).toBe(directionNodes.south!.position.x)
+    expect(directionNodes.west!.position.y).toBe(directionNodes.east!.position.y)
+    expect(directionNodes.west!.position.x).toBeLessThan(directionNodes.north!.position.x)
+    expect(directionNodes.north!.position.x).toBeLessThan(directionNodes.east!.position.x)
+    expect(directionNodes.north!.position.y).toBeLessThan(directionNodes.west!.position.y)
+    expect(directionNodes.west!.position.y).toBeLessThan(directionNodes.south!.position.y)
+    expect(
+      directionNodes.south!.position.y - directionNodes.north!.position.y,
+    ).toBeGreaterThanOrEqual(800)
+    expect(
+      latestFlowProps().nodes.some(
+        (node) =>
+          node.position.x === directionNodes.north!.position.x &&
+          node.position.y === directionNodes.west!.position.y,
+      ),
+    ).toBe(false)
+  })
+
+  it('生成整组首帧前保存各真实源方向的提示词', async () => {
+    const workflow = reviewingActionWorkflow()
+    const firstFrame = workflow.nodes.find((node) => node.type === 'action-first-frame')
+    if (!firstFrame || firstFrame.type !== 'action-first-frame') throw new Error('missing frame')
+    Object.assign(firstFrame, {
+      status: 'active',
+      phase: 'configuring',
+      generations: [],
+      selectedFirstFrameUrl: null,
+      selectedFirstFrameUrls: undefined,
+    })
+    const session = createSession(workflow, {
+      project: { ...projectFixture(), directionalMovement: 'four-way' },
+    })
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    fireEvent.change(await screen.findByRole('textbox', { name: '东向动作描述' }), {
+      target: { value: '向右行走' },
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: '北向动作描述' }), {
+      target: { value: '背向镜头行走' },
+    })
+    fireEvent.change(screen.getByRole('textbox', { name: '南向动作描述' }), {
+      target: { value: '面向镜头行走' },
+    })
+    fireEvent.click(screen.getAllByRole('button', { name: '生成全部真实方向首帧' })[0]!)
+
+    await waitFor(() =>
+      expect(
+        session.controller.getWorkflow().nodes.find((node) => node.id === firstFrame.id),
+      ).toMatchObject({
+        input: {
+          directionPrompts: {
+            east: '向右行走',
+            north: '背向镜头行走',
+            south: '面向镜头行走',
+          },
+        },
+      }),
+    )
+  })
+
+  it('八向动作首帧完成态展示八张独立方向卡片并复用镜像源图', async () => {
     const directions = [
       'east',
       'west',
@@ -1329,34 +1493,53 @@ describe('WorkflowEditorPage real runtime boundary', () => {
       ]),
     )
     firstFrame.selectedFirstFrameUrl = 'https://assets.windup.test/first-east.png'
-    defaultSessionLoader.mockResolvedValue(
-      createSession(workflow, {
-        project: { ...projectFixture(), directionalMovement: 'eight-way' },
-      }),
-    )
+    const session = createSession(workflow, {
+      project: { ...projectFixture(), directionalMovement: 'eight-way' },
+    })
+    const regenerate = vi
+      .spyOn(session.controller, 'regenerateFirstFrame')
+      .mockResolvedValue(undefined)
+    defaultSessionLoader.mockResolvedValue(session)
 
     renderEditor('/workflow-editor/42')
 
-    const group = await screen.findByRole('group', { name: '八向动作首帧集合' })
-    expect(group.className).toContain('grid-cols-3')
-    expect(within(group).getAllByRole('img')).toHaveLength(8)
-    expect(within(group).getByLabelText('八向宫格中心留空')).toBeTruthy()
     for (const [direction, label] of [
       ['east', '东'],
-      ['west', '西'],
       ['north', '北'],
       ['south', '南'],
       ['north_east', '东北'],
-      ['north_west', '西北'],
       ['south_east', '东南'],
-      ['south_west', '西南'],
     ] as const) {
+      const card = await screen.findByRole('article', { name: `${label}向动作首帧` })
       expect(
-        within(group)
-          .getByRole('img', { name: `${label}方向动作首帧` })
+        within(card)
+          .getByRole('img', { name: `${label}向已确认动作首帧` })
           .getAttribute('src'),
       ).toContain(`/first-${direction}.png`)
     }
+
+    for (const [label, sourceDirection, sourceLabel] of [
+      ['西', 'east', '东'],
+      ['西北', 'north_east', '东北'],
+      ['西南', 'south_east', '东南'],
+    ] as const) {
+      const card = await screen.findByRole('article', { name: `${label}向动作首帧` })
+      expect(
+        within(card)
+          .getByRole('img', { name: `${label}向镜像动作首帧` })
+          .getAttribute('src'),
+      ).toContain(`/first-${sourceDirection}.png`)
+      expect(within(card).queryByRole('textbox')).toBeNull()
+      expect(within(card).getByText(`由${sourceLabel}向结果水平镜像，不单独调用模型`)).toBeTruthy()
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: '重新生成动作首帧' }))
+    expect(regenerate).toHaveBeenCalledWith(
+      firstFrame.id,
+      expect.objectContaining({ mode: 'regenerate' }),
+    )
+    fireEvent.click(await screen.findByRole('button', { name: '微调动作首帧' }))
+    expect(screen.getByRole('textbox', { name: '动作首帧微调描述' })).toBeTruthy()
   })
 
   it('该造型没有 3D 资产时禁用三渲二选项并给出原因', async () => {

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -34,6 +34,7 @@ import {
   type WorkflowRun,
   getDirectionGridLayout,
   getDirectionProfile,
+  resolveActionDirection,
 } from '@/entities'
 import type { WorkflowController } from '@/features/workflow-controller'
 import {
@@ -138,6 +139,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
   } = state
   const [selectedImages, setSelectedImages] = useState<Record<string, string>>({})
   const [setupPromptDrafts, setSetupPromptDrafts] = useState<Record<string, string>>({})
+  const [directionPromptDrafts, setDirectionPromptDrafts] = useState<Record<string, string>>({})
   const [actionPromptDraft, setActionPromptDraft] = useState('')
   const [actionMenuOpen, setActionMenuOpen] = useState(false)
   const [actionMenuLevel, setActionMenuLevel] = useState<ActionMenuLevel>('root')
@@ -166,6 +168,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
   useEffect(() => {
     setSelectedImages({})
     setSetupPromptDrafts({})
+    setDirectionPromptDrafts({})
     setActionPromptDraft('')
     setActionMenuOpen(false)
     setActionMenuLevel('root')
@@ -219,6 +222,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
             exportModels,
             selectedImages,
             setupPromptDrafts,
+            directionPromptDrafts,
             actionPromptDraft,
             actionMenuOpen,
             actionMenuLevel,
@@ -229,6 +233,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
             resumeBlocked: Boolean(resumeError),
             setSelectedImages,
             setSetupPromptDrafts,
+            setDirectionPromptDrafts,
             setActionPromptDraft,
             setActionMenuOpen,
             setActionMenuLevel,
@@ -247,6 +252,7 @@ export function WorkflowEditorPage({ loadSession }: WorkflowEditorPageProps = {}
       character,
       exportModels,
       generations,
+      directionPromptDrafts,
       run,
       runCommand,
       resumeError,
@@ -356,6 +362,7 @@ interface ProjectionInput {
   exportModels: ReadonlyMap<string, ExportPackageModel>
   selectedImages: Record<string, string>
   setupPromptDrafts: Record<string, string>
+  directionPromptDrafts: Record<string, string>
   actionPromptDraft: string
   actionMenuOpen: boolean
   actionMenuLevel: ActionMenuLevel
@@ -367,6 +374,7 @@ interface ProjectionInput {
   resumeBlocked: boolean
   setSelectedImages: React.Dispatch<React.SetStateAction<Record<string, string>>>
   setSetupPromptDrafts: React.Dispatch<React.SetStateAction<Record<string, string>>>
+  setDirectionPromptDrafts: React.Dispatch<React.SetStateAction<Record<string, string>>>
   setActionPromptDraft(value: string): void
   setActionMenuOpen(open: boolean): void
   setActionMenuLevel(level: ActionMenuLevel): void
@@ -395,22 +403,66 @@ function projectCanvas(input: ProjectionInput): {
     .filter((node) => node.type === 'action-first-frame')
     .map((node) => node.id)
   const nodesById = new Map(activeNodes.map((node) => [node.id, node]))
-  const nodes = activeNodes.map((node) =>
-    toCanvasNode(node, branchIndexFor(branchKeyFor(node, nodesById), actionRootIds), input),
-  )
+  const movement = input.project.directionalMovement
+  const directions = getDirectionProfile(movement).logicalDirections
+  const nodes = activeNodes.flatMap((node) => {
+    const branchIndex = branchIndexFor(branchKeyFor(node, nodesById), actionRootIds)
+    if (movement !== 'single' && node.type === 'action-first-frame') {
+      return directions.map((direction) =>
+        toDirectionCanvasNode(node, direction, branchIndex, input),
+      )
+    }
+    return [toCanvasNode(node, branchIndex, input)]
+  })
   const edges: Edge[] = activeNodes.flatMap((node) => {
     const confirmed = node.status === 'passed'
-    return node.dependsOnNodeIds.map((source) => ({
-      id: `${source}->${node.id}`,
-      source,
-      target: node.id,
-      selectable: false,
-      deletable: false,
-      className: confirmed ? 'workflow-edge--confirmed' : 'workflow-edge--flowing',
-    }))
+    const targetIds =
+      movement !== 'single' && node.type === 'action-first-frame'
+        ? directions.map((direction) => directionCanvasNodeId(node.id, direction))
+        : [node.id]
+    return node.dependsOnNodeIds.flatMap((source) => {
+      const sourceNode = nodesById.get(source)
+      const sourceIds =
+        movement !== 'single' && sourceNode?.type === 'action-first-frame'
+          ? directions.map((direction) => directionCanvasNodeId(source, direction))
+          : [source]
+      return sourceIds.flatMap((sourceId) =>
+        targetIds.map((targetId) => ({
+          id: `${sourceId}->${targetId}`,
+          source: sourceId,
+          target: targetId,
+          selectable: false,
+          deletable: false,
+          className: confirmed ? 'workflow-edge--confirmed' : 'workflow-edge--flowing',
+        })),
+      )
+    })
   })
 
   return { nodes, edges }
+}
+
+function toDirectionCanvasNode(
+  node: ActionFirstFrameWorkflowNode,
+  direction: ActionDirection,
+  branchIndex: number,
+  input: ProjectionInput,
+): WorkflowCardNode {
+  return {
+    id: directionCanvasNodeId(node.id, direction),
+    type: 'workflow-card',
+    position: positionForDirection(direction, branchIndex),
+    zIndex: 0,
+    draggable: true,
+    dragHandle: '.workflow-card__handle',
+    deletable: false,
+    data: {
+      eyebrow: CARD_LABELS[node.type].eyebrow,
+      title: `${directionLabel(direction)}向动作首帧`,
+      status: node.status,
+      content: <FirstFrameDirectionContent node={node} direction={direction} input={input} />,
+    },
+  }
 }
 
 function toCanvasNode(
@@ -421,7 +473,7 @@ function toCanvasNode(
   return {
     id: node.id,
     type: 'workflow-card',
-    position: positionFor(node.type, branchIndex),
+    position: positionFor(node.type, branchIndex, input.project.directionalMovement),
     zIndex: node.type === 'character-template' && input.actionMenuOpen ? 1000 : 0,
     draggable: true,
     dragHandle: '.workflow-card__handle',
@@ -514,24 +566,35 @@ function DirectionAssetGrid({
   kind: '角色母版' | '动作首帧'
   singleAlt: string
 }) {
-  const layout = getDirectionGridLayout(movement)
+  const layout =
+    movement === 'four-way'
+      ? {
+          columns: 3,
+          cells: [null, 'north', null, 'west', null, 'east', null, 'south', null] as const,
+        }
+      : getDirectionGridLayout(movement)
   const eastImage = images.east
   if (layout.columns === 1) {
     return eastImage ? <WorkflowImage src={eastImage} alt={singleAlt} variant="master" /> : null
   }
 
-  const directionCountLabel = layout.columns === 3 ? '八向' : '四向'
-  const columnClass = layout.columns === 3 ? 'grid-cols-3' : 'grid-cols-2'
+  const directionCountLabel = movement === 'eight-way' ? '八向' : '四向'
   return (
     <div
       role="group"
       aria-label={`${directionCountLabel}${kind}集合`}
       data-layout="direction-asset-grid"
-      className={`grid aspect-square w-full ${columnClass} gap-2 overflow-hidden rounded-xl border border-app-line-strong bg-app-surface-muted p-2`}
+      className="grid aspect-square w-full grid-cols-3 gap-2 overflow-hidden rounded-xl border border-app-line-strong bg-app-surface-muted p-2"
     >
       {layout.cells.map((direction, index) => {
         if (!direction) {
-          return <div key={`empty-${index}`} aria-label="八向宫格中心留空" className="min-h-0" />
+          return (
+            <div
+              key={`empty-${index}`}
+              aria-label={`${directionCountLabel}宫格空位`}
+              className="min-h-0"
+            />
+          )
         }
         const imageUrl = images[direction]
         return imageUrl ? (
@@ -1320,6 +1383,224 @@ function ActionMenu({ input, templateNodeId }: { input: ProjectionInput; templat
   )
 }
 
+function FirstFrameDirectionContent({
+  node,
+  direction,
+  input,
+}: {
+  node: ActionFirstFrameWorkflowNode
+  direction: ActionDirection
+  input: ProjectionInput
+}) {
+  const branchKey = branchKeyOf(node, input)
+  const branchBusy = input.busyBranches.has(branchKey)
+  const profile = getDirectionProfile(input.project.directionalMovement)
+  const resolved = resolveActionDirection(direction)
+  const sourceDirection = resolved.sourceDirection
+  const generation = input.generations[generationKey(node.id, 'first_frame', sourceDirection)]
+  const result = generation?.result
+  const images = result?.type === 'first_frame' ? result.images : []
+  const selectedImage =
+    node.selectedFirstFrameUrls?.[sourceDirection] ??
+    (sourceDirection === 'east' ? node.selectedFirstFrameUrl : null)
+  const selectedCandidateKey = selectionKey(node.id, sourceDirection)
+  const storedCandidate = input.selectedImages[selectedCandidateKey]
+  const selectedCandidate = images.find((image) => image.url === storedCandidate)?.url
+  const retryDirection = () => {
+    input.setSelectedImages((selected) => {
+      if (!(selectedCandidateKey in selected)) return selected
+      const next = { ...selected }
+      delete next[selectedCandidateKey]
+      return next
+    })
+    return input.runCommand(branchKey, () =>
+      input.controller.retryGenerationDirection(node.id, sourceDirection, {
+        spriteWidth: input.project.spriteSize.width,
+        spriteHeight: input.project.spriteSize.height,
+        referenceMedia: [],
+      }),
+    )
+  }
+
+  if (resolved.mirrorX) {
+    const preview = selectedImage ?? selectedCandidate ?? images[0]?.url
+    return (
+      <div className={CARD_STACK}>
+        <p className={CARD_SUMMARY}>
+          由{directionLabel(sourceDirection)}向结果水平镜像，不单独调用模型
+        </p>
+        {preview ? (
+          <div className="-scale-x-100">
+            <WorkflowImage
+              src={preview}
+              alt={`${directionLabel(direction)}向镜像动作首帧`}
+              variant="frame"
+            />
+          </div>
+        ) : null}
+      </div>
+    )
+  }
+
+  const promptKey = directionPromptKey(node.id, direction)
+  const promptDraft =
+    input.directionPromptDrafts[promptKey] ??
+    node.input.directionPrompts?.[direction] ??
+    node.input.prompt ??
+    ''
+
+  if (node.phase === 'configuring') {
+    return (
+      <div className={CARD_STACK}>
+        <p className={CARD_TEXT}>
+          {node.input.name} · {node.input.fps} FPS
+        </p>
+        <textarea
+          aria-label={`${directionLabel(direction)}向动作描述`}
+          rows={3}
+          value={promptDraft}
+          disabled={branchBusy}
+          onChange={(event) =>
+            input.setDirectionPromptDrafts((drafts) => ({
+              ...drafts,
+              [promptKey]: event.target.value,
+            }))
+          }
+          className="nodrag nopan nowheel min-h-20 resize-y rounded-md border border-app-line-strong bg-app-surface p-2 text-[11px] text-app-ink outline-none focus:border-app-accent"
+        />
+        {direction === profile.generationDirections[0] ? (
+          <button
+            type="button"
+            className={CARD_BUTTON}
+            disabled={branchBusy}
+            onClick={() =>
+              input.runCommand(branchKey, async () => {
+                const prompts = Object.fromEntries(
+                  profile.generationDirections.map((source) => [
+                    source,
+                    input.directionPromptDrafts[directionPromptKey(node.id, source)] ??
+                      node.input.directionPrompts?.[source] ??
+                      node.input.prompt ??
+                      '',
+                  ]),
+                ) as Partial<Record<ActionDirection, string>>
+                await input.controller.updateFirstFrameDirectionPrompts(node.id, prompts)
+                await input.controller.generateFirstFrame(node.id, {
+                  spriteWidth: input.project.spriteSize.width,
+                  spriteHeight: input.project.spriteSize.height,
+                })
+              })
+            }
+          >
+            生成全部真实方向首帧
+          </button>
+        ) : null}
+      </div>
+    )
+  }
+
+  if (!selectedImage && images.length > 0) {
+    return (
+      <div className={CARD_STACK}>
+        <p className={CARD_TEXT}>选择{directionLabel(direction)}向动作首帧</p>
+        <div className="grid grid-cols-2 gap-[7px]">
+          {images.map((image, index) => (
+            <button
+              key={image.url}
+              type="button"
+              className={THUMB_BUTTON}
+              aria-label={`选择${directionLabel(direction)}动作首帧候选 ${index + 1}`}
+              aria-pressed={selectedCandidate === image.url}
+              onClick={() =>
+                input.setSelectedImages((selected) => ({
+                  ...selected,
+                  [selectionKey(node.id, direction)]: image.url,
+                }))
+              }
+            >
+              <WorkflowImage
+                src={image.url}
+                alt={`${directionLabel(direction)}动作首帧候选 ${index + 1}`}
+                variant="thumbnail"
+              />
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className={CARD_BUTTON}
+          disabled={!selectedCandidate || branchBusy}
+          onClick={() => {
+            if (!selectedCandidate) return
+            input.runCommand(branchKey, () =>
+              input.controller.confirmFirstFrame(node.id, selectedCandidate, direction),
+            )
+          }}
+        >
+          确认{directionLabel(direction)}向首帧
+        </button>
+        <button
+          type="button"
+          className={CARD_BUTTON_SECONDARY}
+          disabled={branchBusy}
+          onClick={retryDirection}
+        >
+          重做{directionLabel(direction)}方向
+        </button>
+      </div>
+    )
+  }
+
+  if (selectedImage) {
+    return (
+      <div className={CARD_STACK}>
+        <WorkflowImage
+          src={selectedImage}
+          alt={`${directionLabel(direction)}向已确认动作首帧`}
+          variant="frame"
+        />
+        <p className={CARD_SUMMARY}>该方向首帧已确认</p>
+        {node.phase === 'completed' && direction === profile.generationDirections[0] ? (
+          <FirstFrameCompletedControls node={node} input={input} />
+        ) : null}
+      </div>
+    )
+  }
+
+  if (generation?.status === 'failed') {
+    return (
+      <div className={CARD_STACK}>
+        <p className={CARD_SUMMARY}>
+          {generation.error ?? `${directionLabel(direction)}向生成失败`}
+        </p>
+        <button
+          type="button"
+          className={CARD_BUTTON}
+          disabled={branchBusy}
+          onClick={retryDirection}
+        >
+          重试{directionLabel(direction)}方向
+        </button>
+      </div>
+    )
+  }
+
+  if (node.status === 'failed') return <StatusText node={node} input={input} />
+  if (node.phase === 'generating') {
+    return (
+      <div className={`${CARD_STACK} justify-items-center`}>
+        <GenerationProgressCopy
+          kind="action-first-frame"
+          label="动作首帧生成进度"
+          placement="node"
+        />
+        <GenerationPreviewCard label="动作首帧生成预览" radius="node" size="candidate" />
+      </div>
+    )
+  }
+  return <p className={CARD_SUMMARY}>等待该方向结果</p>
+}
+
 function FirstFrameContent({
   node,
   input,
@@ -1329,8 +1610,6 @@ function FirstFrameContent({
 }) {
   const branchKey = branchKeyOf(node, input)
   const branchBusy = input.busyBranches.has(branchKey)
-  const [refining, setRefining] = useState(false)
-  const [adjustmentPrompt, setAdjustmentPrompt] = useState('')
   const directions = getDirectionProfile(input.project.directionalMovement).generationDirections
   const groups = directions.map((direction) => {
     const result = input.generations[generationKey(node.id, 'first_frame', direction)]?.result
@@ -1456,74 +1735,91 @@ function FirstFrameContent({
           kind="动作首帧"
           singleAlt="已确认动作首帧"
         />
-        <div className="grid gap-2">
-          <button
-            type="button"
-            className={CARD_BUTTON}
-            disabled={branchBusy}
-            onClick={() =>
-              input.runCommand(branchKey, () =>
-                input.controller.regenerateFirstFrame(node.id, {
-                  spriteWidth: input.project.spriteSize.width,
-                  spriteHeight: input.project.spriteSize.height,
-                  mode: 'regenerate',
-                }),
-              )
-            }
-          >
-            重新生成动作首帧
-          </button>
-          <button
-            type="button"
-            className={CARD_BUTTON}
-            disabled={branchBusy}
-            onClick={() => setRefining((active) => !active)}
-          >
-            微调动作首帧
-          </button>
-          {refining ? (
-            <div className="grid gap-2">
-              <textarea
-                aria-label="动作首帧微调描述"
-                rows={3}
-                className="min-h-[64px] w-full resize-y rounded-lg border border-[var(--color-app-line)] bg-app-surface-raised px-3 py-2.5 font-[inherit] text-[11px] leading-[1.55] text-[var(--color-app-ink)] focus:border-app-accent focus:outline focus:outline-2 focus:outline-offset-1 focus:outline-app-accent-soft"
-                value={adjustmentPrompt}
-                disabled={branchBusy}
-                onChange={(event) => setAdjustmentPrompt(event.target.value)}
-              />
-              <button
-                type="button"
-                className={CARD_BUTTON}
-                disabled={branchBusy || !adjustmentPrompt.trim()}
-                onClick={() => {
-                  const prompt = adjustmentPrompt.trim()
-                  if (!prompt) return
-                  input.runCommand(
-                    branchKey,
-                    () =>
-                      input.controller.regenerateFirstFrame(node.id, {
-                        spriteWidth: input.project.spriteSize.width,
-                        spriteHeight: input.project.spriteSize.height,
-                        mode: 'refine',
-                        adjustmentPrompt: prompt,
-                      }),
-                    () => {
-                      setRefining(false)
-                      setAdjustmentPrompt('')
-                    },
-                  )
-                }}
-              >
-                提交动作首帧微调
-              </button>
-            </div>
-          ) : null}
-        </div>
-        <NodeExportButton model={input.exportModels.get(node.input.outfitId)} />
+        <FirstFrameCompletedControls node={node} input={input} />
       </div>
     )
   }
   return <StatusText node={node} input={input} />
+}
+
+function FirstFrameCompletedControls({
+  node,
+  input,
+}: {
+  node: ActionFirstFrameWorkflowNode
+  input: ProjectionInput
+}) {
+  const branchKey = branchKeyOf(node, input)
+  const branchBusy = input.busyBranches.has(branchKey)
+  const [refining, setRefining] = useState(false)
+  const [adjustmentPrompt, setAdjustmentPrompt] = useState('')
+
+  return (
+    <div className="grid gap-2">
+      <button
+        type="button"
+        className={CARD_BUTTON}
+        disabled={branchBusy}
+        onClick={() =>
+          input.runCommand(branchKey, () =>
+            input.controller.regenerateFirstFrame(node.id, {
+              spriteWidth: input.project.spriteSize.width,
+              spriteHeight: input.project.spriteSize.height,
+              mode: 'regenerate',
+            }),
+          )
+        }
+      >
+        重新生成动作首帧
+      </button>
+      <button
+        type="button"
+        className={CARD_BUTTON}
+        disabled={branchBusy}
+        onClick={() => setRefining((active) => !active)}
+      >
+        微调动作首帧
+      </button>
+      {refining ? (
+        <div className="grid gap-2">
+          <textarea
+            aria-label="动作首帧微调描述"
+            rows={3}
+            className="min-h-[64px] w-full resize-y rounded-lg border border-[var(--color-app-line)] bg-app-surface-raised px-3 py-2.5 font-[inherit] text-[11px] leading-[1.55] text-[var(--color-app-ink)] focus:border-app-accent focus:outline focus:outline-2 focus:outline-offset-1 focus:outline-app-accent-soft"
+            value={adjustmentPrompt}
+            disabled={branchBusy}
+            onChange={(event) => setAdjustmentPrompt(event.target.value)}
+          />
+          <button
+            type="button"
+            className={CARD_BUTTON}
+            disabled={branchBusy || !adjustmentPrompt.trim()}
+            onClick={() => {
+              const prompt = adjustmentPrompt.trim()
+              if (!prompt) return
+              input.runCommand(
+                branchKey,
+                () =>
+                  input.controller.regenerateFirstFrame(node.id, {
+                    spriteWidth: input.project.spriteSize.width,
+                    spriteHeight: input.project.spriteSize.height,
+                    mode: 'refine',
+                    adjustmentPrompt: prompt,
+                  }),
+                () => {
+                  setRefining(false)
+                  setAdjustmentPrompt('')
+                },
+              )
+            }}
+          >
+            提交动作首帧微调
+          </button>
+        </div>
+      ) : null}
+      <NodeExportButton model={input.exportModels.get(node.input.outfitId)} />
+    </div>
+  )
 }
 
 function MethodContent({
@@ -1863,6 +2159,14 @@ function selectionKey(nodeId: WorkflowNode['id'], direction: ActionDirection) {
   return direction === 'east' ? nodeId : `${nodeId}:${direction}`
 }
 
+function directionPromptKey(nodeId: WorkflowNode['id'], direction: ActionDirection) {
+  return `${nodeId}:prompt:${direction}`
+}
+
+function directionCanvasNodeId(nodeId: WorkflowNode['id'], direction: ActionDirection) {
+  return `${nodeId}:direction:${direction}`
+}
+
 function directionLabel(direction: ActionDirection) {
   const labels: Record<ActionDirection, string> = {
     east: '东',
@@ -1899,19 +2203,50 @@ function branchIndexFor(branchKey: string, actionRootIds: string[]): number {
   return Math.max(0, actionRootIds.indexOf(branchKey))
 }
 
-function positionFor(type: WorkflowNode['type'], branchIndex: number) {
+const DIRECTION_ROW_GAP = 440
+const MULTI_DIRECTION_BRANCH_GAP = 1400
+
+function positionFor(
+  type: WorkflowNode['type'],
+  branchIndex: number,
+  movement: Project['directionalMovement'],
+) {
+  const multiDirection = movement !== 'single'
   const x: Record<WorkflowNode['type'], number> = {
     'character-setup': 60,
     'character-template': 400,
     'action-first-frame': 740,
-    'action-generation-method': 1080,
-    'action-full-frame': 1420,
-    review: 1760,
+    'action-generation-method': multiDirection ? 1760 : 1080,
+    'action-full-frame': multiDirection ? 2100 : 1420,
+    review: multiDirection ? 2440 : 1760,
   }
   const isActionBranch = type.startsWith('action') || type === 'review'
+  const branchStep = multiDirection ? MULTI_DIRECTION_BRANCH_GAP : 380
   return {
     x: x[type],
-    y: isActionBranch ? 48 + branchIndex * 380 : 218,
+    y: isActionBranch
+      ? 48 +
+        branchIndex * branchStep +
+        (multiDirection && type !== 'action-first-frame' ? DIRECTION_ROW_GAP : 0)
+      : 218,
+  }
+}
+
+function positionForDirection(direction: ActionDirection, branchIndex: number) {
+  const cells: Record<ActionDirection, readonly [column: number, row: number]> = {
+    north_west: [0, 0],
+    north: [1, 0],
+    north_east: [2, 0],
+    west: [0, 1],
+    east: [2, 1],
+    south_west: [0, 2],
+    south: [1, 2],
+    south_east: [2, 2],
+  }
+  const [column, row] = cells[direction]
+  return {
+    x: 740 + column * 320,
+    y: 48 + branchIndex * MULTI_DIRECTION_BRANCH_GAP + row * DIRECTION_ROW_GAP,
   }
 }
 


### PR DESCRIPTION
## 变更说明

- 在 Workflow Editor 中按四向 / 八向罗盘展开独立动作首帧节点，镜像方向只复用源方向结果，不重复调用模型。
- 为每个真实源方向保存动作描述，并在首次生成、失败重试、重新生成和微调时保持方向提示词与参考图一一对应。
- 补齐逐方向候选确认、失败方向重试、九宫格展示及完成态的重新生成、微调和渐进导出入口。
- 防止方向重做后误确认旧候选，并补充 WorkflowRun 持久化与恢复校验。
- 修正 Windows 环境下字体交付测试的 URL 路径解析。

## 验证

- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage`（80 个测试文件、1241 项测试通过；行覆盖率 90.56%）
- `npm run build`
- 本次 8 个变更文件格式检查与 `git diff --check`

Closes #783