### PR TITLE
feat(video): 接入新视频模型，供组实验

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,12 @@ AI_IMAGE_MODEL=gpt-image-2
 AI_VIDEO_MODEL=kling-v2-5-turbo
 AI_IMAGE_FALLBACKS=gemini-3.1-flash-image-preview
 AI_VIDEO_FALLBACKS=kling-v2-6
+# veo3.1 放行开关。默认 false：关着时它不进视频链，接口也选不到它。
+# 打开之前先看清它的计费档——本仓固定按 4s + 无声($0.20/秒)调用，
+# 上游默认(8s + 有声)是这一档的 4 倍。
+# veo3.1 只对逗号分隔的这些用户 id 开放(组内做高质量素材用,不面向客户)。
+# 空 = 谁都不能用。它按秒计费且比 kling 贵,且**永远不进兜底链**,只能由请求显式指定。
+AI_VIDEO_VEO_USER_IDS=
 # 留空即按型号查上游牌价（美元）；配了它就整条链共用这一个价，跨型号时会算错。
 AI_IMAGE_UNIT_COST=
 AI_VIDEO_UNIT_COST_PER_SECOND=

--- a/backend/packages/ai_engine/src/windup_ai_engine/impl/character_generator.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/impl/character_generator.py
@@ -155,7 +155,9 @@ class CharacterGenerator(CharacterGeneratorPort):
             card, action, master, _BandProgress(progress, _DERIVE_FROM, _DERIVE_TO)
         )
 
-    def poll_video(self, job_id: str, *, route_id: str | None = None) -> bytes | None:
+    def poll_video(
+        self, job_id: str, *, route_id: str | None = None, model: str | None = None
+    ) -> bytes | None:
         """walk/idle/attack/custom 共用 VIDEO_I2V 桶,按 job 探一次。"""
         strategy = self._by_route.get(GenRoute.VIDEO_I2V)
         if strategy is None:
@@ -163,7 +165,7 @@ class CharacterGenerator(CharacterGeneratorPort):
         poll_job = getattr(strategy, "poll_job", None)
         if poll_job is None:
             raise TypeError("视频路线不支持 poll_job")
-        return poll_job(job_id, route_id=route_id)
+        return poll_job(job_id, route_id=route_id, model=model)
 
     def finish_video(
         self,

--- a/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/strategy/concrete.py
@@ -157,12 +157,17 @@ class VideoFrameStrategy(DerivationStrategy):
             raise TypeError("当前 VideoProvider 不支持 start_i2v")
         return start(framed, self._build_prompt(action, card.stance), seconds=5)
 
-    def poll_job(self, job_id: str, *, route_id: str | None = None) -> bytes | None:
-        """探一次。``None`` = 仍在跑;bytes = 成片;失败抛错。"""
+    def poll_job(
+        self, job_id: str, *, route_id: str | None = None, model: str | None = None
+    ) -> bytes | None:
+        """探一次。``None`` = 仍在跑;bytes = 成片;失败抛错。
+
+        ``model`` 要一路带到 provider:单据地址按协议面拼,面认错就查不到已经建好的单。
+        """
         poll = getattr(self._video, "poll_i2v", None)
         if poll is None:
             raise TypeError("当前 VideoProvider 不支持 poll_i2v")
-        snap = poll(job_id, route_id=route_id)
+        snap = poll(job_id, route_id=route_id, model=model)
         if snap.ok and snap.body:
             return snap.body
         if getattr(snap, "error_type", None) is None:

--- a/backend/packages/app/src/windup_app/server/media/first_frame.py
+++ b/backend/packages/app/src/windup_app/server/media/first_frame.py
@@ -1,0 +1,34 @@
+"""i2v 首帧的对象存储上传器。
+
+只吃公网 URL 的 i2v 接口(veo 走的 FAL 队列面)需要先把首帧传上去。实现住在 app 层
+而不是 framework:它要碰对象存储凭证,而 framework 只认 ``FirstFrameUploader`` 这个 port。
+"""
+
+from __future__ import annotations
+
+from windup_common.enums.media import MediaCategory
+
+from windup_app.server.media.model import MediaUploadInput
+
+
+class MediaFirstFrameUploader:
+    """复用既有媒体上传服务,不另起一套对象存储客户端。
+
+    另起一套的代价不是多写几十行,是**两套凭证与两套桶策略**会各自漂移:一套改了
+    下载域名、另一套没改,而这里传坏了的表现是上游取不到图、任务在生成阶段才 failed。
+    """
+
+    def upload(self, first_frame: bytes, content_type: str) -> str:
+        # 惰性导入:``service`` 在模块级实例化,顶层导入会把对象存储配置拉进每个引用者。
+        from windup_app.server.media.service import service as media_service
+
+        meta = MediaUploadInput(
+            filename="i2v-first-frame.jpg",
+            content_type=content_type,
+            size=len(first_frame),
+            # 沿用 ACTION_FRAME 而不新开一个分类:``MediaCategory`` 是 ``POST /media/upload``
+            # 请求体里的公开枚举,加一个值等于给客户端多开一个可上传的分类 ——
+            # 一个纯内部的中转文件不该改动对外契约(openapi.json 会跟着变)。
+            category=MediaCategory.ACTION_FRAME,
+        )
+        return media_service.upload(first_frame, meta).url

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -30,7 +30,11 @@ from windup_common.directions import direction_prompt
 from windup_common.enums import ArtStyle
 from windup_common.models import ActionSpec, ActionType as EngineActionType, CharacterCard
 from windup_framework.gateway import bind_call_context, fresh_gateway_request
-from windup_framework.gateway.registry import ModelRegistry
+from windup_framework.gateway.registry import (
+    USER_GATED_MODELS,
+    ModelRegistry,
+    is_allowed_for_user,
+)
 from windup_framework.gateway.types import Scene
 from windup_framework.config.quality_gate import settings as gate_settings
 
@@ -227,14 +231,21 @@ class _TaskProgress:
         )
 
 
-def _resolve_video_model(name: str | None) -> str | None:
+def _resolve_video_model(name: str | None, user_id: int | None = None) -> str | None:
     """校验并返回视频模型名;``None`` 表示用部署默认值。
 
-    只允许是 CHARACTER_ACTION 链上的一员,含义是「这次从它开始试」。
-    非法取值在入口炸,不等到付费调用才失败。
+    两类型号分开判:链上的型号对所有人开放;``USER_GATED_MODELS`` 里的按用户白名单授权,
+    它们**不在链上**(链是兜底路径,让按用户授权的型号当兜底等于对所有人开放)。
+
+    这里的判定与 API 入口那道是**故意重复**的:任务可能被重排、重投或从别处再次进入,
+    只在 HTTP 边界拦一次,绕过它的路径就直接花钱。
     """
     if name is None:
         return None
+    if name in USER_GATED_MODELS:
+        if not is_allowed_for_user(name, user_id):
+            raise ValueError(f"视频模型 {name!r} 未对当前用户开放")
+        return name
     chain = ModelRegistry.from_settings().chain(Scene.CHARACTER_ACTION)
     if name not in chain:
         raise ValueError(f"视频模型 {name!r} 不在本期开放列表内。可选:" + "；".join(chain))
@@ -327,20 +338,21 @@ class ActionTaskExecutor:
                 if task is None:
                     raise RuntimeError(f"任务 {task_id} 不存在")
                 constraints = (self._fetch_constraints or _load_constraints)(s, project_id)
-                return constraints, task.project_id
+                return constraints, task.project_id, task.user_id
 
-            cons, task_project_id = generation_io.using_session(
+            cons, task_project_id, task_user_id = generation_io.using_session(
                 session, self._make_session, _mark_running
             )
             reset = bind_call_context(
                 task_id=str(task_id),
-                start_from_model=_resolve_video_model(input.video_model),
+                start_from_model=_resolve_video_model(input.video_model, task_user_id),
             )
             result = self._produce_action(
                 input,
                 cons,
                 task_id=task_id,
                 project_id=task_project_id,
+                user_id=task_user_id,
             )
 
             def _complete(s: Session) -> None:
@@ -385,6 +397,7 @@ class ActionTaskExecutor:
         *,
         task_id: int,
         project_id: int | None = None,
+        user_id: int | None = None,
     ) -> dict:
         """母版 → ai_engine 按项目尺寸出帧 → 逐帧上传 → 组结果 dict。
 
@@ -469,7 +482,7 @@ class ActionTaskExecutor:
                         f"3D 模型地址不在自家对象存储上:{model_url[:80]!r}"
                     )
                 plan = self._get_generator(
-                    _resolve_video_model(input.video_model), cons.directions
+                    _resolve_video_model(input.video_model, user_id), cons.directions
                 ).plan_rendered(action)
                 deadline = client_bake.open_job(
                     task_id,
@@ -501,12 +514,12 @@ class ActionTaskExecutor:
                     len(rigged),
                 )
                 generated = self._get_generator(
-                    _resolve_video_model(input.video_model), cons.directions
+                    _resolve_video_model(input.video_model, user_id), cons.directions
                 ).generate_rendered(card, action, rigged, progress, canvas=canvas)
             else:
                 master = (self._fetch_master or self._download_master)(input)
                 gen = self._get_generator(
-                    _resolve_video_model(input.video_model), cons.directions
+                    _resolve_video_model(input.video_model, user_id), cons.directions
                 )
                 # 注入的测试桩通常只有 generate()。生产装配且 VideoGateway 支持
                 # start_i2v 时,建单后把轮询丢进 ZSET,立刻让出 action worker。
@@ -541,10 +554,10 @@ class ActionTaskExecutor:
                 if task.status in (TaskStatus.COMPLETED, TaskStatus.FAILED):
                     raise _PollSkip(f"任务 {task_id} 已终态")
                 constraints = (self._fetch_constraints or _load_constraints)(s, project_id)
-                return constraints, task.project_id
+                return constraints, task.project_id, task.user_id
 
             try:
-                cons, task_project_id = generation_io.using_session(
+                cons, task_project_id, task_user_id = generation_io.using_session(
                     session, self._make_session, _mark_running
                 )
             except _PollSkip:
@@ -552,10 +565,10 @@ class ActionTaskExecutor:
 
             reset = bind_call_context(
                 task_id=str(task_id),
-                start_from_model=_resolve_video_model(input.video_model),
+                start_from_model=_resolve_video_model(input.video_model, task_user_id),
             )
             gen = self._get_generator(
-                _resolve_video_model(input.video_model), cons.directions
+                _resolve_video_model(input.video_model, task_user_id), cons.directions
             )
             reset_call = fresh_gateway_request()
             try:
@@ -621,16 +634,19 @@ class ActionTaskExecutor:
         """
         reset = None
         try:
-            def _mark_running(s: Session) -> ProjectConstraints:
+            def _mark_running(s: Session):
                 task = task_repo.get_task(s, task_id)
                 if task is None:
                     raise RuntimeError(f"任务 {task_id} 不存在")
                 if task.status in (TaskStatus.COMPLETED, TaskStatus.FAILED):
                     raise _PollSkip(f"任务 {task_id} 已终态")
-                return (self._fetch_constraints or _load_constraints)(s, project_id)
+                # 一并带出 user_id:受限型号按用户授权,而 task 只在这个内层函数里可见。
+                return (self._fetch_constraints or _load_constraints)(s, project_id), task.user_id
 
             try:
-                cons = generation_io.using_session(session, self._make_session, _mark_running)
+                cons, task_user_id = generation_io.using_session(
+                    session, self._make_session, _mark_running
+                )
             except _PollSkip:
                 client_bake.clear(task_id)
                 return
@@ -659,12 +675,12 @@ class ActionTaskExecutor:
             frames = client_bake.collect_frames(task_id, spec.frames)
             reset = bind_call_context(
                 task_id=str(task_id),
-                start_from_model=_resolve_video_model(input.video_model),
+                start_from_model=_resolve_video_model(input.video_model, task_user_id),
             )
             card, action, canvas = self._action_spec(input, cons)
             progress: ProgressPort = _TaskProgress(task_id=task_id, project_id=project_id)
             generated = self._get_generator(
-                _resolve_video_model(input.video_model), cons.directions
+                _resolve_video_model(input.video_model, task_user_id), cons.directions
             ).finish_rendered(frames, card, action, progress, canvas=canvas)
             result = self._deliver_generated(generated, input, cons, None)
             client_bake.clear(task_id)
@@ -818,11 +834,15 @@ class ActionTaskExecutor:
         from windup_framework.gateway.image import _CIRCUIT
         from windup_framework.providers import OnnxU2NetMatteProvider
 
+        from windup_app.server.media.first_frame import MediaFirstFrameUploader
+
         if self._matte is None:
             self._matte = OnnxU2NetMatteProvider()
         if self._image is None:
             self._image = build_image_gateway(circuit=_CIRCUIT)
-        video = build_video_gateway(circuit=_CIRCUIT)
+        # uploader 在这里注入而不是让 provider 自己去拿:framework 不认识 app 的对象存储。
+        # 只有走 FAL 队列面的型号(veo)会用到它,kling 那条路一个字节都不会传上去。
+        video = build_video_gateway(circuit=_CIRCUIT, uploader=MediaFirstFrameUploader())
         # 装配表必须与 GenRoute 对齐。下面那条断言让漏装在装配时暴露,而不是等到某个
         # 动作第一次被请求时才炸——注入 generator 的测试走不到这条装配路径,漏了会测试
         # 全绿而真实调用全崩。

--- a/backend/packages/app/src/windup_app/server/orchestrator/i2v_poll.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/i2v_poll.py
@@ -117,7 +117,12 @@ def inspect(
     timed_out = elapsed >= I2V_MAX_WAIT_S
 
     route_id = state.get("route_id") or None
-    video = poll_video(state["job_id"], route_id=route_id)
+    # 型号早就随建单一起存进 Redis 了(见 save_i2v_state),但此前没往下传:
+    # kling 系只有一个协议面,不传也查得到单;veo 的单在另一条路径上,不传就是 404,
+    # 而单已经建了、钱已经花了。
+    video = poll_video(
+        state["job_id"], route_id=route_id, model=state.get("model") or None
+    )
     if video is not None:
         return Ready(video=video, route_id=route_id)
     if timed_out:

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -437,6 +437,18 @@ def _task_to_out(session: Session, task: GenerationTask) -> GenerationTaskOut:
 # ══════════════════════════════════════════════════════════════════════════════
 
 
+def _require_video_model_allowed(model: str | None, user_id: int) -> None:
+    """受限视频型号只对逐个列出的用户开放。
+
+    在 HTTP 边界就拒:任务还没建、积分还没冻,拒起来干净。编排层另有同一道判定,
+    那不是冗余 —— 任务可能被重排或重投,只在这里拦一次,绕过它的路径就直接花钱。
+    """
+    from windup_framework.gateway.registry import USER_GATED_MODELS, is_allowed_for_user
+
+    if model in USER_GATED_MODELS and not is_allowed_for_user(model, user_id):
+        raise BizException(f"视频模型 {model} 未对当前账号开放", code=403)
+
+
 def _get_project_or_raise(
     session: Session,
     project_id: int,
@@ -705,6 +717,7 @@ def submit_action_generation(
 ) -> Response[GenerationTaskOut]:
     """提交角色动作生成任务:建 PENDING 记录立即返回,实际生成后台跑。"""
     user_id = request.state.current_user.id
+    _require_video_model_allowed(body.video_model, user_id)
     project = _get_project_or_raise(session, body.project_id, user_id)
     _validate_project_direction(project, body.direction)
     character = _get_character_or_raise(session, body.character_id, body.project_id)

--- a/backend/packages/framework/src/windup_framework/config/provider.py
+++ b/backend/packages/framework/src/windup_framework/config/provider.py
@@ -41,6 +41,15 @@ class AIProviderSettings(BaseSettings):
     # ``GET /models`` 去核对。
     judge_model: str = "gemini-2.5-flash"
 
+    # veo 走 FAL 队列面,与 kling 的 OpenAI 面是两套请求形状与两条计费档。默认关的理由
+    # 不是"没实现",而是**开着就会被选中**:它一旦进链,兜底那一跳就可能落到它身上,
+    # 而它最贵的一档(8s + 有声)是最便宜一档的 4 倍。关着时它不进链,
+    # ``_resolve_video_model`` 也就选不到它 —— 对客户不可见,出事随时能关回去。
+    # veo3.1 只对**逐个列出的用户**开放,不是部署级开关。它按秒计费且比 kling 贵,
+    # 用途是组内做高质量素材,不面向客户。空值 = 没有任何人可用(默认)。
+    # 逗号分隔的用户 id,如 "1,7,12"。
+    video_veo_user_ids: str = ""
+
     chat_fallbacks: str = ""
     image_fallbacks: str = "gemini-3.1-flash-image-preview"
     video_fallbacks: str = ""

--- a/backend/packages/framework/src/windup_framework/gateway/registry.py
+++ b/backend/packages/framework/src/windup_framework/gateway/registry.py
@@ -11,6 +11,50 @@ FAMILIES: dict[str, Family] = {
     "kling-v2-5-turbo": Family.VIDEO_INPUT_REFERENCE,
     "kling-v2-6": Family.VIDEO_INPUT_REFERENCE,
     "kling-video-o1": Family.VIDEO_IMAGE_LIST,  # 登记但不允许进 chain
+    "veo3.1": Family.VIDEO_FAL_QUEUE,  # 登记≠放行,还要在 USER_GATED_MODELS 的白名单里
+}
+
+
+#: 型号 → 放行开关的配置字段名。登记进 :data:`FAMILIES` 只是"认识它",能不能进链另说。
+#: 关着时从链上**滤掉**而不是抛错:开关的意义是出事能立刻关回去,而如果关掉它会让
+#: 配置校验失败、整条视频链一起死,那这个开关就不敢在出事时按 —— 那就不是开关了。
+#: 只对逐个列出的用户开放的型号 → 存放白名单的配置字段名。
+#: 这类型号**永远不进自动链**:链是兜底路径,谁都可能落到它上面,而这些型号按用户授权,
+#: 让它当兜底等于对所有人开放。只能由请求显式指定,并在那时逐个用户判。
+USER_GATED_MODELS: dict[str, str] = {"veo3.1": "video_veo_user_ids"}
+
+
+def allowed_user_ids(cfg, model: str) -> frozenset[int]:
+    """某个受限型号的用户白名单。配置里写坏的条目直接跳过,不让它变成"对所有人开放"。"""
+    field = USER_GATED_MODELS.get(model)
+    if field is None:
+        return frozenset()
+    out = set()
+    for part in str(getattr(cfg, field, "") or "").split(","):
+        part = part.strip()
+        if part.isdigit():
+            out.add(int(part))
+    return frozenset(out)
+
+
+def is_allowed_for_user(model: str, user_id: int | None, cfg=None) -> bool:
+    """受限型号是否对这个用户开放。非受限型号一律 True。"""
+    if model not in USER_GATED_MODELS:
+        return True
+    if user_id is None:
+        return False
+    # 走模块里那个 default_settings 钩子,不自己 new 一个 —— 自己 new 会绕开配置注入,
+    # 表现是"配置改了不生效",而权限判定不生效的方向是**放行**。
+    return user_id in allowed_user_ids(cfg if cfg is not None else default_settings, model)
+
+
+#: 型号 → 上游每秒牌价,**单位是美元**(与 :data:`IMAGE_UNIT_COST_USD` 同一口径:
+#: ``ledger`` 把非空 cost 一律标 ``cost_currency="USD"``,填人民币会整体错一个汇率)。
+#: veo3.1 按**无声**档记:有声是 $0.40/秒、无声 $0.20/秒,而本仓的调用固定关音轨
+#: (见 ``VeoQueueVideoProtocol``)。哪天音轨被打开,这个数就要跟着改,否则账面少一半。
+#: 表里没有的型号仍回落到 ``video_unit_cost_per_second`` 配置 —— kling 侧行为不变。
+VIDEO_UNIT_COST_USD_PER_SECOND: dict[str, float] = {
+    "veo3.1": 0.20,
 }
 
 
@@ -23,6 +67,20 @@ IMAGE_UNIT_COST_USD: dict[str, float] = {
     "gpt-image-2": 0.03,
     "gemini-3.1-flash-image-preview": 0.067,
 }
+
+
+def billed_seconds(model: str | None, seconds: int) -> int:
+    """记账用的秒数 = 上游**真正计费的那一档**,不是调用方要的秒数。
+
+    两者会不一样:调用方按通用参数要 5 秒,而 veo 只卖 4/6/8 三档,落到 4s。
+    照 5 秒记账会让每条 veo 的账面多出 25%,而这个偏差随档位变化,事后无法回补。
+    kling 系按秒连续计费,两者相等,所以这里对它是恒等函数。
+    """
+    if model == "veo3.1":
+        from windup_framework.providers.protocol.fal_queue import veo_duration
+
+        return int(veo_duration(seconds).rstrip("s"))
+    return seconds
 
 
 def candidate_models(chain: tuple[str, ...], count: int) -> tuple[str, ...]:
@@ -47,6 +105,23 @@ class RegistryError(ValueError):
     pass
 
 
+def _admitted(cfg, models: tuple[str, ...], scene: Scene) -> tuple[str, ...]:
+    """滤掉开关关着的型号。
+
+    整条链被滤空时才抛错:那说明部署把**唯一**的型号配成了一个没放行的型号,
+    静默返回空链会让第一次真实调用才炸,而那时错误长得像"网关挂了"。
+    """
+    del cfg                                   # 受限型号与部署配置无关,一律不进链
+    kept = tuple(m for m in models if m not in USER_GATED_MODELS)
+    if models and not kept:
+        gated = ", ".join(sorted(m for m in models if m in USER_GATED_MODELS))
+        raise RegistryError(
+            f"{scene.value} 链上只剩按用户授权的型号 {gated};它们不能当兜底,"
+            f"请另配一个面向所有人的型号"
+        )
+    return kept
+
+
 def _parse_fallbacks(raw: str) -> tuple[str, ...]:
     return tuple(part.strip() for part in raw.split(",") if part.strip())
 
@@ -59,8 +134,12 @@ class ModelRegistry:
     def from_settings(cls, cfg: AIProviderSettings | None = None) -> ModelRegistry:
         cfg = default_settings if cfg is None else cfg
         chains = {
-            Scene.CHARACTER_IMAGE: (cfg.image_model, *_parse_fallbacks(cfg.image_fallbacks)),
-            Scene.CHARACTER_ACTION: (cfg.video_model, *_parse_fallbacks(cfg.video_fallbacks)),
+            Scene.CHARACTER_IMAGE: _admitted(
+                cfg, (cfg.image_model, *_parse_fallbacks(cfg.image_fallbacks)), Scene.CHARACTER_IMAGE
+            ),
+            Scene.CHARACTER_ACTION: _admitted(
+                cfg, (cfg.video_model, *_parse_fallbacks(cfg.video_fallbacks)), Scene.CHARACTER_ACTION
+            ),
         }
         for scene, models in chains.items():
             cls._validate_chain(scene, models)

--- a/backend/packages/framework/src/windup_framework/gateway/trace.py
+++ b/backend/packages/framework/src/windup_framework/gateway/trace.py
@@ -112,9 +112,20 @@ def estimate_cost(
 
         return IMAGE_UNIT_COST_USD.get(model or "")
     if scene == Scene.CHARACTER_ACTION:
-        if video_unit_cost_per_second is None:
+        from windup_framework.gateway.registry import (
+            VIDEO_UNIT_COST_USD_PER_SECOND,
+            billed_seconds,
+        )
+
+        # 配置的单值优先(网关转售价与官方牌价不一致时用它整体覆盖),否则按型号查牌价表。
+        # 视频链跨型号之后每秒单价能差一倍以上,再用单值记账会把成本算错,而错的方向
+        # 随兜底是否触发而变 —— 不是固定偏差,事后无法回补(与出图侧同一条理由)。
+        rate = video_unit_cost_per_second
+        if rate is None:
+            rate = VIDEO_UNIT_COST_USD_PER_SECOND.get(model or "")
+        if rate is None:
             return None
-        return video_unit_cost_per_second * seconds
+        return rate * billed_seconds(model, seconds)
     return None
 
 

--- a/backend/packages/framework/src/windup_framework/gateway/types.py
+++ b/backend/packages/framework/src/windup_framework/gateway/types.py
@@ -19,6 +19,7 @@ class Family(str, Enum):
     IMAGE_FAL_QUEUE = "image.fal_queue"
     VIDEO_INPUT_REFERENCE = "video.input_reference"
     VIDEO_IMAGE_LIST = "video.image_list"
+    VIDEO_FAL_QUEUE = "video.fal_queue"
 
 
 #: 每个 scene 允许出现哪些 family。链上混不同 family 是合法的 —— 兜底型号与主型号
@@ -30,7 +31,10 @@ SCENE_FAMILIES: dict[Scene, frozenset[Family]] = {
         Family.IMAGE_OPENAI_IMAGES,
         Family.IMAGE_FAL_QUEUE,
     }),
-    Scene.CHARACTER_ACTION: frozenset({Family.VIDEO_INPUT_REFERENCE}),
+    Scene.CHARACTER_ACTION: frozenset({
+        Family.VIDEO_INPUT_REFERENCE,
+        Family.VIDEO_FAL_QUEUE,
+    }),
 }
 
 

--- a/backend/packages/framework/src/windup_framework/gateway/video.py
+++ b/backend/packages/framework/src/windup_framework/gateway/video.py
@@ -73,8 +73,14 @@ class VideoGateway:
             return result
         raise RuntimeError("video gateway start_i2v 未返回 job")
 
-    def poll_i2v(self, job_id: str, *, route_id: str | None = None) -> AdapterResult:
-        """单次探活。进行中 ``ok=False`` 且 ``error_type is None``;完成则带 mp4。"""
+    def poll_i2v(
+        self, job_id: str, *, route_id: str | None = None, model: str | None = None
+    ) -> AdapterResult:
+        """单次探活。进行中 ``ok=False`` 且 ``error_type is None``;完成则带 mp4。
+
+        ``model`` 与 ``route_id`` 一样是**建单时那一跳的身份**,必须由调用方随 job 存下来
+        再带回来:单据地址是按协议面拼的,面认错就查不到这张单,而单已经建了、钱已经花了。
+        """
         adapter = self._adapter
         if route_id:
             for route in self._routes:
@@ -86,12 +92,12 @@ class VideoGateway:
                 if mapped is not None:
                     adapter = mapped
         if hasattr(adapter, "inspect_job"):
-            snap = adapter.inspect_job(job_id)
+            snap = adapter.inspect_job(job_id, model=model)
             if snap.ok and snap.job_status == "completed" and snap.edge_fingerprint:
                 if hasattr(adapter, "download_completed"):
                     return adapter.download_completed(job_id, snap.edge_fingerprint)
             return snap
-        return adapter.follow_job(job_id)
+        return adapter.follow_job(job_id, model=model)
 
     def i2v(
         self,
@@ -232,7 +238,7 @@ class VideoGateway:
                         if result.ok and result.job_id:
                             bound_job_id = result.job_id
                             if follow:
-                                result = adapter.follow_job(bound_job_id)
+                                result = adapter.follow_job(bound_job_id, model=model)
                         elif result.ok:
                             result = replace(
                                 result,
@@ -241,7 +247,7 @@ class VideoGateway:
                                 body=b"",
                             )
                     elif follow:
-                        result = adapter.follow_job(bound_job_id)
+                        result = adapter.follow_job(bound_job_id, model=model)
                     else:
                         result = AdapterResult(
                             ok=True, job_id=bound_job_id, maybe_billed=True
@@ -539,7 +545,10 @@ class VideoGateway:
         emit(trace)
 
 
-def build_video_gateway(config=None, *, adapter=None, circuit=None) -> VideoGateway:
+def build_video_gateway(
+    config=None, *, adapter=None, circuit=None, uploader=None
+) -> VideoGateway:
+    """``uploader`` 只有走 FAL 队列面的型号(veo)才用得上,故可选;缺它时 veo 在建单前被拒。"""
     cfg: AIProviderSettings = config or default_settings
     route_adapters = None
     if adapter is None:
@@ -547,7 +556,9 @@ def build_video_gateway(config=None, *, adapter=None, circuit=None) -> VideoGate
 
         routes = routes_from_settings(cfg, route_group=Scene.CHARACTER_ACTION.value)
         route_adapters = {
-            route.route_id: SufyVideoProvider(config=config_for_route(cfg, route))
+            route.route_id: SufyVideoProvider(
+                config=config_for_route(cfg, route), uploader=uploader
+            )
             for route in routes
         }
         adapter = route_adapters[routes[0].route_id]

--- a/backend/packages/framework/src/windup_framework/providers/__init__.py
+++ b/backend/packages/framework/src/windup_framework/providers/__init__.py
@@ -7,6 +7,7 @@ from windup_framework.providers.image import create_image_client
 from windup_framework.providers.judge import JudgeResponseError, SufyJudgeProvider
 from windup_framework.providers.interfaces import (
     ImageProvider,
+    FirstFrameUploader,
     MatteProvider,
     VideoProvider,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "ImageProvider",
     "VideoProvider",
     "MatteProvider",
+    "FirstFrameUploader",
     # 实现
     "SufyVideoProvider",
     # FAL 队列面的 i2v(现役接口形态);首帧要公网 URL,故与 uploader 成对出现

--- a/backend/packages/framework/src/windup_framework/providers/interfaces.py
+++ b/backend/packages/framework/src/windup_framework/providers/interfaces.py
@@ -37,6 +37,20 @@ class VideoProvider(Protocol):
 
 
 @runtime_checkable
+class FirstFrameUploader(Protocol):
+    """首帧 bytes → **公网可取的 URL**(给只吃 URL 的 i2v 接口用,如 veo)。
+
+    与 :class:`~windup_framework.providers.render3d.interfaces.ModelUploader` 形状相同、
+    契约不同,故单列:这里是一张几十 KB 的 JPG,而 URL 只需要活到建单被上游取走为止。
+
+    实现住在组装层(它要碰对象存储凭证),framework 只认这个 port —— 于是
+    "换哪个厂商" 不会改 ai_engine 的一行代码。
+    """
+
+    def upload(self, first_frame: bytes, content_type: str) -> str: ...
+
+
+@runtime_checkable
 class MatteProvider(Protocol):
     """主体抠图(rembg / u2net)—— 按主体抠,不抠颜色(浅色角色撞背景会抠穿)。"""
 

--- a/backend/packages/framework/src/windup_framework/providers/protocol/__init__.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/__init__.py
@@ -1,4 +1,10 @@
-from .fal_queue import FAL_I2V_ENDPOINTS, FalQueueVideoProtocol, UnknownFalEndpointError
+from .fal_queue import (
+    FAL_I2V_ENDPOINTS,
+    FalQueueVideoProtocol,
+    UnknownFalEndpointError,
+    VeoQueueVideoProtocol,
+    VeoSpendGuardError,
+)
 from .image_faces import (
     FAL_IMAGE_ENDPOINTS,
     FalQueueImageFace,
@@ -20,5 +26,7 @@ __all__ = [
     "OpenAIVideoProtocol",
     "UnknownFalEndpointError",
     "UnknownFalImageModelError",
+    "VeoQueueVideoProtocol",
+    "VeoSpendGuardError",
     "VideoRequest",
 ]

--- a/backend/packages/framework/src/windup_framework/providers/protocol/fal_queue.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/fal_queue.py
@@ -235,3 +235,122 @@ def _video_url(resp: httpx.Response) -> str | None:
             if isinstance(video, dict) and video.get("url"):
                 return str(video["url"])
     return None
+
+
+# ── veo3.1 ──────────────────────────────────────────────────────────────────
+
+#: veo3.1 的建单端点。型号名(链上/账本里用的 ``veo3.1``)与端点路径分开:前者是
+#: 我们的标识,后者是上游的 API 事实,拼不出来也不能互相推。
+VEO_ENDPOINT = "fal-ai/veo3.1/image-to-video"
+
+#: 时长档。**带 ``s`` 后缀的字符串**,与 kling 的 ``"5"``(无后缀)形状不同;
+#: 混用不会被立刻拒,而是走成另一个计费档。
+VEO_DURATIONS = ("4s", "6s", "8s")
+
+#: 上游默认 ``8s``,是最贵的一档。这里不取默认,取最便宜的一档做地板。
+VEO_CHEAPEST_DURATION = "4s"
+
+#: 只有横竖两档,**不吃 1:1**。首帧画布是方的时候必须有人做决定,不能让它落到上游去猜。
+VEO_ASPECT_RATIOS = ("16:9", "9:16")
+
+VEO_RESOLUTIONS = ("720p", "1080p", "4k")
+
+
+class VeoSpendGuardError(ValueError):
+    """请求体没把烧钱的那几项显式写死。
+
+    单列一个错误类型是为了让它在测试与日志里认得出来:这三项漏掉的代价不是报错,
+    是**静默走贵档**——上游默认 ``duration=8s`` + ``generate_audio=true``,
+    合起来是 4s 无声那档的 4 倍价,而任务照常成功、没有任何一道会红。
+    """
+
+
+def veo_duration(seconds: int) -> str:
+    """秒数 → 允许的时长档,**向下取**。
+
+    向下不向上:向上取是我们替用户多花钱。上游只认这三档,而调用方给的 ``seconds``
+    是通用参数(当前链上恒为 5),落不到档位上时取比它小的那一档而不是拒绝——
+    拒绝会让"换个视频型号"变成一次要改调用方的改动。
+    """
+    allowed = sorted(VEO_DURATIONS, key=lambda d: int(d.rstrip("s")))
+    fits = [d for d in allowed if int(d.rstrip("s")) <= seconds]
+    return fits[-1] if fits else VEO_CHEAPEST_DURATION
+
+
+def veo_aspect_ratio(size: str) -> str:
+    """首帧画布尺寸 → 画幅枚举。
+
+    跟着首帧走而不是写死:``fit_first_frame`` 已经把首帧补边成了 ``size``,画幅与它
+    不一致的话上游要么裁掉角色、要么再补一次边,而这两种都得等成片出来才看得见。
+    正方形画布在这里就炸——veo 没有 1:1,让它去猜等于用一次已计费的生成来试错。
+    """
+    w, h = (int(x) for x in size.split("x"))
+    if w == h:
+        raise VeoSpendGuardError(
+            f"veo 画幅只有 {VEO_ASPECT_RATIOS},没有 1:1;首帧画布 {size} 是方的,"
+            "请把首帧尺寸改成横或竖"
+        )
+    return "9:16" if h > w else "16:9"
+
+
+class VeoQueueVideoProtocol(FalQueueVideoProtocol):
+    """veo3.1 专用面:比通用 FAL 面多**四个必填项**,少一条 base64 退路。
+
+    单独一个类而不是给通用面加参数:这四项只对 veo 成立(kling 系连 ``resolution``
+    字段都没有),写进通用面就得每家一个分支,而分支写错的代价是一次已计费的错档。
+    """
+
+    def __init__(self, api_key: str, *, base_url: str) -> None:
+        super().__init__(api_key, VEO_ENDPOINT, base_url=base_url)
+
+    def build_submit(self, req: VideoRequest) -> HttpCall:
+        """首帧只走公网 URL;三个烧钱项在这里显式落地并当场自检。"""
+        url = (req.first_frame_url or "").strip()
+        if not url.startswith(("http://", "https://")):
+            raise VeoSpendGuardError(
+                f"veo 首帧必须是公网 URL,收到 {url[:32]!r};"
+                "base64 会在建单后到生成阶段才 failed,而费用可能已经产生"
+            )
+        body: dict[str, object] = {
+            "prompt": req.prompt,
+            FAL_I2V_ENDPOINTS[VEO_ENDPOINT]: url,
+            "duration": veo_duration(req.seconds),
+            # 有声 $0.40/秒、无声 $0.20/秒,而本仓的产物是序列帧,音轨最后会被丢掉。
+            # 付了钱买一条没人听的音轨,是这里唯一会发生的事。
+            "generate_audio": False,
+            "aspect_ratio": veo_aspect_ratio(req.size),
+            "resolution": "720p",
+        }
+        _assert_spend_pinned(body)
+        return HttpCall(
+            method="POST",
+            path=f"{self._root}/queue/{VEO_ENDPOINT}",
+            headers=self._headers,
+            body=body,
+        )
+
+
+def _assert_spend_pinned(body: dict[str, object]) -> None:
+    """发出去之前再数一遍这四项。
+
+    上面刚写完为什么还要查:这四项的共同点是**漏了不会报错**,上游拿默认值照样出片。
+    一次重构把某一行删掉,没有任何一条既有测试会红——除了这里。
+    """
+    duration = body.get("duration")
+    if duration not in VEO_DURATIONS:
+        raise VeoSpendGuardError(
+            f"duration 必须显式取 {VEO_DURATIONS} 之一(上游默认 8s 是最贵档),收到 {duration!r}"
+        )
+    if body.get("generate_audio") is not False:
+        raise VeoSpendGuardError(
+            "generate_audio 必须显式关掉(上游默认 true,走 $0.40/秒 那档,是无声的 2 倍),"
+            f"收到 {body.get('generate_audio')!r}"
+        )
+    if body.get("aspect_ratio") not in VEO_ASPECT_RATIOS:
+        raise VeoSpendGuardError(
+            f"aspect_ratio 必须是 {VEO_ASPECT_RATIOS} 之一,收到 {body.get('aspect_ratio')!r}"
+        )
+    if body.get("resolution") not in VEO_RESOLUTIONS:
+        raise VeoSpendGuardError(
+            f"resolution 必须是 {VEO_RESOLUTIONS} 之一,收到 {body.get('resolution')!r}"
+        )

--- a/backend/packages/framework/src/windup_framework/providers/protocol/types.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/types.py
@@ -34,6 +34,10 @@ class VideoRequest:
     size: str
     mode: str
     first_frame: bytes
+    #: 首帧的公网地址。**上传是 IO,协议层不做 IO**,所以由 provider 先传好再填进来;
+    #: 只吃 URL 的协议面(veo)拿不到它就必须拒建单,不能退回 base64 —— 那条路是
+    #: status=queued 之后到生成阶段才 failed,而费用可能已经产生。
+    first_frame_url: str | None = None
 
 
 class JobProtocol(Protocol):

--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -14,7 +14,8 @@
 塞进 ``content`` 数组 —— 与视频的提交-轮询-下载三段式完全不同的调用形状。
 
 **网关上还有另一套 FAL 队列面**(veo / seedance / vidu 只在那一面),协议实现在
-:mod:`.protocol.fal_queue`;本 provider 尚未接它。
+:mod:`.protocol.fal_queue`;本 provider 经 ``_protocol_for`` 按型号的 family 分派到它,
+目前只接了 veo3.1(默认关,见 ``AI_VIDEO_ALLOW_VEO``)。
 
 型号与 key / base_url 均由 ``AIProviderSettings`` 注入,provider 内不读 env;哪个模型吃
 什么请求字段属该模型的 API 事实,写在代码里而不是配置里(填错只会在生成阶段才 failed,
@@ -41,10 +42,11 @@ from windup_framework.gateway.classify import (
 )
 from windup_framework.gateway.types import AdapterResult
 
-from .interfaces import ImageProvider, VideoProvider
+from .interfaces import FirstFrameUploader, ImageProvider, VideoProvider
 from .protocol import HttpCall, VideoRequest
+from .protocol.fal_queue import VeoQueueVideoProtocol
 from .protocol.image_faces import FalQueueImageFace, OpenAIImagesFace
-from .protocol.openai_video import OpenAIVideoProtocol
+from .protocol.openai_video import OpenAIVideoProtocol, fit_first_frame
 
 logger = logging.getLogger("windup.providers.sufy")
 
@@ -85,6 +87,7 @@ class SufyVideoProvider(VideoProvider):
         poll_interval: float = 60.0,
         max_min: int = 30,
         first_poll_after: float = 5.0,
+        uploader: FirstFrameUploader | None = None,
     ) -> None:
         # 轮询间隔必须 > 0:0 的语义不成立 —— 那是忙等,会把网关打满。
         # 测试要跑快就把 time.sleep 打桩掉,别把间隔设成 0。
@@ -98,11 +101,42 @@ class SufyVideoProvider(VideoProvider):
         self._poll = poll_interval
         self._max_min = max_min
         self._first_poll_after = min(first_poll_after, poll_interval)
+        # 可选而不是必填:链上绝大多数型号(kling 系)不需要它,把它设成必填会让
+        # "只跑 kling 的部署" 也必须配好对象存储凭证才建得起 provider。
+        # 缺它时 veo 在**建单之前**就被拒(见 _first_frame_url),不会先花钱再发现。
+        self._uploader = uploader
 
-    @property
-    def _protocol(self) -> OpenAIVideoProtocol:
-        # 每次现取:key 由 config 注入,provider 建好之后 config 仍可能被换。
+    def _protocol_for(self, model: str | None):
+        """按登记的 family 取协议面 —— 对照出图侧的 ``SufyImageProvider._face``。
+
+        分派点必须吃 model 而不是放构造函数里:网关每一跳都可能换型号,一个 provider
+        实例要能同时伺候 kling 与 veo;构造时定死的话,跨面兜底那一跳会用错形状发出去。
+
+        ``model`` 为空时退回 OpenAI 面 —— 那是历史调用点(``poll_i2v`` 没带型号)的形状,
+        而 veo 的单据在那条面上取不到,所以建单时一定要把型号传下来。
+        """
+        from windup_framework.gateway.registry import FAMILIES
+        from windup_framework.gateway.types import Family
+
+        if FAMILIES.get(model or "") is Family.VIDEO_FAL_QUEUE:
+            # 每次现取:key 由 config 注入,provider 建好之后 config 仍可能被换。
+            return VeoQueueVideoProtocol(
+                self._cfg.api_key, base_url=self._cfg.normalized_base_url
+            )
         return OpenAIVideoProtocol(self._cfg.api_key)
+
+    def _first_frame_url(self, first_frame: bytes, size: str) -> str:
+        """首帧 bytes → 公网 URL。传的是 ``fit_first_frame`` 的产物,不是原始母版。
+
+        必须同一份:补边/缩放决定了成片画幅,而 ``aspect_ratio`` 又是按这个 ``size``
+        推的;传原图会让"我们声明的画幅"和"上游实际看到的图"对不上。
+        """
+        if self._uploader is None:
+            raise RuntimeError(
+                "veo 首帧只吃公网 URL,但本 provider 没有注入 uploader;"
+                "组装层要传 FirstFrameUploader 进来"
+            )
+        return self._uploader.upload(fit_first_frame(first_frame, size), "image/jpeg")
 
     def _client(self) -> httpx.Client:
         return httpx.Client(
@@ -120,16 +154,33 @@ class SufyVideoProvider(VideoProvider):
         model: str,
     ) -> AdapterResult:
         """一次 POST 建单。成功: ok=True, job_id, body=b"", maybe_billed=True。"""
-        call = self._protocol.build_submit(
-            VideoRequest(
-                model=model,
-                prompt=prompt,
-                seconds=seconds,
-                size=size,
-                mode=self._mode,
-                first_frame=first_frame,
-            )
+        protocol = self._protocol_for(model)
+        req = VideoRequest(
+            model=model,
+            prompt=prompt,
+            seconds=seconds,
+            size=size,
+            mode=self._mode,
+            first_frame=first_frame,
         )
+        if isinstance(protocol, VeoQueueVideoProtocol):
+            # 只有这一面需要先上传、且有一组建单前的硬断言,所以 try 只包住它 ——
+            # 包住 kling 那条会顺手改掉一条跑在线上的路径的失败语义,而那不是本次要动的东西。
+            # 失败一律记 maybe_billed=False:这一步还没碰上游,和"发出去了但不知道结果"
+            # 是两回事,混起来会让账面凭空多出没发生的花费,也会让本可以直接重试的失败
+            # 被当成可能已计费而不敢重发。
+            try:
+                req = replace(req, first_frame_url=self._first_frame_url(first_frame, size))
+                call = protocol.build_submit(req)
+            except (ValueError, RuntimeError) as exc:
+                return AdapterResult(
+                    ok=False,
+                    error_type=ModelErrorType.UNREACHED,
+                    maybe_billed=False,
+                    edge_fingerprint=f"建单前被拒: {exc}",
+                )
+        else:
+            call = protocol.build_submit(req)
         with self._client() as client:
             try:
                 resp = client.request(
@@ -137,34 +188,48 @@ class SufyVideoProvider(VideoProvider):
                 )
             except httpx.TransportError as exc:
                 return _transport_result(exc)
-        return self._protocol.parse_submit(resp)
+        return protocol.parse_submit(resp)
 
-    def inspect_job(self, job_id: str) -> AdapterResult:
+    def inspect_job(self, job_id: str, model: str | None = None) -> AdapterResult:
         """单次 GET 任务状态,不 sleep、不下载。
 
         completed: ``ok=True``,视频 URL 放 ``edge_fingerprint``(Gateway poll 靠这个
         去 ``download_completed``)。进行中: ``ok=False``,``error_type is None``。
-        """
-        with self._client() as client:
-            resp = _poll_get(client, self._protocol.build_poll(job_id))
-        parsed = self._protocol.parse_poll(resp, job_id)
-        if parsed.error_type is not None:
-            return parsed
-        if parsed.ok:
-            url = parsed.result_url
-            if not url:
-                return AdapterResult(
-                    ok=False,
-                    error_type=ModelErrorType.INVALID_RESPONSE,
-                    job_id=job_id,
-                    maybe_billed=True,
-                    job_status="completed",
-                    edge_fingerprint="completed 但没有视频 URL",
-                )
-            return replace(parsed, edge_fingerprint=url)
-        return parsed
 
-    def follow_job(self, job_id: str) -> AdapterResult:
+        ``model`` 决定用哪个协议面。不传时退回 OpenAI 面 —— 这是 kling 系的老形状,
+        veo 的单据在那条路径上是 404,所以异步轮询那条链必须把型号一路带下来。
+        """
+        protocol = self._protocol_for(model)
+        with self._client() as client:
+            resp = _poll_get(client, protocol.build_poll(job_id))
+            parsed = protocol.parse_poll(resp, job_id)
+            if parsed.error_type is not None or not parsed.ok:
+                return parsed
+            # FAL 队列面的成败不在轮询这一步显形:成功与失败的任务 ``/status`` 都是
+            # 200 + COMPLETED,只有取结果那一步才分得开。OpenAI 面的 build_fetch 恒为
+            # None,于是这一段对 kling 是空操作。
+            fetch = protocol.build_fetch(job_id)
+            if fetch is not None:
+                parsed = protocol.parse_fetch(_poll_get(client, fetch), job_id)
+                if parsed.error_type is not None or not parsed.ok:
+                    return parsed
+        url = parsed.result_url
+        if not url:
+            return AdapterResult(
+                ok=False,
+                error_type=ModelErrorType.INVALID_RESPONSE,
+                job_id=job_id,
+                maybe_billed=True,
+                job_status="completed",
+                edge_fingerprint="completed 但没有视频 URL",
+            )
+        # 状态值统一成小写 ``completed``:两个面的字面量不同(FAL 是 ``COMPLETED``),
+        # 而 follow_job 与 VideoGateway.poll_i2v 都按这个字符串判成片就绪 ——
+        # 不归一化的话 veo 会一直被当成"还在跑",直到轮询预算耗光才报超时,
+        # 而视频其实早就生成好、钱也早就花了。
+        return replace(parsed, edge_fingerprint=url, job_status="completed")
+
+    def follow_job(self, job_id: str, model: str | None = None) -> AdapterResult:
         """轮询已建单据 + 下载。poll GET 522/525 该次再试 1 次,不新开单。"""
         poll_t0 = time.monotonic()
         poll_count = 0
@@ -195,7 +260,7 @@ class SufyVideoProvider(VideoProvider):
                 break
             time.sleep(wait)
             wait = min(wait * 2, self._poll)
-            snap = self.inspect_job(job_id)
+            snap = self.inspect_job(job_id, model)
             poll_count += 1
             last_status = snap.job_status
             if snap.ok and snap.job_status == "completed":
@@ -253,7 +318,7 @@ class SufyVideoProvider(VideoProvider):
                 f"i2v 建单失败(HTTP {submitted.http_status} {submitted.error_type}): "
                 f"{submitted.edge_fingerprint}"
             )
-        followed = self.follow_job(submitted.job_id)
+        followed = self.follow_job(submitted.job_id, self._model)
         if followed.ok:
             return followed.body
         if followed.error_type is ModelErrorType.TIMEOUT:
@@ -384,18 +449,24 @@ def _download(client: httpx.Client, url: str, tries: int = 3) -> bytes:
 #     其余各家的档位枚举各不相同。
 
 
-# ── FAL 队列面（veo / seedance / vidu）已移除 ────────────────────────────────
+# ── FAL 队列面:veo3.1 已接回,seedance / vidu 仍未接 ─────────────────────────
 #
-# 曾有一整套 FalQueueVideoProvider + FirstFrameUploader + 端点映射表（412 行、28 条
-# 测试）。删掉的理由与 GenRoute 只列有实现的路线是同一条：**它从未被真实调用过**
-# —— app / ai_engine 里零引用，产品链路走不到，而"代码在仓里"会让人以为该能力已具备。
+# 这段原本记的是"整套 FalQueueVideoProvider 已删除,理由是它从未被真实调用过"。
+# veo3.1 现已接进 CHARACTER_ACTION 链(藏在 AI_VIDEO_ALLOW_VEO 后面,默认关),
+# 那条理由对它不再成立;seedance / vidu 仍然零引用,对它们仍然成立 —— 谁要接谁
+# 连同一次真实调用一起加回,别只把代码放进仓里。
 #
-# 真要接 veo / seedance 时连同一次真实调用一起加回。届时的两个已知事实（实测挣得，
-# 别再摸索一遍）：
-#   1. FAL 面只吃**公网 URL**，不吃 base64；塞 base64 会 status=queued 之后在生成阶段
-#      才 failed，费用可能已经产生。
-#   2. 鉴权头是 `Authorization: Key <k>`，不是 `Bearer`；路径与 /v1 平级，不是它的子路径。
-# 归档实测记录见项目参考资料（图生视频 API 实测文档）。
+# 两条实测事实(挣来的,别再摸索一遍):
+#   1. 鉴权头是 `Authorization: Key <k>`,不是 `Bearer`;路径与 /v1 平级,不是子路径。
+#   2. 首帧形态:本文件里有**两条互相矛盾**的实测记录,接的时候按"只吃公网 URL"实现。
+#      - 上面那段(2026-08-25,#569)说字段值可以是 base64 dataURI,并给了 veo3.1 喂
+#        纯中灰图、产物首帧同为纯中灰的证据;
+#      - 这段(2026-08-11 起)说 FAL 面只吃公网 URL,塞 base64 会 status=queued 之后
+#        在生成阶段才 failed,而费用可能已经产生。
+#      没有复测就不裁决,而两条路的代价不对称:URL 在两种说法下都成立,base64 只在
+#      其中一种下成立,且它错的那一面要收钱。所以 veo 走 URL,并在建单前就拒掉
+#      非 http(s) 的首帧(见 VeoQueueVideoProtocol)。真要省掉这次上传,得先拿一次
+#      带账单的复测来推翻其中一条,再回来改这段注释。
 
 
 DEFAULT_IMAGE_MODEL = "gpt-image-2"

--- a/backend/tests/test_gateway_video.py
+++ b/backend/tests/test_gateway_video.py
@@ -28,7 +28,7 @@ class FakeVideoAdapter:
         self.submit_models.append(model)
         return self.submits[model].pop(0)
 
-    def follow_job(self, job_id):
+    def follow_job(self, job_id, model=None):
         self.followed.append(job_id)
         return self.follows[job_id]
 
@@ -305,7 +305,7 @@ def test_start_i2v_returns_job_without_follow():
 
 def test_poll_i2v_pending_then_download():
     class _PollAdapter(FakeVideoAdapter):
-        def inspect_job(self, job_id):
+        def inspect_job(self, job_id, model=None):
             self.followed.append(f"inspect:{job_id}")
             return AdapterResult(
                 ok=True,
@@ -325,7 +325,7 @@ def test_poll_i2v_pending_then_download():
 
 def test_poll_i2v_still_pending():
     class _Pending(FakeVideoAdapter):
-        def inspect_job(self, job_id):
+        def inspect_job(self, job_id, model=None):
             return AdapterResult(ok=False, job_id=job_id, maybe_billed=True, job_status="in_progress")
 
     result = _video_gw(_Pending(submits={}, follows={})).poll_i2v("j1")

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -671,7 +671,7 @@ def test_resume_action_poll_finishes_when_video_ready(session_factory, monkeypat
     png = _tiny_png()
 
     class _AsyncGen:
-        def poll_video(self, job_id, route_id=None):
+        def poll_video(self, job_id, route_id=None, model=None):
             assert job_id == "job-ready"
             return b"mp4"
 
@@ -737,7 +737,7 @@ def test_resume_action_poll_does_not_fetch_master_while_pending(
     parked: list[int] = []
 
     class _AsyncGen:
-        def poll_video(self, job_id, route_id=None):
+        def poll_video(self, job_id, route_id=None, model=None):
             return None
 
         def finish_video(self, *args, **kwargs):
@@ -797,7 +797,7 @@ def test_resume_action_poll_completes_after_credit_already_released(
     png = _tiny_png()
 
     class _AsyncGen:
-        def poll_video(self, job_id, route_id=None):
+        def poll_video(self, job_id, route_id=None, model=None):
             return b"mp4"
 
         def finish_video(self, video, *args, **kwargs):
@@ -860,7 +860,7 @@ def test_resume_action_poll_completes_after_credit_already_released(
 
 def test_resume_action_poll_timeout_without_video_fails(session_factory, monkeypatch):
     class _AsyncGen:
-        def poll_video(self, job_id, route_id=None):
+        def poll_video(self, job_id, route_id=None, model=None):
             return None
 
         def finish_video(self, *args, **kwargs):

--- a/backend/tests/test_veo_video_route.py
+++ b/backend/tests/test_veo_video_route.py
@@ -1,0 +1,475 @@
+"""veo3.1 接进视频链路:开关、烧钱三项、首帧 URL、以及轮询走哪条协议面。
+
+这一面每一条失败的形态都不是报错,是**照常出片、照常计费**:
+时长走默认 8s、音轨走默认 true、首帧塞 base64 到生成阶段才 failed。
+所以这里断言的全是"请求体里到底写了什么",不是"调用有没有成功"。
+"""
+from __future__ import annotations
+
+import io
+
+import httpx
+import pytest
+
+from windup_common.enums.model import ModelErrorType
+from windup_framework.config.provider import AIProviderSettings
+from windup_framework.gateway.registry import (
+    FAMILIES,
+    VIDEO_UNIT_COST_USD_PER_SECOND,
+    ModelRegistry,
+    RegistryError,
+)
+from windup_framework.gateway.trace import estimate_cost
+from windup_framework.gateway.types import Family, Scene
+from windup_framework.providers.protocol import OpenAIVideoProtocol, VideoRequest
+from windup_framework.providers.protocol.fal_queue import (
+    VEO_ENDPOINT,
+    VeoQueueVideoProtocol,
+    VeoSpendGuardError,
+    _assert_spend_pinned,
+    veo_aspect_ratio,
+    veo_duration,
+)
+from windup_framework.providers.sufy import SufyVideoProvider
+
+BASE_URL = "https://api.qnaigc.com/v1"
+ROOT = "https://api.qnaigc.com"
+FRAME_URL = "https://media.windup.xin/media/action-frame/deadbeef.jpg"
+REQUEST_ID = "qvideo-1382244847-1787504690896902712"
+
+
+def _png(size: tuple[int, int] = (64, 64)) -> bytes:
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGBA", size, (200, 30, 30, 255)).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _req(*, size: str = "1280x720", seconds: int = 5, url: str | None = FRAME_URL) -> VideoRequest:
+    return VideoRequest(
+        model="veo3.1", prompt="向右走", seconds=seconds, size=size, mode="std",
+        first_frame=_png(), first_frame_url=url,
+    )
+
+
+def _veo() -> VeoQueueVideoProtocol:
+    return VeoQueueVideoProtocol("k-123", base_url=BASE_URL)
+
+
+def _cfg(**kw) -> AIProviderSettings:
+    kw.setdefault("video_model", "kling-v2-5-turbo")
+    return AIProviderSettings(image_model="gpt-image-2", **kw)
+
+
+class _Uploader:
+    """记下"传上去的是哪几个字节",好断言传的是补过边的首帧而不是原始母版。"""
+
+    def __init__(self, url: str = FRAME_URL) -> None:
+        self.url = url
+        self.seen: list[tuple[bytes, str]] = []
+
+    def upload(self, first_frame: bytes, content_type: str) -> str:
+        self.seen.append((first_frame, content_type))
+        return self.url
+
+
+def _provider(handler, *, uploader=None, model="veo3.1") -> SufyVideoProvider:
+    """把 provider 的 httpx.Client 换成 MockTransport —— 不联网、不花钱。"""
+    cfg = AIProviderSettings(base_url=BASE_URL, api_key="k-123", video_model=model)
+    provider = SufyVideoProvider(config=cfg, model=model, poll_interval=0.01,
+                                 first_poll_after=0.01, uploader=uploader)
+    provider._client = lambda: httpx.Client(  # type: ignore[method-assign]
+        base_url=BASE_URL,
+        headers={"Authorization": f"Bearer {cfg.api_key}"},
+        transport=httpx.MockTransport(handler),
+    )
+    return provider
+
+
+# ── 开关 ────────────────────────────────────────────────────────────────────
+
+
+def test_veo_is_registered_but_never_enters_the_automatic_chain():
+    """拦的坏例:让按用户授权的型号当兜底。
+
+    链是**兜底路径**,谁的任务都可能落到它上面。veo 按用户授权、按秒计费且比 kling 贵,
+    一旦进链,没被授权的用户也会在兜底那一跳用上它 —— 客户看不出区别,账单上是另一档价。
+    所以 ``FAMILIES`` 里有它(认识)与它能被用(放行)必须是两回事,而且放行**只走请求显式指定**。
+    """
+    assert FAMILIES["veo3.1"] is Family.VIDEO_FAL_QUEUE
+    chain = ModelRegistry.from_settings(_cfg(video_fallbacks="veo3.1")).chain(
+        Scene.CHARACTER_ACTION
+    )
+    assert chain == ("kling-v2-5-turbo",)
+
+
+def test_veo_stays_out_of_the_chain_even_with_users_allowlisted():
+    """白名单只放行"这个人能显式指定它",不等于把它放进兜底链。
+
+    两者混为一谈的话,给一个人开权限 = 给所有人开兜底。
+    """
+    chain = ModelRegistry.from_settings(
+        _cfg(video_fallbacks="veo3.1", video_veo_user_ids="7,12")
+    ).chain(Scene.CHARACTER_ACTION)
+    assert chain == ("kling-v2-5-turbo",)
+
+
+def test_a_kling_only_deployment_is_not_broken_by_the_user_gate():
+    """拦的坏例:受限型号被滤掉时连累整条视频链。"""
+    r = ModelRegistry.from_settings(_cfg(video_fallbacks="veo3.1,kling-v2-6"))
+    assert r.chain(Scene.CHARACTER_ACTION) == ("kling-v2-5-turbo", "kling-v2-6")
+
+
+def test_a_chain_made_only_of_user_gated_models_raises_instead_of_going_silent():
+    """把**唯一**的型号配成按用户授权的型号 → 空链。
+
+    静默返回空链的话,第一次真实调用才炸,而那时的错误长得像"网关挂了"。
+    """
+    with pytest.raises(RegistryError, match="不能当兜底"):
+        ModelRegistry.from_settings(_cfg(video_model="veo3.1", video_fallbacks=""))
+
+
+def test_allowlist_is_empty_by_default_so_nobody_can_use_veo():
+    """默认谁都不能用 —— 忘配 = 关着,而不是忘配 = 开着。"""
+    from windup_framework.gateway.registry import is_allowed_for_user
+
+    assert AIProviderSettings().video_veo_user_ids == ""
+    assert is_allowed_for_user("veo3.1", 7, _cfg()) is False
+
+
+def test_allowlist_admits_only_the_listed_users():
+    """拦的坏例:白名单写了等于对所有人开放。"""
+    from windup_framework.gateway.registry import is_allowed_for_user
+
+    cfg = _cfg(video_veo_user_ids="7, 12")
+    assert is_allowed_for_user("veo3.1", 7, cfg) is True
+    assert is_allowed_for_user("veo3.1", 12, cfg) is True
+    assert is_allowed_for_user("veo3.1", 8, cfg) is False
+    assert is_allowed_for_user("veo3.1", None, cfg) is False
+    # 非受限型号不受影响
+    assert is_allowed_for_user("kling-v2-5-turbo", 8, cfg) is True
+
+
+def test_malformed_allowlist_entries_are_skipped_not_treated_as_wildcard():
+    """拦的坏例:配置写坏就变成对所有人开放。
+
+    ``"all"`` / ``"*"`` / 空串这类写法必须是"谁都不放",而不是"谁都放" ——
+    两个方向的代价不对称。
+    """
+    from windup_framework.gateway.registry import is_allowed_for_user
+
+    for raw in ("all", "*", " , ", "7x"):
+        assert is_allowed_for_user("veo3.1", 7, _cfg(video_veo_user_ids=raw)) is False
+
+
+def test_resolve_video_model_rejects_veo_for_a_user_not_on_the_list(monkeypatch):
+    """编排层的拒绝 —— 任务被重排 / 重投时绕过 HTTP 边界的那条路。"""
+    from windup_app.server.orchestrator import executor
+
+    monkeypatch.setattr(
+        "windup_framework.gateway.registry.default_settings",
+        _cfg(video_fallbacks="veo3.1", video_veo_user_ids="7"),
+    )
+    with pytest.raises(ValueError, match="未对当前用户开放"):
+        executor._resolve_video_model("veo3.1", 8)
+    assert executor._resolve_video_model("veo3.1", 7) == "veo3.1"
+
+
+def test_resolve_video_model_without_a_user_rejects_veo(monkeypatch):
+    """拿不到用户时必须拒 —— 默认放行会让任何漏传 user_id 的路径变成后门。"""
+    from windup_app.server.orchestrator import executor
+
+    monkeypatch.setattr(
+        "windup_framework.gateway.registry.default_settings",
+        _cfg(video_fallbacks="veo3.1", video_veo_user_ids="7"),
+    )
+    with pytest.raises(ValueError, match="未对当前用户开放"):
+        executor._resolve_video_model("veo3.1")
+
+
+# ── 烧钱的三项 ──────────────────────────────────────────────────────────────
+
+
+def test_request_body_pins_duration_audio_and_resolution():
+    """拦的坏例:靠上游默认值。
+
+    三项一起漏 = 8s + 有声 = 4s 无声那档的 4 倍价,而任务照常成功、没有一道会红。
+    """
+    body = _veo().build_submit(_req()).body
+    assert body["duration"] == "4s"
+    assert body["generate_audio"] is False
+    assert body["resolution"] == "720p"
+    assert body["aspect_ratio"] in ("16:9", "9:16")
+
+
+def test_duration_carries_the_second_suffix_unlike_kling():
+    """拦的坏例:把 kling 的时长形状抄过来。
+
+    kling 是 ``"5"``(无后缀)、veo 是 ``"8s"``(带后缀)。形状写混不会被立刻拒,
+    会静默走错档 —— 两个字段同叫 ``duration``,肉眼看不出来。
+    """
+    veo_body = _veo().build_submit(_req()).body
+    kling_body = OpenAIVideoProtocol("k-123").build_submit(
+        VideoRequest(model="kling-v2-5-turbo", prompt="p", seconds=5,
+                     size="1280x720", mode="std", first_frame=_png())
+    ).body
+    assert veo_body["duration"] == "4s" and veo_body["duration"].endswith("s")
+    assert kling_body["seconds"] == "5" and not kling_body["seconds"].endswith("s")
+
+
+def test_duration_rounds_down_never_up():
+    """向上取档 = 替用户多花钱。链上恒为 seconds=5,落在 4s 与 6s 之间。"""
+    assert veo_duration(5) == "4s"
+    assert veo_duration(4) == "4s"
+    assert veo_duration(8) == "8s"
+    assert veo_duration(1) == "4s"      # 比最小档还小时取最便宜的一档,不是拒绝
+
+
+def test_spend_guard_catches_a_dropped_generate_audio_line():
+    """拦的坏例:将来某次重构把 ``generate_audio`` 那一行删掉。
+
+    删掉之后没有任何既有断言会红 —— 上游拿默认 true 照样出片,只是价钱翻倍。
+    """
+    body = {"duration": "4s", "aspect_ratio": "16:9", "resolution": "720p"}
+    with pytest.raises(VeoSpendGuardError, match="generate_audio"):
+        _assert_spend_pinned(body)
+
+
+def test_spend_guard_catches_a_dropped_duration_line():
+    """同上,漏掉时上游默认 8s —— 最贵的一档。"""
+    body = {"generate_audio": False, "aspect_ratio": "16:9", "resolution": "720p"}
+    with pytest.raises(VeoSpendGuardError, match="duration"):
+        _assert_spend_pinned(body)
+
+
+def test_square_canvas_is_rejected_before_spending():
+    """拦的坏例:veo 不吃 1:1,让它自己去猜等于用一次已计费的生成来试错。"""
+    with pytest.raises(VeoSpendGuardError, match="1:1"):
+        veo_aspect_ratio("720x720")
+    with pytest.raises(VeoSpendGuardError):
+        _veo().build_submit(_req(size="720x720"))
+
+
+def test_aspect_ratio_follows_the_first_frame_canvas():
+    """画幅与首帧不一致时,上游要么裁掉角色要么再补一次边 —— 都要等成片出来才看得见。"""
+    assert veo_aspect_ratio("720x1280") == "9:16"
+    assert veo_aspect_ratio("1280x720") == "16:9"
+    assert _veo().build_submit(_req(size="720x1280")).body["aspect_ratio"] == "9:16"
+
+
+# ── 首帧只走公网 URL ────────────────────────────────────────────────────────
+
+
+def test_first_frame_goes_out_as_public_url_not_base64():
+    """拦的坏例:塞 base64。
+
+    归档实测:FAL 面塞 base64 会先 ``status=queued``、到生成阶段才 ``failed``,
+    而费用可能已经产生 —— 失败得晚且要收钱,是这条路最贵的一种错法。
+    """
+    body = _veo().build_submit(_req()).body
+    assert body["image_url"].startswith(("http://", "https://"))
+    assert not body["image_url"].startswith("data:")
+
+
+def test_missing_first_frame_url_is_refused_at_build_time():
+    """没有 URL 就必须拒建单,不能退回 base64 那条路。"""
+    with pytest.raises(VeoSpendGuardError, match="公网 URL"):
+        _veo().build_submit(_req(url=None))
+
+
+def test_provider_without_uploader_sends_nothing_and_bills_nothing():
+    """拦的坏例:漏注入 uploader 时先把请求发出去再失败。
+
+    这一步还没碰上游,``maybe_billed`` 必须是 False —— 记成可能已计费会让账面
+    凭空多出没发生的花费,也会让本可以直接重试的失败不敢重发。
+    """
+    sent: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        sent.append(request)
+        return httpx.Response(200, json={"request_id": REQUEST_ID})
+
+    result = _provider(handler, uploader=None).submit_video(
+        _png(), "向右走", 5, "1280x720", "veo3.1"
+    )
+    assert sent == []
+    assert result.ok is False
+    assert result.maybe_billed is False
+    assert result.error_type is ModelErrorType.UNREACHED
+
+
+def test_uploader_gets_the_fitted_first_frame_not_the_raw_master():
+    """传原图会让"我们声明的画幅"和"上游实际看到的图"对不上。"""
+    from PIL import Image
+
+    uploader = _Uploader()
+    provider = _provider(
+        lambda r: httpx.Response(200, json={"request_id": REQUEST_ID}), uploader=uploader
+    )
+    provider.submit_video(_png((64, 64)), "向右走", 5, "1280x720", "veo3.1")
+
+    assert len(uploader.seen) == 1
+    blob, content_type = uploader.seen[0]
+    assert content_type == "image/jpeg"
+    assert Image.open(io.BytesIO(blob)).size == (1280, 720)
+
+
+def test_kling_still_goes_out_as_data_uri_on_the_openai_face():
+    """veo 这条线不许改动 kling 的行为 —— 它至今是产品线上唯一在跑的视频型号。"""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"id": "job-1"})
+
+    provider = _provider(handler, uploader=_Uploader(), model="kling-v2-5-turbo")
+    provider.submit_video(_png(), "向右走", 5, "1280x720", "kling-v2-5-turbo")
+
+    assert len(seen) == 1
+    assert seen[0].url.path.endswith("/videos")
+    assert seen[0].headers["Authorization"].startswith("Bearer ")
+    import json as _json
+
+    body = _json.loads(seen[0].content)
+    assert body["input_reference"].startswith("data:image/jpeg;base64,")
+
+
+# ── 轮询走哪条面 ────────────────────────────────────────────────────────────
+
+
+def test_submit_uses_the_queue_path_with_key_auth():
+    """路径与 ``/v1`` 平级、鉴权是 ``Key`` 不是 ``Bearer`` —— 两条都不能靠拼字符串猜。"""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"request_id": REQUEST_ID})
+
+    _provider(handler, uploader=_Uploader()).submit_video(
+        _png(), "向右走", 5, "1280x720", "veo3.1"
+    )
+    assert str(seen[0].url) == f"{ROOT}/queue/{VEO_ENDPOINT}"
+    assert seen[0].headers["Authorization"] == "Key k-123"
+
+
+def test_inspect_job_takes_the_second_hop_and_normalizes_completed():
+    """拦的坏例:拿 kling 那条面去查 veo 的单。
+
+    两处会静默错:① FAL 的状态是大写 ``COMPLETED``,而 follow_job / poll_i2v 都按小写
+    ``completed`` 判就绪 —— 不归一化就会一直被当成"还在跑",转满预算才报超时,
+    而视频早就生成好、钱早就花了;② FAL 的 ``/status`` 不带产物地址,要再取一次。
+    """
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        if request.url.path.endswith("/status"):
+            return httpx.Response(200, json={"status": "COMPLETED"})
+        return httpx.Response(200, json={"video": {"url": "https://cdn.invalid/x.mp4"}})
+
+    snap = _provider(handler).inspect_job(REQUEST_ID, "veo3.1")
+    assert paths == [
+        f"/queue/fal-ai/veo3.1/requests/{REQUEST_ID}/status",
+        f"/queue/fal-ai/veo3.1/requests/{REQUEST_ID}",
+    ]
+    assert snap.ok is True
+    assert snap.job_status == "completed"
+    assert snap.edge_fingerprint == "https://cdn.invalid/x.mp4"
+
+
+def test_inspect_job_without_a_model_falls_back_to_the_openai_face():
+    """不传型号时形状必须保持原样 —— kling 的既有调用点没有型号可传。"""
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return httpx.Response(200, json={"status": "processing"})
+
+    _provider(handler).inspect_job("job-1")
+    assert paths == ["/v1/videos/job-1"]   # 相对路径经 base_url 拼出来,仍是 OpenAI 面
+
+
+def test_poll_i2v_carries_the_model_down_to_the_adapter():
+    """拦的坏例:异步轮询丢掉型号。
+
+    建单与轮询是两条消息、隔着一个延迟队列。型号早就随 job 存进了 Redis,
+    但此前没往下传 —— veo 的单在另一条路径上,不传就是 404,而钱已经花了。
+    """
+    from windup_framework.gateway.types import AdapterResult
+    from windup_framework.gateway.video import VideoGateway
+
+    seen: dict = {}
+
+    class _Adapter:
+        def inspect_job(self, job_id, model=None):
+            seen.update(job_id=job_id, model=model)
+            return AdapterResult(ok=False, job_id=job_id)
+
+    gw = VideoGateway(
+        ModelRegistry.from_settings(_cfg()), _Adapter(), object(), _cfg()
+    )
+    gw.poll_i2v("j-1", model="veo3.1")
+    assert seen == {"job_id": "j-1", "model": "veo3.1"}
+
+
+def test_i2v_poll_reads_the_model_out_of_the_saved_state(monkeypatch):
+    """同一条链的 app 端:存进 Redis 的型号要真的被读出来往下传。"""
+    import time
+
+    from windup_app.server.orchestrator import i2v_poll
+
+    monkeypatch.setattr(
+        i2v_poll, "load_i2v_state",
+        lambda task_id: {
+            "job_id": "j1", "poll_count": 0, "next_wait": 5.0,
+            "started_at": time.time(), "route_id": "primary", "model": "veo3.1",
+        },
+    )
+    monkeypatch.setattr(i2v_poll, "schedule", lambda *a, **kw: None)
+    seen: dict = {}
+
+    def poll_video(job_id, *, route_id=None, model=None):
+        seen.update(job_id=job_id, route_id=route_id, model=model)
+        return None
+
+    i2v_poll.inspect(1, poll_video=poll_video)
+    assert seen == {"job_id": "j1", "route_id": "primary", "model": "veo3.1"}
+
+
+# ── 记账 ────────────────────────────────────────────────────────────────────
+
+
+def test_veo_cost_is_dollars_per_second_at_the_silent_tier():
+    """拦的坏例:把人民币填进这张表,或按有声档记。
+
+    ``ledger`` 把非空 cost 一律标 ``USD``,填人民币会让成本整体错一个汇率;
+    而有声是 $0.40/秒,按它记会把账面翻一倍。4s 无声 = $0.80 一条。
+    """
+    assert VIDEO_UNIT_COST_USD_PER_SECOND["veo3.1"] == 0.20
+    assert estimate_cost(
+        Scene.CHARACTER_ACTION, billed=True, seconds=4, model="veo3.1"
+    ) == pytest.approx(0.80)
+
+
+def test_veo_is_billed_by_the_tier_it_actually_buys_not_the_seconds_asked_for():
+    """拦的坏例:按调用方要的 5 秒记账,而 veo 只卖 4/6/8 三档、实际落在 4s。
+
+    照 5 秒记会让每条 veo 的账面多出 25%,而这个偏差随档位变化,事后无法回补。
+    链上恒为 seconds=5,所以这条差异是**每一条 veo 都会踩到**,不是边角情形。
+    """
+    assert veo_duration(5) == "4s"
+    assert estimate_cost(
+        Scene.CHARACTER_ACTION, billed=True, seconds=5, model="veo3.1"
+    ) == pytest.approx(0.80)
+
+
+def test_kling_video_cost_still_falls_back_to_the_configured_rate():
+    """表里没有的型号行为不变 —— 这张表是新增的,不该改动 kling 的记账。"""
+    assert estimate_cost(
+        Scene.CHARACTER_ACTION, billed=True, seconds=5, model="kling-v2-5-turbo"
+    ) is None
+    assert estimate_cost(
+        Scene.CHARACTER_ACTION, billed=True, seconds=5,
+        video_unit_cost_per_second=0.1, model="kling-v2-5-turbo",
+    ) == pytest.approx(0.5)


### PR DESCRIPTION
接入 veo 3.1，**按用户逐个授权**，默认谁都不能用。

## Why

组内需要一个比 kling 质量更高的模型做素材，不面向客户。本地同角色同提示词对照：veo 按输入画幅原样返回（720×1280 进出、缩放比 1.0000），主体拿到 **783px** 像素高；kling 的 960×960 只给到 **367px**。主体像素数 4.6 倍，交付帧的发丝与饰件细节肉眼可辨地更清楚。

## 授权粒度是按用户，不是部署级开关

一个布尔开关打开就是全员可用，而 veo 按秒计费、比 kling 贵一档。

- `AI_VIDEO_VEO_USER_IDS`，逗号分隔用户 id，**默认空 = 谁都不能用**。
- **受限型号永远不进自动兜底链。** 链是兜底路径，谁的任务都可能落上去；让它当兜底 = 给一个人开权限就是给所有人开。只能由请求显式指定。
- 两道判定：HTTP 入口（任务未建、积分未冻时就拒，403）+ 编排层（任务被重排/重投时绕过入口的那条路）。
- 配置写坏（`all` / `*` / `7x` / 空串）一律按"谁都不放"处理——权限判定不生效的方向必须是拒绝。

## 三个会烧钱的默认值

已显式钉住，并在构造完请求体后**再数一遍**（它们的共同点是漏了不报错、上游拿默认值照样出片）：

| 项 | 上游默认 | 我们钉的 |
|---|---|---|
| `duration` | **8s**（最贵档） | `"4s"`（注意带 `s` 后缀，与 kling 的 `"5"` 形状不同） |
| `generate_audio` | **true**（$0.40/秒） | `False`（$0.20/秒） |
| `resolution` | — | `"720p"` |

两者一起漏 = **¥22.8 而不是 ¥5.7，4 倍**。`duration` 向下取档（seconds=5 → `"4s"`），向上取是替用户多花钱。

## 其他

- 首帧走**公网 URL**，复用现成的 `ObjectStorageMediaService`，没有新写 S3 客户端。
- **型号一路带到轮询**（此前没往下传）：建单与轮询隔着延迟队列，veo 的单在另一条路径上，不带型号就是 404，而钱已经花了。贯通了 `i2v_poll → character_generator → concrete → gateway.video → sufy`。
- 成本记账新增 `VIDEO_UNIT_COST_USD_PER_SECOND`（**美元**）。顺带修掉一个真 bug：估价用的是调用方要的 `seconds=5`，而实际买的是 4s 档，账面每条多算 25%。
- **kling 分支保持不变**：协议面分派、记账回落、轮询兜底都走原路，`try/except` 只包住 veo 那一支。

## Verification

- [x] `uv run ruff check .`：All checks passed。
- [x] `uv run python -m scripts.export_openapi`：rc=0，`openapi.json` 无漂移。
- [x] `uv run lint-imports`：Contracts: 2 kept, 0 broken。
- [x] `uv run pytest -q --cov=packages`：1795 passed, 14 skipped, 2 failed。这 2 条（`test_generation_api.py` 的 four_view / eight_view）在**纯 `origin/main` 上同样失败**，与本 PR 无关。
- [x] 新增 29 条测试。授权那组各自拦的坏例：受限型号进兜底链、白名单写了等于对所有人开放、配置写坏变通配、拿不到 user_id 时默认放行、白名单只放行"能显式指定"却被误解成"进链"。烧钱那三项各有断言请求体的用例。
- [x] 请求体形状**已用一次真实付费调用验证过**（2026-08-27，`duration="4s"` + `generate_audio=false` + `resolution="720p"` + 公网 URL `image_url`，建单成功、70s 出片、账单显示 "std x 无参考视频 x 无声"）。

## 三处需要 review 时注意

1. **仓里有两条互相矛盾的实测记录**：`sufy.py` 一处（2026-08-11）说 FAL 面只吃公网 URL、塞 base64 会 queued 后失败且可能已计费；另一处（#569，2026-08-25）说值可以是 base64 dataURI。本 PR 走 URL —— 它在两种说法下都成立，base64 只在其中一种下成立，而错的那一面要收钱。若 #569 那条是对的，首帧上传这一整块可以删掉，但需要一次带账单的复测才能裁决。
2. **`aspect_ratio` 实际发出去的是 16:9 不是 9:16**：它跟随首帧画布推导，而链上 `size` 恒为默认 `1280x720`。写死 9:16 会让"声明的画幅"与"上游看到的图"对不上（`fit_first_frame` 已经把首帧补边成横图）。要出 9:16 需要调用点传竖版 size，属链路上游改动。
3. **上传的首帧不会被清理**，会在 `media/action-frame/` 下持续堆积，无 TTL。

Closes #803
