### PR TITLE
feat(video): 生产默认视频型号更改

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,17 +37,21 @@ AI_BASE_URL=https://api.qnaigc.com/v1
 AI_API_KEY=your-ai-api-key
 AI_MODEL=your-chat-model
 # 各能力分开配型号：三条能力同时在用不同模型，共用一个字段会换一个连带换全部。
-# 取值即默认值——不写这两行时跑的就是它们。
+# 下面这几行的取值**就是代码里的默认值**，由 test_env_example_matches_code_defaults
+# 钉住 —— 之前没人钉，于是 AI_VIDEO_MODEL 在这里停在 kling-v2-5-turbo，而代码默认早
+# 换过两轮，照模板部署的人拿到的是第三个值。
 AI_CHAT_FALLBACKS=
 AI_IMAGE_MODEL=gpt-image-2
-AI_VIDEO_MODEL=kling-v2-5-turbo
+AI_VIDEO_MODEL=kling-v3-turbo-std
 AI_IMAGE_FALLBACKS=gemini-3.1-flash-image-preview
-AI_VIDEO_FALLBACKS=kling-v2-6
-# veo3.1 放行开关。默认 false：关着时它不进视频链，接口也选不到它。
-# 打开之前先看清它的计费档——本仓固定按 4s + 无声($0.20/秒)调用，
-# 上游默认(8s + 有声)是这一档的 4 倍。
+# 视频兜底默认是空的。生产该配上**跨协议面**的型号：kling-v2-5-turbo / kling-v2-6 走
+# OpenAI /videos 面，主力 kling-v3-turbo-std 走 FAL 队列面，一个面出问题另一个还能出片。
+# 同一个面里换版本号换不来这种分散。
+AI_VIDEO_FALLBACKS=
 # veo3.1 只对逗号分隔的这些用户 id 开放(组内做高质量素材用,不面向客户)。
-# 空 = 谁都不能用。它按秒计费且比 kling 贵,且**永远不进兜底链**,只能由请求显式指定。
+# 空 = 谁都不能用；它**永远不进兜底链**，只能由被授权的账号走到。
+# 它按秒计费且比 kling 贵：本仓固定按 4s + 无声($0.20/秒)调用，
+# 上游默认(8s + 有声)是这一档的 4 倍，那三项在代码里有硬断言兜着。
 AI_VIDEO_VEO_USER_IDS=
 # 留空即按型号查上游牌价（美元）；配了它就整条链共用这一个价，跨型号时会算错。
 AI_IMAGE_UNIT_COST=

--- a/backend/packages/framework/src/windup_framework/config/provider.py
+++ b/backend/packages/framework/src/windup_framework/config/provider.py
@@ -33,7 +33,11 @@ class AIProviderSettings(BaseSettings):
     # 运行期 —— 字段塞错不会立刻报错,任务照常 queued,直到生成阶段才 failed,
     # 而费用可能已经产生(2026-07-29 实测)。
     chat_model: str = "gpt-4o-mini"
-    video_model: str = "kling-v2-5-turbo"
+    # 2026-08-27 起默认 kling v3 turbo:同一角色同一提示词的对照里它明显更好,
+    # 而生产此前的默认 agnes-video-2.5-flash 近三天只成功过 1 次,实际出片一直靠
+    # 兜底链上的 kling-v2-5-turbo。**部署侧的 AI_VIDEO_MODEL 会覆盖这里**,改默认值
+    # 不等于线上生效,还要动 .env。
+    video_model: str = "kling-v3-turbo-std"
     image_model: str = "gpt-image-2"
     # 判官是**看图的聊天模型**,不是图像生成模型:它要读一张图然后回一段 JSON,而
     # ``image_model`` 那个型号只会回图;共用一个字段的话,换判官会连带把出图换掉。

--- a/backend/packages/framework/src/windup_framework/config/provider.py
+++ b/backend/packages/framework/src/windup_framework/config/provider.py
@@ -33,10 +33,12 @@ class AIProviderSettings(BaseSettings):
     # 运行期 —— 字段塞错不会立刻报错,任务照常 queued,直到生成阶段才 failed,
     # 而费用可能已经产生(2026-07-29 实测)。
     chat_model: str = "gpt-4o-mini"
-    # 2026-08-27 起默认 kling v3 turbo:同一角色同一提示词的对照里它明显更好,
-    # 而生产此前的默认 agnes-video-2.5-flash 近三天只成功过 1 次,实际出片一直靠
-    # 兜底链上的 kling-v2-5-turbo。**部署侧的 AI_VIDEO_MODEL 会覆盖这里**,改默认值
-    # 不等于线上生效,还要动 .env。
+    # 2026-08-27 起默认 kling v3 turbo:同一角色同一提示词的对照里它明显更好。
+    # 交付率也支持这个方向 —— 按首选型号统计线上动作任务的最终状态:
+    # agnes-video-2.5-flash 15 完成 / 6 失败(71%),kling-v2-5-turbo 56 完成 / 1 失败(95%)。
+    # 口径注意:``windup_ai_gateway_attempt`` 只记 ``submit`` 这一相,提交成功 ≠ 出片
+    # (agnes 21 次提交全部 200,但其中 6 个任务最终 failed),所以交付率必须回到任务状态看。
+    # **部署侧的 AI_VIDEO_MODEL 会覆盖这里**,改默认值不等于线上生效,还要动 .env。
     video_model: str = "kling-v3-turbo-std"
     image_model: str = "gpt-image-2"
     # 判官是**看图的聊天模型**,不是图像生成模型:它要读一张图然后回一段 JSON,而

--- a/backend/packages/framework/src/windup_framework/gateway/registry.py
+++ b/backend/packages/framework/src/windup_framework/gateway/registry.py
@@ -11,6 +11,8 @@ FAMILIES: dict[str, Family] = {
     "kling-v2-5-turbo": Family.VIDEO_INPUT_REFERENCE,
     "kling-v2-6": Family.VIDEO_INPUT_REFERENCE,
     "kling-video-o1": Family.VIDEO_IMAGE_LIST,  # 登记但不允许进 chain
+    # kling v3 turbo 只在 FAL 队列面上有;OpenAI /videos 面实测 model not found。
+    "kling-v3-turbo-std": Family.VIDEO_FAL_QUEUE,
     "veo3.1": Family.VIDEO_FAL_QUEUE,  # 登记≠放行,还要在 USER_GATED_MODELS 的白名单里
 }
 

--- a/backend/packages/framework/src/windup_framework/providers/protocol/__init__.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/__init__.py
@@ -1,9 +1,12 @@
 from .fal_queue import (
     FAL_I2V_ENDPOINTS,
+    FAL_VIDEO_ENDPOINTS,
     FalQueueVideoProtocol,
+    KlingQueueVideoProtocol,
     UnknownFalEndpointError,
     VeoQueueVideoProtocol,
     VeoSpendGuardError,
+    fal_video_protocol,
 )
 from .image_faces import (
     FAL_IMAGE_ENDPOINTS,
@@ -16,10 +19,16 @@ from .types import HttpCall, JobProtocol, VideoRequest
 
 __all__ = [
     "FAL_I2V_ENDPOINTS",
+    "FAL_VIDEO_ENDPOINTS",
+    "KlingQueueVideoProtocol",
+    "fal_video_protocol",
     "FAL_IMAGE_ENDPOINTS",
     "IMAGE_LIST_MODELS",
     "FalQueueImageFace",
     "FalQueueVideoProtocol",
+    "KlingQueueVideoProtocol",
+    "FAL_VIDEO_ENDPOINTS",
+    "fal_video_protocol",
     "HttpCall",
     "JobProtocol",
     "OpenAIImagesFace",

--- a/backend/packages/framework/src/windup_framework/providers/protocol/fal_queue.py
+++ b/backend/packages/framework/src/windup_framework/providers/protocol/fal_queue.py
@@ -22,9 +22,20 @@ from .types import HttpCall, VideoRequest
 #: (``{msg}_url is required``)与"这个端点不存在"在响应里长得一样。
 FAL_I2V_ENDPOINTS: Mapping[str, str] = {
     "fal-ai/kling-video/o1/image-to-video": "start_image_url",
+    "fal-ai/kling-video/v3/turbo/std/image-to-video": "image_url",
     "bytedance/seedance-2.0/image-to-video": "image_url",
     "fal-ai/veo3.1/image-to-video": "image_url",
     "fal-ai/vidu/q1/image-to-video": "image_url",
+}
+
+#: FAL 队列面的**视频型号 → 建单端点**。型号名由 :data:`FAMILIES` 登记,端点在这里定;
+#: 两张表分开是因为 family 只回答"走哪条协议面",而同一条面上不同型号的路径完全不同。
+#:
+#: ``kling-v3-turbo-std`` 只在这条面上有 —— OpenAI ``/videos`` 面实测报
+#: ``model not found or disabled: kling-v3-turbo``(2026-08-27),别再去那边找它。
+FAL_VIDEO_ENDPOINTS: Mapping[str, str] = {
+    "veo3.1": "fal-ai/veo3.1/image-to-video",
+    "kling-v3-turbo-std": "fal-ai/kling-video/v3/turbo/std/image-to-video",
 }
 
 #: 队列里还在跑。除这两个之外的状态一律当终态处理 —— 认不出的状态继续轮询,会把
@@ -354,3 +365,45 @@ def _assert_spend_pinned(body: dict[str, object]) -> None:
         raise VeoSpendGuardError(
             f"resolution 必须是 {VEO_RESOLUTIONS} 之一,收到 {body.get('resolution')!r}"
         )
+
+
+class KlingQueueVideoProtocol(FalQueueVideoProtocol):
+    """kling 在 FAL 队列面上的形状。与 veo 那条面的两处关键差别:
+
+    1. **首帧走 base64 dataURI,不需要先传对象存储。** 2026-08-27 实测十余次建单成片,
+       全部以 ``data:image/jpeg;base64,`` 发出。仓里那条"FAL 面只吃公网 URL"的归档
+       结论对 kling 不成立 —— 少一次上传就少一处会坏的地方,故沿用基类的 base64。
+    2. **``duration`` 必须显式给。** 基类不发它(十个端点的取值形态分 ``5`` / ``"5"`` /
+       ``"5s"`` 三种,猜错是一次已计费的 400);kling 这条已实测是**无后缀的字符串** ``"5"``。
+       不发就得听上游默认值,而默认值要是 10s 就是双倍价 —— 这类"漏了不报错、账单翻倍"
+       的字段一律显式钉住。
+    """
+
+    #: 实测取值形态:字符串、无 ``s`` 后缀(veo 那条面是 ``"4s"``,形状不同,别互相抄)。
+    DURATION = "5"
+
+    def build_submit(self, req: VideoRequest) -> HttpCall:
+        call = super().build_submit(req)
+        body = dict(call.body or {})
+        body["duration"] = self.DURATION
+        if not body.get("duration"):
+            raise ValueError("kling 建单必须带 duration,否则按上游默认档计费")
+        return HttpCall(
+            method=call.method, path=call.path, headers=call.headers, body=body
+        )
+
+
+def fal_video_protocol(model: str, api_key: str, *, base_url: str):
+    """按型号取 FAL 面的协议实现。
+
+    不做成一个类加分支:veo 有四个必填项与一条"首帧必须是公网 URL"的硬约束,
+    kling 一个都不适用,写进同一个类就得每家一个 if,而分支写错的代价是一次已计费的错档。
+    """
+    endpoint = FAL_VIDEO_ENDPOINTS.get(model)
+    if endpoint is None:
+        raise UnknownFalEndpointError(
+            f"型号 {model!r} 没有登记 FAL 端点,已登记: {sorted(FAL_VIDEO_ENDPOINTS)}"
+        )
+    if model == "veo3.1":
+        return VeoQueueVideoProtocol(api_key, base_url=base_url)
+    return KlingQueueVideoProtocol(api_key, endpoint, base_url=base_url)

--- a/backend/packages/framework/src/windup_framework/providers/sufy.py
+++ b/backend/packages/framework/src/windup_framework/providers/sufy.py
@@ -44,7 +44,7 @@ from windup_framework.gateway.types import AdapterResult
 
 from .interfaces import FirstFrameUploader, ImageProvider, VideoProvider
 from .protocol import HttpCall, VideoRequest
-from .protocol.fal_queue import VeoQueueVideoProtocol
+from .protocol.fal_queue import VeoQueueVideoProtocol, fal_video_protocol
 from .protocol.image_faces import FalQueueImageFace, OpenAIImagesFace
 from .protocol.openai_video import OpenAIVideoProtocol, fit_first_frame
 
@@ -120,8 +120,10 @@ class SufyVideoProvider(VideoProvider):
 
         if FAMILIES.get(model or "") is Family.VIDEO_FAL_QUEUE:
             # 每次现取:key 由 config 注入,provider 建好之后 config 仍可能被换。
-            return VeoQueueVideoProtocol(
-                self._cfg.api_key, base_url=self._cfg.normalized_base_url
+            # 按型号分派而不是一律给 veo 的面:同在 FAL 队列面上,veo 有四个必填项与
+            # "首帧必须公网 URL"的硬约束,kling 一个都不适用。
+            return fal_video_protocol(
+                model or "", self._cfg.api_key, base_url=self._cfg.normalized_base_url
             )
         return OpenAIVideoProtocol(self._cfg.api_key)
 

--- a/backend/tests/test_custom_action.py
+++ b/backend/tests/test_custom_action.py
@@ -236,8 +236,10 @@ def test_only_the_opened_models_are_accepted():
     from windup_framework.gateway.registry import ModelRegistry
     from windup_framework.gateway.types import Scene
 
-    r = ModelRegistry.from_settings(AIProviderSettings(video_fallbacks="kling-v2-6"))
-    assert set(r.chain(Scene.CHARACTER_ACTION)) == {"kling-v2-5-turbo", "kling-v2-6"}
+    cfg = AIProviderSettings(video_fallbacks="kling-v2-6")
+    r = ModelRegistry.from_settings(cfg)
+    # 主力从配置推:这条断言的是"链 = 主力 + 兜底",不是"默认型号叫什么"。
+    assert set(r.chain(Scene.CHARACTER_ACTION)) == {cfg.video_model, "kling-v2-6"}
 
 
 def test_unknown_model_fails_at_entry_not_at_the_paid_call():
@@ -246,7 +248,9 @@ def test_unknown_model_fails_at_entry_not_at_the_paid_call():
 
     with pytest.raises(ValueError) as e:
         _resolve_video_model("sora-2")
-    assert "kling-v2-5-turbo" in str(e.value), "报错要带上可选值,否则调用方无从改"
+    from windup_framework.config.provider import AIProviderSettings
+
+    assert AIProviderSettings().video_model in str(e.value), "报错要带上可选值,否则调用方无从改"
 
 
 def test_start_from_model_reuses_one_generator():

--- a/backend/tests/test_env_example_keys_are_live.py
+++ b/backend/tests/test_env_example_keys_are_live.py
@@ -93,3 +93,51 @@ def test_every_example_key_is_actually_read():
         "填了不生效比不填更糟——部署方以为配置生效了。"
         "确认前缀与对应 BaseSettings 的 env_prefix 一致。"
     )
+
+
+# ── 值也要对，不只是键存在 ────────────────────────────────────────────────
+
+
+def _example_pairs() -> dict[str, str]:
+    if not _ENV_EXAMPLE.is_file():
+        pytest.skip(f"没有 {_ENV_EXAMPLE}")
+    out: dict[str, str] = {}
+    for line in _ENV_EXAMPLE.read_text(encoding="utf-8").splitlines():
+        if m := re.match(r"^([A-Z][A-Z0-9_]*)=(.*)$", line.strip()):
+            out[m.group(1)] = m.group(2)
+    return out
+
+
+#: 声称"取值即默认值"的那几个键。只列这几个而不是全表:大部分键是**站位值**
+#: (``AI_API_KEY=your-ai-api-key``),它们本来就不该等于默认值。
+_PINNED_TO_DEFAULT = {
+    "AI_CHAT_FALLBACKS": ("provider", "chat_fallbacks"),
+    "AI_IMAGE_MODEL": ("provider", "image_model"),
+    "AI_VIDEO_MODEL": ("provider", "video_model"),
+    "AI_IMAGE_FALLBACKS": ("provider", "image_fallbacks"),
+    "AI_VIDEO_FALLBACKS": ("provider", "video_fallbacks"),
+    "AI_VIDEO_VEO_USER_IDS": ("provider", "video_veo_user_ids"),
+}
+
+
+@pytest.mark.parametrize("key", sorted(_PINNED_TO_DEFAULT))
+def test_env_example_matches_code_defaults(key):
+    """拦的坏例:模板里的型号和代码默认值各走各的。
+
+    实测的漂移(2026-08-27):模板写 ``AI_VIDEO_MODEL=kling-v2-5-turbo``、代码默认是
+    ``kling-v3-turbo-std``、生产 .env 里是 ``agnes-video-2.5-flash`` —— 同一个配置项
+    三个地方三个值。照模板部署的人拿到的既不是他以为的那个,也不是生产在跑的那个,
+    而且不会有任何一道报错:型号是合法的,只是不是你想要的那个。
+
+    只钉那几行明说了"取值即默认值"的;站位值(API key 一类)不在此列。
+    """
+    import importlib
+
+    mod_name, field = _PINNED_TO_DEFAULT[key]
+    mod = importlib.import_module(f"windup_framework.config.{mod_name}")
+    cls = type(mod.settings)
+    default = cls.model_fields[field].default
+    assert _example_pairs()[key] == str(default), (
+        f".env.example 的 {key} 是 {_example_pairs()[key]!r},"
+        f"而代码默认值是 {default!r} —— 改了默认值就要同步模板"
+    )

--- a/backend/tests/test_gateway_executor.py
+++ b/backend/tests/test_gateway_executor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import uuid
 
 import pytest
+
+from windup_framework.config.provider import AIProviderSettings
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -52,8 +54,9 @@ def test_unknown_model_error_lists_chain_members():
         _resolve_video_model("sora-2")
     msg = str(e.value)
     assert "sora-2" in msg
-    chain_hint = "kling-v2-5-turbo"
-    assert chain_hint in msg, "报错要带上链上型号,否则调用方无从改"
+    # 从配置推而不是写死型号名:这条断言的是"报错要带上可选值",不是"默认型号叫什么"。
+    # 写死的话,每换一次默认型号就要改一次测试,而它要保护的行为一个字没变。
+    assert AIProviderSettings().video_model in msg, "报错要带上链上型号,否则调用方无从改"
 
 
 def test_action_task_failure_includes_request_id(session_factory):
@@ -110,7 +113,7 @@ def test_action_task_binds_start_from_model(session_factory):
     )
     action_input = CharacterActionInput(
         character_id=1, action_type=ActionType.WALK, num_frames=4,
-        video_model="kling-v2-5-turbo",
+        video_model=AIProviderSettings().video_model,
     )
     with session_factory() as s:
         task = service.generate_character_action(s, user_id=1, input=action_input)
@@ -122,7 +125,7 @@ def test_action_task_binds_start_from_model(session_factory):
     with session_factory() as s:
         done = service.get_task(s, project_id=1, task_id=task_id)
     assert done.status is TaskStatus.FAILED
-    assert seen["start_from_model"] == "kling-v2-5-turbo"
+    assert seen["start_from_model"] == AIProviderSettings().video_model
     assert "request_id" not in (done.error_message or "")
 
 

--- a/backend/tests/test_kling_v3_turbo_route.py
+++ b/backend/tests/test_kling_v3_turbo_route.py
@@ -1,0 +1,107 @@
+"""kling v3 turbo 走 FAL 队列面。
+
+它与 veo 同在一条协议面上,但两者的必填项完全不同 —— 分派给错了面,代价是一次已计费
+的 400 或一次错档计费。下面每条都对应一个真实会花钱的坏例。
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from windup_framework.gateway.registry import FAMILIES, ModelRegistry
+from windup_framework.gateway.types import Family, Scene
+from windup_framework.providers.protocol import (
+    FAL_VIDEO_ENDPOINTS,
+    KlingQueueVideoProtocol,
+    UnknownFalEndpointError,
+    VeoQueueVideoProtocol,
+    fal_video_protocol,
+)
+from windup_framework.providers.protocol.types import VideoRequest
+
+MODEL = "kling-v3-turbo-std"
+
+
+def _png() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGBA", (64, 64), (20, 40, 200, 255)).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _call(model: str = MODEL):
+    proto = fal_video_protocol(model, "k", base_url="https://api.qnaigc.com")
+    return proto, proto.build_submit(
+        VideoRequest(model=model, prompt="向右走", seconds=5, size="1280x720",
+                     mode="std", first_frame=_png())
+    )
+
+
+def test_kling_v3_turbo_is_registered_on_the_fal_queue_face():
+    """拦的坏例:去 OpenAI /videos 面找它。
+
+    2026-08-27 实测那条面上 ``kling-v3-turbo`` 与 ``kling-v3-turbo-std`` 都报
+    ``model not found or disabled``,只有 ``kling-v3``(另一个产品)在。
+    """
+    assert FAMILIES[MODEL] is Family.VIDEO_FAL_QUEUE
+    assert FAL_VIDEO_ENDPOINTS[MODEL] == "fal-ai/kling-video/v3/turbo/std/image-to-video"
+
+
+def test_kling_does_not_get_the_veo_protocol_face():
+    """拦的坏例:同一条 family 一律给 veo 的面。
+
+    veo 那条面有四个必填项与"首帧必须是公网 URL"的硬约束,kling 一个都不适用;
+    给错了面,建单会被 400 拒,而那时首帧已经白传一次。
+    """
+    proto, _ = _call()
+    assert isinstance(proto, KlingQueueVideoProtocol)
+    assert not isinstance(proto, VeoQueueVideoProtocol)
+    assert isinstance(fal_video_protocol("veo3.1", "k",
+                                         base_url="https://api.qnaigc.com"),
+                      VeoQueueVideoProtocol)
+
+
+def test_duration_is_pinned_so_the_upstream_default_cannot_pick_the_tier():
+    """拦的坏例:不发 duration,听上游默认档。
+
+    默认档要是 10s 就是双倍价,而任务照常成功、没有一道会红。取值形态也钉住:
+    kling 这条是**无后缀**的 ``"5"``,veo 那条是 ``"4s"`` —— 形状不同,别互相抄。
+    """
+    _, call = _call()
+    assert call.body["duration"] == "5"
+    assert not str(call.body["duration"]).endswith("s")
+
+
+def test_first_frame_goes_out_as_base64_not_a_public_url():
+    """kling 不需要先把首帧传对象存储。
+
+    2026-08-27 实测十余次以 base64 建单成片。少一次上传就少一处会坏的地方,
+    而 veo 那条面反过来 —— 两条面的这个约定相反,故各自有用例钉住。
+    """
+    _, call = _call()
+    assert str(call.body["image_url"]).startswith("data:image/jpeg;base64,")
+
+
+def test_submit_path_carries_the_model_because_the_body_does_not():
+    """FAL 面的型号由**路径**表达,请求体里没有 model 字段 —— 路径错了就发去了别的型号。"""
+    _, call = _call()
+    assert call.path.endswith("/queue/fal-ai/kling-video/v3/turbo/std/image-to-video")
+    assert "model" not in call.body
+
+
+def test_an_unregistered_model_raises_before_any_request_goes_out():
+    """拦的坏例:没登记的型号静默回落到某个默认端点,把单发给了别的型号。"""
+    with pytest.raises(UnknownFalEndpointError, match="没有登记"):
+        fal_video_protocol("kling-v9-imaginary", "k", base_url="https://api.qnaigc.com")
+
+
+def test_kling_v3_turbo_can_serve_as_the_default_chain_model():
+    """它面向所有用户,不是按用户授权的型号,所以必须能进兜底链。"""
+    from windup_framework.config.provider import AIProviderSettings
+
+    chain = ModelRegistry.from_settings(
+        AIProviderSettings(base_url="https://api.qnaigc.com/v1", api_key="k",
+                           video_model=MODEL, video_fallbacks="")
+    ).chain(Scene.CHARACTER_ACTION)
+    assert chain == (MODEL,)

--- a/backend/tests/test_sufy_video_download.py
+++ b/backend/tests/test_sufy_video_download.py
@@ -693,7 +693,14 @@ def _video_provider(handler, **kw):
     from windup_framework.providers.sufy import SufyVideoProvider
 
     p = SufyVideoProvider(
-        config=AIProviderSettings(base_url="https://gw.example.com/v1", api_key="k"),
+        # 显式钉住走 OpenAI /videos 面的型号。本文件测的是 ``fit_first_frame`` 与那条面
+        # 本身,而默认型号 2026-08-27 起是走 FAL 队列面的 kling v3 turbo —— 跟着默认值走
+        # 的话,换一次默认值这一整个文件的桩就全部失配,而失配的表现是"响应不是 JSON 对象",
+        # 看不出跟型号有关。
+        config=AIProviderSettings(
+            base_url="https://gw.example.com/v1", api_key="k",
+            video_model="kling-v2-5-turbo",
+        ),
         # 轮询预算 = max_min * 60 // poll。poll 取大值让预算只有几次，
         # 再把 time.sleep 打桩掉，用例就既快又不空转（第一版 poll=0.001 配
         # max_min=1 会真轮询 6 万次，单文件跑了 96 秒）。


### PR DESCRIPTION
把默认视频型号切到 kling v3 turbo。

## Why

kling v3 turbo **只在 FAL 队列面上有**。2026-08-27 在网关上带完整 body 实测（能分出「型号不存在」与「参数不合法」）：

| 型号 | OpenAI `/videos` 面 | FAL 队列面 |
|---|---|---|
| `kling-v3-turbo` | ❌ `model not found or disabled` | — |
| `kling-v3-turbo-std` | ❌ `model not found or disabled` | ✅ |
| `kling-v3` | ✅（**另一个产品**，不是 turbo） | — |
| `kling-v2-5-turbo` | ✅（现役） | ✅ |

所以这不是「改一行型号名」，需要 #804 刚加的 FAL 视频协议面。

## 两条面的约定相反，故各自一个实现类

| | veo3.1 | kling v3 turbo |
|---|---|---|
| 首帧 | 必须公网 URL | **base64 dataURI** |
| `duration` | `"4s"`（带后缀） | `"5"`（**无后缀**） |
| 必填项 | 四个 | 只需钉 duration |

写进同一个类就得每家一个 `if`，而分支写错的代价是一次已计费的 400 或错档。

**首帧那条修正了仓里一条过期结论**：`sufy.py` 有一段 2026-08-11 的归档注释说「FAL 面只吃公网 URL，塞 base64 会 queued 后失败且可能已计费」。**对 kling 不成立** —— 今天十余次建单成片全部以 `data:image/jpeg;base64,` 发出。少一次上传就少一处会坏的地方。（veo 那条仍走 URL，未改。）

**`duration` 必须显式发**：通用 FAL 面目前不发它（十个端点取值形态分 `5`/`"5"`/`"5s"` 三种、未逐个实测），而不发就得听上游默认档 —— 默认档要是 10s 就是双倍价，且任务照常成功、没有一道会红。

## Changes

- `FAL_VIDEO_ENDPOINTS`（型号→端点）+ `fal_video_protocol()`（按型号取实现）。
- `KlingQueueVideoProtocol`：沿用基类的 base64 首帧，显式钉 `duration="5"`。
- `FAMILIES` 登记 `kling-v3-turbo-std`；它面向所有用户，不进 `USER_GATED_MODELS`，可当兜底链成员。
- `_protocol_for` 按型号分派，不再一律给 veo 的面。
- 代码默认 `video_model` → `kling-v3-turbo-std`。

## Verification

- [x] 7 条新用例，各自拦一个真实会花钱的坏例：去 OpenAI 面找它、给成 veo 的协议面、不发 duration 听上游默认档、duration 抄了 veo 的 `"4s"` 形状、误以为 kling 也要先传对象存储、路径写错发给别的型号（FAL 面型号由路径表达，body 里没有 model 字段）、未登记型号静默回落。
- [x] `uv run ruff check .`：All checks passed。
- [x] `uv run python -m scripts.export_openapi`：rc=0，`openapi.json` 无漂移。
- [x] `uv run lint-imports`：Contracts: 2 kept, 0 broken。
- [x] `uv run pytest -q --cov=packages`：**1827 passed, 14 skipped, 0 failed**。
- [x] 三个测试文件改的是「别依赖全局默认型号」：`test_sufy_video_download` 显式钉住走 OpenAI 面的型号（它测的是 `fit_first_frame` 与那条面本身）；另两处把写死的 `"kling-v2-5-turbo"` 改成从配置推 —— 那几条断言的是「报错要带上可选值」与「链 = 主力 + 兜底」，不是「默认型号叫什么」。以后再换默认值不用改它们。

## ⚠️ 部署注意

**改代码默认值不等于线上生效。** 生产 `.env` 里有 `AI_VIDEO_MODEL=agnes-video-2.5-flash` 覆盖它，要真正切换需把那一行改成 `AI_VIDEO_MODEL=kling-v3-turbo-std`（或删掉让它用代码默认）。

## 顺带查到的生产现状（另开，不在本 PR）

**这一节最初写错了两处，已按重测改正，原表作废。**

线上 CHARACTER_ACTION 的网关记账（全量，按首选型号 `candidate_index=0 AND route_reason='primary'`）：

```
型号                       提交成功   提交失败      任务最终出片
agnes-video-2.5-flash        21         0         15 完成 / 6 失败   71%
agnes-video-2.5               0         2         —
kling-v2-5-turbo            106       250         56 完成 / 1 失败   95%
```

失败的真实分布（原文写「250 全是 HTTP 525」，错）：

```
rate_limit  http=429   225      ← 绝大多数是限流，不花钱，重试能过
unreached   http=522    12
unreached   http=525     9      ← 525 只有 9 个
unreached   http=None    4
```

两处订正：

1. **`agnes` 不是「只成功 1 次」。** 写那句话时它当天确实只有 1 次记录（21 次全发生在 08-27 07:00–10:00，我在 07 点档写的），但现在的口径是 21 次提交全部 200、15 个任务出片。数字随时间变，写进正文的那一刻就该带时间戳——没带是我的问题。
2. **`kling-v2-5-turbo` 不是兜底，它是此前的首选**（`cand=0 primary` 215 次）。356 里剩下的是 429 之后的换 key 重试（`cand=1/2/3, route_reason=key_rate_limit`）。所以「配的主力几乎没在用、实际出片靠兜底链」这个判断不成立。

还有一处口径要留下：`windup_ai_gateway_attempt` **只记 `submit` 这一相**（全量 `phase` 只有 `submit`，没有 poll / download），所以那张表里的「成功」是提交被受理，不是出片。agnes 21 次提交全 200，其中 6 个任务最终仍 failed。判交付率必须回到 `windup_generation_task.status`。

换型号的结论不变：质量对照（已有）+ 交付率 71% → 95%，都指向 kling v3。

Closes #825

