### PR TITLE
fix(mq): 撞上游限流的任务放回队列重投，不判失败

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -50,6 +50,8 @@ from windup_app.server.orchestrator._failure import user_message
 from windup_app.server.orchestrator.i2v_poll import ActionAwaitingVideo
 from windup_app.server.orchestrator._fetch import FetchNotAllowed, fetch_own_media, is_own_media
 from windup_app.server.orchestrator.client_bake import ActionAwaitingClientBake
+from windup_app.server.orchestrator.signals import ActionRateLimited
+from windup_framework.gateway.errors import UpstreamExhaustedError
 from windup_app.server.orchestrator.model import (
     ActionType,
     CharacterActionInput,
@@ -374,6 +376,20 @@ class ActionTaskExecutor:
                 task_repo.fail_task(s, task_id, error_message=error_message)
 
             generation_io.using_session(session, self._make_session, _reject)
+        except UpstreamExhaustedError as exc:
+            if not exc.is_free_retryable:
+                raise
+            # 限流被拒:上游没建单、没扣配额。把任务放回 PENDING 让消费层稍后重投,
+            # 不判失败也不结算积分 —— 结算了就等于这次尝试真的花掉了什么。
+            logger.warning("动作任务 %s 撞上游限流,放回队列稍后重试", task_id)
+            if session is not None:
+                session.rollback()
+
+            def _requeue(s: Session) -> None:
+                task_repo.update_status(s, task_id, TaskStatus.PENDING)
+
+            generation_io.using_session(session, self._make_session, _requeue)
+            raise ActionRateLimited(str(exc)) from exc
         except Exception as exc:  # noqa: BLE001 —— 兜底任何生成/上传/网络异常
             logger.exception("动作任务 %s 失败", task_id)
             if session is not None:

--- a/backend/packages/app/src/windup_app/server/orchestrator/signals.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/signals.py
@@ -1,0 +1,21 @@
+"""编排层往消费层抛的信号异常。
+
+单独一个**零依赖**模块:这些异常要被 ``worker.handlers`` import,而 ``executor`` 依赖
+``ai_engine``,从那里 import 会让入口层经由 handlers 间接连上 ai_engine —— 分层契约
+"入口层不经 ai_engine 直连"就是拦这个的。信号本身不需要任何依赖,分出来即可。
+"""
+
+from __future__ import annotations
+
+__all__ = ["ActionRateLimited"]
+
+
+class ActionRateLimited(Exception):
+    """上游限流把重试与兜底都用完了,而这次**一分钱没花** —— 任务应稍后重投,不是失败。
+
+    与 ``ActionAwaitingClientBake`` 同一个模式:编排层抛,消费层接。区别是那个表示
+    "已挂给别人、任务保持 RUNNING",这个表示"没开始、放回队列"。
+
+    为什么值得单开一条路:限流被拒时上游没有建单、没有消耗配额,判失败等于凭空丢掉一个
+    本来能成的任务。实测近三天 143 个动作任务里有 40 个是这么失败的。
+    """

--- a/backend/packages/app/src/windup_app/worker/consumer.py
+++ b/backend/packages/app/src/windup_app/worker/consumer.py
@@ -235,14 +235,14 @@ class StreamConsumer:
                 self._config.group,
                 stream_id,
             )
-        except HandlerDeferred:
+        except HandlerDeferred as deferred:
             logger.info(
                 "消息延后重试 | stream=%s stream_id=%s message_id=%s",
                 self._config.stream,
                 stream_id,
                 message_id,
             )
-            self._defer_message(message_id)
+            self._defer_message(message_id, stream_id=stream_id, reason=deferred)
         except Exception as exc:
             logger.exception(
                 "消息处理失败 | stream=%s stream_id=%s",
@@ -259,12 +259,39 @@ class StreamConsumer:
     def _semaphore_for(self, msg_type: str) -> threading.Semaphore | None:
         return self._semaphores.get(msg_type)
 
-    def _defer_message(self, message_id: uuid.UUID | None) -> None:
-        """释放 processing 认领但不 XACK，留 PEL 待 XAUTOCLAIM 重投。"""
+    def _defer_message(
+        self,
+        message_id: uuid.UUID | None,
+        *,
+        stream_id: str | None = None,
+        reason: BaseException | None = None,
+    ) -> None:
+        """释放 processing 认领但不 XACK，留 PEL 待 XAUTOCLAIM 重投。
+
+        **延后也要吃 ``MAX_CONSUME_ATTEMPTS``。** 只释放认领而不查上限的话,一条持续
+        延后的消息会被无限重认领 —— 任务永远停在 PENDING、永远不终结,而这条路径上
+        既没有失败也没有成功,监控上看不出任何异常。上限走的是与 ``_handle_failure``
+        同一个计数与同一个终结动作,免得两条路各有一套"到底算不算重试"的口径。
+        """
         if message_id is None:
             return
         session = SessionLocal()
         try:
+            row = mq_repo.get_by_id(session, message_id)
+            if (
+                row is not None
+                and row.consume_attempts >= MAX_CONSUME_ATTEMPTS
+                and stream_id is not None
+            ):
+                mq_repo.mark_consumed(
+                    session, message_id, "failed",
+                    error=f"延后重试已达上限 {MAX_CONSUME_ATTEMPTS} 次: {reason}",
+                )
+                session.commit()
+                mq_client.xack(
+                    get_redis(), self._config.stream, self._config.group, stream_id
+                )
+                return
             mq_repo.release_processing_claim(session, message_id)
             session.commit()
         finally:

--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -16,6 +16,7 @@ from windup_app.server.mq.catalog import (
     MSG_TYPE_VERIFICATION_CODE,
 )
 from windup_app.server.orchestrator import billing, task_repo
+from windup_app.server.orchestrator.signals import ActionRateLimited
 from windup_app.server.orchestrator.model import (
     ActionType,
     CharacterActionInput,
@@ -196,7 +197,14 @@ def handle_generation(
             project_id,
         )
     elif task_type == GenerationType.CHARACTER_ACTION.value:
-        run_action_task(task_id, _action_input(input_payload), project_id)
+        try:
+            run_action_task(task_id, _action_input(input_payload), project_id)
+        except ActionRateLimited as exc:
+            # 上游限流,而这次一分钱没花:让消息留在 PEL 稍后重认领,而不是判任务失败。
+            # 翻成 HandlerDeferred 是因为重投的预算与节奏由消费层统一管
+            # (MAX_CONSUME_ATTEMPTS × PEL_CLAIM_INTERVAL_SECONDS),在这里自己 sleep
+            # 会把 action worker 占住,而限流期间恰恰是它最该去干别的活的时候。
+            raise HandlerDeferred(f"task {task_id} rate limited upstream") from exc
     else:
         raise ValueError(f"未知生成任务类型: {task_type}")
 

--- a/backend/packages/framework/src/windup_framework/gateway/errors.py
+++ b/backend/packages/framework/src/windup_framework/gateway/errors.py
@@ -1,0 +1,46 @@
+"""网关对外抛的异常。
+
+单独一个模块而不是散在各 gateway 文件里:调用方要 ``except`` 它,而 ``chat`` / ``image``
+/ ``video`` 互不 import,放在其中任何一个都会让另外两个的调用方去 import 一条无关的面。
+"""
+
+from __future__ import annotations
+
+from windup_common.enums.model import ModelErrorType
+
+__all__ = ["UpstreamExhaustedError"]
+
+
+class UpstreamExhaustedError(RuntimeError):
+    """一次请求的重试与兜底都用完了。
+
+    带上 ``error_type`` 与 ``maybe_billed``,是为了让调用方能分开两件性质完全不同的事:
+
+    - **这次白跑了**(限流被拒、根本没到上游):没有消耗任何配额,整条任务可以过一会儿
+      再来一遍,判失败等于凭空丢掉一个本来能成的任务。
+    - **这次可能已计费**:再来一遍就是再花一次钱,只能判失败。
+
+    过去这里抛的是裸 ``RuntimeError``,类型只出现在消息字符串里 —— 调用方要么去
+    ``in`` 匹配文案(改一次文案就静默失效),要么一律当失败(就是现在的样子)。
+
+    继承 ``RuntimeError`` 是为了向后兼容:既有的 ``except RuntimeError`` / ``except
+    Exception`` 一个都不用改。
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_type: ModelErrorType | None = None,
+        maybe_billed: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.error_type = error_type
+        self.maybe_billed = maybe_billed
+
+    @property
+    def is_free_retryable(self) -> bool:
+        """这次失败没有消耗任何配额,原样重投是安全的。"""
+        return (
+            self.error_type is ModelErrorType.RATE_LIMIT and not self.maybe_billed
+        )

--- a/backend/packages/framework/src/windup_framework/gateway/video.py
+++ b/backend/packages/framework/src/windup_framework/gateway/video.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 from windup_common.enums.model import ModelErrorType
 from windup_framework.config.provider import AIProviderSettings, settings as default_settings
+from windup_framework.gateway.errors import UpstreamExhaustedError
 from windup_framework.gateway.billing import billing_flags, upstream_reached_label
 from windup_framework.gateway.budget import AttemptBudget
 from windup_framework.gateway.context import current_call_context
@@ -114,6 +115,9 @@ class VideoGateway:
         input_hash = hash_image_input(prompt, [first_frame])
         last_http_status: int | None = None
         last_error: ModelErrorType | None = None
+        # 这次请求有没有在任何一跳上绑过单。``bound_job_id`` 是循环内的局部量,fail() 看不到,
+        # 而"绑过单"正是"可能已计费"的判据 —— 判错的方向是拿钱重投,所以宁可多记不可漏记。
+        ever_bound_job = False
         fallback_used = False
         fallback_reason: str | None = None
         route_reason_override: str | None = None
@@ -134,9 +138,11 @@ class VideoGateway:
 
         def fail(http_status: int | None) -> None:
             err = last_error.value if last_error is not None else None
-            raise RuntimeError(
+            raise UpstreamExhaustedError(
                 f"video gateway failed request_id={request_id} "
-                f"http_status={http_status} error_type={err}"
+                f"http_status={http_status} error_type={err}",
+                error_type=last_error,
+                maybe_billed=ever_bound_job,
             )
 
         if self._circuit.is_open("aggregator"):
@@ -237,6 +243,7 @@ class VideoGateway:
                         submit_ms = int((time.monotonic() - submit_t0) * 1000)
                         if result.ok and result.job_id:
                             bound_job_id = result.job_id
+                            ever_bound_job = True
                             if follow:
                                 result = adapter.follow_job(bound_job_id, model=model)
                         elif result.ok:

--- a/backend/tests/test_rate_limit_requeue.py
+++ b/backend/tests/test_rate_limit_requeue.py
@@ -68,3 +68,48 @@ def test_the_signal_module_pulls_in_nothing():
     ]
     assert all(m == "__future__" for m in imported), f"信号模块引入了依赖: {imported}"
     assert issubclass(ActionRateLimited, Exception)
+
+
+def test_deferral_also_honors_the_consume_attempt_limit(monkeypatch):
+    """拦的坏例:延后路径绕开 ``MAX_CONSUME_ATTEMPTS``,消息被无限重认领。
+
+    ``HandlerDeferred`` 走的是 ``_defer_message``,而上限原本只在 ``_handle_failure``
+    里查;``try_claim_for_consume`` 也没有上限守卫。所以持续限流下那条消息会一直被
+    XAUTOCLAIM 捡回来重跑,任务永远停在 PENDING、永远不终结 —— 这条路径上既没有失败
+    也没有成功,监控上看不出任何异常。(FennoAI 在 #828 上指出。)
+
+    断言的是**行为**不是源码文本:第一版用 ``inspect.getsource`` 查关键字,把常量换成
+    ``False`` 之后它照样绿 —— 那种写法测的是"代码里提没提这个名字",不是"到了上限会不会
+    终结消息"。
+    """
+    import uuid as _uuid
+
+    from windup_app.worker import consumer as C
+
+    acked, consumed, released = [], [], []
+
+    class _Row:
+        consume_attempts = 999            # 远超上限
+
+    class _Repo:
+        get_by_id = staticmethod(lambda s, mid: _Row())
+        mark_consumed = staticmethod(lambda s, mid, st, error=None: consumed.append(st))
+        release_processing_claim = staticmethod(lambda s, mid: released.append(mid))
+
+    class _Sess:
+        def commit(self): pass
+        def close(self): pass
+
+    monkeypatch.setattr(C, "mq_repo", _Repo)
+    monkeypatch.setattr(C, "SessionLocal", lambda: _Sess())
+    monkeypatch.setattr(C, "get_redis", lambda: object())
+    monkeypatch.setattr(C.mq_client, "xack", lambda *a, **k: acked.append(a))
+
+    consumer = C.StreamConsumer.__new__(C.StreamConsumer)
+    consumer._config = type("C", (), {"stream": "s", "group": "g"})()
+    consumer._defer_message(_uuid.uuid4(), stream_id="1-1",
+                            reason=RuntimeError("持续限流"))
+
+    assert consumed == ["failed"], "到上限后没有终结消息,会被无限重认领"
+    assert acked, "终结了 DB 记录却没 XACK,消息仍留在 PEL 里"
+    assert not released, "到上限还释放认领 = 又放回去让人重认领一次"

--- a/backend/tests/test_rate_limit_requeue.py
+++ b/backend/tests/test_rate_limit_requeue.py
@@ -1,0 +1,70 @@
+"""限流被拒的任务应当重投,不是判失败。
+
+实测(2026-08-27,近三天):143 个动作任务里 50 个失败,其中 40 个的失败原因是通用的
+"生成没能完成",而网关记账显示同期 252 次失败里 225 次是 429 且 ``maybe_billed=False``
+—— 上游根本没建单、没扣配额。这些任务是被"20 秒内放弃"判死的,不是真的做不出来。
+"""
+from __future__ import annotations
+
+import pytest
+
+from windup_app.server.orchestrator.signals import ActionRateLimited
+from windup_common.enums.model import ModelErrorType
+from windup_framework.gateway.errors import UpstreamExhaustedError
+
+
+def test_rate_limited_without_a_job_is_free_to_retry():
+    """拦的坏例:把"被限流"和"可能已计费"当成一回事。
+
+    前者重投是免费的,后者重投就是再花一次钱。判错的方向不同、代价不对称,
+    所以判据挂在异常上,而不是留给每个调用方自己 in 匹配文案。
+    """
+    e = UpstreamExhaustedError("x", error_type=ModelErrorType.RATE_LIMIT, maybe_billed=False)
+    assert e.is_free_retryable is True
+
+
+def test_rate_limited_after_binding_a_job_is_not_free():
+    """已经绑过单就可能已计费 —— 重投等于再花一次钱,只能判失败。"""
+    e = UpstreamExhaustedError("x", error_type=ModelErrorType.RATE_LIMIT, maybe_billed=True)
+    assert e.is_free_retryable is False
+
+
+@pytest.mark.parametrize("kind", [ModelErrorType.UNREACHED, ModelErrorType.UPSTREAM_FAILED,
+                                  ModelErrorType.AUTH, None])
+def test_only_rate_limit_gets_the_free_retry_path(kind):
+    """拦的坏例:把所有失败都当成可重投。
+
+    鉴权错、上游真失败这些重投多少次都一样,而每次重投都要再跑一遍抠图与上传。
+    """
+    assert UpstreamExhaustedError("x", error_type=kind).is_free_retryable is False
+
+
+def test_the_typed_exception_stays_a_runtime_error():
+    """既有的 ``except RuntimeError`` / ``except Exception`` 一个都不该改。
+
+    换异常类型时最容易漏的就是这条:某个上层只 catch RuntimeError,换成裸 Exception
+    子类之后那里就漏网,而漏网的表现是任务卡在 RUNNING 不是报错。
+    """
+    assert issubclass(UpstreamExhaustedError, RuntimeError)
+
+
+def test_the_signal_module_pulls_in_nothing():
+    """信号模块必须零依赖。
+
+    它要被 ``worker.handlers`` import,而 ``executor`` 依赖 ai_engine ——
+    从 executor 里 import 会让入口层经由 handlers 间接连上 ai_engine,
+    分层契约"入口层不经 ai_engine 直连"就是拦这个的(本用例写下时刚踩过一次)。
+    """
+    import ast
+    import pathlib
+
+    src = pathlib.Path(
+        "packages/app/src/windup_app/server/orchestrator/signals.py"
+    ).read_text()
+    imported = [
+        n.module or ""
+        for n in ast.walk(ast.parse(src))
+        if isinstance(n, ast.ImportFrom)
+    ]
+    assert all(m == "__future__" for m in imported), f"信号模块引入了依赖: {imported}"
+    assert issubclass(ActionRateLimited, Exception)


### PR DESCRIPTION
撞上游限流的任务放回队列重投，不判失败。

## Why

生产实测（2026-08-27，近三天）：**143 个动作任务 → 100 完成 / 50 失败**。50 个失败里 **40 个**是通用的「生成没能完成，请稍后重试」，另外 10 个是提示词校验拒绝（那是正确行为）。

同期网关 252 次失败：**225 次是 429 `rate_limit` 且 `maybe_billed=False`** —— 上游根本没建单、没扣配额。**每成功一次平均要试 3.3 次。**

限流是**持续**的而非瞬时突发。峰值那小时逐分钟看，单个任务一分钟内会打 5–10 次：

```
05:20  429×10  只涉及 2 个任务
05:25  429× 5  只涉及 1 个任务
```

对上现在的策略：

| 现在 | 问题 |
|---|---|
| 429 → 重试，等 **2.0 秒**（上游不给 `Retry-After`，走代码默认） | 平退避，对持续限流无意义 |
| 重试 2 次 → 换 key | **实测无效**：一个任务 10 次里没一次成功，说明限流不按 key 分 |
| 换完还不行 → **FAIL** | 整个重试预算约 20 秒，然后判用户任务失败 |

## Changes

三层：

1. **网关**：`UpstreamExhaustedError` 带 `error_type` 与 `maybe_billed`。过去抛的是裸 `RuntimeError`、类型只在消息字符串里 —— 调用方要么 `in` 匹配文案（改一次文案就静默失效），要么一律当失败（就是现在的样子）。它仍是 `RuntimeError` 子类，既有 `except` 一个都不用改。
2. **编排层**：遇到「限流且未绑单」→ 任务放回 `PENDING`、**不结算积分**（结算了就等于这次尝试真花掉了什么），抛 `ActionRateLimited`。
3. **消费层**：翻成 `HandlerDeferred`，消息留 PEL 稍后重认领。预算由 `MAX_CONSUME_ATTEMPTS × PEL_CLAIM_INTERVAL_SECONDS`（默认 5 × 30s ≈ 2.5 分钟）统一管，而不是在 worker 里自己 sleep —— 限流期间恰恰是 action worker 最该去干别的活的时候。

信号异常放在**零依赖**的 `signals.py`：`executor` 依赖 `ai_engine`，从那里 import 会让入口层经由 `handlers` 间接连上它，分层契约「入口层不经 ai_engine 直连」就是拦这个的。**我写这条时刚踩过一次**（`lint-imports` 报 BROKEN），已有一条用例用 AST 断言该模块除 `__future__` 外不引入任何依赖。

## Verification

- [x] 8 条新用例，各自拦一个坏例：把「被限流」与「可能已计费」当一回事（重投方向不同、代价不对称）、已绑单也走免费重投（等于再花一次钱）、把所有失败都当可重投（鉴权错重投多少次都一样，而每次都要再跑一遍抠图与上传）、换异常类型后某个只 catch `RuntimeError` 的上层漏网、信号模块引入依赖破坏分层。
- [x] `uv run ruff check .`：All checks passed。
- [x] `uv run python -m scripts.export_openapi`：rc=0，`openapi.json` 无漂移。
- [x] `uv run lint-imports`：**Contracts: 2 kept, 0 broken**。
- [x] `uv run pytest -q --cov=packages`：**1828 passed, 14 skipped, 0 failed**。

## Scope

不含：退避曲线本身（无 `Retry-After` 时应指数退避而不是平 2 秒）、429 时换 key 的策略（实测无效，去掉是另一个改动）、`API key daily quota exceeded`（需额度侧动作）、`WINDUP_MQ_GENERATION_ACTION_CONCURRENCY`（分钟级数据显示突发不是主因）。

Closes #827
