### PR TITLE
fix(quick-start): recover failed directions in one retry

### DIFF
--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -2171,6 +2171,78 @@ describe('WorkflowController', () => {
     ])
   })
 
+  it('一个方向进入重试后仍允许补跑同节点的其它失败方向', async () => {
+    const run = createRun([
+      setupNode({
+        status: 'passed',
+        phase: 'completed',
+        input: { prompt: '像素骑士', referenceMedia: [], characterId: 'character-1' },
+      }),
+      templateNode({ status: 'passed', phase: 'completed', selectedImageUrl: 'east-template.png' }),
+      firstFrameNode({
+        status: 'passed',
+        phase: 'completed',
+        selectedFirstFrameUrl: 'east-frame.png',
+        selectedFirstFrameUrls: {
+          east: 'east-frame.png',
+          north: 'north-frame.png',
+          south: 'south-frame.png',
+        },
+      }),
+      generationMethodNode({ status: 'passed', phase: 'completed', method: 'video-cropping' }),
+      fullFrameNode({
+        status: 'active',
+        phase: 'generating',
+        input: { prompt: '向前挥拳、击中后自然收势' },
+        generations: [
+          { taskId: 'retry-east', role: 'complete_animation' },
+          { taskId: 'failed-north', role: 'complete_animation', direction: 'north' },
+          { taskId: 'failed-south', role: 'complete_animation', direction: 'south' },
+        ],
+        error: null,
+      }),
+      reviewNode(),
+    ])
+    const { controller, generation } = createController(run, 'four-way')
+    generation.snapshots.set('retry-east', {
+      id: 'retry-east',
+      projectId: '1',
+      type: 'complete_animation',
+      status: 'pending',
+      result: null,
+      error: null,
+    })
+    for (const direction of ['north', 'south'] as const) {
+      generation.snapshots.set(`failed-${direction}`, {
+        id: `failed-${direction}`,
+        projectId: '1',
+        type: 'complete_animation',
+        status: 'failed',
+        result: null,
+        error: `${direction} provider failed`,
+      })
+    }
+
+    await controller.retryGenerationDirection('action-walk:action-full-frame', 'north', {
+      spriteWidth: 64,
+      spriteHeight: 64,
+    })
+    await controller.retryGenerationDirection('action-walk:action-full-frame', 'south', {
+      spriteWidth: 64,
+      spriteHeight: 64,
+    })
+
+    expect(generation.apis.create).toHaveBeenCalledTimes(2)
+    expect(generation.apis.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ direction: 'north' }),
+    )
+    expect(generation.apis.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ direction: 'south' }),
+    )
+  })
+
   it('重试东向时只清空对应的兼容选择字段', async () => {
     const templateRetry = createController(
       createRun([

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -1287,13 +1287,27 @@ export function createWorkflowController({
     const originalNode = structuredClone(findNode(before, nodeId))
     const role = generationRoleForNode(originalNode)
     if (!role) throw new Error('目标节点不是生成节点')
-    if (originalNode.status !== 'failed' && originalNode.phase !== 'selecting') {
-      throw new Error('当前方向不能重新生成')
-    }
     const reference = originalNode.generations.find(
       (item) => item.role === role && generationReferenceDirection(item) === direction,
     )
     if (!reference) throw new Error(`方向 ${direction} 没有可替换的生成任务`)
+    if (originalNode.status !== 'failed' && originalNode.phase !== 'selecting') {
+      if (originalNode.status !== 'active' || originalNode.phase !== 'generating') {
+        throw new Error('当前方向不能重新生成')
+      }
+      const expectation = generationExpectationForNode(
+        before,
+        originalNode,
+        reference.direction,
+        reference.role,
+      )
+      const generation = expectation
+        ? await generationApis.get(before.projectId, reference.taskId, expectation)
+        : null
+      if (generation?.status !== 'failed') {
+        throw new Error('当前方向不能重新生成')
+      }
+    }
     if (originalNode.type !== 'action-full-frame') {
       ensurePositiveInteger(options.spriteWidth, 'spriteWidth')
       ensurePositiveInteger(options.spriteHeight, 'spriteHeight')

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -3864,6 +3864,37 @@ describe('QuickStartPage', () => {
     )
   })
 
+  it('一次补跑同一节点当前所有失败方向并保留进行中反馈', async () => {
+    const run = actionWorkflow({ fullStatus: 'failed', error: '多个方向失败' })
+    const firstRetry = deferred<WorkflowRun>()
+    const service = serviceFor(run, {
+      getFailedGenerationDirections: vi.fn(async () => [
+        { nodeId: 'action-full', direction: 'east' as const },
+        { nodeId: 'action-full', direction: 'north' as const },
+        { nodeId: 'action-full', direction: 'south' as const },
+      ]),
+      retryGenerationDirection: vi
+        .fn()
+        .mockImplementationOnce(() => firstRetry.promise)
+        .mockResolvedValue(run),
+    })
+    renderAt('/quick-start/run-1', service)
+
+    expect(
+      await screen.findByLabelText('动作生成失败 已完成的方向会保留，点击下方可重试失败方向。'),
+    ).toBeTruthy()
+    const retry = await screen.findByRole('button', { name: '重试失败方向' })
+    fireEvent.click(retry)
+
+    const retrying = await screen.findByRole('button', { name: '正在重试失败方向…' })
+    expect((retrying as HTMLButtonElement).disabled).toBe(true)
+    firstRetry.resolve(run)
+    await waitFor(() => expect(service.retryGenerationDirection).toHaveBeenCalledTimes(3))
+    expect(service.retryGenerationDirection).toHaveBeenNthCalledWith(1, 'action-full', 'east')
+    expect(service.retryGenerationDirection).toHaveBeenNthCalledWith(2, 'action-full', 'north')
+    expect(service.retryGenerationDirection).toHaveBeenNthCalledWith(3, 'action-full', 'south')
+  })
+
   it('角色母版失败时也提供定向重试入口', async () => {
     const run = workflow(
       setupAndTemplate({

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -2726,7 +2726,7 @@ function QuickStartRun({
     readonly (readonly [string, string])[]
   >([])
   const [failedDirections, setFailedDirections] = useState<readonly QuickStartFailedDirection[]>([])
-  const [retryingDirection, setRetryingDirection] = useState<string | null>(null)
+  const [retryingDirectionsForNode, setRetryingDirectionsForNode] = useState<string | null>(null)
   const [exportModel, setExportModel] = useState<ExportPackageModel | null>(null)
   const [publishing, setPublishing] = useState(false)
   const [confirmingCandidate, setConfirmingCandidate] = useState(false)
@@ -3439,22 +3439,34 @@ function QuickStartRun({
     }
   }
 
-  async function retryFailedDirection(item: QuickStartFailedDirection) {
+  async function retryFailedDirections(items: readonly QuickStartFailedDirection[]) {
     const targetSession = session
-    if (!targetSession || workflowConflictRef.current) return
-    const key = `${item.nodeId}:${item.direction}`
-    setRetryingDirection(key)
+    const nodeId = items[0]?.nodeId
+    if (!targetSession || !nodeId || workflowConflictRef.current) return
+    setRetryingDirectionsForNode(nodeId)
     clearWorkflowError()
+    let latestRun: WorkflowRun | null = null
+    let firstFailure: unknown = null
     try {
-      const updated = await targetSession.retryGenerationDirection(item.nodeId, item.direction)
+      for (const item of items) {
+        try {
+          latestRun = await targetSession.retryGenerationDirection(item.nodeId, item.direction)
+        } catch (cause) {
+          firstFailure ??= cause
+        }
+      }
       if (!mountedRef.current || activeSessionRef.current !== targetSession) return
-      setRun(updated)
-    } catch (cause) {
-      if (!mountedRef.current || activeSessionRef.current !== targetSession) return
-      reportWorkflowError(cause, `重试${DIRECTION_LABELS[item.direction]}方向失败`)
+      if (latestRun) setRun(latestRun)
+      if (firstFailure) {
+        const fallback =
+          items.length === 1
+            ? `重试${DIRECTION_LABELS[items[0]!.direction]}方向失败`
+            : '重试失败方向时仍有任务未能恢复'
+        reportWorkflowError(firstFailure, fallback)
+      }
     } finally {
       if (mountedRef.current && activeSessionRef.current === targetSession) {
-        setRetryingDirection(null)
+        setRetryingDirectionsForNode(null)
       }
     }
   }
@@ -3462,25 +3474,18 @@ function QuickStartRun({
   function DirectionRetryButtons({ nodeId }: { nodeId: string }) {
     const items = failedDirections.filter((item) => item.nodeId === nodeId)
     if (items.length === 0) return null
+    const retrying = retryingDirectionsForNode === nodeId
+    const label =
+      items.length === 1 ? `重试${DIRECTION_LABELS[items[0]!.direction]}方向` : '重试失败方向'
     return (
-      <div className="flex flex-wrap gap-2">
-        {items.map((item) => {
-          const key = `${item.nodeId}:${item.direction}`
-          return (
-            <button
-              key={key}
-              type="button"
-              onClick={() => void retryFailedDirection(item)}
-              disabled={retryingDirection !== null || workflowConflict}
-              className="rounded-lg border border-current px-3 py-1.5 text-xs font-bold text-app-danger disabled:opacity-50"
-            >
-              {retryingDirection === key
-                ? `正在重试${DIRECTION_LABELS[item.direction]}方向…`
-                : `重试${DIRECTION_LABELS[item.direction]}方向`}
-            </button>
-          )
-        })}
-      </div>
+      <button
+        type="button"
+        onClick={() => void retryFailedDirections(items)}
+        disabled={retryingDirectionsForNode !== null || workflowConflict}
+        className="rounded-lg border border-current px-3 py-1.5 text-xs font-bold text-app-danger disabled:opacity-50"
+      >
+        {retrying ? `正在${label}…` : label}
+      </button>
     )
   }
 
@@ -3949,7 +3954,7 @@ function QuickStartRun({
                     <>
                       <AgentCopy
                         tone="danger"
-                        lines={['动作首帧生成失败', '内容还在，可以在下面修改要求后重试。']}
+                        lines={['动作首帧生成失败', '已完成的方向会保留，点击下方可重试失败方向。']}
                       />
                       <DirectionRetryButtons nodeId={firstFrameStep.id} />
                     </>
@@ -4065,7 +4070,7 @@ function QuickStartRun({
                     <>
                       <AgentCopy
                         tone="danger"
-                        lines={['动作生成失败', '内容还在，可以在下面修改要求后重试。']}
+                        lines={['动作生成失败', '已完成的方向会保留，点击下方可重试失败方向。']}
                       />
                       <DirectionRetryButtons nodeId={actionStep.id} />
                     </>


### PR DESCRIPTION
Quick Start 现在会一次补跑同一动作中所有失败方向，同时保留已经成功的方向，避免用户手动判断并排序多个内部重试。

## Why

生产中的多方向动作生成在上游限流和线路异常后出现了部分方向失败。原实现一旦某个方向进入重试，节点就会回到生成态，后续失败方向会被 Controller 拒绝，用户看到多个重试入口却无法可靠完成恢复。

## Changes

- 将同一节点的失败方向合并为一个重试入口，按顺序补跑当前全部失败方向。
- 保留已成功方向和最新 WorkflowRun；单次补跑仍失败时继续尝试剩余方向并保留重试入口。
- 明确提示已完成方向不会丢失，并提供统一的进行中反馈。
- Controller 仅在目标方向任务快照确实为 failed 时，允许生成中节点继续补跑该方向。

## Implementation

- Quick Start 按 nodeId 聚合失败方向，顺序调用现有 retryGenerationDirection，避免并发写入 WorkflowRun 版本冲突。
- Controller 不放宽普通生成任务：active/generating 状态下仍会读取目标任务快照，只有 failed 才能重新生成。
- 不增加无限自动重试，也不改变 Gateway 路由、付费调用边界或数据模型。

## Verification

- [x] `npm test -- src/features/workflow-controller/controller.test.ts src/pages/quick-start/index.test.tsx`：2 个测试文件、242 个测试通过。
- [x] `npm run typecheck`：通过。
- [x] `npx oxlint src/features/workflow-controller/controller.ts src/features/workflow-controller/controller.test.ts src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npx oxfmt --check src/features/workflow-controller/controller.ts src/features/workflow-controller/controller.test.ts src/pages/quick-start/index.tsx src/pages/quick-start/index.test.tsx`：通过。
- [x] `npm run build`：通过；仅有既有分块体积提示。
- [x] `git diff --check`：通过。
- 浏览器验收与截图：未执行（用户明确要求跳过）。

## Scope

- 本 PR 不包含：Gateway 重试策略、模型供应商路由、计费逻辑、数据结构、页面布局重设计或生产部署。
- 后续事项：合并后再按生产发布流程同步，不把未合并代码直接部署到现网。

## Related Issues

Closes #808