### PR TITLE
feat(quick-start): add resumable history sidebar

### DIFF
--- a/backend/packages/app/src/windup_app/server/workflow_run/interface.py
+++ b/backend/packages/app/src/windup_app/server/workflow_run/interface.py
@@ -55,6 +55,17 @@ class WorkflowRunService(ABC):
         """分页查询项目下的执行记录，返回 (当前页数据, 总数)。"""
 
     @abstractmethod
+    def list_user_runs(
+        self,
+        session: Session,
+        *,
+        user_id: int,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[WorkflowRun], int]:
+        """分页查询用户跨项目的执行记录，返回 (当前页数据, 总数)。"""
+
+    @abstractmethod
     def update_run(
         self,
         session: Session,

--- a/backend/packages/app/src/windup_app/server/workflow_run/schema.py
+++ b/backend/packages/app/src/windup_app/server/workflow_run/schema.py
@@ -8,6 +8,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -54,3 +56,4 @@ class WorkflowRunOut(BaseModel):
     nodes: list = Field(default_factory=list, description="节点树（前端自定义结构）")
     status: str = Field(description="active / soft_deleted")
     version: int = Field(description="乐观锁版本号，从 1 递增")
+    created_at: datetime

--- a/backend/packages/app/src/windup_app/server/workflow_run/service.py
+++ b/backend/packages/app/src/windup_app/server/workflow_run/service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from windup_common.enums.biz_code import BizCode
 from windup_common.exceptions import BizException
 
+from windup_app.server.project.model import Project
 from windup_app.server.workflow_run.interface import WorkflowRunService
 from windup_app.server.workflow_run.model import RunStatus, WorkflowRun
 
@@ -76,6 +77,36 @@ class SqlAlchemyWorkflowRunService(WorkflowRunService):
         total = session.scalar(count_stmt) or 0
         items = list(session.scalars(stmt))
         return items, total
+
+    def list_user_runs(
+        self,
+        session: Session,
+        *,
+        user_id: int,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[WorkflowRun], int]:
+        """按最近创建顺序查询当前用户跨项目的运行记录。"""
+        conditions = (
+            Project.user_id == user_id,
+            WorkflowRun.status != RunStatus.SOFT_DELETED.value,
+        )
+        count_stmt = (
+            select(func.count())
+            .select_from(WorkflowRun)
+            .join(Project, Project.id == WorkflowRun.project_id)
+            .where(*conditions)
+        )
+        stmt = (
+            select(WorkflowRun)
+            .join(Project, Project.id == WorkflowRun.project_id)
+            .where(*conditions)
+            .order_by(WorkflowRun.created_at.desc(), WorkflowRun.id.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        total = session.scalar(count_stmt) or 0
+        return list(session.scalars(stmt)), total
 
     def update_run(
         self,

--- a/backend/packages/app/src/windup_app/web/api/workflow_run.py
+++ b/backend/packages/app/src/windup_app/web/api/workflow_run.py
@@ -17,6 +17,7 @@ nodes 字段由前端自定义，后端只做全量读写，不校验 nodes 内�
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
@@ -73,6 +74,7 @@ class WorkflowRunOut(BaseModel):
     nodes: list = Field(default_factory=list, description="节点树")
     status: str
     version: int
+    created_at: datetime
 
 
 # ── 归属校验 ─────────────────────────────────────────────────────────────────
@@ -119,18 +121,23 @@ def create_run(
 
 @router.get("", response_model=ListResponse[WorkflowRunOut])
 def list_runs(
-    project_id: int = Query(..., gt=0),
+    project_id: int | None = Query(None, gt=0),
     request: Request = None,
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
     session: Session = Depends(get_session),
 ) -> ListResponse[WorkflowRunOut]:
-    """分页查询项目下的执行记录。"""
+    """分页查询项目记录；未指定项目时返回当前用户的跨项目历史。"""
     user_id = request.state.current_user.id
-    _get_project_or_raise(session, project_id, user_id)
-    items, total = service.list_runs(
-        session, project_id=project_id, page=page, page_size=page_size,
-    )
+    if project_id is None:
+        items, total = service.list_user_runs(
+            session, user_id=user_id, page=page, page_size=page_size,
+        )
+    else:
+        _get_project_or_raise(session, project_id, user_id)
+        items, total = service.list_runs(
+            session, project_id=project_id, page=page, page_size=page_size,
+        )
     return ListResponse.success(
         [WorkflowRunOut.model_validate(r) for r in items],
         total=total,

--- a/backend/tests/test_workflow_run_api.py
+++ b/backend/tests/test_workflow_run_api.py
@@ -111,6 +111,33 @@ def test_list_other_users_project_returns_404(auth_client, auth_client_b):
     )
     assert resp.json()["code"] == 404
 
+def test_list_without_project_returns_only_current_users_recent_runs(
+    auth_client,
+    auth_client_b,
+):
+    """Quick Start 历史栏能一次读取当前用户跨项目的最近运行记录。"""
+    first_project = _create_project(auth_client, "像素骑士")
+    second_project = _create_project(auth_client, "森林法师")
+    other_project = _create_project(auth_client_b, "别人的角色")
+
+    first = auth_client.post(
+        "/workflow-runs",
+        json=_payload(first_project["id"], nodes=[{"id": "first"}]),
+    ).json()["data"]
+    second = auth_client.post(
+        "/workflow-runs",
+        json=_payload(second_project["id"], nodes=[{"id": "second"}]),
+    ).json()["data"]
+    auth_client_b.post("/workflow-runs", json=_payload(other_project["id"]))
+
+    resp = auth_client.get("/workflow-runs", params={"page": 1, "page_size": 20})
+
+    body = resp.json()
+    assert body["code"] == 200
+    assert body["total"] == 2
+    assert [item["id"] for item in body["data"]] == [second["id"], first["id"]]
+    assert all(item["created_at"] for item in body["data"])
+
 
 # -- GET /workflow-runs/{id} ---------------------------------------------------
 

--- a/frontend/src/entities/workflow-run/api.test.ts
+++ b/frontend/src/entities/workflow-run/api.test.ts
@@ -533,4 +533,32 @@ describe('workflowRunApis', () => {
       'https://api.windup.test/workflow-runs?project_id=42&page=2&page_size=10',
     )
   })
+
+  it('lists the current users recent runs without a project filter', async () => {
+    let requestUrl = ''
+    const apis = await loadWorkflowRunApis(async (input) => {
+      requestUrl = String(input)
+      return new Response(
+        JSON.stringify({
+          code: 200,
+          message: 'success',
+          data: [workflowRunDto],
+          total: 1,
+          page: 1,
+          page_size: 20,
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      )
+    })
+
+    const recentApis = apis as typeof apis & {
+      listRecent(query?: { page?: number; pageSize?: number }): Promise<unknown>
+    }
+
+    await expect(recentApis.listRecent()).resolves.toMatchObject({
+      items: [{ id: '17', projectId: '42' }],
+      total: 1,
+    })
+    expect(requestUrl).toBe('https://api.windup.test/workflow-runs?page=1&page_size=20')
+  })
 })

--- a/frontend/src/entities/workflow-run/api.ts
+++ b/frontend/src/entities/workflow-run/api.ts
@@ -350,8 +350,9 @@ function getApiClient() {
   return createApiClient({ getAccessToken: getApiAccessToken })
 }
 
-/** 精确对应后端已公开的 CRUD 与项目内分页列表；不声明尚未提供的按 Character 查询。 */
-export const workflowRunApis: WorkflowRunApis & Required<Pick<WorkflowRunApis, 'listByProject'>> = {
+/** 精确对应后端已公开的 CRUD 与运行记录分页列表。 */
+export const workflowRunApis: WorkflowRunApis &
+  Required<Pick<WorkflowRunApis, 'listByProject' | 'listRecent'>> = {
   async create(input) {
     return mapWorkflowRun(
       await getApiClient().request<WorkflowRunDto>('/workflow-runs', {
@@ -366,6 +367,15 @@ export const workflowRunApis: WorkflowRunApis & Required<Pick<WorkflowRunApis, '
         project_id: toBackendId(projectId, 'projectId'),
         page: query.page,
         page_size: query.pageSize,
+      },
+    })
+    return { ...result, items: result.items.map(mapWorkflowRun) }
+  },
+  async listRecent(query = {}) {
+    const result = await getApiClient().requestList<WorkflowRunDto>('/workflow-runs', {
+      query: {
+        page: query.page ?? 1,
+        page_size: query.pageSize ?? 20,
       },
     })
     return { ...result, items: result.items.map(mapWorkflowRun) }

--- a/frontend/src/entities/workflow-run/index.ts
+++ b/frontend/src/entities/workflow-run/index.ts
@@ -165,6 +165,8 @@ export interface CreateWorkflowRunInput {
 
 export interface WorkflowRunApis {
   create(input: CreateWorkflowRunInput): Promise<WorkflowRun>
+  /** 当前用户跨项目的最近运行记录，供 Quick Start 历史侧栏使用。 */
+  listRecent?(query?: PageQuery): Promise<Paged<WorkflowRun>>
   /** 后端只返回未软删除的运行记录。 */
   listByProject?(projectId: string, query?: PageQuery): Promise<Paged<WorkflowRun>>
   get(id: WorkflowRun['id']): Promise<WorkflowRun>

--- a/frontend/src/pages/quick-start/history-sidebar.tsx
+++ b/frontend/src/pages/quick-start/history-sidebar.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react'
+import {
+  ChatCircle,
+  ClockCounterClockwise,
+  NotePencil,
+  SidebarSimple,
+  X,
+} from '@phosphor-icons/react'
+import { Link } from 'react-router'
+
+import type { QuickStartEntryService, QuickStartHistoryItem } from './service'
+
+export function QuickStartHistorySidebar({
+  service,
+  activeRunId,
+}: {
+  service: QuickStartEntryService
+  activeRunId?: string
+}) {
+  const [items, setItems] = useState<readonly QuickStartHistoryItem[]>([])
+  const [loading, setLoading] = useState(Boolean(service.listHistory))
+  const [error, setError] = useState<string | null>(null)
+  const [mobileOpen, setMobileOpen] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    setLoading(Boolean(service.listHistory))
+    setError(null)
+    void (service.listHistory?.() ?? Promise.resolve([])).then(
+      (nextItems) => {
+        if (!active) return
+        setItems(nextItems)
+        setLoading(false)
+      },
+      () => {
+        if (!active) return
+        setItems([])
+        setError('历史记录暂时无法加载')
+        setLoading(false)
+      },
+    )
+    return () => {
+      active = false
+    }
+  }, [activeRunId, service])
+
+  const closeMobile = () => setMobileOpen(false)
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="打开创作历史"
+        aria-expanded={mobileOpen}
+        onClick={() => setMobileOpen(true)}
+        className="fixed top-[4.25rem] left-3 z-40 grid size-10 place-items-center rounded-xl border border-app-line bg-app-surface-raised text-app-muted shadow-app-card transition hover:text-app-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent lg:hidden"
+      >
+        <SidebarSimple aria-hidden="true" size={21} weight="bold" />
+      </button>
+
+      {mobileOpen ? (
+        <button
+          type="button"
+          aria-label="关闭创作历史"
+          onClick={closeMobile}
+          className="fixed inset-0 z-40 bg-app-ink/20 backdrop-blur-[2px] lg:hidden"
+        />
+      ) : null}
+
+      <aside
+        data-open={mobileOpen ? 'true' : 'false'}
+        className={`fixed top-14 bottom-0 left-0 z-50 flex w-72 flex-col border-r border-app-line bg-app-surface px-3 py-4 text-app-ink shadow-app-panel transition-transform duration-200 lg:z-30 lg:translate-x-0 lg:shadow-none ${
+          mobileOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="mb-3 flex items-center justify-between px-2">
+          <div className="flex items-center gap-2.5">
+            <span className="grid size-8 place-items-center rounded-xl bg-app-accent-soft text-app-accent">
+              <ClockCounterClockwise aria-hidden="true" size={18} weight="bold" />
+            </span>
+            <div>
+              <p className="font-serif text-base font-semibold">创作历史</p>
+              <p className="text-[11px] text-app-faint">继续上一次 Quick Start</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label="关闭创作历史"
+            onClick={closeMobile}
+            className="grid size-9 place-items-center rounded-lg text-app-muted hover:bg-app-surface-muted lg:hidden"
+          >
+            <X aria-hidden="true" size={17} weight="bold" />
+          </button>
+        </div>
+
+        <Link
+          to="/quick-start"
+          aria-current={activeRunId ? undefined : 'page'}
+          onClick={closeMobile}
+          className={`mb-4 flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-semibold transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ${
+            activeRunId
+              ? 'text-app-ink-soft hover:bg-app-surface-muted'
+              : 'bg-app-accent-soft text-app-accent'
+          }`}
+        >
+          <NotePencil aria-hidden="true" size={19} weight="bold" />
+          新建创作
+        </Link>
+
+        <nav aria-label="创作历史" className="min-h-0 flex-1 overflow-y-auto">
+          <p className="px-3 pb-2 font-mono text-[10px] font-bold tracking-[0.14em] text-app-faint">
+            RECENT
+          </p>
+          {loading ? (
+            <p role="status" className="px-3 py-3 text-xs text-app-muted">
+              正在读取历史记录…
+            </p>
+          ) : error ? (
+            <p role="alert" className="px-3 py-3 text-xs leading-5 text-app-danger-muted">
+              {error}
+            </p>
+          ) : items.length === 0 ? (
+            <p className="px-3 py-3 text-xs leading-5 text-app-muted">还没有历史创作</p>
+          ) : (
+            <ol className="grid gap-1">
+              {items.map((item) => {
+                const current = item.runId === activeRunId
+                return (
+                  <li key={item.runId}>
+                    <Link
+                      to={`/quick-start/${encodeURIComponent(item.runId)}`}
+                      aria-current={current ? 'page' : undefined}
+                      onClick={closeMobile}
+                      title={item.title}
+                      className={`group flex min-w-0 items-center gap-2.5 rounded-xl px-3 py-2.5 text-sm transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-accent ${
+                        current
+                          ? 'bg-app-surface-strong font-semibold text-app-ink'
+                          : 'text-app-ink-soft hover:bg-app-surface-muted'
+                      }`}
+                    >
+                      <ChatCircle
+                        aria-hidden="true"
+                        size={17}
+                        weight={current ? 'fill' : 'regular'}
+                        className={current ? 'text-app-accent' : 'text-app-faint'}
+                      />
+                      <span className="truncate">{item.title}</span>
+                    </Link>
+                  </li>
+                )
+              })}
+            </ol>
+          )}
+        </nav>
+      </aside>
+    </>
+  )
+}

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -729,6 +729,39 @@ function renderStateFixture(
 }
 
 describe('QuickStartPage', () => {
+  it('从左侧历史栏回到所选 run 的原 Quick Start 会话', async () => {
+    const run = workflow(setupAndTemplate(), 'run-current')
+    const service = serviceFor(run, {
+      listHistory: vi.fn(async () => [
+        { runId: 'run-old', title: '森林里的蓝发弓箭手' },
+        { runId: 'run-current', title: '像素骑士' },
+      ]),
+    })
+    window.localStorage.setItem(
+      'windup.quick-start.agent-chat.v2:run:7:run-old',
+      JSON.stringify({
+        turns: [
+          { role: 'user', content: '保留蓝色斗篷' },
+          { role: 'assistant', content: '上次保留的对话', kind: 'reply' },
+        ],
+      }),
+    )
+
+    renderAt('/quick-start/run-current', service)
+
+    const history = await screen.findByRole('navigation', { name: '创作历史' })
+    expect(
+      within(history).getByRole('link', { name: '像素骑士' }).getAttribute('aria-current'),
+    ).toBe('page')
+    fireEvent.click(within(history).getByRole('link', { name: '森林里的蓝发弓箭手' }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location-probe').textContent).toBe('/quick-start/run-old'),
+    )
+    expect(await screen.findByText('上次保留的对话')).toBeTruthy()
+    expect(service.open).toHaveBeenLastCalledWith('run-old')
+  })
+
   it('keeps the main export capability available in the conversation UI', async () => {
     const run = workflow(setupAndTemplate({ selectedImageUrl: '/master.png' }))
     const model: ExportPackageModel = {

--- a/frontend/src/pages/quick-start/index.tsx
+++ b/frontend/src/pages/quick-start/index.tsx
@@ -35,6 +35,7 @@ import {
 import Markdown, { compiler } from 'markdown-to-jsx'
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router'
 import { InlineArrowAction } from './inline-arrow-action'
+import { QuickStartHistorySidebar } from './history-sidebar'
 import { PixelPerfectVersionSwitch, type PixelPerfectVersion } from './pixel-perfect-version-switch'
 
 import {
@@ -589,26 +590,36 @@ export function QuickStartPage({
     setCreatedSession((current) => (current === consumed ? null : current))
   }, [])
 
-  return runId ? (
-    <QuickStartRun
-      key={runId}
-      service={activeService}
-      runId={runId}
-      initialSession={createdSession?.runId === runId ? createdSession : null}
-      onSessionCreated={setCreatedSession}
-      onInitialSessionConsumed={consumeCreatedSession}
-      activeRunUserId={activeRunUserId}
-      agent={agent}
-    />
-  ) : (
-    <QuickStartInput
-      key={`${location.key}:${activeRunUserId ?? 'local'}`}
-      service={activeService}
-      agent={agent}
-      activeRunUserId={activeRunUserId}
-      projectApis={projectApis}
-      characterApis={characterApis}
-    />
+  return (
+    <div
+      data-layout="quick-start-with-history"
+      className="relative min-h-screen bg-app-canvas lg:pl-72"
+    >
+      <QuickStartHistorySidebar service={activeService} activeRunId={runId} />
+      <div className="min-w-0">
+        {runId ? (
+          <QuickStartRun
+            key={runId}
+            service={activeService}
+            runId={runId}
+            initialSession={createdSession?.runId === runId ? createdSession : null}
+            onSessionCreated={setCreatedSession}
+            onInitialSessionConsumed={consumeCreatedSession}
+            activeRunUserId={activeRunUserId}
+            agent={agent}
+          />
+        ) : (
+          <QuickStartInput
+            key={`${location.key}:${activeRunUserId ?? 'local'}`}
+            service={activeService}
+            agent={agent}
+            activeRunUserId={activeRunUserId}
+            projectApis={projectApis}
+            characterApis={characterApis}
+          />
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -41,6 +41,10 @@ function createWorkflowRunApis(initialRuns: readonly WorkflowRun[] = []): Workfl
       const items = [...runs.values()].filter((run) => run.projectId === projectId)
       return { items: structuredClone(items), total: items.length, page: 1, pageSize: 100 }
     },
+    async listRecent() {
+      const items = [...runs.values()].reverse()
+      return { items: structuredClone(items), total: items.length, page: 1, pageSize: 20 }
+    },
     async get(id) {
       const run = runs.get(id)
       if (!run) throw new Error('not found')
@@ -350,6 +354,30 @@ function actionRun(firstFramePending = false): WorkflowRun {
 }
 
 describe('createQuickStartService', () => {
+  it('把最近运行记录映射为可恢复的 Quick Start 历史项', async () => {
+    const first = actionRun()
+    first.id = 'run-first'
+    const second = actionRun()
+    second.id = 'run-second'
+    const secondSetup = second.nodes.find((node) => node.type === 'character-setup')
+    if (!secondSetup || secondSetup.type !== 'character-setup') throw new Error('fixture invalid')
+    secondSetup.input.prompt = '森林里的蓝发弓箭手'
+    const service = createQuickStartService({
+      workflowRunApis: createWorkflowRunApis([first, second]),
+      generationApis: pendingGenerationApis(),
+      prepareProject: vi.fn(),
+      projectApis: projectReader(),
+    })
+    const historyService = service as typeof service & {
+      listHistory(): Promise<readonly { runId: string; title: string }[]>
+    }
+
+    await expect(historyService.listHistory()).resolves.toEqual([
+      { runId: 'run-second', title: '森林里的蓝发弓箭手' },
+      { runId: 'run-first', title: '像素骑士' },
+    ])
+  })
+
   it('读取当前活跃生成步骤前方的任务数', async () => {
     const run: WorkflowRun = {
       id: 'run-queued',

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -79,6 +79,11 @@ export interface QuickStartResumeOptions {
   automaticActionAdvance?: boolean
 }
 
+export interface QuickStartHistoryItem {
+  runId: WorkflowRun['id']
+  title: string
+}
+
 export interface QuickStartMediaApis {
   upload(file: File, category: 'reference-image', signal?: AbortSignal): Promise<MediaReference>
 }
@@ -148,6 +153,8 @@ export interface QuickStartSession {
 
 export interface QuickStartEntryService {
   readonly unavailableReason: string | null
+  /** 当前用户最近创建的 Quick Start 会话，按新到旧排序。 */
+  listHistory?(): Promise<readonly QuickStartHistoryItem[]>
   /** 上传为 Agent 与角色母版 Generation 共用的原始参考，不创建 WorkflowRun。 */
   uploadReferenceImage(file: File, signal?: AbortSignal): Promise<MediaReference>
   start(
@@ -1460,6 +1467,16 @@ export function createQuickStartService({
 
   return {
     unavailableReason: null,
+
+    async listHistory() {
+      if (!workflowRunApis.listRecent) return []
+      const result = await workflowRunApis.listRecent({ page: 1, pageSize: 50 })
+      return result.items.map((run) => {
+        const setup = run.nodes.find((node) => node.type === 'character-setup')
+        const title = setup?.type === 'character-setup' ? setup.input.prompt.trim() : ''
+        return { runId: run.id, title: title || '未命名创作' }
+      })
+    },
 
     async uploadReferenceImage(file, signal) {
       if (!mediaApis) throw new Error('媒体上传服务尚未配置，不能使用角色参考图')

--- a/openapi.json
+++ b/openapi.json
@@ -3832,6 +3832,11 @@
       "WorkflowRunOut": {
         "description": "执行记录响应。",
         "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
           "id": {
             "title": "Id",
             "type": "integer"
@@ -3859,7 +3864,8 @@
           "id",
           "project_id",
           "status",
-          "version"
+          "version",
+          "created_at"
         ],
         "title": "WorkflowRunOut",
         "type": "object"
@@ -6319,17 +6325,24 @@
     },
     "/workflow-runs": {
       "get": {
-        "description": "分页查询项目下的执行记录。",
+        "description": "分页查询项目记录；未指定项目时返回当前用户的跨项目历史。",
         "operationId": "list_runs_workflow_runs_get",
         "parameters": [
           {
             "in": "query",
             "name": "project_id",
-            "required": true,
+            "required": false,
             "schema": {
-              "exclusiveMinimum": 0,
-              "title": "Project Id",
-              "type": "integer"
+              "anyOf": [
+                {
+                  "exclusiveMinimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Project Id"
             }
           },
           {


### PR DESCRIPTION
## Summary

- add a responsive Quick Start history rail with loading, empty, error, and selected states
- expose recent workflow runs across the signed-in user's projects
- restore the selected run and its run-scoped Agent conversation on navigation
- refresh the OpenAPI snapshot and cover ownership, ordering, mapping, and navigation

## Verification

- `npm test` — 1257 passed
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `uv run pytest -q` — 1847 passed, 14 skipped
- `uv run ruff check ...`
- `uv run lint-imports`
- browser QA at desktop and mobile viewports