### PR TITLE
feat(character): 体型存在角色上，让三道按体型分流的判据不再是死代码

### DIFF
--- a/backend/packages/app/src/windup_app/server/character/model.py
+++ b/backend/packages/app/src/windup_app/server/character/model.py
@@ -54,6 +54,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from windup_common.enums.character import CharacterStatus
+from windup_common.models import CharacterStance
 from windup_framework.db import Base
 
 
@@ -298,6 +299,20 @@ class CharacterData(BaseModel):
     """角色完整数据（方向母版与造型→动作→帧）。"""
 
     version: int = Field(default=1, ge=1, description="结构版本")
+    # 角色体型。决定"手臂/手肘"这类人体部位词能不能进提示词 —— 非双足角色的描述里
+    # 出现它们,模型会凭空接上一对人的上肢,而帧数/时长/成色全部正常、没有一道会红。
+    #
+    # 存在角色上而不是每次动作请求带:体型是角色的属性,不是这次生成的选项。
+    # 放在请求里的那份(``CreateActionInput.stance``)此前 558/558 个任务一个都没传过,
+    # 三道按体型分流的判据因此全是死代码(#840)。
+    #
+    # ``None`` = 没人选过,**与"选了双足"是两回事**。不在这里兜 BIPED:兜了的话
+    # 每个新建角色都会把默认值实体化写进 character_data,于是"有人确认过它是人形"
+    # 和"从来没人看过这个字段"再也分不开 —— 而那正是 #840 本身的形状。
+    # 双足这个默认值由 ``CharacterCard.stance`` 定义一次,下游取不到时用它。
+    stance: CharacterStance | None = Field(
+        default=None, description="角色体型(双足/四足/无肢);未设置时下游按双足处理"
+    )
     templates: list[CharacterTemplateSequence] = Field(
         default_factory=list, description="角色各源方向母版与镜像关系"
     )

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -533,6 +533,29 @@ def _require_3d_action_quota(character: Character, outfit_id: str | None) -> Non
         )
 
 
+def _character_stance(character: Character) -> CharacterStance | None:
+    """角色存的体型;没存过就给 None(让下游用它自己的默认值)。
+
+    返回 None 而不是直接给 BIPED:默认值只该由 ``CharacterCard.stance`` 定义一次。
+    在这里再兜一个,就是第二真相源 —— 两处默认值一定会各自漂。
+
+    ``character_data`` 是裸 dict(存量 96 个角色都没有这个键),按契约解析会因为别的
+    字段不合规而整条炸掉,而这里只要一个字段。取不到就当没存过。
+    """
+    data = character.character_data
+    if not isinstance(data, dict):
+        return None
+    raw = data.get("stance")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return CharacterStance(raw)
+    except ValueError:
+        # 存了个不认识的值 —— 当没存过,别让一个脏字段挡住整条生成。
+        logger.warning("角色 %s 的 stance=%r 不是合法取值,按未设置处理", character.id, raw)
+        return None
+
+
 def _require_master(model_3d_url: str | None, reference_image_urls: list[str]) -> None:
     """动作生成拿不到母版就当场拒收,不收下一个注定在执行阶段失败的任务。"""
     # 判据照抄执行器的取母版逻辑(``ActionTaskExecutor._produce_action``):有 3D 资产走
@@ -774,7 +797,13 @@ def submit_action_generation(
         # 路线选择在这里定死并写进入参,而不是留给编排层现查:这样"这次走的哪条路线"
         # 在任务入参上就是可见的,排查时不用去猜当时 DB 是什么状态。
         model_3d_url=model_3d_url,
-        stance=body.stance,
+        # 请求没显式给就取角色上存的那个。与 model_3d_url 同一个模式:web 层读
+        # character_data、写进入参,这样"这次按什么体型算的"在任务入参上就是可见的,
+        # 排查时不用去猜当时 DB 是什么状态。
+        #
+        # 请求优先于角色:前者是这次生成的显式意图(脚本 / 调试会用),而角色上那个是
+        # 常态。反过来的话,角色一旦存错就没有任何办法单次绕过。
+        stance=body.stance if body.stance is not None else _character_stance(character),
     )
     task = generation_service.generate_character_action(
         session,

--- a/backend/tests/test_character_direction_contract.py
+++ b/backend/tests/test_character_direction_contract.py
@@ -155,7 +155,11 @@ def test_version_one_west_mirror_round_trips_unchanged():
 
     data = CharacterData.model_validate(payload)
 
-    assert data.model_dump() == payload
+    # 存量 payload(96/96 个线上角色)不带 stance,校验照收 —— 这是这条要守的兼容性。
+    # 但 dump 会多出 `stance: None`:新加的可空字段,None 表示"没人选过"。
+    # 期望值写成 payload | {...} 而不是把 stance 塞进 payload:后者会让这条看起来像
+    # "v1 本来就有这个字段",而它没有。
+    assert data.model_dump() == {**payload, "stance": None}
 
 
 def test_version_two_single_keeps_east_to_west_mirror_compatibility():

--- a/backend/tests/test_generation_api.py
+++ b/backend/tests/test_generation_api.py
@@ -911,3 +911,156 @@ def test_frame_convention_covers_every_action_type():
     from windup_app.server.orchestrator.model import ACTION_FRAME_COUNTS, ActionType
 
     assert set(ACTION_FRAME_COUNTS) == set(ActionType)
+
+
+# ── 体型存在角色上,而不是每次请求带(#840)────────────────────────────────
+
+
+def _create_character_with_stance(auth_client, project_id: int, stance: str) -> dict:
+    """建一个存了体型的角色。
+
+    走的是**现有**的角色接口 —— ``CharacterData`` 加了字段之后它自动收下,
+    不需要新端点。这条本身就在证明这一点。
+    """
+    return auth_client.post(
+        "/characters",
+        json={
+            "project_id": project_id,
+            "workflow_run_id": 1,
+            "name": "大蛇",
+            "character_data": {"version": 1, "templates": [], "outfits": [],
+                               "stance": stance},
+        },
+    ).json()["data"]
+
+
+def test_stance_stored_on_the_character_reaches_the_engine(auth_client, monkeypatch):
+    """拦的坏例:体型只能靠每次请求带,而没有任何调用方会带。
+
+    实测(2026-08-27 生产):558/558 个任务的 input_payload 里 stance 都是未传,
+    96/96 个角色的 character_data 里也从没存过它 —— 三道按体型分流的判据因此全是
+    死代码。存在角色上才是对的:体型是角色的属性,不是这次生成的选项。
+    """
+    from windup_app.web.api import generation as gen_api
+    from windup_app.server.orchestrator.model import CharacterActionInput
+
+    dispatched = _capture_action_input(gen_api, monkeypatch)
+    project = _create_project(auth_client)
+    character = _create_character_with_stance(auth_client, project["id"], "serpentine")
+
+    auth_client.post(
+        "/generation/action",
+        json=_action_payload(project["id"], character["id"]),   # 请求不带 stance
+    )
+
+    inputs = [a for args in dispatched for a in args if isinstance(a, CharacterActionInput)]
+    assert inputs, "任务没被收下"
+    assert inputs[0].stance is not None, "角色上存了体型,却没被读出来"
+    assert inputs[0].stance.value == "serpentine"
+
+
+def test_an_explicit_request_stance_beats_the_one_on_the_character(auth_client, monkeypatch):
+    """请求优先。角色上那个存错了的话,得有办法单次绕过。"""
+    from windup_app.web.api import generation as gen_api
+    from windup_app.server.orchestrator.model import CharacterActionInput
+
+    dispatched = _capture_action_input(gen_api, monkeypatch)
+    project = _create_project(auth_client)
+    character = _create_character_with_stance(auth_client, project["id"], "serpentine")
+
+    auth_client.post(
+        "/generation/action",
+        json=_action_payload(project["id"], character["id"], stance="quadruped"),
+    )
+
+    inputs = [a for args in dispatched for a in args if isinstance(a, CharacterActionInput)]
+    assert inputs[0].stance.value == "quadruped"
+
+
+def test_a_character_without_a_stance_behaves_exactly_as_before(auth_client, monkeypatch):
+    """96 个存量角色没有这个字段,行为必须一个字不变。
+
+    这里断言的是 ``None`` 而不是 ``biped``:默认值只该由 ``CharacterCard.stance``
+    定义一次,在读取处再兜一个就是第二真相源,两处一定会各自漂。
+    """
+    from windup_app.web.api import generation as gen_api
+    from windup_app.server.orchestrator.model import CharacterActionInput
+
+    dispatched = _capture_action_input(gen_api, monkeypatch)
+    project = _create_project(auth_client)
+    character = _create_character(auth_client, project["id"])
+
+    auth_client.post(
+        "/generation/action",
+        json=_action_payload(project["id"], character["id"]),
+    )
+
+    inputs = [a for args in dispatched for a in args if isinstance(a, CharacterActionInput)]
+    assert inputs[0].stance is None
+
+
+def test_a_garbage_stance_on_the_character_does_not_block_generation(
+    auth_client, monkeypatch, db_session
+):
+    """拦的坏例:一个脏字段把整条生成挡住。
+
+    ``character_data`` 是裸 JSONB,可能被别的写入方塞进不认识的值。当没存过处理并留
+    一条 WARNING,好过让用户拿到一个他改不动的 5xx。
+    """
+    from windup_app.web.api import generation as gen_api
+    from windup_app.server.character.model import Character
+    from windup_app.server.orchestrator.model import CharacterActionInput
+
+    dispatched = _capture_action_input(gen_api, monkeypatch)
+    project = _create_project(auth_client)
+    character = _create_character(auth_client, project["id"])
+
+    row = db_session.get(Character, character["id"])
+    row.character_data = {**(row.character_data or {}), "stance": "octopod"}
+    db_session.commit()
+
+    resp = auth_client.post(
+        "/generation/action",
+        json=_action_payload(project["id"], character["id"]),
+    )
+    assert resp.status_code < 500, resp.text
+    inputs = [a for args in dispatched for a in args if isinstance(a, CharacterActionInput)]
+    assert inputs and inputs[0].stance is None
+
+
+def test_a_serpentine_character_now_actually_trips_the_body_part_gate(auth_client, monkeypatch):
+    """这条是 #840 的验收:那道门禁**不再是死的**。
+
+    ``stance_mismatch`` 判据一直都在(``ai_engine.prompt.lint``),但生产里 558/558 个
+    任务没传过体型、96/96 个角色没存过 —— 它一次都没触发过。非双足角色的描述里出现
+    "手臂",模型会给它凭空接上一对人的上肢,而帧数、时长、成色全部正常,没有一道会红。
+
+    这条从 HTTP 入口发起,一路走到提示词构建,断言它现在会被拒。
+    """
+    from windup_ai_engine.ports import PromptRejected
+    from windup_ai_engine.strategy.concrete import VideoFrameStrategy
+    from windup_app.web.api import generation as gen_api
+    from windup_app.server.orchestrator.executor import ActionTaskExecutor, ProjectConstraints
+    from windup_app.server.orchestrator.model import CharacterActionInput
+    from windup_common.models import CharacterCard
+
+    dispatched = _capture_action_input(gen_api, monkeypatch)
+    project = _create_project(auth_client)
+    character = _create_character_with_stance(auth_client, project["id"], "serpentine")
+
+    payload = _action_payload(project["id"], character["id"])
+    payload["action_type"] = "custom"
+    payload["custom_prompt"] = "角色挥动双臂，手肘弯曲，双手向前推出。"
+    payload["loop"] = False
+    auth_client.post("/generation/action", json=payload)
+
+    inputs = [a for args in dispatched for a in args if isinstance(a, CharacterActionInput)]
+    assert inputs and inputs[0].stance.value == "serpentine", "体型没走到入参"
+
+    # 入参 → 引擎契约 → 提示词。走的是生产那条路径,不是手搓一个 ActionSpec。
+    _card, spec, _canvas = ActionTaskExecutor._action_spec(
+        object(), inputs[0], ProjectConstraints(facing="side", stylize="pixel"),
+    )
+    card = CharacterCard(name="c", desc="", stance=inputs[0].stance)
+    with pytest.raises(PromptRejected):
+        VideoFrameStrategy(video=None, matte=None)._build_prompt(spec, card.stance)

--- a/openapi.json
+++ b/openapi.json
@@ -687,6 +687,17 @@
             "title": "Outfits",
             "type": "array"
           },
+          "stance": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CharacterStance"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "角色体型(双足/四足/无肢);未设置时下游按双足处理"
+          },
           "templates": {
             "description": "角色各源方向母版与镜像关系",
             "items": {


### PR DESCRIPTION
Closes #840

本 PR 是 #840 的**后端半**：让体型有地方存、有人读。前端那半（让用户选）另开 #847，理由见文末。

## 问题

`CharacterStance` 这三道判据从来没有触发过，因为体型从没被采集过：

```
windup_character.character_data 顶层键   version / templates / outfits    96/96 个角色
windup_generation_task 的 stance 取值    (未传) × 558                     558/558 个任务
```

`CreateActionInput.stance` 缺省 `None`、`CharacterCard.stance` 缺省 `BIPED` —— **生产中每一个角色都被当成双足**。受影响的三处：

1. `stance_mismatch` 提示词门禁（`ai_engine.prompt.lint`）—— 非双足角色写"手臂"，模型凭空接一对人的上肢，而帧数/时长/成色全部正常
2. 攻击模板的人形假设 —— #564 的蓝色史莱姆就是这么套上 thrust 模板的（弓步、后脚承重、腰侧收招）
3. 自动绑骨 —— `render3d.py` 那条路的 `stance` 是必填无默认，注释写着"四足/无肢从模型几何判不出来"。三渲二已经承认这个字段必须由人给，而动作生成这条线还在猜。

## 改法

**`CharacterData` 加 `stance`。** 加了就自动能通过现有的角色接口设置（`POST /characters` 收的就是完整 `CharacterData`），不需要新端点 —— 测试里的 `_create_character_with_stance` 走的正是这条现成的路。

**web 层读出来写进入参**，与 `model_3d_url` 同一个模式。那段注释已经说明了为什么在这里读而不是留给编排层现查：*「这次走的哪条路线在任务入参上就是可见的，排查时不用去猜当时 DB 是什么状态」*。体型同理。

## 三个判断，都可以推翻我

**① 可空，不兜 `BIPED`。**

兜了的话每个新建角色都会把默认值实体化写进 `character_data`，于是「有人确认过它是人形」和「从来没人看过这个字段」再也分不开 —— 而那正是 #840 本身的形状。双足这个默认值由 `CharacterCard.stance` 定义一次，下游取不到时用它；在读取处再兜一个就是第二真相源。

代价：`CharacterData.model_dump()` 现在会多出 `stance: None`，一条契约测试的期望值跟着改了。校验仍然接受不带这个键的存量 payload —— 兼容性没破，破的只是 dump 的逐字节相等。

**② 请求优先于角色。**

角色上那个存错了，得有办法单次绕过（脚本/调试）。反过来的话只能先改角色再重试。

**③ 脏值当没存过。**

`character_data` 是裸 JSONB，别的写入方可能塞进不认识的值。抛错的话一个脏字段会挡住整条生成，而用户改不动它。当没存过 + 一条 WARNING。

## 验证

变异测试，每条回滚即变红：

| 变异 | 结果 |
|---|---|
| 不读角色上的体型（退回只认请求） | 2 红 |
| 角色盖过请求 | 2 红 |
| 脏值抛错而不是当没存过 | 1 红 |

**验收那条是端到端的**：从 `POST /generation/action` 发起，一个 `serpentine` 角色 + 「角色挥动双臂，手肘弯曲」的描述，一路走到提示词构建，断言现在真的 `PromptRejected`。这条在改动之前是绿不了的 —— 那道门禁根本到不了。

CI 原样命令，跑在最后一次编辑之后：`ruff check .` 通过；`export_openapi` rc=0（openapi.json 有变更，是新字段，已提交）；`lint-imports` 2 kept / 0 broken；`pytest -q --cov=packages` **1864 passed, 14 skipped**。

## 为什么前端那半另开

让用户选体型是新 UI，而**这个仓库明确否决过自动识别**：

> 不自动识别：那要调模型，而认错是静默的 —— 错误的体型只在下一次付费生成的画面上显形。

所以不能靠 quick-start 的 planner 顺手分类（它已经在分 `actionType`，加一个 `stance` 技术上很容易，但那正是被否决的做法）。得让人选，而现有前端没有角色属性面板可挂 —— 那是设计决定，不该夹带在实现 PR 里。已开 #847。

在 #847 落地之前，本 PR 的效果是：**字段可存可读、判据接线通了**，但除非有人通过接口写入，生产行为一个字不变（96 个存量角色仍然全部走 `BIPED` 默认）。不能拿本 PR 当「非人形角色已修好」汇报。


