### PR TITLE
fix(auth): 验证码建号用户补全密码设置，修复密码登录/改密 500

### DIFF
--- a/backend/packages/app/src/windup_app/server/user/interface.py
+++ b/backend/packages/app/src/windup_app/server/user/interface.py
@@ -16,6 +16,7 @@ from windup_app.server.user.model import (
     LoginByPasswordInput,
     LoginResult,
     RegisterInput,
+    SetPasswordInput,
     UserView,
 )
 
@@ -87,6 +88,15 @@ class UserService(ABC):
         """修改密码（需验证旧密码）。
 
         :raises windup_common.exceptions.BizException: 旧密码错误。
+        """
+
+    @abstractmethod
+    def set_password(
+        self, session: Session, user_id: int, input: SetPasswordInput
+    ) -> None:
+        """设置初始密码（仅未设密码用户）。
+
+        :raises windup_common.exceptions.BizException: 密码已设置。
         """
 
     # -- 查询 ------------------------------------------------------------

--- a/backend/packages/app/src/windup_app/server/user/model.py
+++ b/backend/packages/app/src/windup_app/server/user/model.py
@@ -92,6 +92,7 @@ class UserView:
     email_verified_at: datetime | None = None
     status: UserStatus = UserStatus.NORMAL
     last_login_at: datetime | None = None
+    has_password: bool = False
     create_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     update_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -139,6 +140,13 @@ class ChangePasswordInput:
     """修改密码入参。"""
 
     old_password: str
+    new_password: str
+
+
+@dataclass
+class SetPasswordInput:
+    """设置初始密码入参（仅未设密码用户）。"""
+
     new_password: str
 
 

--- a/backend/packages/app/src/windup_app/server/user/service.py
+++ b/backend/packages/app/src/windup_app/server/user/service.py
@@ -35,6 +35,7 @@ from windup_app.server.user.model import (
     LoginResult,
     RegisterInput,
     ResetPasswordInput,
+    SetPasswordInput,
     UpdateNicknameInput,
     User,
     UserStatus,
@@ -61,8 +62,15 @@ def _hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
+def _has_password(hashed: str) -> bool:
+    """判断用户是否已设置有效 bcrypt 密码哈希。"""
+    return bool(hashed) and hashed.startswith("$2") and len(hashed) == 60
+
+
 def _verify_password(password: str, hashed: str) -> bool:
     """验证密码。"""
+    if not _has_password(hashed):
+        return False
     return bcrypt.checkpw(password.encode(), hashed.encode())
 
 
@@ -104,6 +112,7 @@ def _to_view(user: User) -> UserView:
         email_verified_at=user.email_verified_at,
         status=UserStatus(user.status),
         last_login_at=user.last_login_at,
+        has_password=_has_password(user.password_hash),
         create_at=user.create_at,
         update_at=user.update_at,
     )
@@ -253,6 +262,13 @@ class SqlAlchemyUserService(UserService):
         if user is None:
             self._record_login_failure(input.email)
             raise BizException("邮箱或密码错误", code=BizCode.BAD_REQUEST)
+
+        if not _has_password(user.password_hash):
+            self._record_login_failure(input.email)
+            raise BizException(
+                "该账号未设置密码，请使用邮箱验证码登录",
+                code=BizCode.BAD_REQUEST,
+            )
 
         if not _verify_password(input.password, user.password_hash):
             self._record_login_failure(input.email)
@@ -470,6 +486,9 @@ class SqlAlchemyUserService(UserService):
         if user is None:
             raise BizException("用户不存在", code=BizCode.NOT_FOUND)
 
+        if not _has_password(user.password_hash):
+            raise BizException("尚未设置密码", code=BizCode.BAD_REQUEST)
+
         if not _verify_password(input.old_password, user.password_hash):
             raise BizException("旧密码错误", code=BizCode.BAD_REQUEST)
 
@@ -479,6 +498,23 @@ class SqlAlchemyUserService(UserService):
         # 修改密码后撤销该用户所有 refresh_token
         self._revoke_all_user_tokens(user_id)
         logger.info("[WINDUP] 密码已修改 | user_id=%s", user_id)
+
+    def set_password(
+        self, session: Session, user_id: int, input: SetPasswordInput
+    ) -> None:
+        """设置初始密码（仅未设密码用户）。"""
+        user = session.get(User, user_id)
+        if user is None:
+            raise BizException("用户不存在", code=BizCode.NOT_FOUND)
+
+        if _has_password(user.password_hash):
+            raise BizException("密码已设置，请使用修改密码", code=BizCode.BAD_REQUEST)
+
+        user.password_hash = _hash_password(input.new_password)
+        session.flush()
+
+        self._revoke_all_user_tokens(user_id)
+        logger.info("[WINDUP] 密码已设置 | user_id=%s", user_id)
 
     def reset_password(self, session: Session, input: ResetPasswordInput) -> None:
         """邮箱+验证码重置密码（忘记密码场景）。"""

--- a/backend/packages/app/src/windup_app/web/api/auth.py
+++ b/backend/packages/app/src/windup_app/web/api/auth.py
@@ -16,11 +16,12 @@ from windup_framework.db import get_session
 from windup_app.server.user.model import (
     RegisterInput,
     ResetPasswordInput,
+    SetPasswordInput,
     UpdateNicknameInput,
     User,
     UserView,
 )
-from windup_app.server.user.service import service
+from windup_app.server.user.service import _has_password, service
 
 logger = logging.getLogger("windup.auth.api")
 
@@ -85,6 +86,12 @@ class ChangePasswordRequest(BaseModel):
     new_password: str = Field(min_length=8, max_length=128)
 
 
+class SetPasswordRequest(BaseModel):
+    """设置初始密码请求。"""
+
+    new_password: str = Field(min_length=8, max_length=128)
+
+
 class UpdateNicknameRequest(BaseModel):
     """修改昵称请求。"""
 
@@ -124,6 +131,33 @@ class UserOut(BaseModel):
     nickname: str | None = None
     email_verified_at: str | None = None
     status: int = 0
+    has_password: bool = False
+
+
+def _user_out_from_orm(user: User) -> UserOut:
+    return UserOut(
+        id=user.id,
+        email=user.email,
+        nickname=user.nickname,
+        email_verified_at=user.email_verified_at.isoformat()
+        if user.email_verified_at
+        else None,
+        status=user.status,
+        has_password=_has_password(user.password_hash),
+    )
+
+
+def _user_out_from_view(user: UserView) -> UserOut:
+    return UserOut(
+        id=user.id,
+        email=user.email,
+        nickname=user.nickname,
+        email_verified_at=user.email_verified_at.isoformat()
+        if user.email_verified_at
+        else None,
+        status=int(user.status),
+        has_password=user.has_password,
+    )
 
 
 # -- 路由 ----------------------------------------------------------------
@@ -225,17 +259,7 @@ def get_me(request: Request, session: Session = Depends(get_session)):
         from windup_common.exceptions import BizException
 
         raise BizException("用户不存在", code=BizCode.NOT_FOUND)
-    return Response.success(
-        UserOut(
-            id=user.id,
-            email=user.email,
-            nickname=user.nickname,
-            email_verified_at=user.email_verified_at.isoformat()
-            if user.email_verified_at
-            else None,
-            status=user.status,
-        )
-    )
+    return Response.success(_user_out_from_orm(user))
 
 
 @router.post("/change-password", response_model=Response[None])
@@ -256,6 +280,22 @@ def change_password(
         )(),
     )
     return Response.success(None, message="密码修改成功")
+
+
+@router.post("/set-password", response_model=Response[None])
+def set_password(
+    body: SetPasswordRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+):
+    """设置初始密码（仅未设密码用户）。"""
+    current_user = request.state.current_user
+    service.set_password(
+        session,
+        current_user.id,
+        SetPasswordInput(new_password=body.new_password),
+    )
+    return Response.success(None, message="密码设置成功")
 
 
 @router.post("/reset-password", response_model=Response[None])
@@ -281,15 +321,4 @@ def update_nickname(
     user_view = service.update_nickname(
         session, current_user.id, UpdateNicknameInput(nickname=body.nickname)
     )
-    return Response.success(
-        UserOut(
-            id=user_view.id,
-            email=user_view.email,
-            nickname=user_view.nickname,
-            email_verified_at=user_view.email_verified_at.isoformat()
-            if user_view.email_verified_at
-            else None,
-            status=user_view.status,
-        ),
-        message="昵称修改成功",
-    )
+    return Response.success(_user_out_from_view(user_view), message="昵称修改成功")

--- a/backend/packages/app/src/windup_app/web/middleware/auth.py
+++ b/backend/packages/app/src/windup_app/web/middleware/auth.py
@@ -47,6 +47,7 @@ AUTH_WHITELIST: set[str] = {
     "/auth/login",
     "/auth/send-code",
     "/auth/login-by-code",
+    "/auth/reset-password",
     "/auth/refresh",
     "/auth/logout",
     "/docs",

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -77,9 +77,9 @@ def test_change_password_endpoint(auth_client, seeded_user, mock_user_redis):
     assert body["message"] == "密码修改成功"
 
 
-def test_reset_password_endpoint(auth_client, seeded_user, mock_user_redis):
+def test_reset_password_endpoint(client, seeded_user, mock_user_redis):
     mock_user_redis.get.return_value = "654321"
-    resp = auth_client.post(
+    resp = client.post(
         "/auth/reset-password",
         json={
             "email": "test@example.com",
@@ -91,6 +91,28 @@ def test_reset_password_endpoint(auth_client, seeded_user, mock_user_redis):
     body = resp.json()
     assert body["code"] == 200
     assert body["message"] == "密码重置成功"
+
+
+def test_set_password_endpoint(auth_client, db_session, mock_user_redis):
+    from windup_app.server.user.model import User
+
+    user = User(
+        id=1,
+        email="test@example.com",
+        password_hash="",
+        nickname="旧昵称",
+    )
+    db_session.merge(user)
+    db_session.flush()
+
+    resp = auth_client.post(
+        "/auth/set-password",
+        json={"new_password": "newpass123"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 200
+    assert body["message"] == "密码设置成功"
 
 
 def test_register_endpoint_success(client, db_session, mock_user_redis):

--- a/backend/tests/test_user_service.py
+++ b/backend/tests/test_user_service.py
@@ -14,6 +14,7 @@ from windup_app.server.user.model import (
     LoginByPasswordInput,
     RegisterInput,
     ResetPasswordInput,
+    SetPasswordInput,
     UpdateNicknameInput,
     User,
     UserStatus,
@@ -433,6 +434,7 @@ def test_login_by_code_unknown_email_creates_user_and_gifts(
     assert user is not None
     assert result.user.id == user.id
     assert result.user.email_verified_at is not None
+    assert result.user.has_password is False
     account = db_session.scalar(
         select(CreditAccount).where(CreditAccount.user_id == user.id)
     )
@@ -644,6 +646,72 @@ def test_change_password_wrong_old(db_session, service, mock_mq_publish):
 
     with pytest.raises(BizException, match="旧密码错误"):
         service.change_password(db_session, result.user.id, change_input)
+
+
+def test_login_by_password_no_password_set(db_session, service, mock_mq_publish):
+    service._redis.get.return_value = "123456"
+    result = service.login_by_code(
+        db_session, LoginByCodeInput(email="nopwd@example.com", code="123456")
+    )
+    assert result.user.has_password is False
+
+    service._redis.get.return_value = None
+    service._redis.incr.return_value = 1
+    with pytest.raises(BizException, match="该账号未设置密码"):
+        service.login_by_password(
+            db_session,
+            LoginByPasswordInput(email="nopwd@example.com", password="anypass12"),
+        )
+
+
+def test_change_password_no_password_set(db_session, service, mock_mq_publish):
+    service._redis.get.return_value = "123456"
+    result = service.login_by_code(
+        db_session, LoginByCodeInput(email="nopwd2@example.com", code="123456")
+    )
+
+    with pytest.raises(BizException, match="尚未设置密码"):
+        service.change_password(
+            db_session,
+            result.user.id,
+            ChangePasswordInput(old_password="anypass12", new_password="newpass123"),
+        )
+
+
+def test_set_password_success(db_session, service, mock_mq_publish):
+    service._redis.get.return_value = "123456"
+    result = service.login_by_code(
+        db_session, LoginByCodeInput(email="setpwd@example.com", code="123456")
+    )
+
+    service.set_password(
+        db_session, result.user.id, SetPasswordInput(new_password="newpass123")
+    )
+
+    service._redis.get.return_value = None
+    login_result = service.login_by_password(
+        db_session,
+        LoginByPasswordInput(email="setpwd@example.com", password="newpass123"),
+    )
+    assert login_result.user.has_password is True
+
+
+def test_set_password_already_set(db_session, service, mock_mq_publish):
+    service._redis.get.return_value = "123456"
+    result = service.register_by_email(
+        db_session,
+        RegisterInput(
+            email="haspwd@example.com",
+            password="oldpass123",
+            code="123456",
+            invite_code="AB23CD45",
+        ),
+    )
+
+    with pytest.raises(BizException, match="密码已设置"):
+        service.set_password(
+            db_session, result.user.id, SetPasswordInput(new_password="newpass123")
+        )
 
 
 # -- 昵称修改测试 --------------------------------------------------------

--- a/frontend/src/app/app.test.tsx
+++ b/frontend/src/app/app.test.tsx
@@ -241,6 +241,7 @@ describe('AppRoutes authentication boundary', () => {
       logout: async () => undefined,
       me: async () => Promise.reject(new Error('not used')),
       updateNickname: async () => Promise.reject(new Error('not used')),
+      setPassword: async () => Promise.reject(new Error('not used')),
       changePassword: async () => Promise.reject(new Error('not used')),
     }
     window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, 'expired-refresh-token')
@@ -269,6 +270,7 @@ describe('AppRoutes authentication boundary', () => {
       logout: async () => undefined,
       me: async () => Promise.reject(new Error('not used')),
       updateNickname: async () => Promise.reject(new Error('not used')),
+      setPassword: async () => Promise.reject(new Error('not used')),
       changePassword: async () => Promise.reject(new Error('not used')),
     }
     window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, 'expired-refresh-token')

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -14,6 +14,7 @@ const user = {
   nickname: 'Reader',
   emailVerifiedAt: '2026-08-07T01:02:03Z',
   statusCode: 0,
+  hasPassword: true,
 }
 
 function tokens(): AuthTokens {
@@ -30,6 +31,7 @@ function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn
     logout: vi.fn(async () => undefined),
     me: vi.fn(async () => user),
     updateNickname: vi.fn(async () => user),
+    setPassword: vi.fn(async () => undefined),
     changePassword: vi.fn(async () => undefined),
   }
 }

--- a/frontend/src/entities/user/api.test.ts
+++ b/frontend/src/entities/user/api.test.ts
@@ -15,6 +15,7 @@ const tokenResponse = {
     nickname: 'Reader',
     email_verified_at: '2026-08-07T01:02:03Z',
     status: 37,
+    has_password: true,
     last_login_at: '2026-08-07T01:02:03Z',
     create_at: '2026-08-01T01:02:03Z',
     update_at: '2026-08-07T01:02:03Z',
@@ -43,6 +44,7 @@ describe('createUserApis', () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(tokenResponse.user)
       .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
 
     const apis = createUserApis({ client })
 
@@ -62,6 +64,7 @@ describe('createUserApis', () => {
     await apis.refresh('refresh-token')
     await apis.logout('refresh-token')
     await apis.updateNickname('New Reader')
+    await apis.setPassword({ newPassword: 'new-password-123' })
     await apis.changePassword({ oldPassword: 'password-123', newPassword: 'new-password-123' })
 
     expect(request.mock.calls).toEqual([
@@ -106,6 +109,13 @@ describe('createUserApis', () => {
       ['/auth/logout', { method: 'POST', json: { refresh_token: 'refresh-token' } }],
       ['/auth/profile', { method: 'PATCH', json: { nickname: 'New Reader' } }],
       [
+        '/auth/set-password',
+        {
+          method: 'POST',
+          json: { new_password: 'new-password-123' },
+        },
+      ],
+      [
         '/auth/change-password',
         {
           method: 'POST',
@@ -128,6 +138,7 @@ describe('createUserApis', () => {
       nickname: 'New Reader',
       emailVerifiedAt: '2026-08-07T01:02:03Z',
       statusCode: 37,
+      hasPassword: true,
     })
   })
 
@@ -153,6 +164,7 @@ describe('createUserApis', () => {
         nickname: 'Reader',
         emailVerifiedAt: '2026-08-07T01:02:03Z',
         statusCode: 37,
+        hasPassword: true,
       },
     })
     await expect(apis.me()).resolves.toEqual({
@@ -161,6 +173,7 @@ describe('createUserApis', () => {
       nickname: null,
       emailVerifiedAt: null,
       statusCode: 37,
+      hasPassword: false,
     })
     expect(request).toHaveBeenLastCalledWith('/auth/me')
   })

--- a/frontend/src/entities/user/api.ts
+++ b/frontend/src/entities/user/api.ts
@@ -9,6 +9,7 @@ interface UserDto {
   nickname: string | null
   email_verified_at: string | null
   status: number
+  has_password?: boolean
   [key: string]: unknown
 }
 
@@ -51,6 +52,7 @@ function toUser(value: unknown): User {
     nickname: dto.nickname,
     emailVerifiedAt: dto.email_verified_at,
     statusCode: dto.status,
+    hasPassword: dto.has_password === true,
   }
 }
 
@@ -148,6 +150,13 @@ export function createUserApis(options: CreateUserApisOptions = {}): UserApis {
       )
     },
 
+    async setPassword(input) {
+      await protectedClient.request<null>('/auth/set-password', {
+        method: 'POST',
+        json: { new_password: input.newPassword },
+      })
+    },
+
     async changePassword(input) {
       await protectedClient.request<null>('/auth/change-password', {
         method: 'POST',
@@ -174,5 +183,6 @@ export const userApis: UserApis = {
   logout: (refreshToken) => getDefaultApis().logout(refreshToken),
   me: () => getDefaultApis().me(),
   updateNickname: (nickname) => getDefaultApis().updateNickname(nickname),
+  setPassword: (input) => getDefaultApis().setPassword(input),
   changePassword: (input) => getDefaultApis().changePassword(input),
 }

--- a/frontend/src/entities/user/index.ts
+++ b/frontend/src/entities/user/index.ts
@@ -5,6 +5,7 @@ export interface User {
   nickname: string | null
   emailVerifiedAt: string | null
   statusCode: number
+  hasPassword: boolean
 }
 
 /** 一次认证成功后由后端签发的完整会话材料。 */
@@ -33,6 +34,7 @@ export interface UserApis {
   logout(refreshToken: string): Promise<void>
   me(): Promise<User>
   updateNickname(nickname: string): Promise<User>
+  setPassword(input: { newPassword: string }): Promise<void>
   changePassword(input: { oldPassword: string; newPassword: string }): Promise<void>
 }
 

--- a/frontend/src/features/account-panel/index.test.tsx
+++ b/frontend/src/features/account-panel/index.test.tsx
@@ -15,6 +15,7 @@ const user = {
   nickname: 'Reader',
   emailVerifiedAt: '2026-08-07T01:02:03Z',
   statusCode: 0,
+  hasPassword: true,
 }
 
 function tokens(): AuthTokens {
@@ -41,6 +42,7 @@ function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn
     logout: vi.fn(async () => undefined),
     me: vi.fn(async () => user),
     updateNickname: vi.fn(async () => user),
+    setPassword: vi.fn(async () => undefined),
     changePassword: vi.fn(async () => undefined),
   }
 }

--- a/frontend/src/features/account-panel/index.tsx
+++ b/frontend/src/features/account-panel/index.tsx
@@ -235,6 +235,10 @@ function AccountPanelDialog({
   const [success, setSuccess] = useState<string | null>(null)
   const [isSendingCode, setIsSendingCode] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showSetPasswordPrompt, setShowSetPasswordPrompt] = useState(false)
+  const [setPasswordValue, setSetPasswordValue] = useState('')
+  const [confirmPasswordValue, setConfirmPasswordValue] = useState('')
+  const [showSetPassword, setShowSetPassword] = useState(false)
   const [cooldowns, setCooldowns] = useState<Map<string, number>>(() => new Map())
   const [now, setNow] = useState(Date.now())
   const emailInputRef = useRef<HTMLInputElement>(null)
@@ -252,6 +256,8 @@ function AccountPanelDialog({
   const passwordId = useId()
   const codeId = useId()
   const inviteCodeId = useId()
+  const setPasswordId = useId()
+  const confirmPasswordId = useId()
   const isRegister = entry === 'register'
   const shouldShowMotionCopy = !isRegister || registerStep === 0
   const motionCopy = isRegister ? registrationWelcomeMotionCopy : loginMotionCopy
@@ -445,6 +451,48 @@ function AccountPanelDialog({
     setRegisterStep((current) => Math.max(0, current - 1))
   }
 
+  function completeNavigation(message: string) {
+    if (dismissedRef.current) return
+    setSuccess(message)
+    navigationTimerRef.current = window.setTimeout(
+      () => leaveWithAnimation(() => navigate(returnTarget, { replace: true })),
+      SUCCESS_NAVIGATION_DELAY_MS - AUTH_EXIT_DURATION_MS,
+    )
+  }
+
+  function skipSetPassword() {
+    setError(null)
+    completeNavigation('登录成功，正在继续。')
+  }
+
+  async function submitSetPassword(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (isSubmitting) return
+
+    if (setPasswordValue.length < 8 || setPasswordValue.length > 128) {
+      setError('密码需为 8–128 位')
+      return
+    }
+    if (setPasswordValue !== confirmPasswordValue) {
+      setError('两次输入的密码不一致')
+      return
+    }
+
+    setError(null)
+    setSuccess(null)
+    setIsSubmitting(true)
+    try {
+      await session.setPassword({ newPassword: setPasswordValue }, { keepSession: true })
+      await session.login({ email: normalizedEmail, password: setPasswordValue })
+      setShowSetPasswordPrompt(false)
+      completeNavigation('密码已设置，正在继续。')
+    } catch (submitError) {
+      if (dismissedRef.current) return
+      setError(errorMessage(submitError))
+      setIsSubmitting(false)
+    }
+  }
+
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     if (isSubmitting || isSendingCode) return
@@ -475,7 +523,12 @@ function AccountPanelDialog({
         })
         successMessage = '账号已创建，正在继续。'
       } else if (mode === 'code') {
-        await session.loginByCode({ email: normalizedEmail, code })
+        const tokens = await session.loginByCode({ email: normalizedEmail, code })
+        if (!tokens.user.hasPassword) {
+          setShowSetPasswordPrompt(true)
+          setIsSubmitting(false)
+          return
+        }
         successMessage = '登录成功，正在继续。'
       } else {
         await session.login({ email: normalizedEmail, password })
@@ -483,11 +536,7 @@ function AccountPanelDialog({
       }
 
       if (dismissedRef.current) return
-      setSuccess(successMessage)
-      navigationTimerRef.current = window.setTimeout(
-        () => leaveWithAnimation(() => navigate(returnTarget, { replace: true })),
-        SUCCESS_NAVIGATION_DELAY_MS - AUTH_EXIT_DURATION_MS,
-      )
+      completeNavigation(successMessage)
     } catch (submitError) {
       if (dismissedRef.current) return
       setError(errorMessage(submitError))
@@ -528,7 +577,11 @@ function AccountPanelDialog({
   const registerCopy = registrationStepCopy[registerStep]
   const titleCopy = isRegister ? registerCopy.title : loginWelcomeCopy.title
   const descriptionCopy = isRegister ? registerCopy.description : loginWelcomeCopy.description
-  const dialogLabel = isRegister ? '创建 Windup 账号' : '登录 Windup'
+  const dialogLabel = showSetPasswordPrompt
+    ? '设置登录密码'
+    : isRegister
+      ? '创建 Windup 账号'
+      : '登录 Windup'
   const submitContent = isSubmitting
     ? '正在处理…'
     : isSendingCode
@@ -608,29 +661,39 @@ function AccountPanelDialog({
           <div className="auth-screen-intro relative z-[3] text-center">
             <KineticTitle
               id={titleId}
-              text={titleCopy}
+              text={
+                showSetPasswordPrompt ? '为账号加一道保护' : titleCopy
+              }
               emphasis={isRegister && registerStep === 0 ? 'Windup' : undefined}
             />
             <p id={descriptionId} className="sr-only">
-              {descriptionCopy}
+              {showSetPasswordPrompt
+                ? '设置 8–128 位密码，方便日后使用密码登录。'
+                : descriptionCopy}
             </p>
-            {shouldShowMotionCopy && (
-              <div className="auth-register-description mx-auto mt-3">
-                <KineticCopy
-                  lines={activeMotionCopy}
-                  copyKey={`${entry}-${registerStep}-${copyIndex}`}
-                  phase={copyPhase}
-                />
-              </div>
+            {showSetPasswordPrompt ? (
+              <p className="auth-register-step-description mx-auto mt-3 max-w-[30rem]">
+                设置 8–128 位密码，方便日后使用密码登录。
+              </p>
+            ) : (
+              shouldShowMotionCopy && (
+                <div className="auth-register-description mx-auto mt-3">
+                  <KineticCopy
+                    lines={activeMotionCopy}
+                    copyKey={`${entry}-${registerStep}-${copyIndex}`}
+                    phase={copyPhase}
+                  />
+                </div>
+              )
             )}
-            {isRegister && registerStep > 0 && (
+            {isRegister && registerStep > 0 && !showSetPasswordPrompt && (
               <p className="auth-register-step-description mx-auto mt-3 max-w-[30rem]">
                 {descriptionCopy}
               </p>
             )}
           </div>
 
-          {!isRegister && (
+          {!isRegister && !showSetPasswordPrompt && (
             <div
               role="tablist"
               aria-label="账号操作"
@@ -659,12 +722,62 @@ function AccountPanelDialog({
             </p>
           )}
 
-          <form
-            data-testid={isRegister ? 'register-fields' : undefined}
-            className={`auth-register-fields ${isRegister ? '' : 'auth-login-fields'}`}
-            onSubmit={submit}
-            noValidate
-          >
+          {showSetPasswordPrompt ? (
+            <form className="auth-register-fields auth-login-fields" onSubmit={submitSetPassword} noValidate>
+              <AuthField
+                id={setPasswordId}
+                label="新密码"
+                icon={Keyhole}
+                value={setPasswordValue}
+                autoComplete="new-password"
+                placeholder="新密码"
+                disabled={isSubmitting}
+                type={showSetPassword ? 'text' : 'password'}
+                variant="password"
+                onValueChange={setSetPasswordValue}
+                action={
+                  <PasswordVisibilityButton
+                    visible={showSetPassword}
+                    onClick={() => setShowSetPassword((visible) => !visible)}
+                  />
+                }
+              />
+              <AuthField
+                id={confirmPasswordId}
+                label="确认密码"
+                icon={Keyhole}
+                value={confirmPasswordValue}
+                autoComplete="new-password"
+                placeholder="再次输入密码"
+                disabled={isSubmitting}
+                type={showSetPassword ? 'text' : 'password'}
+                variant="password"
+                onValueChange={setConfirmPasswordValue}
+              />
+              {feedback}
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="auth-screen-submit px-4 text-white disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? '正在设置…' : '设置密码'}
+              </button>
+              <button
+                type="button"
+                disabled={isSubmitting}
+                onClick={skipSetPassword}
+                className="auth-screen-helper mt-3 w-full text-center text-sm underline-offset-2 hover:underline"
+              >
+                稍后设置
+              </button>
+            </form>
+          ) : (
+            <form
+              data-testid={isRegister ? 'register-fields' : undefined}
+              className={`auth-register-fields ${isRegister ? '' : 'auth-login-fields'}`}
+              onSubmit={submit}
+              noValidate
+            >
             {isRegister && registerStep > 0 && (
               <button
                 type="button"
@@ -815,14 +928,17 @@ function AccountPanelDialog({
               </span>
             </button>
           </form>
+          )}
 
+          {!showSetPasswordPrompt && (
           <p className="auth-screen-entry-switch mt-7 text-center text-sm">
             {isRegister ? '已有账号？' : '还没有账号？'}{' '}
             <button type="button" onClick={() => switchEntry(isRegister ? 'login' : 'register')}>
               {isRegister ? '登录' : '创建账号'}
             </button>
           </p>
-          {isRegister && (
+          )}
+          {isRegister && !showSetPasswordPrompt && (
             <p className="auth-screen-helper mt-2 text-center text-sm">
               {normalizedInviteCode ? '填写邀请码，注册后共得 500 积分。' : '注册即赠 300 积分。'}
             </p>

--- a/frontend/src/features/account-panel/index.tsx
+++ b/frontend/src/features/account-panel/index.tsx
@@ -661,9 +661,7 @@ function AccountPanelDialog({
           <div className="auth-screen-intro relative z-[3] text-center">
             <KineticTitle
               id={titleId}
-              text={
-                showSetPasswordPrompt ? '为账号加一道保护' : titleCopy
-              }
+              text={showSetPasswordPrompt ? '为账号加一道保护' : titleCopy}
               emphasis={isRegister && registerStep === 0 ? 'Windup' : undefined}
             />
             <p id={descriptionId} className="sr-only">
@@ -723,7 +721,11 @@ function AccountPanelDialog({
           )}
 
           {showSetPasswordPrompt ? (
-            <form className="auth-register-fields auth-login-fields" onSubmit={submitSetPassword} noValidate>
+            <form
+              className="auth-register-fields auth-login-fields"
+              onSubmit={submitSetPassword}
+              noValidate
+            >
               <AuthField
                 id={setPasswordId}
                 label="新密码"
@@ -778,165 +780,165 @@ function AccountPanelDialog({
               onSubmit={submit}
               noValidate
             >
-            {isRegister && registerStep > 0 && (
-              <button
-                type="button"
-                className="auth-register-back"
-                onClick={returnToPreviousRegistrationStep}
-                aria-label="返回上一步"
+              {isRegister && registerStep > 0 && (
+                <button
+                  type="button"
+                  className="auth-register-back"
+                  onClick={returnToPreviousRegistrationStep}
+                  aria-label="返回上一步"
+                >
+                  <ArrowLeft {...AUTH_ICON_PROPS} />
+                </button>
+              )}
+
+              <div
+                key={isRegister ? `register-${registerStep}` : `login-${mode}`}
+                data-testid="auth-motion-stage"
+                data-motion-direction={motionDirection}
+                className={`auth-motion-stage auth-motion-stage-${motionDirection}`}
               >
-                <ArrowLeft {...AUTH_ICON_PROPS} />
-              </button>
-            )}
-
-            <div
-              key={isRegister ? `register-${registerStep}` : `login-${mode}`}
-              data-testid="auth-motion-stage"
-              data-motion-direction={motionDirection}
-              className={`auth-motion-stage auth-motion-stage-${motionDirection}`}
-            >
-              {(!isRegister || registerStep === 0) && (
-                <AuthField
-                  id={emailId}
-                  label="邮箱"
-                  icon={isRegister ? RegisterFieldIcon : EnvelopeSimple}
-                  type="email"
-                  autoComplete="email"
-                  required
-                  value={email}
-                  onValueChange={setEmail}
-                  inputRef={emailInputRef}
-                  disabled={isSubmitting || isSendingCode}
-                  placeholder="邮箱地址"
-                />
-              )}
-
-              {isRegister && registerStep === 1 && (
-                <div className="auth-invite-field">
+                {(!isRegister || registerStep === 0) && (
                   <AuthField
-                    id={inviteCodeId}
-                    label="邀请码（选填）"
-                    icon={RegisterFieldIcon}
-                    value={inviteCode}
-                    onValueChange={setInviteCode}
+                    id={emailId}
+                    label="邮箱"
+                    icon={isRegister ? RegisterFieldIcon : EnvelopeSimple}
+                    type="email"
+                    autoComplete="email"
+                    required
+                    value={email}
+                    onValueChange={setEmail}
+                    inputRef={emailInputRef}
                     disabled={isSubmitting || isSendingCode}
-                    placeholder="邀请码（选填）"
-                    autoComplete="off"
-                    autoCapitalize="characters"
-                    spellCheck={false}
+                    placeholder="邮箱地址"
                   />
-                  {initialInviteCode && (
-                    <p className="auth-invite-helper">已从邀请链接带入，可修改或清空。</p>
-                  )}
-                </div>
-              )}
+                )}
 
-              {((isRegister && registerStep === 2) || (!isRegister && mode === 'password')) && (
-                <AuthField
-                  id={passwordId}
-                  label="密码"
-                  icon={isRegister ? RegisterFieldIcon : Keyhole}
-                  value={password}
-                  autoComplete={isRegister ? 'new-password' : 'current-password'}
-                  placeholder={isRegister ? '创建密码' : '密码'}
-                  disabled={isSubmitting}
-                  type={showPassword ? 'text' : 'password'}
-                  variant="password"
-                  onValueChange={setPassword}
-                  action={
-                    <PasswordVisibilityButton
-                      visible={showPassword}
-                      onClick={() => setShowPassword((visible) => !visible)}
+                {isRegister && registerStep === 1 && (
+                  <div className="auth-invite-field">
+                    <AuthField
+                      id={inviteCodeId}
+                      label="邀请码（选填）"
+                      icon={RegisterFieldIcon}
+                      value={inviteCode}
+                      onValueChange={setInviteCode}
+                      disabled={isSubmitting || isSendingCode}
+                      placeholder="邀请码（选填）"
+                      autoComplete="off"
+                      autoCapitalize="characters"
+                      spellCheck={false}
                     />
-                  }
-                />
-              )}
+                    {initialInviteCode && (
+                      <p className="auth-invite-helper">已从邀请链接带入，可修改或清空。</p>
+                    )}
+                  </div>
+                )}
 
-              {isRegister && registerStep === 3 && (
-                <AuthField
-                  id={nicknameId}
-                  label="昵称（选填）"
-                  icon={RegisterFieldIcon}
-                  autoComplete="nickname"
-                  maxLength={51}
-                  value={nickname}
-                  onValueChange={setNickname}
-                  disabled={isSubmitting}
-                  placeholder="昵称（可以稍后填写）"
-                />
-              )}
+                {((isRegister && registerStep === 2) || (!isRegister && mode === 'password')) && (
+                  <AuthField
+                    id={passwordId}
+                    label="密码"
+                    icon={isRegister ? RegisterFieldIcon : Keyhole}
+                    value={password}
+                    autoComplete={isRegister ? 'new-password' : 'current-password'}
+                    placeholder={isRegister ? '创建密码' : '密码'}
+                    disabled={isSubmitting}
+                    type={showPassword ? 'text' : 'password'}
+                    variant="password"
+                    onValueChange={setPassword}
+                    action={
+                      <PasswordVisibilityButton
+                        visible={showPassword}
+                        onClick={() => setShowPassword((visible) => !visible)}
+                      />
+                    }
+                  />
+                )}
 
-              {((isRegister && registerStep === 4) || (!isRegister && mode === 'code')) && (
-                <AuthField
-                  id={codeId}
-                  label="验证码"
-                  icon={isRegister ? RegisterFieldIcon : SealCheck}
-                  value={code}
-                  placeholder={isRegister ? '6 位验证码' : '6 位数字'}
-                  disabled={isSubmitting}
-                  inputMode="numeric"
-                  autoComplete="one-time-code"
-                  maxLength={6}
-                  variant="code"
-                  onValueChange={setCode}
-                  action={
-                    <button
-                      type="button"
-                      onClick={() => void sendCode()}
-                      disabled={isSendingCode || isSubmitting || cooldownSeconds > 0}
-                      aria-label={isRegister ? '重新发送验证码' : undefined}
-                      className="auth-screen-code-action disabled:cursor-not-allowed"
+                {isRegister && registerStep === 3 && (
+                  <AuthField
+                    id={nicknameId}
+                    label="昵称（选填）"
+                    icon={RegisterFieldIcon}
+                    autoComplete="nickname"
+                    maxLength={51}
+                    value={nickname}
+                    onValueChange={setNickname}
+                    disabled={isSubmitting}
+                    placeholder="昵称（可以稍后填写）"
+                  />
+                )}
+
+                {((isRegister && registerStep === 4) || (!isRegister && mode === 'code')) && (
+                  <AuthField
+                    id={codeId}
+                    label="验证码"
+                    icon={isRegister ? RegisterFieldIcon : SealCheck}
+                    value={code}
+                    placeholder={isRegister ? '6 位验证码' : '6 位数字'}
+                    disabled={isSubmitting}
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    maxLength={6}
+                    variant="code"
+                    onValueChange={setCode}
+                    action={
+                      <button
+                        type="button"
+                        onClick={() => void sendCode()}
+                        disabled={isSendingCode || isSubmitting || cooldownSeconds > 0}
+                        aria-label={isRegister ? '重新发送验证码' : undefined}
+                        className="auth-screen-code-action disabled:cursor-not-allowed"
+                      >
+                        {isSendingCode ? (
+                          '正在发送…'
+                        ) : cooldownSeconds > 0 ? (
+                          `${cooldownSeconds}s`
+                        ) : isRegister ? (
+                          <ArrowsClockwise {...AUTH_ICON_PROPS} />
+                        ) : (
+                          '发送验证码'
+                        )}
+                      </button>
+                    }
+                  />
+                )}
+
+                {!isRegister && mode === 'code' && (
+                  <p className="auth-screen-helper text-xs leading-5">
+                    未注册的邮箱将在验证后自动创建账号，并获得 300 积分。
+                  </p>
+                )}
+              </div>
+
+              {isRegister ? <div className="auth-register-feedback">{feedback}</div> : feedback}
+
+              <button
+                type="submit"
+                disabled={isSubmitting || isSendingCode}
+                className="auth-screen-submit px-4 text-white disabled:cursor-not-allowed"
+              >
+                <span key={submitContent} className="auth-submit-label">
+                  {Array.from(submitContent).map((character, index) => (
+                    <span
+                      key={`${character}-${index}`}
+                      className="auth-submit-character"
+                      style={{ '--auth-character-index': index } as CSSProperties}
                     >
-                      {isSendingCode ? (
-                        '正在发送…'
-                      ) : cooldownSeconds > 0 ? (
-                        `${cooldownSeconds}s`
-                      ) : isRegister ? (
-                        <ArrowsClockwise {...AUTH_ICON_PROPS} />
-                      ) : (
-                        '发送验证码'
-                      )}
-                    </button>
-                  }
-                />
-              )}
-
-              {!isRegister && mode === 'code' && (
-                <p className="auth-screen-helper text-xs leading-5">
-                  未注册的邮箱将在验证后自动创建账号，并获得 300 积分。
-                </p>
-              )}
-            </div>
-
-            {isRegister ? <div className="auth-register-feedback">{feedback}</div> : feedback}
-
-            <button
-              type="submit"
-              disabled={isSubmitting || isSendingCode}
-              className="auth-screen-submit px-4 text-white disabled:cursor-not-allowed"
-            >
-              <span key={submitContent} className="auth-submit-label">
-                {Array.from(submitContent).map((character, index) => (
-                  <span
-                    key={`${character}-${index}`}
-                    className="auth-submit-character"
-                    style={{ '--auth-character-index': index } as CSSProperties}
-                  >
-                    {character}
-                  </span>
-                ))}
-              </span>
-            </button>
-          </form>
+                      {character}
+                    </span>
+                  ))}
+                </span>
+              </button>
+            </form>
           )}
 
           {!showSetPasswordPrompt && (
-          <p className="auth-screen-entry-switch mt-7 text-center text-sm">
-            {isRegister ? '已有账号？' : '还没有账号？'}{' '}
-            <button type="button" onClick={() => switchEntry(isRegister ? 'login' : 'register')}>
-              {isRegister ? '登录' : '创建账号'}
-            </button>
-          </p>
+            <p className="auth-screen-entry-switch mt-7 text-center text-sm">
+              {isRegister ? '已有账号？' : '还没有账号？'}{' '}
+              <button type="button" onClick={() => switchEntry(isRegister ? 'login' : 'register')}>
+                {isRegister ? '登录' : '创建账号'}
+              </button>
+            </p>
           )}
           {isRegister && !showSetPasswordPrompt && (
             <p className="auth-screen-helper mt-2 text-center text-sm">

--- a/frontend/src/features/auth-session/index.test.tsx
+++ b/frontend/src/features/auth-session/index.test.tsx
@@ -14,6 +14,7 @@ const user = {
   nickname: 'Reader',
   emailVerifiedAt: '2026-08-07T01:02:03Z',
   statusCode: 37,
+  hasPassword: true,
 }
 
 function jwt(exp: number): string {
@@ -48,6 +49,7 @@ function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn
     logout: vi.fn(async () => undefined),
     me: vi.fn(async () => user),
     updateNickname: vi.fn(async () => user),
+    setPassword: vi.fn(async () => undefined),
     changePassword: vi.fn(async () => undefined),
   }
 }

--- a/frontend/src/features/auth-session/index.tsx
+++ b/frontend/src/features/auth-session/index.tsx
@@ -355,10 +355,7 @@ export function AuthSessionProvider({ apis, children }: AuthSessionProviderProps
     [apis, commitCurrentUser],
   )
   const setPassword = useCallback(
-    async (
-      input: Parameters<UserApis['setPassword']>[0],
-      options?: { keepSession?: boolean },
-    ) => {
+    async (input: Parameters<UserApis['setPassword']>[0], options?: { keepSession?: boolean }) => {
       await apis.setPassword(input)
       if (!options?.keepSession) clearSession('password-changed')
     },

--- a/frontend/src/features/auth-session/index.tsx
+++ b/frontend/src/features/auth-session/index.tsx
@@ -37,6 +37,10 @@ export interface AuthSessionValue {
   loginByCode(input: Parameters<UserApis['loginByCode']>[0]): Promise<AuthTokens>
   refreshCurrentUser(): Promise<User>
   updateNickname(nickname: string): Promise<User>
+  setPassword(
+    input: Parameters<UserApis['setPassword']>[0],
+    options?: { keepSession?: boolean },
+  ): Promise<void>
   changePassword(input: Parameters<UserApis['changePassword']>[0]): Promise<void>
   logout(): Promise<void>
 }
@@ -350,6 +354,16 @@ export function AuthSessionProvider({ apis, children }: AuthSessionProviderProps
     },
     [apis, commitCurrentUser],
   )
+  const setPassword = useCallback(
+    async (
+      input: Parameters<UserApis['setPassword']>[0],
+      options?: { keepSession?: boolean },
+    ) => {
+      await apis.setPassword(input)
+      if (!options?.keepSession) clearSession('password-changed')
+    },
+    [apis, clearSession],
+  )
   const changePassword = useCallback(
     async (input: Parameters<UserApis['changePassword']>[0]) => {
       await apis.changePassword(input)
@@ -372,6 +386,7 @@ export function AuthSessionProvider({ apis, children }: AuthSessionProviderProps
       loginByCode,
       refreshCurrentUser,
       updateNickname,
+      setPassword,
       changePassword,
       logout,
     }),
@@ -383,6 +398,7 @@ export function AuthSessionProvider({ apis, children }: AuthSessionProviderProps
       refreshCurrentUser,
       register,
       sendCode,
+      setPassword,
       state,
       updateNickname,
     ],

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -14,6 +14,7 @@ const user: User = {
   nickname: 'Reader',
   emailVerifiedAt: '2026-08-07T01:02:03Z',
   statusCode: 0,
+  hasPassword: true,
 }
 
 function tokens(): AuthTokens {
@@ -40,6 +41,7 @@ function createApis(): UserApis & Record<keyof UserApis, ReturnType<typeof vi.fn
     logout: vi.fn(async () => undefined),
     me: vi.fn(async () => user),
     updateNickname: vi.fn(async (nickname: string) => ({ ...user, nickname })),
+    setPassword: vi.fn(async () => undefined),
     changePassword: vi.fn(async () => undefined),
   }
 }

--- a/frontend/src/pages/account/index.tsx
+++ b/frontend/src/pages/account/index.tsx
@@ -488,6 +488,7 @@ export function AccountPage() {
   const session = useAuthSession()
   const {
     changePassword: changeSessionPassword,
+    setPassword: setSessionPassword,
     logout,
     refreshCurrentUser,
     updateNickname,
@@ -506,6 +507,7 @@ export function AccountPage() {
   const nicknameId = useId()
   const oldPasswordId = useId()
   const newPasswordId = useId()
+  const confirmPasswordId = useId()
 
   useEffect(() => {
     let active = true
@@ -551,10 +553,13 @@ export function AccountPage() {
     }
   }
 
-  async function changePassword(event: FormEvent<HTMLFormElement>) {
+  async function submitSecurityForm(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     if (security.isChanging) return
-    if (!security.oldPassword) {
+
+    const hasPassword = currentUser?.hasPassword ?? true
+
+    if (hasPassword && !security.oldPassword) {
       dispatchSecurity({ type: 'validationFailed', error: '请输入当前密码' })
       return
     }
@@ -562,13 +567,21 @@ export function AccountPage() {
       dispatchSecurity({ type: 'validationFailed', error: '新密码需为 8–128 位' })
       return
     }
+    if (!hasPassword && security.newPassword !== security.confirmPassword) {
+      dispatchSecurity({ type: 'validationFailed', error: '两次输入的密码不一致' })
+      return
+    }
 
     dispatchSecurity({ type: 'changeStarted' })
     try {
-      await changeSessionPassword({
-        oldPassword: security.oldPassword,
-        newPassword: security.newPassword,
-      })
+      if (hasPassword) {
+        await changeSessionPassword({
+          oldPassword: security.oldPassword,
+          newPassword: security.newPassword,
+        })
+      } else {
+        await setSessionPassword({ newPassword: security.newPassword })
+      }
     } catch (error) {
       dispatchSecurity({ type: 'changeFailed', error: errorMessage(error) })
     }
@@ -586,6 +599,7 @@ export function AccountPage() {
 
   if (!currentUser) return null
 
+  const hasPassword = currentUser.hasPassword
   const displayName = currentUser.nickname || currentUser.email.split('@')[0]
   const initial = Array.from(displayName)[0]?.toUpperCase() ?? 'W'
 
@@ -768,36 +782,40 @@ export function AccountPage() {
               <div>
                 <header>
                   <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">
-                    登录安全
+                    {hasPassword ? '登录安全' : '设置密码'}
                   </h2>
                   <p className="mt-1.5 text-sm leading-6 text-app-muted">
-                    修改密码后，当前会话会退出。
+                    {hasPassword
+                      ? '修改密码后，当前会话会退出。'
+                      : '设置密码后，当前会话会退出，之后可使用密码登录。'}
                   </p>
                 </header>
 
-                <form className="mt-5 grid max-w-xl gap-4" onSubmit={changePassword} noValidate>
-                  <label
-                    htmlFor={oldPasswordId}
-                    className="grid gap-1.5 text-sm font-medium text-app-ink-soft"
-                  >
-                    当前密码
-                    <input
-                      id={oldPasswordId}
-                      type="password"
-                      autoComplete="current-password"
-                      value={security.oldPassword}
-                      disabled={security.isChanging}
-                      onChange={(event) =>
-                        dispatchSecurity({
-                          type: 'oldPasswordChanged',
-                          password: event.target.value,
-                        })
-                      }
-                      className="account-field"
-                    />
-                  </label>
+                <form className="mt-5 grid max-w-xl gap-4" onSubmit={submitSecurityForm} noValidate>
+                  {hasPassword && (
+                    <label
+                      htmlFor={oldPasswordId}
+                      className="grid gap-1.5 text-sm font-medium text-app-ink-soft"
+                    >
+                      当前密码
+                      <input
+                        id={oldPasswordId}
+                        type="password"
+                        autoComplete="current-password"
+                        value={security.oldPassword}
+                        disabled={security.isChanging}
+                        onChange={(event) =>
+                          dispatchSecurity({
+                            type: 'oldPasswordChanged',
+                            password: event.target.value,
+                          })
+                        }
+                        className="account-field"
+                      />
+                    </label>
+                  )}
                   <div className="grid gap-1.5 text-sm font-medium text-app-ink-soft">
-                    <label htmlFor={newPasswordId}>新密码</label>
+                    <label htmlFor={newPasswordId}>{hasPassword ? '新密码' : '密码'}</label>
                     <input
                       id={newPasswordId}
                       type="password"
@@ -820,6 +838,28 @@ export function AccountPage() {
                       8–128 位
                     </span>
                   </div>
+                  {!hasPassword && (
+                    <label
+                      htmlFor={confirmPasswordId}
+                      className="grid gap-1.5 text-sm font-medium text-app-ink-soft"
+                    >
+                      确认密码
+                      <input
+                        id={confirmPasswordId}
+                        type="password"
+                        autoComplete="new-password"
+                        value={security.confirmPassword}
+                        disabled={security.isChanging}
+                        onChange={(event) =>
+                          dispatchSecurity({
+                            type: 'confirmPasswordChanged',
+                            password: event.target.value,
+                          })
+                        }
+                        className="account-field"
+                      />
+                    </label>
+                  )}
                   {security.error && (
                     <p
                       role="alert"
@@ -833,7 +873,13 @@ export function AccountPage() {
                     disabled={security.isChanging}
                     className="account-primary-button justify-self-start"
                   >
-                    {security.isChanging ? '正在修改…' : '修改密码'}
+                    {security.isChanging
+                      ? hasPassword
+                        ? '正在修改…'
+                        : '正在设置…'
+                      : hasPassword
+                        ? '修改密码'
+                        : '设置密码'}
                   </button>
                 </form>
               </div>

--- a/frontend/src/pages/account/state.test.ts
+++ b/frontend/src/pages/account/state.test.ts
@@ -56,6 +56,7 @@ describe('account security state', () => {
     expect(failed).toEqual({
       oldPassword: 'old-password',
       newPassword: 'new-password-123',
+      confirmPassword: '',
       isChanging: false,
       error: '当前密码错误',
     })
@@ -65,6 +66,7 @@ describe('account security state', () => {
     const populated = {
       oldPassword: 'old-password',
       newPassword: 'new-password-123',
+      confirmPassword: 'new-password-123',
       isChanging: true,
       error: '旧错误',
     }

--- a/frontend/src/pages/account/state.ts
+++ b/frontend/src/pages/account/state.ts
@@ -64,6 +64,7 @@ export function profileReducer(state: ProfileState, action: ProfileAction): Prof
 export type SecurityState = {
   oldPassword: string
   newPassword: string
+  confirmPassword: string
   isChanging: boolean
   error: string | null
 }
@@ -71,6 +72,7 @@ export type SecurityState = {
 export type SecurityAction =
   | { type: 'oldPasswordChanged'; password: string }
   | { type: 'newPasswordChanged'; password: string }
+  | { type: 'confirmPasswordChanged'; password: string }
   | { type: 'validationFailed'; error: string }
   | { type: 'changeStarted' }
   | { type: 'changeFailed'; error: string }
@@ -79,6 +81,7 @@ export type SecurityAction =
 export const initialSecurityState: SecurityState = {
   oldPassword: '',
   newPassword: '',
+  confirmPassword: '',
   isChanging: false,
   error: null,
 }
@@ -89,6 +92,8 @@ export function securityReducer(state: SecurityState, action: SecurityAction): S
       return { ...state, oldPassword: action.password }
     case 'newPasswordChanged':
       return { ...state, newPassword: action.password }
+    case 'confirmPasswordChanged':
+      return { ...state, confirmPassword: action.password }
     case 'validationFailed':
       return { ...state, error: action.error }
     case 'changeStarted':

--- a/frontend/src/test/auth-session.tsx
+++ b/frontend/src/test/auth-session.tsx
@@ -10,6 +10,7 @@ export const testUser: User = {
   nickname: 'Reader',
   emailVerifiedAt: '2026-08-07T01:02:03Z',
   statusCode: 0,
+  hasPassword: true,
 }
 
 function tokens(): AuthTokens {
@@ -30,6 +31,7 @@ export function createAuthenticatedTestApis(): UserApis {
     logout: async () => undefined,
     me: async () => testUser,
     updateNickname: async () => testUser,
+    setPassword: async () => undefined,
     changePassword: async () => undefined,
   }
 }
@@ -43,6 +45,7 @@ const guestApis: UserApis = {
   logout: async () => undefined,
   me: async () => Promise.reject(new Error('guest test session has no current user')),
   updateNickname: async () => Promise.reject(new Error('guest test session cannot update profile')),
+  setPassword: async () => Promise.reject(new Error('guest test session cannot set password')),
   changePassword: async () =>
     Promise.reject(new Error('guest test session cannot change password')),
 }

--- a/openapi.json
+++ b/openapi.json
@@ -3225,6 +3225,22 @@
         "title": "SendCodeRequest",
         "type": "object"
       },
+      "SetPasswordRequest": {
+        "description": "设置初始密码请求。",
+        "properties": {
+          "new_password": {
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "New Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "new_password"
+        ],
+        "title": "SetPasswordRequest",
+        "type": "object"
+      },
       "TokenResponse": {
         "description": "登录/注册/刷新成功响应。",
         "properties": {
@@ -3325,6 +3341,11 @@
             ],
             "title": "Email Verified At"
           },
+          "has_password": {
+            "default": false,
+            "title": "Has Password",
+            "type": "boolean"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -3392,6 +3413,11 @@
               }
             ],
             "title": "Email Verified At"
+          },
+          "has_password": {
+            "default": false,
+            "title": "Has Password",
+            "type": "boolean"
           },
           "id": {
             "anyOf": [
@@ -4105,6 +4131,48 @@
           }
         },
         "summary": "Send Code",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/auth/set-password": {
+      "post": {
+        "description": "设置初始密码（仅未设密码用户）。",
+        "operationId": "set_password_auth_set_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetPasswordRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_NoneType_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Set Password",
         "tags": [
           "auth"
         ]


### PR DESCRIPTION
## Summary

- 空 `password_hash` 不再触发 bcrypt 500；密码登录返回明确业务错误
- 新增 `POST /auth/set-password` 与 `has_password` 字段，供首次设密与账号中心分流
- 验证码建号登录后展示可跳过的设置密码提示
- 账号中心按 `hasPassword` 区分「设置密码」与「修改密码」
- `/auth/reset-password` 加入鉴权白名单

Closes #805

## Test plan

- [x] `uv run pytest tests/test_user_service.py`（新增空哈希登录/改密、set-password 用例）
- [x] `uv run pytest tests/test_auth_api.py`（reset-password 无 token、set-password）
- [x] `npm test -- --run src/entities/user/api.test.ts src/pages/account/state.test.ts src/features/auth-session/index.test.tsx`
- [ ] 手工：验证码建号 → 跳过/设置密码 → 密码登录
- [ ] 手工：密码注册 → 账号中心改密 → 重新登录