### PR TITLE
fix(gateway): 台账记下每一跳实际发给上游的提示词正文

### DIFF
--- a/backend/packages/framework/src/windup_framework/gateway/ledger.py
+++ b/backend/packages/framework/src/windup_framework/gateway/ledger.py
@@ -60,6 +60,10 @@ def _json_or_none(value: Any) -> Any:
     return {"value": str(value)}
 
 
+#: 落库的提示词正文长度上限。当前正文约 1–2KB,留足余量。
+_PROMPT_MAX_CHARS = 8000
+
+
 def _audit_extra(detail: AttemptDetail) -> dict | None:
     extra: dict[str, object] = {}
     if detail.policy_next_step:
@@ -72,6 +76,10 @@ def _audit_extra(detail: AttemptDetail) -> dict | None:
         extra["finish_reason"] = detail.finish_reason
     if detail.has_tool_calls is not None:
         extra["has_tool_calls"] = detail.has_tool_calls
+    if detail.prompt:
+        # 截断而不是整条存:提示词正文约 1–2KB,而一次生成会记多跳(429 换 key 时更多)。
+        # 上限取得比正文长,截断实际不会发生;它防的是将来某次把整本 md 塞进提示词。
+        extra["prompt"] = detail.prompt[:_PROMPT_MAX_CHARS]
     return extra or None
 
 

--- a/backend/packages/framework/src/windup_framework/gateway/trace.py
+++ b/backend/packages/framework/src/windup_framework/gateway/trace.py
@@ -34,6 +34,16 @@ class AttemptDetail:
     upstream_reached: str | None = None
     model_index: int | None = None
     error_message: str | None = None
+    #: 这一跳**实际发给上游的提示词正文**(#841)。
+    #:
+    #: 存正文而不是只存 ``input_hash``:哈希能证明"两次发的一样",却答不了用户那句
+    #: "这不是我要的动作"——而那正是它唯一会被查的场合。生产 #564 的诊断全部成本
+    #: 都花在这里:任务结果里只有 ``prompt_version: v2``,要证明"我们发的和用户写的
+    #: 不是一回事",只能读代码反推 + 去上游捞源视频(而源视频会过期)。
+    #:
+    #: 落 ``extra`` 而不是新开一列:这张表本来就是"我们往上游发了什么"的台账,
+    #: 而 ``extra`` 已经在装同类的取证字段(policy_next_step / upstream_reached)。
+    prompt: str | None = None
     finish_reason: str | None = None
     has_tool_calls: bool | None = None
 

--- a/backend/packages/framework/src/windup_framework/gateway/video.py
+++ b/backend/packages/framework/src/windup_framework/gateway/video.py
@@ -285,6 +285,7 @@ class VideoGateway:
                             attempt_latency_ms=attempt_latency_ms,
                             resend_spent=resend_spent,
                             seconds=seconds,
+                            prompt=prompt,
                             outcome="failed",
                             error_type=error_type,
                             submit_ms=submit_ms,
@@ -312,6 +313,7 @@ class VideoGateway:
                             attempt_latency_ms=attempt_latency_ms,
                             resend_spent=resend_spent,
                             seconds=seconds,
+                            prompt=prompt,
                             outcome="fallback_success" if fallback_used else "success",
                             submit_ms=submit_ms,
                             policy_next_step="success",
@@ -378,6 +380,7 @@ class VideoGateway:
                         attempt_latency_ms=attempt_latency_ms,
                         resend_spent=resend_spent,
                         seconds=seconds,
+                            prompt=prompt,
                         outcome="failed",
                         circuit_scope=circuit_scope,
                         error_type=error_type,
@@ -476,6 +479,7 @@ class VideoGateway:
         attempt_latency_ms: int,
         resend_spent: int,
         seconds: int,
+        prompt: str,
         outcome: str,
         circuit_scope: str | None = None,
         error_type: ModelErrorType | None = None,
@@ -542,6 +546,7 @@ class VideoGateway:
                         error_type, http_status=result.http_status, ok=result.ok
                     ),
                     model_index=model_index,
+                    prompt=prompt,
                 ),
             )
         )

--- a/backend/tests/test_sent_prompt_is_recorded.py
+++ b/backend/tests/test_sent_prompt_is_recorded.py
@@ -1,0 +1,97 @@
+"""发给上游的提示词正文要落进网关台账(#841)。
+
+拦的坏例:用户说"这不是我要的动作",而我们答不上来到底发了什么。
+
+生产 #564 就是这个形状 —— 用户选 attack、写了"炸开分裂成小史莱姆",拿回来一段
+金发人形武者。任务结果里只有:
+
+    {type, frames, quality, geometry, direction, action_type, prompt_version: "v2"}
+
+没有正文。要证明"我们发的和他写的不是一回事",只能读代码反推运动拓扑,再去上游
+按 job_id 捞源视频 —— 而上游的视频会过期,捞不到就再也说不清了。
+
+``input_hash`` 答不了这个问题:哈希能证明两次发的一样,答不了发的是什么。
+"""
+from __future__ import annotations
+
+from windup_framework.gateway.ledger import _PROMPT_MAX_CHARS, _audit_extra
+from windup_framework.gateway.trace import AttemptDetail
+
+# #564 发出去的那段(节选)。它与用户写的那句毫无关系,而这正是要能查出来的东西。
+THRUST = (
+    "coiled low with the weight on the back foot and the striking side pulled in "
+    "at waist height, the hips snap forward"
+)
+
+
+def test_the_prompt_text_reaches_the_ledger_row():
+    """正文要真的落进 extra —— 字段加了没人写,是本仓最典型的静默失败。"""
+    extra = _audit_extra(AttemptDetail(input_hash="h", prompt=THRUST))
+    assert extra is not None
+    assert extra["prompt"] == THRUST
+
+
+def test_a_hash_alone_does_not_answer_what_we_sent():
+    """只有 input_hash 时,extra 里没有任何能回答"发了什么"的东西。
+
+    这条钉的是**为什么要加这个字段**:没有它,台账里关于提示词的全部信息就是一个
+    64 位十六进制串。
+    """
+    extra = _audit_extra(AttemptDetail(input_hash="a" * 64))
+    assert extra is None or "prompt" not in extra
+
+
+def test_no_prompt_leaves_the_extra_untouched():
+    """没提示词的场次(轮询、纯失败跳)不该凭空多出一个空键。"""
+    assert _audit_extra(AttemptDetail(input_hash="h", prompt=None)) is None
+    assert _audit_extra(AttemptDetail(input_hash="h", prompt="")) is None
+
+
+def test_a_runaway_prompt_is_truncated_not_dropped():
+    """超长时截断,不是整条丢掉。
+
+    丢掉等于回到"查不出发了什么";而不设上限,将来某次把整份 md 塞进提示词时,
+    这张按跳记录的表会被撑爆(一次生成在 429 换 key 时能记十几跳)。
+    """
+    extra = _audit_extra(AttemptDetail(prompt="字" * (_PROMPT_MAX_CHARS + 500)))
+    assert extra is not None
+    assert len(extra["prompt"]) == _PROMPT_MAX_CHARS
+
+
+def test_the_video_gateway_records_the_prompt_it_actually_sent():
+    """接线检查:真跑一次网关,断言台账那条记录里带着这一跳发出去的正文。
+
+    只测 ``_audit_extra`` 的话,字段可以完美地落库、却永远是 None —— 因为没人填。
+    这条从 ``i2v`` 发起,走的是生产那条路径。
+    """
+    from windup_framework.config.provider import AIProviderSettings
+    from windup_framework.gateway.circuit import CircuitBreaker
+    from windup_framework.gateway.registry import ModelRegistry
+    from windup_framework.gateway.types import AdapterResult
+    from windup_framework.gateway.video import VideoGateway
+
+    from test_gateway_video import FakeVideoAdapter
+
+    cfg = AIProviderSettings(video_model="kling-v2-5-turbo", video_fallbacks="")
+    adapter = FakeVideoAdapter(
+        submits={"kling-v2-5-turbo": [AdapterResult(ok=True, job_id="j1", maybe_billed=True)]},
+        follows={"j1": AdapterResult(ok=True, body=b"\x00\x00\x00\x18ftypmp42",
+                                     maybe_billed=True, job_id="j1")},
+    )
+    gw = VideoGateway(
+        registry=ModelRegistry.from_settings(cfg), adapter=adapter,
+        circuit=CircuitBreaker(cooldown_s=60), settings=cfg,
+    )
+
+    seen: list = []
+    original = gw._emit
+
+    def _capture(trace):
+        seen.append(trace)
+        return original(trace)
+
+    gw._emit = _capture
+    gw.i2v(b"frame", THRUST)
+
+    prompts = [t.detail.prompt for t in seen if t.detail is not None]
+    assert THRUST in prompts, f"台账里没有这一跳发出去的正文,只有 {prompts!r}"


### PR DESCRIPTION
Closes #844

## 问题

用户说「这不是我要的动作」时，**我们答不上来到底发了什么。**

任务结果里关于提示词只有一个版本号（`prompt_version: "v2"`），网关台账里只有 `input_hash`。哈希能证明「两次发的一样」，答不了「发的是什么」—— 而后者才是它唯一会被查的场合。

#564 已经付过一次这个代价。要证明「我们发的和用户写的不是一回事」，实际走的路是：读 `strategy/concrete.py` 反推 attack 取了哪个模板 → 读 `attack.md` 确认那段在描述人形武者 → 按 `job_id` 去上游把源视频捞回来逐帧看。

第三步是运气 —— **上游的视频会过期**。如果台账里有正文，这是一条 SQL。

#839 之后这个缺口更疼：同一个 `action_type` 现在可能带用户细节、也可能不带，产物对不对全看那一句。

## 改法

```
AttemptDetail.prompt  →  _audit_extra（已有）  →  attempt_detail.extra（JSONB，已有列）
```

选这里而不是 `GeneratedAction` / `ai_engine`：

- 这张表本来就是「我们往上游发了什么」的台账，`extra` 已经在装同类取证字段（`policy_next_step` / `upstream_reached`）。
- **不碰 `ai_engine` / `strategy` / `GeneratedAction`** —— 那几处正被 #777、#839 改着，在那里加字段必然冲突。本 PR 只动 `gateway/{trace,ledger,video}.py`。
- 按跳记录：429 换 key 重试的每一跳都留痕，能看出换 key 之后发的还是不是同一段。

超长截断 8000 字符（当前正文约 1–2KB）。截断而不是丢弃：丢弃等于回到查不出发了什么；不设上限则是将来某次把整份 md 塞进提示词时，这张按跳记录的表会被撑爆。

无 schema 变更 —— `extra` 是已有的 JSONB 列。

## 验证

变异测试，每条都验过回滚即变红：

| 变异 | 结果 |
|---|---|
| 网关收了 `prompt` 但不传给 `AttemptDetail` | 1 红 |
| `ledger` 不落库 | 2 红 |
| 超长时整条丢掉而不是截断 | 1 红 |

接线那条测试是**真跑一次 `i2v`** 然后断言台账记录里带着正文，不是 `inspect.getsource` 匹配关键词 —— 后者在本仓栽过一次（假测试在变异下照样绿）。

CI 原样命令，跑在最后一次编辑之后：`ruff check .` 通过；`export_openapi` rc=0 且 openapi.json 无漂移；`lint-imports` 2 kept / 0 broken；`pytest -q --cov=packages` **1864 passed, 14 skipped**。

## 一处留给评审拍板的

正文里含用户写的文字。它已经存在于 `windup_generation_task.input_payload.custom_prompt`，本 PR 不引入新的数据类别，只是让「发出去的成品」也可查。如果认为台账该只留哈希，我可以改成只在 `outcome=failed` 或 `maybe_billed` 时记 —— 但那样最需要它的场合（任务成功、产物却不对，正是 #564）恰好记不到。
