### PR TITLE
fix(video): add_headroom 保住 alpha，attack/jump 的 i2v 首帧不再是黑底

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/master_prep.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/master_prep.py
@@ -62,9 +62,21 @@ def add_headroom(master: bytes, ratio: float = 0.6) -> bytes:
     """
     if not 0.1 < ratio < 1.0:
         raise ValueError("ratio 需在 (0.1, 1.0) 之间")
-    img = Image.open(io.BytesIO(master)).convert("RGB")
-    new_h = max(img.height + 1, int(round(img.height / ratio)))
-    canvas = Image.new("RGB", (img.width, new_h), _bg_color(img))
+    src = Image.open(io.BytesIO(master))
+    # **带 alpha 的母版必须保住 alpha。** 曾经这里无条件 ``convert("RGB")``:透明像素的
+    # RGB 是未定义值(实际为 0),整幅底色因此变成纯黑,而 attack / jump 是仅有的两个走这条
+    # 路的动作 —— 走路不走,所以只有这两个动作的 i2v 首帧是黑底。后果有两层:模型为了把
+    # 角色从黑底里分出来会自己画一圈白描边;而黑发黑裤这类深色角色与黑底同色,抠图必然
+    # 在角色内部打洞(实测生产 attack 帧内部洞占主体 13.8%~31.7%)。
+    # 这与 #509 在 ``fit_first_frame`` 修掉的是同一个错,只是它当时没被一起改到。
+    if src.mode in ("RGBA", "LA") or (src.mode == "P" and "transparency" in src.info):
+        img = src.convert("RGBA")
+        new_h = max(img.height + 1, int(round(img.height / ratio)))
+        canvas = Image.new("RGBA", (img.width, new_h), (0, 0, 0, 0))
+    else:
+        img = src.convert("RGB")
+        new_h = max(img.height + 1, int(round(img.height / ratio)))
+        canvas = Image.new("RGB", (img.width, new_h), _bg_color(img))
     canvas.paste(img, (0, new_h - img.height))       # 原图贴底,空间加在顶部
     buf = io.BytesIO()
     canvas.save(buf, "PNG")

--- a/backend/tests/test_frame_timing_and_master_prep.py
+++ b/backend/tests/test_frame_timing_and_master_prep.py
@@ -134,3 +134,52 @@ def test_jump_gets_more_headroom_than_attack():
 def test_invalid_ratio_raises(bad: float):
     with pytest.raises(ValueError, match="ratio"):
         add_headroom(_png(32, 32), ratio=bad)
+
+
+def _rgba_png(w: int = 64, h: int = 90) -> bytes:
+    """带透明背景的母版：中间一块不透明主体，四周 alpha=0 且 RGB 为 0。
+
+    RGB 取 0 是刻意的 —— 透明像素的 RGB 本来就是未定义值，PIL 抠图产物实测就是 0。
+    这正是 ``convert("RGB")`` 会把它当真、整幅变黑的那个输入。
+    """
+    im = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    im.paste((20, 40, 200, 255), (w // 4, h // 4, w * 3 // 4, h * 3 // 4))
+    buf = io.BytesIO()
+    im.save(buf, "PNG")
+    return buf.getvalue()
+
+
+def test_headroom_keeps_alpha_instead_of_flattening_it_to_black():
+    """带 alpha 的母版补顶空间后必须仍带 alpha。
+
+    曾经这里无条件 ``convert("RGB")``：透明像素的 RGB 是未定义值（实际为 0），
+    整幅底色因此变成纯黑。而 ``add_headroom`` 只被 attack / jump 调用，所以只有这两个
+    动作的 i2v 首帧是黑底 —— 模型会自己画一圈白描边把角色从黑底里分出来，而黑发黑裤
+    这类深色角色与黑底同色，抠图会在角色内部打洞。
+    """
+    out = Image.open(io.BytesIO(add_headroom(_rgba_png(), ratio=0.7)))
+    assert out.mode == "RGBA", f"补顶空间后 mode={out.mode}，alpha 被丢了"
+    assert out.getpixel((2, 2))[3] == 0, "顶部新增区域应保持透明，而不是被填成不透明底色"
+
+
+def test_attack_and_jump_first_frames_do_not_go_out_on_a_black_canvas():
+    """端到端：母版带 alpha 时，三个动作送进 i2v 的画布底色都应是声明的那一个。
+
+    只断言 ``add_headroom`` 保住 alpha 还不够 —— 真正出问题的是它下游那一步：
+    不透明输入会让 ``fit_first_frame`` 沿用角点色补边，黑角点就把整张 1280x720 铺黑。
+    这条把两步接起来测，锁的是用户实际看到的那个量。
+    """
+    from windup_framework.providers.protocol.openai_video import (
+        FIRST_FRAME_BG,
+        fit_first_frame,
+    )
+
+    master = _rgba_png()
+    for action in ("walk", "attack", "jump"):
+        canvas = Image.open(
+            io.BytesIO(fit_first_frame(prepare_master(master, action), "1280x720"))
+        ).convert("RGB")
+        corner = canvas.getpixel((4, 4))
+        assert all(abs(a - b) <= 12 for a, b in zip(corner, FIRST_FRAME_BG)), (
+            f"{action} 送出去的画布角点 {corner}，应为声明的 {FIRST_FRAME_BG}"
+        )


### PR DESCRIPTION
让 `add_headroom` 在母版带 alpha 时保住 alpha，attack / jump 的 i2v 首帧不再变成黑底。

## Why

`add_headroom()` 无条件 `convert("RGB")`，把带 alpha 的母版拍平。透明像素的 RGB 是未定义值（抠图产物实测为 0），整幅底色因此变成纯黑。它只被 attack 与 jump 调用（`prepare_master`），**所以只有这两个动作的首帧是黑底**，走路不受影响。

黑底带来两层后果：模型为了把角色从黑底里分出来会自己给角色画一圈白描边；而黑发、黑裤这类深色角色与黑底同色，抠图无法分离，在角色内部打洞。

这与 #509 在 `fit_first_frame` 修掉的是同一个错，当时没有一起改到这里。`fit_first_frame` 本身是对的（对 RGBA 输入用声明的 `FIRST_FRAME_BG`），但 `add_headroom` 先把图变成了不透明黑底，于是走的是「不透明输入沿用角点色」那一支。

## 证据

取回生产 task 391「像素程序员法师」attack 动作的**真实源视频**（1280×720、121 帧、h264）后实测：

- 源视频四角均为 `(0,0,0)`，纯黑底，角色身上有模型自己加的白描边。
- 用生产同一份 `cutout()` 跑该视频：内部洞占主体 **13.8% ~ 31.7%**（帧 0/30/60/90/120），与交付帧实测的 20%~32% 吻合，洞集中在黑头发与黑裤子。
- 对照：同一角色的**母版**（未经 `add_headroom`）过同一个 `cutout()`，内部洞仅 **0.8%**。

本地复跑 `prepare_master` + `fit_first_frame`，同一张 RGBA 首帧，修复前后：

| 动作 | 修复前送出去的画布角点 | 修复后 |
|---|---|---|
| walk | (128,128,128) | (128,128,128) |
| attack | **(0,0,0)** | (128,128,128) |
| jump | **(0,0,0)** | (128,128,128) |

## Changes

- `add_headroom`：输入带 alpha 时保持 RGBA、顶部补透明；不透明输入维持原行为（沿用四角中位色）。

## Verification

- [x] `test_headroom_keeps_alpha_instead_of_flattening_it_to_black`：只回退源文件、保留测试跑在 `origin/main` 代码上是 **failed**（`补顶空间后 mode=RGB，alpha 被丢了`），本分支 passed。
- [x] `test_attack_and_jump_first_frames_do_not_go_out_on_a_black_canvas`：同法验证在 main 上 **failed**（`attack 送出去的画布角点 (0, 0, 0)，应为声明的 (128, 128, 128)`）。这条把 `add_headroom` 与 `fit_first_frame` 两步接起来测——只断言前者保住 alpha 不够，真正出问题的是下游那一步。
- [x] 回退验证用 cp 备份并在结束时核对 `sha256` 一致，未使用 `git checkout --`。
- [x] `uv run ruff check .`：All checks passed。
- [x] `uv run python -m scripts.export_openapi`：rc=0，`openapi.json` 无漂移。
- [x] `uv run lint-imports`：Contracts: 2 kept, 0 broken。
- [x] `uv run pytest -q --cov=packages`：1768 passed, 14 skipped, 2 failed。这 2 条（`test_generation_api.py` 的 four_view / eight_view）在**纯 `origin/main` 上同样失败**，与本 PR 无关。

## Scope

不含：抠图模型替换、完美像素化算法、最后一公里定标。

Closes #801
