### PR TITLE
feat: 增加积分兑换券管理平台

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,8 @@ VITE_API_BASE_URL=/api
 WINDUP_CORS_ORIGINS=
 # 跨域正则匹配（默认关闭；如需 Vercel 预览域名，请限制到自己的项目名前缀）
 WINDUP_CORS_ORIGIN_REGEX=
+# 管理员邮箱白名单，逗号分隔；生产环境在私有 .env 中填写真实邮箱
+WINDUP_ADMIN_EMAILS=admin@example.com
 
 # ── MQ（Redis Stream 轻量消息队列） ──
 # 本地/Compose 须同时起 web + worker，否则生成任务会一直 PENDING、邮件不会发出。

--- a/backend/packages/app/src/windup_app/bootstrap/app.py
+++ b/backend/packages/app/src/windup_app/bootstrap/app.py
@@ -34,6 +34,7 @@ from windup_app.server.user.model import User  # noqa: F401
 from windup_app.server.workflow_run.model import WorkflowRun  # noqa: F401
 from windup_app.server.action_preset import ACTION_PRESETS
 from windup_app.web.api.action_preset import router as action_preset_router
+from windup_app.web.api.admin_quota import router as admin_quota_router
 from windup_app.web.api.agent import router as agent_router
 from windup_framework.mq.model import MqMessage  # noqa: F401
 from windup_app.web.api.auth import router as auth_router
@@ -175,6 +176,7 @@ def create_app() -> FastAPI:
     app.include_router(media_router)
     app.include_router(generation_router)
     app.include_router(quota_router)
+    app.include_router(admin_quota_router)
     app.include_router(render3d_router)
     app.include_router(agent_router)
     app.include_router(action_preset_router)

--- a/backend/packages/app/src/windup_app/server/quota/redemption.py
+++ b/backend/packages/app/src/windup_app/server/quota/redemption.py
@@ -3,16 +3,37 @@
 from __future__ import annotations
 
 import secrets
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
 
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
+from windup_common.exceptions import BizException
 from windup_app.server.quota.model import CreditRedemptionCode
 from windup_app.server.quota.service import redemption_code_hash
 
 _ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
 _BODY_LENGTH = 12
-_AMOUNT = 1000
+
+RedemptionCodeStatus = Literal[
+    "valid",
+    "redeemed",
+    "expired",
+    "not_found",
+    "invalid_format",
+]
+
+
+@dataclass(frozen=True)
+class RedemptionCodeInspection:
+    """兑换码的只读状态视图。"""
+
+    status: RedemptionCodeStatus
+    amount: int | None = None
+    expires_at: datetime | None = None
+    redeemed_at: datetime | None = None
 
 
 def _format_code(body: str) -> str:
@@ -25,11 +46,17 @@ def _new_code() -> str:
 
 
 def create_codes(
-    session, *, count: int, expires_at: datetime | None = None
+    session,
+    *,
+    count: int,
+    amount: int = 1000,
+    expires_at: datetime | None = None,
 ) -> list[str]:
     """生成兑换码并 flush；提交事务由调用方控制。"""
     if count < 1:
         raise ValueError("count must be positive")
+    if amount < 1:
+        raise ValueError("amount must be positive")
 
     codes: list[str] = []
     hashes: set[str] = set()
@@ -52,9 +79,48 @@ def create_codes(
         session.add(
             CreditRedemptionCode(
                 code_hash=digest,
-                amount=_AMOUNT,
+                amount=amount,
                 expires_at=expires_at,
             )
         )
     session.flush()
     return codes
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def inspect_code(
+    session: Session,
+    code: str,
+    *,
+    now: datetime | None = None,
+) -> RedemptionCodeInspection:
+    """只读查询兑换码状态，不锁行、不 flush，也不更新任何字段。"""
+    try:
+        digest = redemption_code_hash(code)
+    except BizException:
+        return RedemptionCodeInspection(status="invalid_format")
+
+    row = session.scalar(
+        select(CreditRedemptionCode).where(CreditRedemptionCode.code_hash == digest)
+    )
+    if row is None:
+        return RedemptionCodeInspection(status="not_found")
+
+    current = _utc(now or datetime.now(timezone.utc))
+    if row.redeemed_by is not None:
+        status: RedemptionCodeStatus = "redeemed"
+    elif row.expires_at is not None and _utc(row.expires_at) <= current:
+        status = "expired"
+    else:
+        status = "valid"
+    return RedemptionCodeInspection(
+        status=status,
+        amount=row.amount,
+        expires_at=_utc(row.expires_at) if row.expires_at is not None else None,
+        redeemed_at=_utc(row.redeemed_at) if row.redeemed_at is not None else None,
+    )

--- a/backend/packages/app/src/windup_app/web/api/admin_quota.py
+++ b/backend/packages/app/src/windup_app/web/api/admin_quota.py
@@ -1,0 +1,140 @@
+"""管理员积分兑换码 API。"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import AwareDatetime, BaseModel, Field, model_validator
+from sqlalchemy.orm import Session
+
+from windup_common.exceptions import BizException
+from windup_common.result import Response
+from windup_framework.config.admin import settings as admin_settings
+from windup_framework.db import get_session
+
+from windup_app.server.quota.redemption import create_codes, inspect_code
+from windup_app.server.user.model import User, UserStatus
+
+router = APIRouter(prefix="/admin/quota/redemption-codes", tags=["admin-quota"])
+logger = logging.getLogger("windup.admin.quota.api")
+
+
+class AdminAccessOut(BaseModel):
+    """管理页访问探针响应。"""
+
+    allowed: bool
+
+
+class GenerateCodesIn(BaseModel):
+    """批量生成兑换码参数。"""
+
+    count: int = Field(ge=1, le=100)
+    amount: int = Field(ge=1, le=1_000_000)
+    expires_at: AwareDatetime | None = None
+
+    @model_validator(mode="after")
+    def future_expiry(self) -> "GenerateCodesIn":
+        if self.expires_at is not None and self.expires_at <= datetime.now(timezone.utc):
+            raise ValueError("有效期必须晚于当前时间")
+        return self
+
+
+class GeneratedCodesOut(BaseModel):
+    """明文只随本次响应返回。"""
+
+    count: int
+    amount: int
+    expires_at: datetime | None
+    codes: list[str]
+
+
+class ValidateCodeIn(BaseModel):
+    """待核验的兑换码。"""
+
+    code: str = Field(max_length=64)
+
+
+class ValidateCodeOut(BaseModel):
+    """兑换码只读核验结果。"""
+
+    status: Literal["valid", "redeemed", "expired", "not_found", "invalid_format"]
+    amount: int | None
+    expires_at: datetime | None
+    redeemed_at: datetime | None
+
+
+def require_admin_user(
+    request: Request,
+    session: Session = Depends(get_session),
+) -> User:
+    """重新读取数据库用户，并校验状态与服务端邮箱白名单。"""
+    user = session.get(User, request.state.current_user.id)
+    if (
+        user is None
+        or user.status != UserStatus.NORMAL
+        or user.email.strip().lower() not in admin_settings.admin_email_set
+    ):
+        raise BizException("没有管理员权限", code=403)
+    return user
+
+
+@router.get("/access", response_model=Response[AdminAccessOut])
+def check_admin_access(
+    _admin: User = Depends(require_admin_user),
+) -> Response[AdminAccessOut]:
+    """供管理页加载时确认当前会话是否具备管理员权限。"""
+    return Response.success(AdminAccessOut(allowed=True))
+
+
+@router.post("", response_model=Response[GeneratedCodesOut])
+def generate_redemption_codes(
+    payload: GenerateCodesIn,
+    session: Session = Depends(get_session),
+    admin: User = Depends(require_admin_user),
+) -> Response[GeneratedCodesOut]:
+    """批量生成兑换码；数据库只保存摘要，明文只返回一次。"""
+    codes = create_codes(
+        session,
+        count=payload.count,
+        amount=payload.amount,
+        expires_at=payload.expires_at,
+    )
+    logger.info(
+        "[WINDUP] 管理员生成兑换码 | admin_user_id=%s count=%s amount=%s expires_at=%s",
+        admin.id,
+        payload.count,
+        payload.amount,
+        payload.expires_at,
+    )
+    return Response.success(
+        GeneratedCodesOut(
+            count=len(codes),
+            amount=payload.amount,
+            expires_at=payload.expires_at,
+            codes=codes,
+        )
+    )
+
+
+@router.post("/validate", response_model=Response[ValidateCodeOut])
+def validate_redemption_code(
+    payload: ValidateCodeIn,
+    session: Session = Depends(get_session),
+    admin: User = Depends(require_admin_user),
+) -> Response[ValidateCodeOut]:
+    """核验兑换码状态，不消费兑换码，也不修改积分数据。"""
+    inspected = inspect_code(session, payload.code)
+    logger.info(
+        "[WINDUP] 管理员核验兑换码 | admin_user_id=%s status=%s",
+        admin.id,
+        inspected.status,
+    )
+    return Response.success(
+        ValidateCodeOut(
+            status=inspected.status,
+            amount=inspected.amount,
+            expires_at=inspected.expires_at,
+            redeemed_at=inspected.redeemed_at,
+        )
+    )

--- a/backend/packages/framework/src/windup_framework/config/admin.py
+++ b/backend/packages/framework/src/windup_framework/config/admin.py
@@ -1,0 +1,28 @@
+"""管理端访问控制配置。"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AdminSettings(BaseSettings):
+    """从服务端环境变量读取管理员邮箱白名单。"""
+
+    model_config = SettingsConfigDict(
+        env_prefix="WINDUP_",
+        env_file=("../.env", ".env"),
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    admin_emails: str = ""
+
+    @property
+    def admin_email_set(self) -> frozenset[str]:
+        """返回去重、去空白且不区分大小写的邮箱集合。"""
+        return frozenset(
+            email.strip().lower()
+            for email in self.admin_emails.split(",")
+            if email.strip()
+        )
+
+
+settings = AdminSettings()

--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router'
 
 import { AssetLibraryPage } from '@/pages/asset-library'
 import { AccountPage } from '@/pages/account'
+import { AdminRedemptionCodesPage } from '@/pages/admin-redemption-codes'
 import { CharacterDetailPage } from '@/pages/character-detail'
 import { LandingPage } from '@/pages/landing'
 import { NotFoundPage } from '@/pages/not-found'
@@ -72,6 +73,7 @@ export function AppRoutes() {
         <Route element={<AppShellRoute />}>
           <Route path="/workspace" element={<WorkspacePage />} />
           <Route path="/account" element={<AccountPage />} />
+          <Route path="/admin/redemption-codes" element={<AdminRedemptionCodesPage />} />
           <Route path="/quick-start" element={<QuickStartRoute />} />
           <Route path="/quick-start/:runId" element={<QuickStartRoute />} />
           <Route path="/projects" element={<ProjectsPage />} />

--- a/frontend/src/entities/admin-redemption/api.ts
+++ b/frontend/src/entities/admin-redemption/api.ts
@@ -1,0 +1,103 @@
+import type {
+  AdminRedemptionApis,
+  CodeValidation,
+  GeneratedCodes,
+  GenerateCodesInput,
+  RedemptionCodeStatus,
+} from './types'
+
+import { createApiClient, getApiAccessToken } from '@/shared/api'
+import type { ApiClient, ApiClientOptions } from '@/shared/api'
+
+interface AdminAccessDto {
+  allowed: boolean
+}
+
+interface GeneratedCodesDto {
+  count: number
+  amount: number
+  expires_at: string | null
+  codes: string[]
+}
+
+interface CodeValidationDto {
+  status: RedemptionCodeStatus
+  amount: number | null
+  expires_at: string | null
+  redeemed_at: string | null
+}
+
+export interface CreateAdminRedemptionApisOptions extends ApiClientOptions {
+  client?: ApiClient
+}
+
+function toGeneratedCodes(dto: GeneratedCodesDto): GeneratedCodes {
+  return {
+    count: dto.count,
+    amount: dto.amount,
+    expiresAt: dto.expires_at,
+    codes: dto.codes,
+  }
+}
+
+function toCodeValidation(dto: CodeValidationDto): CodeValidation {
+  return {
+    status: dto.status,
+    amount: dto.amount,
+    expiresAt: dto.expires_at,
+    redeemedAt: dto.redeemed_at,
+  }
+}
+
+export function createAdminRedemptionApis(
+  options: CreateAdminRedemptionApisOptions = {},
+): AdminRedemptionApis {
+  const { client, ...clientOptions } = options
+  const protectedClient =
+    client ??
+    createApiClient({
+      ...clientOptions,
+      getAccessToken: clientOptions.getAccessToken ?? getApiAccessToken,
+    })
+
+  return {
+    async checkAccess() {
+      await protectedClient.request<AdminAccessDto>('/admin/quota/redemption-codes/access')
+    },
+    async generateCodes(input: GenerateCodesInput) {
+      return toGeneratedCodes(
+        await protectedClient.request<GeneratedCodesDto>('/admin/quota/redemption-codes', {
+          method: 'POST',
+          json: {
+            count: input.count,
+            amount: input.amount,
+            expires_at: input.expiresAt,
+          },
+          replayAfterAuth: false,
+        }),
+      )
+    },
+    async validateCode(code: string) {
+      return toCodeValidation(
+        await protectedClient.request<CodeValidationDto>('/admin/quota/redemption-codes/validate', {
+          method: 'POST',
+          json: { code },
+          replayAfterAuth: false,
+        }),
+      )
+    },
+  }
+}
+
+let defaultApis: AdminRedemptionApis | undefined
+
+function getDefaultApis(): AdminRedemptionApis {
+  defaultApis ??= createAdminRedemptionApis()
+  return defaultApis
+}
+
+export const adminRedemptionApis: AdminRedemptionApis = {
+  checkAccess: () => getDefaultApis().checkAccess(),
+  generateCodes: (input) => getDefaultApis().generateCodes(input),
+  validateCode: (code) => getDefaultApis().validateCode(code),
+}

--- a/frontend/src/entities/admin-redemption/index.ts
+++ b/frontend/src/entities/admin-redemption/index.ts
@@ -1,0 +1,9 @@
+export { adminRedemptionApis, createAdminRedemptionApis } from './api'
+export type { CreateAdminRedemptionApisOptions } from './api'
+export type {
+  AdminRedemptionApis,
+  CodeValidation,
+  GeneratedCodes,
+  GenerateCodesInput,
+  RedemptionCodeStatus,
+} from './types'

--- a/frontend/src/entities/admin-redemption/types.ts
+++ b/frontend/src/entities/admin-redemption/types.ts
@@ -1,0 +1,27 @@
+export type RedemptionCodeStatus = 'valid' | 'redeemed' | 'expired' | 'not_found' | 'invalid_format'
+
+export interface GenerateCodesInput {
+  count: number
+  amount: number
+  expiresAt: string | null
+}
+
+export interface GeneratedCodes {
+  count: number
+  amount: number
+  expiresAt: string | null
+  codes: string[]
+}
+
+export interface CodeValidation {
+  status: RedemptionCodeStatus
+  amount: number | null
+  expiresAt: string | null
+  redeemedAt: string | null
+}
+
+export interface AdminRedemptionApis {
+  checkAccess(): Promise<void>
+  generateCodes(input: GenerateCodesInput): Promise<GeneratedCodes>
+  validateCode(code: string): Promise<CodeValidation>
+}

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -22,6 +22,17 @@ export type {
   QuotaTransactionPageQuery,
 } from './quota'
 
+/* 管理员积分兑换码 —— 生成明文仅在内存中交付，核验严格只读 */
+export { adminRedemptionApis, createAdminRedemptionApis } from './admin-redemption'
+export type {
+  AdminRedemptionApis,
+  CodeValidation,
+  CreateAdminRedemptionApisOptions,
+  GeneratedCodes,
+  GenerateCodesInput,
+  RedemptionCodeStatus,
+} from './admin-redemption'
+
 /* 项目 —— 全局约束：视角、朝向、精灵尺寸、画风 */
 export {
   ART_STYLE,

--- a/frontend/src/pages/admin-redemption-codes/index.tsx
+++ b/frontend/src/pages/admin-redemption-codes/index.tsx
@@ -1,0 +1,525 @@
+import {
+  CheckCircle,
+  ClockCounterClockwise,
+  Copy,
+  DownloadSimple,
+  MagnifyingGlass,
+  ShieldCheck,
+  Ticket,
+  Trash,
+  WarningCircle,
+} from '@phosphor-icons/react'
+import { useEffect, useId, useState } from 'react'
+import type { FormEvent } from 'react'
+
+import { adminRedemptionApis } from '@/entities'
+import type {
+  AdminRedemptionApis,
+  CodeValidation,
+  GeneratedCodes,
+  RedemptionCodeStatus,
+} from '@/entities'
+import { ApiError } from '@/shared/api'
+
+interface AdminRedemptionCodesPageProps {
+  apis?: AdminRedemptionApis
+}
+
+type AccessState =
+  | { kind: 'loading' }
+  | { kind: 'allowed' }
+  | { kind: 'forbidden' }
+  | { kind: 'error'; message: string }
+
+const fieldClass =
+  'mt-2 min-h-11 w-full rounded-xl border border-app-line bg-app-surface px-3.5 py-2.5 text-sm text-app-ink outline-none transition focus:border-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-60'
+const primaryButtonClass =
+  'inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-app-ink px-5 text-sm font-semibold text-app-surface-raised transition-colors hover:bg-app-ink-soft focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-50'
+const secondaryButtonClass =
+  'inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-app-line bg-app-surface-raised px-3.5 text-sm font-semibold text-app-ink-soft transition-colors hover:border-app-line-strong hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:cursor-not-allowed disabled:opacity-50'
+
+const validationCopy: Record<
+  RedemptionCodeStatus,
+  { label: string; description: string; tone: string }
+> = {
+  valid: {
+    label: '当前有效',
+    description: '兑换码尚未使用，可以正常兑换。',
+    tone: 'border-app-line-strong bg-app-accent-muted text-app-accent',
+  },
+  redeemed: {
+    label: '已兑换',
+    description: '兑换码已被使用，不能再次兑换。',
+    tone: 'border-app-line-strong bg-app-surface-muted text-app-ink-soft',
+  },
+  expired: {
+    label: '已过期',
+    description: '兑换码已超过有效期，不能再使用。',
+    tone: 'border-app-warning-line bg-app-warning-soft text-app-warning',
+  },
+  not_found: {
+    label: '未找到',
+    description: '格式正确，但系统中没有这个兑换码。',
+    tone: 'border-app-danger/30 bg-app-danger/10 text-app-danger',
+  },
+  invalid_format: {
+    label: '格式无效',
+    description: '请输入完整的 Windup 积分兑换码。',
+    tone: 'border-app-danger/30 bg-app-danger/10 text-app-danger',
+  },
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message
+  return '操作失败，请稍后重试'
+}
+
+function formatMoment(value: string | null): string {
+  if (!value) return '未设置'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '时间未知'
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+function AccessStateView({
+  state,
+  onRetry,
+}: {
+  state: Exclude<AccessState, { kind: 'allowed' }>
+  onRetry: () => void
+}) {
+  if (state.kind === 'loading') {
+    return (
+      <main
+        aria-label="正在验证管理员权限"
+        className="grid min-h-[100dvh] place-items-center bg-app-canvas px-5 pt-16 text-app-ink"
+      >
+        <div className="text-center">
+          <ShieldCheck aria-hidden="true" className="mx-auto text-app-muted" size={32} />
+          <p className="mt-3 text-sm text-app-muted">正在验证管理员权限…</p>
+        </div>
+      </main>
+    )
+  }
+
+  const forbidden = state.kind === 'forbidden'
+  return (
+    <main className="grid min-h-[100dvh] place-items-center bg-app-canvas px-5 pt-16 text-app-ink">
+      <section className="w-full max-w-lg rounded-[1.5rem] border border-app-line bg-app-surface-raised p-7 text-center shadow-app-panel sm:p-9">
+        <WarningCircle aria-hidden="true" className="mx-auto text-app-muted" size={36} />
+        <h1 className="mt-5 font-serif text-3xl font-medium tracking-[-0.04em]">
+          {forbidden ? '无权访问' : '暂时无法验证权限'}
+        </h1>
+        <p className="mx-auto mt-3 max-w-sm text-sm leading-6 text-app-muted">
+          {forbidden ? '当前账号不在管理员白名单中。' : state.message}
+        </p>
+        {!forbidden ? (
+          <button type="button" onClick={onRetry} className={`${secondaryButtonClass} mt-6`}>
+            重新验证
+          </button>
+        ) : null}
+      </section>
+    </main>
+  )
+}
+
+function GeneratedResult({
+  result,
+  feedback,
+  onCopy,
+  onDownload,
+  onClear,
+}: {
+  result: GeneratedCodes
+  feedback: string | null
+  onCopy: () => void
+  onDownload: () => void
+  onClear: () => void
+}) {
+  return (
+    <section
+      aria-labelledby="generated-codes-title"
+      className="mt-6 overflow-hidden rounded-2xl border border-app-accent/25 bg-app-accent-soft"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-app-accent/15 px-4 py-4 sm:px-5">
+        <div>
+          <h3 id="generated-codes-title" className="font-semibold text-app-ink">
+            本次生成结果
+          </h3>
+          <p className="mt-1 text-xs leading-5 text-app-muted">
+            明文只展示一次。离开或刷新页面后无法恢复，请立即复制或下载。
+          </p>
+        </div>
+        <span className="rounded-full bg-app-surface-raised px-3 py-1 font-mono text-xs text-app-ink-soft">
+          {result.count} 个 · 每个 {result.amount.toLocaleString('zh-CN')} 积分
+        </span>
+      </div>
+      <ol className="max-h-72 divide-y divide-app-accent/10 overflow-y-auto bg-app-surface-raised/55">
+        {result.codes.map((code, index) => (
+          <li key={code} className="flex items-center gap-3 px-4 py-3 sm:px-5">
+            <span className="w-5 shrink-0 text-right font-mono text-xs text-app-faint">
+              {index + 1}
+            </span>
+            <code className="min-w-0 flex-1 select-all overflow-x-auto font-mono text-sm tracking-[0.08em] text-app-ink">
+              {code}
+            </code>
+          </li>
+        ))}
+      </ol>
+      <div className="flex flex-wrap items-center gap-2 border-t border-app-accent/15 px-4 py-4 sm:px-5">
+        <button type="button" onClick={onCopy} className={secondaryButtonClass}>
+          <Copy size={17} aria-hidden="true" />
+          全部复制
+        </button>
+        <button type="button" onClick={onDownload} className={secondaryButtonClass}>
+          <DownloadSimple size={17} aria-hidden="true" />
+          下载 TXT
+        </button>
+        <button type="button" onClick={onClear} className={secondaryButtonClass}>
+          <Trash size={17} aria-hidden="true" />
+          清空结果
+        </button>
+        {feedback ? (
+          <p role="status" aria-live="polite" className="ml-auto text-xs text-app-muted">
+            {feedback}
+          </p>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+function ValidationResult({ result }: { result: CodeValidation }) {
+  const copy = validationCopy[result.status]
+  const valid = result.status === 'valid'
+  return (
+    <section aria-live="polite" className={`mt-6 rounded-2xl border p-5 ${copy.tone}`}>
+      <div className="flex items-start gap-3">
+        {valid ? (
+          <CheckCircle size={24} weight="fill" aria-hidden="true" />
+        ) : (
+          <ClockCounterClockwise size={24} aria-hidden="true" />
+        )}
+        <div className="min-w-0">
+          <h3 className="font-semibold">{copy.label}</h3>
+          <p className="mt-1 text-sm leading-6 text-current/80">{copy.description}</p>
+        </div>
+      </div>
+      {result.amount !== null ? (
+        <dl className="mt-5 grid gap-3 border-t border-current/15 pt-4 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-xs text-current/65">积分额度</dt>
+            <dd className="mt-1 font-mono font-semibold">
+              {result.amount.toLocaleString('zh-CN')}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-current/65">有效期</dt>
+            <dd className="mt-1">{formatMoment(result.expiresAt)}</dd>
+          </div>
+          {result.redeemedAt ? (
+            <div className="sm:col-span-2">
+              <dt className="text-xs text-current/65">兑换时间</dt>
+              <dd className="mt-1">{formatMoment(result.redeemedAt)}</dd>
+            </div>
+          ) : null}
+        </dl>
+      ) : null}
+    </section>
+  )
+}
+
+export function AdminRedemptionCodesPage({
+  apis = adminRedemptionApis,
+}: AdminRedemptionCodesPageProps) {
+  const [access, setAccess] = useState<AccessState>({ kind: 'loading' })
+  const [count, setCount] = useState('10')
+  const [amount, setAmount] = useState('1000')
+  const [expiresAt, setExpiresAt] = useState('')
+  const [generated, setGenerated] = useState<GeneratedCodes | null>(null)
+  const [generationError, setGenerationError] = useState<string | null>(null)
+  const [generating, setGenerating] = useState(false)
+  const [generationFeedback, setGenerationFeedback] = useState<string | null>(null)
+  const [code, setCode] = useState('')
+  const [validation, setValidation] = useState<CodeValidation | null>(null)
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [validating, setValidating] = useState(false)
+  const countId = useId()
+  const amountId = useId()
+  const expiryId = useId()
+  const codeId = useId()
+
+  function verifyAccess() {
+    setAccess({ kind: 'loading' })
+    void apis.checkAccess().then(
+      () => setAccess({ kind: 'allowed' }),
+      (error) => {
+        if (error instanceof ApiError && error.code === 403) {
+          setAccess({ kind: 'forbidden' })
+          return
+        }
+        setAccess({ kind: 'error', message: errorMessage(error) })
+      },
+    )
+  }
+
+  useEffect(verifyAccess, [apis])
+
+  async function generate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const parsedCount = Number(count)
+    const parsedAmount = Number(amount)
+    if (!Number.isInteger(parsedCount) || parsedCount < 1 || parsedCount > 100) {
+      setGenerationError('生成数量需为 1–100 的整数')
+      return
+    }
+    if (!Number.isInteger(parsedAmount) || parsedAmount < 1 || parsedAmount > 1_000_000) {
+      setGenerationError('单码积分需为 1–1,000,000 的整数')
+      return
+    }
+    let expiryIso: string | null = null
+    if (expiresAt) {
+      const expiry = new Date(expiresAt)
+      if (Number.isNaN(expiry.getTime()) || expiry.getTime() <= Date.now()) {
+        setGenerationError('有效期必须晚于当前时间')
+        return
+      }
+      expiryIso = expiry.toISOString()
+    }
+
+    setGenerating(true)
+    setGenerationError(null)
+    setGenerationFeedback(null)
+    setGenerated(null)
+    try {
+      setGenerated(
+        await apis.generateCodes({
+          count: parsedCount,
+          amount: parsedAmount,
+          expiresAt: expiryIso,
+        }),
+      )
+    } catch (error) {
+      setGenerationError(errorMessage(error))
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  async function copyGeneratedCodes() {
+    if (!generated) return
+    try {
+      await navigator.clipboard.writeText(generated.codes.join('\n'))
+      setGenerationFeedback('兑换码已复制')
+    } catch {
+      setGenerationFeedback('复制失败，请重试')
+    }
+  }
+
+  function downloadGeneratedCodes() {
+    if (!generated) return
+    const blob = new Blob([`${generated.codes.join('\n')}\n`], {
+      type: 'text/plain;charset=utf-8',
+    })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `windup-redemption-codes-${new Date().toISOString().slice(0, 10)}.txt`
+    anchor.click()
+    URL.revokeObjectURL(url)
+    setGenerationFeedback('TXT 已下载')
+  }
+
+  async function validate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!code.trim()) {
+      setValidationError('请输入兑换码')
+      return
+    }
+    setValidating(true)
+    setValidation(null)
+    setValidationError(null)
+    try {
+      setValidation(await apis.validateCode(code.trim()))
+    } catch (error) {
+      setValidationError(errorMessage(error))
+    } finally {
+      setValidating(false)
+    }
+  }
+
+  if (access.kind !== 'allowed') {
+    return <AccessStateView state={access} onRetry={verifyAccess} />
+  }
+
+  return (
+    <main
+      data-admin-redemption-page
+      className="min-h-[100dvh] bg-app-canvas px-5 pb-20 pt-24 text-app-ink sm:px-8 sm:pt-28 lg:px-12"
+    >
+      <div className="mx-auto w-full max-w-[82rem]">
+        <header className="border-b border-app-line pb-8">
+          <div className="flex items-center gap-2 text-xs font-semibold tracking-[0.12em] text-app-muted uppercase">
+            <ShieldCheck size={16} aria-hidden="true" />
+            管理工具
+          </div>
+          <h1 className="mt-4 font-serif text-[clamp(2.5rem,6vw,4.75rem)] leading-none font-medium tracking-[-0.055em] text-app-ink">
+            积分兑换券
+          </h1>
+          <p className="mt-5 max-w-2xl text-sm leading-7 text-app-muted sm:text-base">
+            批量签发一次性积分码，并在不消耗兑换码的前提下核验当前状态。
+          </p>
+        </header>
+
+        <div className="mt-8 grid items-start gap-6 lg:grid-cols-[minmax(0,1.12fr)_minmax(22rem,0.88fr)]">
+          <section className="rounded-[1.5rem] border border-app-line bg-app-surface-raised p-5 shadow-app-panel sm:p-7">
+            <div className="flex items-start gap-3">
+              <span className="grid size-11 shrink-0 place-items-center rounded-xl bg-app-accent-soft text-app-accent">
+                <Ticket size={22} aria-hidden="true" />
+              </span>
+              <div>
+                <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">
+                  生成兑换码
+                </h2>
+                <p className="mt-1 text-sm leading-6 text-app-muted">
+                  每个兑换码只能使用一次，额度和有效期按本批次统一设置。
+                </p>
+              </div>
+            </div>
+
+            <form onSubmit={generate} className="mt-7">
+              <div className="grid gap-5 sm:grid-cols-2">
+                <label htmlFor={countId} className="text-sm font-medium text-app-ink-soft">
+                  生成数量
+                  <input
+                    id={countId}
+                    aria-label="生成数量"
+                    type="number"
+                    min={1}
+                    max={100}
+                    step={1}
+                    value={count}
+                    disabled={generating}
+                    onChange={(event) => setCount(event.target.value)}
+                    className={fieldClass}
+                  />
+                  <span className="mt-1.5 block text-xs font-normal text-app-faint">1–100 个</span>
+                </label>
+                <label htmlFor={amountId} className="text-sm font-medium text-app-ink-soft">
+                  单码积分
+                  <input
+                    id={amountId}
+                    aria-label="单码积分"
+                    type="number"
+                    min={1}
+                    max={1_000_000}
+                    step={1}
+                    value={amount}
+                    disabled={generating}
+                    onChange={(event) => setAmount(event.target.value)}
+                    className={fieldClass}
+                  />
+                  <span className="mt-1.5 block text-xs font-normal text-app-faint">
+                    1–1,000,000 积分
+                  </span>
+                </label>
+              </div>
+              <label
+                htmlFor={expiryId}
+                className="mt-5 block text-sm font-medium text-app-ink-soft"
+              >
+                有效期
+                <input
+                  id={expiryId}
+                  aria-label="有效期"
+                  type="datetime-local"
+                  value={expiresAt}
+                  disabled={generating}
+                  onChange={(event) => setExpiresAt(event.target.value)}
+                  className={fieldClass}
+                />
+                <span className="mt-1.5 block text-xs font-normal text-app-faint">
+                  可不填写；未设置时长期有效，直至被兑换。
+                </span>
+              </label>
+              {generationError ? (
+                <p role="alert" className="mt-4 text-sm text-app-danger">
+                  {generationError}
+                </p>
+              ) : null}
+              <button type="submit" disabled={generating} className={`${primaryButtonClass} mt-6`}>
+                <Ticket size={18} aria-hidden="true" />
+                {generating ? '正在生成…' : '生成兑换码'}
+              </button>
+            </form>
+
+            {generated ? (
+              <GeneratedResult
+                result={generated}
+                feedback={generationFeedback}
+                onCopy={() => void copyGeneratedCodes()}
+                onDownload={downloadGeneratedCodes}
+                onClear={() => {
+                  setGenerated(null)
+                  setGenerationFeedback(null)
+                }}
+              />
+            ) : null}
+          </section>
+
+          <section className="rounded-[1.5rem] border border-app-line bg-app-surface-raised p-5 shadow-app-panel sm:p-7">
+            <div className="flex items-start gap-3">
+              <span className="grid size-11 shrink-0 place-items-center rounded-xl bg-app-surface-muted text-app-ink-soft">
+                <MagnifyingGlass size={22} aria-hidden="true" />
+              </span>
+              <div>
+                <h2 className="text-xl font-semibold tracking-[-0.025em] text-app-ink-soft">
+                  核验兑换码
+                </h2>
+                <p className="mt-1 text-sm leading-6 text-app-muted">
+                  只读取状态，不会兑换、占用或改变积分。
+                </p>
+              </div>
+            </div>
+
+            <form onSubmit={validate} className="mt-7">
+              <label htmlFor={codeId} className="text-sm font-medium text-app-ink-soft">
+                待核验兑换码
+                <input
+                  id={codeId}
+                  aria-label="待核验兑换码"
+                  type="text"
+                  value={code}
+                  maxLength={64}
+                  autoComplete="off"
+                  spellCheck={false}
+                  disabled={validating}
+                  placeholder="WU-XXXX-XXXX-XXXX"
+                  onChange={(event) => setCode(event.target.value)}
+                  className={`${fieldClass} font-mono tracking-[0.06em]`}
+                />
+              </label>
+              {validationError ? (
+                <p role="alert" className="mt-4 text-sm text-app-danger">
+                  {validationError}
+                </p>
+              ) : null}
+              <button type="submit" disabled={validating} className={`${primaryButtonClass} mt-6`}>
+                <MagnifyingGlass size={18} aria-hidden="true" />
+                {validating ? '正在核验…' : '核验兑换码'}
+              </button>
+            </form>
+
+            {validation ? <ValidationResult result={validation} /> : null}
+          </section>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/openapi.json
+++ b/openapi.json
@@ -56,6 +56,20 @@
         "title": "ActionType",
         "type": "string"
       },
+      "AdminAccessOut": {
+        "description": "管理页访问探针响应。",
+        "properties": {
+          "allowed": {
+            "title": "Allowed",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "allowed"
+        ],
+        "title": "AdminAccessOut",
+        "type": "object"
+      },
       "ArtStyle": {
         "description": "项目的美术风格。\n\n只有 ``PIXEL`` 改变管线行为(出帧吸附母版像素网格、颜色吸回母版色板),其余取值\n只进提示词。像素网格密度不在这一维 —— 它由目标分辨率定,两处各定一遍会打架。",
         "enum": [
@@ -1586,6 +1600,81 @@
         "title": "FunctionDefinition",
         "type": "object"
       },
+      "GenerateCodesIn": {
+        "description": "批量生成兑换码参数。",
+        "properties": {
+          "amount": {
+            "maximum": 1000000.0,
+            "minimum": 1.0,
+            "title": "Amount",
+            "type": "integer"
+          },
+          "count": {
+            "maximum": 100.0,
+            "minimum": 1.0,
+            "title": "Count",
+            "type": "integer"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          }
+        },
+        "required": [
+          "count",
+          "amount"
+        ],
+        "title": "GenerateCodesIn",
+        "type": "object"
+      },
+      "GeneratedCodesOut": {
+        "description": "明文只随本次响应返回。",
+        "properties": {
+          "amount": {
+            "title": "Amount",
+            "type": "integer"
+          },
+          "codes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Codes",
+            "type": "array"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          }
+        },
+        "required": [
+          "count",
+          "amount",
+          "expires_at",
+          "codes"
+        ],
+        "title": "GeneratedCodesOut",
+        "type": "object"
+      },
       "GenerationTaskOut": {
         "description": "生成任务响应。",
         "properties": {
@@ -2704,6 +2793,48 @@
         "title": "ResetPasswordRequest",
         "type": "object"
       },
+      "Response_AdminAccessOut_": {
+        "properties": {
+          "code": {
+            "default": 200,
+            "description": "业务状态码:成功 200,失败非 200",
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AdminAccessOut"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "业务数据"
+          },
+          "message": {
+            "default": "success",
+            "description": "提示信息",
+            "title": "Message",
+            "type": "string"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "响应时间;默认不携带,不携带时省略",
+            "title": "Timestamp"
+          }
+        },
+        "title": "Response[AdminAccessOut]",
+        "type": "object"
+      },
       "Response_CharacterOut_": {
         "properties": {
           "code": {
@@ -2786,6 +2917,48 @@
           }
         },
         "title": "Response[CreditAccountOut]",
+        "type": "object"
+      },
+      "Response_GeneratedCodesOut_": {
+        "properties": {
+          "code": {
+            "default": 200,
+            "description": "业务状态码:成功 200,失败非 200",
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GeneratedCodesOut"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "业务数据"
+          },
+          "message": {
+            "default": "success",
+            "description": "提示信息",
+            "title": "Message",
+            "type": "string"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "响应时间;默认不携带,不携带时省略",
+            "title": "Timestamp"
+          }
+        },
+        "title": "Response[GeneratedCodesOut]",
         "type": "object"
       },
       "Response_GenerationTaskOut_": {
@@ -3116,6 +3289,48 @@
           }
         },
         "title": "Response[UserOut]",
+        "type": "object"
+      },
+      "Response_ValidateCodeOut_": {
+        "properties": {
+          "code": {
+            "default": 200,
+            "description": "业务状态码:成功 200,失败非 200",
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ValidateCodeOut"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "业务数据"
+          },
+          "message": {
+            "default": "success",
+            "description": "提示信息",
+            "title": "Message",
+            "type": "string"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "响应时间;默认不携带,不携带时省略",
+            "title": "Timestamp"
+          }
+        },
+        "title": "Response[ValidateCodeOut]",
         "type": "object"
       },
       "Response_WorkflowRunOut_": {
@@ -3466,6 +3681,80 @@
         "title": "UserView",
         "type": "object"
       },
+      "ValidateCodeIn": {
+        "description": "待核验的兑换码。",
+        "properties": {
+          "code": {
+            "maxLength": 64,
+            "title": "Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "ValidateCodeIn",
+        "type": "object"
+      },
+      "ValidateCodeOut": {
+        "description": "兑换码只读核验结果。",
+        "properties": {
+          "amount": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "redeemed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Redeemed At"
+          },
+          "status": {
+            "enum": [
+              "valid",
+              "redeemed",
+              "expired",
+              "not_found",
+              "invalid_format"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "amount",
+          "expires_at",
+          "redeemed_at"
+        ],
+        "title": "ValidateCodeOut",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "ctx": {
@@ -3636,6 +3925,112 @@
         "summary": "List Action Presets",
         "tags": [
           "action-presets"
+        ]
+      }
+    },
+    "/admin/quota/redemption-codes": {
+      "post": {
+        "description": "批量生成兑换码；数据库只保存摘要，明文只返回一次。",
+        "operationId": "generate_redemption_codes_admin_quota_redemption_codes_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateCodesIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_GeneratedCodesOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Generate Redemption Codes",
+        "tags": [
+          "admin-quota"
+        ]
+      }
+    },
+    "/admin/quota/redemption-codes/access": {
+      "get": {
+        "description": "供管理页加载时确认当前会话是否具备管理员权限。",
+        "operationId": "check_admin_access_admin_quota_redemption_codes_access_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_AdminAccessOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Check Admin Access",
+        "tags": [
+          "admin-quota"
+        ]
+      }
+    },
+    "/admin/quota/redemption-codes/validate": {
+      "post": {
+        "description": "核验兑换码状态，不消费兑换码，也不修改积分数据。",
+        "operationId": "validate_redemption_code_admin_quota_redemption_codes_validate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidateCodeIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_ValidateCodeOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Validate Redemption Code",
+        "tags": [
+          "admin-quota"
         ]
       }
     },


### PR DESCRIPTION
## 变更内容

- 新增管理员积分兑换券生成与只读核验接口
- 生成数量、单码积分和有效期均可配置
- 使用服务端邮箱白名单与数据库用户状态共同鉴权
- 新增与现有 Windup 产品风格一致的管理页面
- 明文兑换码只在生成响应中返回，不写入日志或浏览器持久化存储

## 验证

- 后端全量测试：1783 passed，14 skipped
- 前端全量测试：1241 passed
- 前端生产构建、lint、格式检查通过
- Ruff 与 import-linter 通过

Closes #815