### PR TITLE
fix(pack): 交付帧不再把角色的头平切掉

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/postprocess/pack.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/postprocess/pack.py
@@ -257,6 +257,7 @@ def align_bottom_center(
     max_core, max_full = max(1.0, max(core_w)), max(1.0, max(full_w))
     scale = min(scale, (cw * fill_w) / max_core)
 
+
     # 整帧装不下时**不为它压缩角色**,让延展物溢出被裁。
     #
     # 这两个目标本身冲突:延展物越宽,"装进画布"就把角色压得越小,而那正是本函数要消除的
@@ -283,6 +284,43 @@ def align_bottom_center(
             ratio * 100, min(per_frame), max(per_frame),
         )
 
+    # ── 高度夹取。必须放在 per_frame 之后 ────────────────────────────────────
+    #
+    # 高度方向溢出的不是翅尖尾尖,是**脑袋**。上面的定标取的是中位数,按构造就有约一半
+    # 的帧比它高;而摆放时 ``top = ch*foot_line - h`` 允许为负,``alpha_composite`` 到负
+    # 坐标会把顶部**静默**裁掉。生产 #604(老妇待机)实测:32 帧里 9 帧顶边贴 y=0、
+    # 头顶被平切,而帧数、时长、脚线、成色全部正常 —— 只能靠人看动图发现。
+    #
+    # 乘 ``per_frame`` 是防御性的:实际用的是 ``scale * per_frame[idx]``,补偿系数以 1.0
+    # 为中心,原理上可以大于 1 并把某帧顶回去。**但这一项目前没有用例覆盖** —— 造了三种
+    # 漂移形态(单调推镜 / 阶跃 / 强推镜),``scale_drift`` 给出的系数恒为 1.0,拿掉这一项
+    # 测试也不会红。留着是因为它对且零成本,不是因为它被验证过。
+    #
+    # 夹取按**本体**跨度而不是整体包围盒,与宽度同一条理由:按包围盒夹会让"举过头顶"
+    # 那一帧把整段压小(实测人形举武器 68.4%)。举起来的武器仍可溢出被裁、和翅尖同档;
+    # 本体(含头)必须完整。
+    # 要夹的量是**本体顶到包围盒底**的距离,不是本体跨度 —— 摆放时 ``top`` 按包围盒底
+    # 定位(``foot_line - h``),所以决定本体会不会顶出去的正是这一段。
+    # 拿本体跨度去夹会差一个"本体顶到包围盒顶"的偏移;实测那样写仍然切进身体,
+    # 这是本修复里唯一真正起作用的那一处改动。
+    foot_px = int(ch * foot_line)          # 摆放用的是这个整数,夹取也要用它
+    need_h = 0.0
+    for f, box, pf in zip(frames, boxes, per_frame):
+        if box is None:
+            continue
+        m = np.asarray(f.crop(box))[:, :, 3] > 128
+        r0, _r1 = _core_rows(m)
+        need_h = max(need_h, ((box[3] - box[1]) - r0) * pf)
+    if need_h > 0:
+        height_bound = foot_px / need_h
+        if height_bound < scale:
+            _logger.info(
+                "按最高帧的本体高度收窄定标(避免头顶被裁):%.4f → %.4f;"
+                "最高需求(本体顶→脚线,含漂移补偿) %.0fpx、可用高 %dpx",
+                scale, height_bound, need_h, foot_px,
+            )
+            scale = height_bound
+
     if max_full * scale > cw:
         _logger.info(
             "保尺寸一致而不压缩:整帧需 %.0fpx、画布 %dpx,两侧各溢出约 %.0fpx",
@@ -305,6 +343,12 @@ def align_bottom_center(
         else:
             lift = round((ground - box[3]) * fs) if preserve_lift else 0
             top = int(ch * foot_line) - h - lift
+            if top < 0:
+                # 夹取之后还溢出,只可能是举过头顶的延展物(与宽度那档同理)。
+                # 但**不静默** —— 这正是 #604 头被切掉却无人知晓的那条路。
+                _logger.info(
+                    "第 %d 帧顶部溢出 %dpx 被裁(本体已夹取,溢出的是延展物)", idx, -top,
+                )
         crop = crop.resize((w, h), resample)
         canvas = Image.new("RGBA", (cw, ch), (0, 0, 0, 0))
         canvas.alpha_composite(crop, (cw // 2 - w // 2, top))

--- a/backend/tests/test_head_not_clipped.py
+++ b/backend/tests/test_head_not_clipped.py
@@ -1,0 +1,144 @@
+"""交付帧不许把角色的头裁掉(#604)。
+
+生产实测:任务 604(老妇待机,veo 出的源视频)32 帧里 **9 帧顶边贴 y=0、头顶被平切**,
+而源视频里头是完整的、四周留白很足。链上的事实:
+
+    fill_h = min(FOOT_LINE, 母版主体占幅)   → 这个母版占幅高,fill_h 顶到 0.92 = 脚线
+    scale  = ch*fill_h / median(本体跨度)    → 按构造约一半的帧高于目标高度
+    top    = ch*foot_line - h                → h 超了就是负数
+    alpha_composite(crop, (x, top))          → 负坐标**静默**裁掉顶部
+
+而帧数、时长、脚线、成色全部正常,没有任何一处报错。同一个函数在**宽度**方向既夹取
+(``scale = min(scale, (cw*fill_w)/max_core)``)又打日志,高度方向两样都没有。
+"""
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image
+
+from windup_ai_engine.postprocess.pack import FOOT_LINE, align_bottom_center
+
+
+def _figure(h: int, body_w: int = 60, head_w: int = 24, canvas: int = 400) -> Image.Image:
+    """一个立在画布底部、**头比身体窄**的人形。``h`` 是总高。
+
+    头必须比身体窄:这样"被切"才可判 —— 切到身体那一层,顶行宽度就是身体宽;
+    头完整时顶行宽度是头宽。生产 #604 第 0 帧顶行 70 个不透明像素,正是身体那么宽的
+    一条横切面,而不是头顶。只断言"顶行有没有像素"会把**贴边**误判成**被切**。
+    """
+    a = np.zeros((canvas, canvas, 4), dtype=np.uint8)
+    y1 = canvas - 20                      # 脚离画布底 20px
+    head_h = max(6, h // 5)
+    bx = (canvas - body_w) // 2
+    hx = (canvas - head_w) // 2
+    a[y1 - h + head_h:y1, bx:bx + body_w] = (200, 180, 160, 255)   # 身体
+    a[y1 - h:y1 - h + head_h, hx:hx + head_w] = (230, 210, 190, 255)  # 头
+    return Image.fromarray(a, "RGBA")
+
+
+def _top_row_width(im: Image.Image) -> int:
+    """交付帧顶行的不透明像素数。头完整 → 约等于头宽;切到身体 → 约等于身体宽。"""
+    arr = np.asarray(im)[:, :, 3]
+    return int((arr[0] > 128).sum())
+
+
+def _head_is_intact(im: Image.Image, body_w_scaled: float) -> bool:
+    """顶行没有宽到身体那一层,就说明没切进身体。"""
+    return _top_row_width(im) < body_w_scaled * 0.7
+
+
+# #604 的形状:老妇从直立慢慢弯腰,身高随姿态变化。中位数定标会让直立那几帧超出。
+_UPRIGHT, _BENT = 300, 250
+POSES = [_UPRIGHT] * 12 + [_BENT] * 20          # 直立少、弯腰多 → 中位数落在弯腰那档
+
+
+def test_the_tallest_pose_is_not_clipped_at_the_top():
+    """拦的坏例:#604 —— 中位数定标 + 零余量,直立帧的头被平切。
+
+    判据是"顶行没有不透明像素",不是"看起来还行"。头被切时顶行会是一整条横切面
+    (实测 #604 第 0 帧顶行 70 个不透明像素)。
+    """
+    frames = [_figure(h) for h in POSES]
+    out = align_bottom_center(frames, cell=256, fill_h=FOOT_LINE, resample=Image.Resampling.NEAREST)
+    # 交付后的身体宽:用最矮那帧量(它一定没被裁),作为"切到身体"的判据基准。
+    body_scaled = max(_top_row_width(im) for im in out) or 1
+    ref = out[POSES.index(min(POSES))]
+    bb = ref.split()[-1].getbbox()
+    body_scaled = bb[2] - bb[0]
+    clipped = [i for i, im in enumerate(out) if not _head_is_intact(im, body_scaled)]
+    assert not clipped, (
+        f"{len(clipped)}/{len(out)} 帧切进了身体(帧号 {clipped[:8]});"
+        "这正是 #604 的形状 —— 头被平切而帧数/时长/脚线/成色全部正常"
+    )
+
+
+def test_the_feet_stay_on_the_foot_line():
+    """夹取不能靠把角色往下挪来避开裁剪 —— 那会让她不站在地上。
+
+    这条是上一条的对照:光让顶部不裁很容易(整体下移即可),但脚线是这条管线的核心
+    契约(#21 逐帧对齐、跨动作一致都建在它上面)。
+    """
+    frames = [_figure(h) for h in POSES]
+    out = align_bottom_center(frames, cell=256, fill_h=FOOT_LINE, resample=Image.Resampling.NEAREST)
+    want = int(256 * FOOT_LINE)
+    for i, im in enumerate(out):
+        bb = im.split()[-1].getbbox()
+        assert bb is not None and abs(bb[3] - want) <= 1, f"第 {i} 帧脚线 {bb[3]}，应为 {want}"
+
+
+def test_all_frames_keep_one_shared_scale():
+    """夹取之后仍然是整段共用一个缩放系数,不是逐帧各自归一化。
+
+    逐帧归一化会把姿态造成的身高起伏反向变成"忽大忽小"(本函数 docstring 的原意)。
+    所以直立帧与弯腰帧的高度比,必须仍然等于它们原始高度的比。
+    """
+    frames = [_figure(h) for h in POSES]
+    out = align_bottom_center(frames, cell=256, fill_h=FOOT_LINE, resample=Image.Resampling.NEAREST)
+    hs = [im.split()[-1].getbbox()[3] - im.split()[-1].getbbox()[1] for im in out]
+    tall, short = max(hs), min(hs)
+    assert abs(tall / short - _UPRIGHT / _BENT) < 0.05, (
+        f"交付高度比 {tall/short:.3f} 与原始比 {_UPRIGHT/_BENT:.3f} 不符 —— 像是逐帧归一化了"
+    )
+
+
+def test_a_raised_extremity_may_overflow_but_the_body_may_not():
+    """举过头顶的武器可以溢出被裁(与翅尖同档),但本体必须完整。
+
+    按整体包围盒夹取会让举武器那一帧把整段压小(实测人形举武器 68.4%),那比武器尖
+    缺一点严重得多 —— 与宽度方向的取舍是同一条。
+    """
+    frames = [_figure(_BENT) for _ in range(8)]
+    # 第 3 帧加一根细长"武器",高出头顶很多但很薄
+    arr = np.asarray(frames[3]).copy()
+    cx = arr.shape[1] // 2
+    arr[10:arr.shape[0] - 20, cx - 2:cx + 2] = (255, 255, 255, 255)
+    frames[3] = Image.fromarray(arr, "RGBA")
+
+    out = align_bottom_center(frames, cell=256, fill_h=FOOT_LINE, resample=Image.Resampling.NEAREST)
+    # 本体那几帧一律不许被裁
+    bb = out[0].split()[-1].getbbox()
+    for i in (0, 1, 2, 4, 5, 6, 7):
+        assert _head_is_intact(out[i], bb[2] - bb[0]), f"第 {i} 帧本体被裁了"
+    # 而角色本体没有因为那一帧被压小
+    body = out[0].split()[-1].getbbox()
+    assert (body[3] - body[1]) > 256 * FOOT_LINE * 0.75, "角色被那根武器压得太小"
+
+
+def test_drift_compensation_cannot_push_a_frame_back_over_the_top():
+    """拦的坏例:夹取放在漂移补偿**之前**算。
+
+    实际用的是 ``scale * per_frame[idx]``。i2v 常有单调推镜(整段尺度漂移),本函数会
+    逐帧补偿把趋势项除掉,补偿系数以 1.0 为中心 —— 也就是**有些帧的系数大于 1**。
+    先夹后补偿等于没夹:被补偿放大的那几帧照样顶出画布。
+
+    (这个错我写过一遍:第一版把夹取放在 per_frame 之前,测出来仍有 12/32 帧被切。)
+    """
+    # 单调放大的一段(推镜),让 scale_drift 真的算出补偿
+    poses = [220 + i * 4 for i in range(24)]
+    frames = [_figure(h) for h in poses]
+    out = align_bottom_center(frames, cell=256, fill_h=FOOT_LINE,
+                              resample=Image.Resampling.NEAREST)
+    ref = out[0].split()[-1].getbbox()
+    body_scaled = ref[2] - ref[0]
+    clipped = [i for i, im in enumerate(out) if not _head_is_intact(im, body_scaled)]
+    assert not clipped, f"补偿放大的帧被切了:{clipped[:8]}"


### PR DESCRIPTION
Closes #851

## 问题

交付帧里角色的头被**平切**，而源视频里头是完整的。

生产任务 **#604**（老妇待机，veo 源视频，32 帧），逐帧量 alpha 包围盒：

```
帧 00–08   bbox=(52, 0, 205, 235)   顶边贴 y=0，顶行 44–70 个不透明像素
帧 12+     bbox=(45,19, 212, 235)   有 19px 余量，头完整
────────── 32 帧里 9 帧顶部被裁
```

顶行 70 个不透明像素是**身体那么宽的一条横切面**，不是头顶的弧线。

已核对源视频（1280×720，96 帧）：角色四周留白很足、头完整。抠图也正常。产物见 `用户反馈_604_20260828/`（含 `_切头对照.png` 与 `_源视频五帧.png`）。

## 根因：静默裁剪

```python
top = int(ch * foot_line) - h - lift          # 235 - h，可以是负数
canvas.alpha_composite(crop, (cw//2 - w//2, top))   # 负坐标 → 顶部被静默裁掉
```

`h` 超出是按构造发生的：`scale` 取本体跨度的**中位数**，所以约一半的帧高于目标；而视频路线把 `fill_h` 覆盖成 `min(FOOT_LINE, 母版占幅)`，这个母版占幅高，`fill_h` 顶到 0.92 = 脚线，**余量归零**（`FILL_H` 默认 0.62 正是为了留余量）。

**同一个函数在宽度方向既夹取又打日志，高度方向两样都没有** —— 而它自己的注释写着「关键是不静默：裁掉多少写进日志，让丢了像素可见而不是靠人看图发现」。

高度方向溢出的还不是翅尖尾尖，是脑袋。

## 改法

夹取按**本体顶到包围盒底**的距离，不是本体跨度：摆放时 `top` 按包围盒底定位，决定本体会不会顶出去的正是这一段。

按跨度夹会差一个「本体顶到包围盒顶」的偏移 —— **实测那样写仍然切进身体**，这是本修复里唯一真正起作用的改动。

举过头顶的武器仍可溢出被裁（与翅尖同档，理由相同：按整体包围盒夹会让举武器那一帧把整段压小，实测人形举武器 68.4%），但本体必须完整，且溢出写日志。

## 验证

变异测试，回滚即变红：

| 变异 | 结果 |
|---|---|
| 拆掉高度夹取 | 1 红 |
| 夹取用包围盒顶而非本体顶 | 1 红 |

用例的判据是「**切没切进身体**」而不是「顶行有没有像素」：后者会把**贴边**误判成**被切**，而贴边是夹取之后的正常结果（这一版判据我改过一次，第一版就是这么误判的）。所以造的形状是**头比身体窄**的人形 —— 切到身体那层，顶行宽度就是身体宽（正是 #604 第 0 帧那 70px）；头完整时顶行宽度是头宽。

四条用例分别钉：不切进身体、脚线仍在 `foot_line`（不能靠整体下移避开裁剪）、整段仍共用一个缩放系数（不能退化成逐帧归一化）、举过头顶的延展物可溢出但不压小本体。

CI 原样命令跑在最后一次编辑之后：`ruff check .` 通过；`export_openapi` rc=0 无漂移；`lint-imports` 2 kept / 0 broken；`pytest -q --cov=packages` **1916 passed, 14 skipped**。

## 一处诚实说明

夹取里乘 `per_frame`（漂移补偿系数）是**防御性的、没有用例覆盖**。造了三种漂移形态（单调推镜 / 阶跃 / 强推镜），`scale_drift` 给出的系数恒为 1.0，拿掉这一项测试也不会红。留着是因为它对且零成本，不是因为它被验证过 —— 代码注释里也这么写了。
