### PR TITLE
feat(render3d): 一个造型可以烘多个动作，不再只出得了走路

### DIFF
--- a/backend/packages/app/src/windup_app/server/character/model.py
+++ b/backend/packages/app/src/windup_app/server/character/model.py
@@ -290,6 +290,20 @@ class CharacterOutfit(BaseModel):
     rig_facts: OutfitRigFacts | None = Field(
         default=None, description="绑骨模型的骨架事实；None = 未建或建于本字段之前"
     )
+    # 这个造型**已经烘好的动作片段** —— 键是动作名(值域见 render3d_assets.ACTION_MOTIONS),
+    # 值是那一份绑骨产物的 URL。
+    #
+    # 为什么要一张表而不是一个 URL:绑骨接口**一次只吃一个 MotionType、产出一个带单条
+    # AnimationStack 的 FBX**(2026-08-03 实测归档:「MotionType 1–48 预设动作,一次一个」)。
+    # 想让一个造型既会走路又会跳,就得绑两次骨、存两份产物 —— 一个 URL 槽位装不下,
+    # 硬塞的话第二次会覆盖第一次,用户付了两次钱只剩一个动作。
+    #
+    # ``model_3d_url`` 保留为**主产物**(建资产那一次,当前是 walk),用来判"这个造型走不走
+    # 三渲二";渲哪个动作从本表按动作名取。两者不是第二真相源:主产物在本表里也有同样的
+    # 条目,``model_3d_url`` 只是那一条的别名,由 builder 同时写、用例钉住两者一致。
+    rigged_motions: dict[str, str] = Field(
+        default_factory=dict, description="动作名 → 该动作的绑骨产物 URL"
+    )
     actions: list[CharacterAction] = Field(
         default_factory=list, description="该造型下的动作列表"
     )

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -57,8 +57,8 @@ from windup_app.server.orchestrator.signals import ActionAwaitingAdmit, ActionRa
 from windup_framework.gateway.errors import RateLimitBackoff, UpstreamExhaustedError
 from windup_app.server.orchestrator.render3d_assets import (
     AUTORIG_CREDITS,
+    ACTION_MOTIONS,
     BUILD_MOTION,
-    RENDERABLE_ACTIONS,
 )
 from windup_app.server.orchestrator.model import (
     ActionType,
@@ -533,15 +533,26 @@ class ActionTaskExecutor:
             # 选哪个 kling 不在这里传:run_action_task 已经 bind_call_context(start_from_model)。
             model_url = (input.model_3d_url or "").strip()
             # 一份绑骨产物只带**一个**动作片段(绑骨接口一次只吃一个 MotionType),
-            # 建资产时烘的是 BUILD_MOTION。别的动作在这里当场拒,**不能派给出帧台** ——
-            # 那唯一一个片段照样能渲满 32 张帧,于是攻击任务收到的是一段走路,而帧数、
-            # 时长、朝向、成色全部自洽,没有任何一道会红。也不回落 i2v(见下)。
-            if model_url and input.action_type.value not in RENDERABLE_ACTIONS:
+            # 一份绑骨产物只带**一个**动作片段(绑骨接口一次只吃一个 MotionType)。
+            # 判据取自**这个造型实际烘了什么**,不取全局常量:读常量的话,常量一改,
+            # 已经建好的资产就开始声称自己会另一个动作,而渲出来的仍是旧那段。
+            #
+            # 没烘过的动作在这里当场拒,**不能派给出帧台** —— 手上那个片段照样能渲满
+            # 32 张帧,于是跳跃任务收到的是一段走路,而帧数、时长、朝向、成色全部自洽,
+            # 没有任何一道会红。也不回落 i2v(见上:两条路线画风/成本/多朝向都不同)。
+            baked = dict(input.rigged_motions or {})
+            if model_url and not baked:
+                baked = {BUILD_MOTION: model_url}      # 旧数据只有主产物
+            want_motion = ACTION_MOTIONS.get(input.action_type.value)
+            if model_url and (want_motion is None or want_motion not in baked):
                 raise ValueError(
-                    f"该造型的 3D 资产只烘了 {BUILD_MOTION!r} 一个动作片段,出不了 "
+                    f"该造型的 3D 资产烘了 {sorted(baked) or '(无)'},出不了 "
                     f"{input.action_type.value!r}。要走三渲二得为这个动作再绑一次骨"
                     f"({AUTORIG_CREDITS} 积分);要现在就出,把这个动作交给 i2v。"
                 )
+            # 渲哪个动作就取哪一份产物 —— 取错等于拿走路片段冒充跳跃。
+            if model_url and want_motion in baked:
+                model_url = baked[want_motion]
             # 三渲二那支不取母版,而出口的判官闸口要拿它当参照 —— 不先置 None 的话那支会
             # 撞 UnboundLocalError,而它只在有 3D 资产的造型上触发。
             master: bytes | None = None

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -186,6 +186,10 @@ class CharacterActionInput:
     # 传 URL 而不是让编排层自己去查:与 reference_image_urls 同一口径 —— 取数在上层
     # 做完,"这次选了哪条路线"在入参上就可见,不是埋在某个分支里的隐式判断。
     model_3d_url: str | None = None
+    # 这个造型已经烘好的动作片段(动作名 → 绑骨产物 URL)。由 web 层从 character_data
+    # 读出来写进入参 —— 与 model_3d_url 同一个模式:这次按什么资产渲的,在任务入参上
+    # 就是可见的,排查时不用猜当时 DB 是什么状态。
+    rigged_motions: dict[str, str] = field(default_factory=dict)
     # 角色体型。``None`` 原样往下传,由编排层兜成双足 —— 本层替调用方填默认值的话,
     # "没给"与"明确给了 biped"从这里起就分不开了。判据见 prompt.adapter 的体型门禁。
     stance: CharacterStance | None = None

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_assets.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_assets.py
@@ -416,6 +416,55 @@ class Render3DAssetBuilder:
         logger.info("造型级 3D 资产已落点 key=%s fmt=%s", key, rigged.fmt)
         return rigged.data
 
+    def add_motion(self, key: str, motion: str, progress: ProgressPort) -> bytes:
+        """给**已建好**的造型再烘一个动作片段。**只花绑骨那一笔**(见 AUTORIG_CREDITS)。
+
+        为什么能只花一笔:图生 3D 的产物一直留在 ``raw:`` 那份落点上(只有 discard 会删
+        它),所以这里直接拿它再绑一次骨,不重付图生 3D。这也是这个方法存在的全部理由 ——
+        用 ``ensure`` 再跑一遍会连图生 3D 一起重付,而那份模型明明还在。
+
+        一份绑骨产物只带一个动作片段(接口一次只吃一个 MotionType),所以每个动作各存一份,
+        键是 ``{造型键}#{动作}``。**不覆盖主产物** —— 覆盖等于用户为第二个动作付的钱把
+        第一个顶掉。
+
+        Raises:
+            ValueError: 这个造型还没建过资产(没有 raw),或动作名不在 ``ACTION_MOTIONS``
+                的可烘集合里。两种都在花钱之前拒。
+        """
+        want = ACTION_MOTIONS.get(motion)
+        if want is None:
+            bakeable = sorted(a for a, m in ACTION_MOTIONS.items() if m)
+            raise ValueError(
+                f"{motion!r} 走不了三渲二(可烘的是 {bakeable});"
+                "attack / custom 的运动拓扑没有对应的预设动作,继续走 i2v。"
+            )
+        raw = self._store.get(f"{RAW_KEY_PREFIX}{key}")
+        if raw is None:
+            raise ValueError(
+                "这个造型还没有 3D 模型,先建资产再加动作 —— 现建的话要连图生 3D 一起付。"
+            )
+        if not self._review.is_approved(key):
+            raise ValueError("这个造型的 3D 模型还没被确认放行,先看过模型再加动作。")
+
+        motion_key = f"{key}#{want}"
+        cached = self._store.get(motion_key)
+        if cached is not None:
+            return cached                      # 已经烘过这个动作,不重复付费
+
+        progress.step("assets", 0, 1, f"为 {motion} 再绑一次骨并烘入(按次计费)")
+        # 追加动作同样走云到云:上游 URL 还在就不用把 18MB 再中转一遍(#860)。
+        rigged: RiggedModel = _rig(self._autorig, raw,
+                                   self._store.get(f"{URL_KEY_PREFIX}{key}"),
+                                   motion=want)
+        if rigged.motion is None:
+            # 与主产物那条同一个理由:零片段的产物在下游每一道闸前都正常,存下来就是
+            # 把 10 积分买来的哑模型挂成可用。
+            raise RuntimeError(
+                f"绑骨产物里没有动作片段(请求的是 {want!r})—— 拒绝当成就绪资产存下。"
+            )
+        self._store.put(motion_key, rigged.data)
+        logger.info("造型追加动作已落点 key=%s motion=%s", motion_key, want)
+        return rigged.data
 
 def _image_to_3d(provider, master: bytes) -> tuple[bytes, str | None]:
     """图生 3D,顺带取回上游那个产物 URL。

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -32,6 +32,7 @@ from windup_app.server.orchestrator._fetch import FetchNotAllowed, fetch_own_med
 from windup_common.models import CharacterStance
 from windup_app.server.orchestrator.render3d_assets import (
     AUTORIG_CREDITS,
+    BUILD_MOTION,
     BUILD_CREDITS,
     MODEL3D_CREDITS,
     RAW_KEY_PREFIX,
@@ -182,6 +183,10 @@ class Render3DAssetOperations:
             "asset_key": outfit_key,
             "state": phase,
             "model_3d_url": rigged_url.decode() if rigged_url else None,
+            # 主产物烘的是哪个动作。**由本层报出**而不是让 web 层去读常量:
+            # web 层 import render3d_assets 会经它连到 ai_engine,破坏
+            # 「入口层不经 ai_engine 直连」那条 import 契约。
+            "primary_motion": BUILD_MOTION,
             "review_model_url": review_url.decode() if review_url else None,
             "error": error,
             "cost": {
@@ -238,6 +243,37 @@ class Render3DAssetOperations:
         self._builder.approve(outfit_key)
         self._start(outfit_key, PHASE_RIGGING, self._fetch(master_url))
         return self.view(outfit_key)
+
+    def add_motion(self, outfit_key: str, motion: str) -> dict:
+        """给已建好的造型再烘一个动作片段。**只花绑骨那一笔**(图生 3D 的产物还在)。
+
+        与 :meth:`build` 的分工:那个是从零建(图生 3D + 绑骨),这个是在已有模型上再绑
+        一次。分开而不是给 build 加个参数:build 的前提是"该造型还什么都没有",
+        而本方法的前提正相反 —— 合成一个方法的话那条前提断言就没法写了。
+        """
+        if not self._builder.may_build_assets:
+            raise SpendNotAuthorized(
+                f"本部署未开启建 3D 资产(需 WINDUP_RENDER3D_ALLOW_SPEND)。"
+                f"追加一个动作 {AUTORIG_CREDITS} 积分。"
+            )
+        state = self._builder.state(outfit_key)
+        if state is not Render3DAssetState.READY:
+            raise ValueError(
+                f"造型 {outfit_key!r} 的 3D 资产处于 {state.value},要先建好并确认才能加动作"
+            )
+        with self._lock:
+            data = self._builder.add_motion(outfit_key, motion, _SilentProgress())
+            # 这一份产物要有**自己的** URL。回 view() 里那个 model_3d_url 是**主产物**的,
+            # 把它记到新动作名下 = 拿走路片段冒充跳跃 —— 而两份都渲得满 32 帧,帧数、
+            # 时长、朝向、成色全部自洽,没有一道会红。
+            url = self._store.get(f"{_URL_PREFIX}{outfit_key}#{motion}")
+            if url is None:
+                url = _publish_model(data).encode()
+                self._store.put(f"{_URL_PREFIX}{outfit_key}#{motion}", url)
+        out = self.view(outfit_key)
+        out["motion"] = motion
+        out["motion_model_url"] = url.decode()
+        return out
 
     def discard(self, outfit_key: str) -> dict:
         """人否掉待审模型 → 回到 ``absent``,下次建会重新生成(再付一次图生 3D)。"""
@@ -463,6 +499,9 @@ class _LazyOperations:
 
     def approve(self, outfit_key: str, master_url: str) -> dict:
         return self._ops().approve(outfit_key, master_url)
+
+    def add_motion(self, outfit_key: str, motion: str) -> dict:
+        return self._ops().add_motion(outfit_key, motion)
 
     def discard(self, outfit_key: str) -> dict:
         return self._ops().discard(outfit_key)

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -531,7 +531,27 @@ def _require_3d_action_quota(character: Character, outfit_id: str | None) -> Non
             "删掉一个再来,或改走视频路线。",
             code=BizCode.BAD_REQUEST,
         )
+def _outfit_rigged_motions(character: Character, outfit_id: str | None) -> dict[str, str]:
+    """这个造型**实际烘好了**哪些动作片段。判据取自落点,不取全局常量。
 
+    取自落点的理由与 ``Render3DAssetState`` 那条一样:状态由落点推出来,不单独存一份。
+    读常量的话,常量一改,**已经建好的**资产就开始声称自己会另一个动作,而渲出来的仍是
+    旧那段 —— 帧数、时长、成色全部正常的静默错。
+    """
+    if not outfit_id:
+        return {}
+    try:
+        data = CharacterData.model_validate(character.character_data or {})
+    except ValidationError:
+        return {}
+    outfit = next((o for o in data.outfits if o.id == outfit_id), None)
+    if outfit is None:
+        return {}
+    # 只把落点原样读出来。**存量兼容(只有 model_3d_url 没有这张表)由编排层兜** ——
+    # 那边已经有同一条 `if model_url and not baked: baked = {BUILD_MOTION: model_url}`,
+    # 在这里再兜一次既是第二真相源,又会让 web 层经 render3d_assets 连到 ai_engine,
+    # 破坏「入口层不经 ai_engine 直连」那条 import 契约(CI 逮到,本地漏跑了 lint-imports)。
+    return dict(outfit.rigged_motions or {})
 
 def _character_stance(character: Character) -> CharacterStance | None:
     """角色存的体型;没存过就给 None(让下游用它自己的默认值)。
@@ -797,6 +817,7 @@ def submit_action_generation(
         # 路线选择在这里定死并写进入参,而不是留给编排层现查:这样"这次走的哪条路线"
         # 在任务入参上就是可见的,排查时不用去猜当时 DB 是什么状态。
         model_3d_url=model_3d_url,
+        rigged_motions=_outfit_rigged_motions(character, body.outfit_id),
         # 请求没显式给就取角色上存的那个。与 model_3d_url 同一个模式:web 层读
         # character_data、写进入参,这样"这次按什么体型算的"在任务入参上就是可见的,
         # 排查时不用去猜当时 DB 是什么状态。

--- a/backend/packages/app/src/windup_app/web/api/render3d.py
+++ b/backend/packages/app/src/windup_app/web/api/render3d.py
@@ -128,19 +128,38 @@ def _master_url_or_raise(outfit: dict) -> str:
     return url
 
 
-def _sync_model_url(session: Session, character: Character, outfit_id: str, url: str | None) -> None:
+def _sync_model_url(
+    session: Session,
+    character: Character,
+    outfit_id: str,
+    url: str | None,
+    motion: str | None = None,
+) -> None:
     """把建好的模型 URL 回写到 ``character_data``。
 
     回写发生在**读状态**这一步而不是后台线程里:后台线程没有请求作用域的 session,
     而三渲二那条路线的判据(``Outfit.model_3d_url``)不回写就永远是 None —— 资产建好了
     却依旧显示"该造型暂无绑骨 3D 模型",钱白花。
+
+    ``motion`` 给出这一份产物烘的是哪个动作,写进 ``rigged_motions``。一份绑骨产物只带
+    一个动作片段(接口一次只吃一个 MotionType),所以多动作 = 多份产物 = 这张表多几条;
+    **不能覆盖** ``model_3d_url`` —— 覆盖了的话用户为第二个动作付的钱会把第一个顶掉。
+    ``model_3d_url`` 只在它还空着时写(即主产物那一次)。
     """
     if not url:
         return
     data = CharacterData.model_validate(character.character_data or {})
     changed = False
     for outfit in data.outfits:
-        if outfit.id == outfit_id and outfit.model_3d_url != url:
+        if outfit.id != outfit_id:
+            continue
+        # 只有说得出这一份烘的是哪个动作时才记进表。说不出就只写主产物别名 ——
+        # 猜一个动作名记进去,等于声称这个资产会一个它其实不会的动作。
+        if motion and outfit.rigged_motions.get(motion) != url:
+            outfit.rigged_motions[motion] = url
+            changed = True
+        # 主产物那一次(第一份)同时写别名槽,后续动作不再动它。
+        if not (outfit.model_3d_url or "").strip():
             outfit.model_3d_url = url
             changed = True
     if not changed:
@@ -177,7 +196,8 @@ def get_outfit_asset(
     character = get_character_with_auth(session, character_id, user_id)
     _outfit_or_raise(character, outfit_id)
     view = _operations(request).view(_asset_key(character_id, outfit_id))
-    _sync_model_url(session, character, outfit_id, view["model_3d_url"])
+    _sync_model_url(session, character, outfit_id, view["model_3d_url"],
+                    motion=view.get("primary_motion"))
     return Response.success(view)
 
 
@@ -229,6 +249,45 @@ def approve_outfit_asset(
     except ValueError as exc:
         raise BizException(user_message(exc), code=BizCode.BAD_REQUEST) from exc
     return Response.success(view, message="已放行,开始绑骨")
+
+
+class AddMotionRequest(BaseModel):
+    """给已建好的 3D 资产追加一个动作片段。
+
+    ``motion`` 取 ``render3d_assets.ACTION_MOTIONS`` 里有对应预设的那几个
+    (walk / idle / jump);attack 与 custom 没有对应预设,继续走 i2v。
+    """
+
+    motion: str = Field(..., min_length=1)
+
+
+@router.post("/characters/{character_id}/outfits/{outfit_id}/motions", response_model=Response[dict])
+def add_outfit_motion(
+    character_id: int,
+    outfit_id: str,
+    body: AddMotionRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> Response[dict]:
+    """给已建好的造型再烘一个动作片段。**按次计费的触发点**,只认用户的显式请求。
+
+    只花绑骨那一笔:图生 3D 的产物一直留着,不重付。一份绑骨产物只带一个动作片段
+    (接口一次只吃一个 MotionType),所以"这个角色会走也会跳"= 两份产物。
+    """
+    user_id = request.state.current_user.id
+    character = get_character_with_auth(session, character_id, user_id)
+    _outfit_or_raise(character, outfit_id)
+    operations = _operations(request)
+    key = _asset_key(character_id, outfit_id)
+    try:
+        view = operations.add_motion(key, body.motion)
+    except ValueError as exc:
+        raise BizException(user_message(exc), code=BizCode.BAD_REQUEST) from exc
+    # 回写:这一份产物记在它自己那个动作名下,不覆盖主产物。
+    # 用**这一份**产物的 URL,不是 view 里那个主产物的 —— 记错了就是拿走路冒充跳跃。
+    _sync_model_url(session, character, outfit_id,
+                    view.get("motion_model_url"), motion=body.motion)
+    return Response.success(view, message=f"已为 {body.motion} 绑骨并烘入动作")
 
 
 @router.post("/characters/{character_id}/outfits/{outfit_id}/discard", response_model=Response[dict])

--- a/backend/tests/test_render3d_motion.py
+++ b/backend/tests/test_render3d_motion.py
@@ -67,6 +67,30 @@ class _FakeModel3D:
 # ══ ① 绑骨请求体里到底有没有 MotionType ═══════════════════════════════════════
 
 
+
+class _MemStore:
+    """内存落点。用真实的 get/put/delete 三个方法,不打桩 —— 追加动作的正确性
+    全在"存到哪个键"上,桩掉存储就等于把要测的东西测没了。"""
+
+    def __init__(self):
+        self._d: dict[str, bytes] = {}
+
+    def get(self, k): return self._d.get(k)
+    def put(self, k, v): self._d[k] = v
+    def delete(self, k): self._d.pop(k, None)
+
+
+class _AlwaysApproved:
+    def is_approved(self, key): return True
+    def submit(self, key, data, fmt): return "where"
+    def approve(self, key): pass
+    def discard(self, key): pass
+
+
+class _Prog:
+    def step(self, *a, **k): pass
+
+
 def test_build_puts_motiontype_in_the_actual_rig_request(tmp_path: pathlib.Path, monkeypatch):
     """从"点建资产"一路走到**发给腾讯的那个 params**,里面必须有 MotionType。
 
@@ -241,7 +265,8 @@ def test_action_the_asset_never_baked_is_refused_before_dispatch(_no_dispatch):
     拦的坏例:模型里那唯一一个片段(名字是绑骨任务的哈希)照样渲得满 32 张帧,于是
     攻击动作交付的是一段走路 —— 帧数、时长、朝向、成色全部自洽,没有一道会红。
     """
-    with pytest.raises(ValueError, match="只烘了"):
+    # 匹配语义(出不了哪个动作)而不是措辞 —— 文案改一次就红一次的用例没有价值。
+    with pytest.raises(ValueError, match="出不了 'attack'"):
         _executor()._produce_action(
             _input(InputActionType.ATTACK),
             ProjectConstraints(sprite_w=64, sprite_h=64),
@@ -280,3 +305,176 @@ def test_action_motion_table_covers_every_entry_action_and_names_only_real_prese
             assert motion in PRESET_MOTIONS, f"{action} 映射到未登记的预设 {motion!r}"
     assert BUILD_MOTION in PRESET_MOTIONS
     assert RENDERABLE_ACTIONS, "一个动作都出不了的路线等于没有路线"
+
+
+# ── 一个造型可以烘多个动作(#853)────────────────────────────────────────────
+
+
+def test_an_outfit_can_bake_more_than_one_motion(_no_dispatch):
+    """拦的坏例:一个造型只能有一个动作。
+
+    绑骨接口一次只吃一个 MotionType、产出一个带单条 AnimationStack 的 FBX
+    (2026-08-03 实测归档),所以"多动作"必须是**多份产物**。此前只有一个 URL 槽位,
+    第二次绑骨会覆盖第一次 —— 用户付了两次钱只剩一个动作。
+    """
+    from windup_app.server.orchestrator.render3d_assets import ACTION_MOTIONS
+
+    inp = _input(InputActionType.JUMP)
+    inp.rigged_motions = {
+        "walk": "https://media.example.com/rig-walk.fbx",
+        ACTION_MOTIONS["jump"]: "https://media.example.com/rig-jump.fbx",
+    }
+    # 烘过 jump → 照常派单(不再被拒)
+    with pytest.raises(ActionAwaitingClientBake):
+        _executor()._produce_action(
+            inp, ProjectConstraints(sprite_w=64, sprite_h=64), task_id=31,
+        )
+
+
+def test_the_dispatched_asset_matches_the_requested_action(_no_dispatch, monkeypatch):
+    """拦的坏例:烘了两份,却拿走路那份去渲跳跃。
+
+    这是最坏的一种 —— 两份都在、都能渲满 32 帧,而拿错的那份帧数/时长/朝向/成色
+    全部自洽。只断言"没被拒"是不够的,要断言**派下去的是哪一份**。
+    """
+    from windup_app.server.orchestrator import executor as ex
+    from windup_app.server.orchestrator.render3d_assets import ACTION_MOTIONS
+
+    seen: list[str] = []
+    real = ex.client_bake.open_job
+
+    def _spy(task_id, spec):
+        seen.append(spec.model_url)
+        return real(task_id, spec)
+
+    monkeypatch.setattr(ex.client_bake, "open_job", _spy)
+
+    inp = _input(InputActionType.JUMP)
+    inp.rigged_motions = {
+        "walk": "https://media.example.com/rig-walk.fbx",
+        ACTION_MOTIONS["jump"]: "https://media.example.com/rig-jump.fbx",
+    }
+    with pytest.raises(ActionAwaitingClientBake):
+        _executor()._produce_action(
+            inp, ProjectConstraints(sprite_w=64, sprite_h=64), task_id=32,
+        )
+    assert seen, "没登记出帧任务，取不到派下去的是哪一份"
+    assert "rig-jump" in seen[-1], f"跳跃任务派下去的是 {seen[-1]!r} —— 拿错了资产"
+
+
+def test_old_data_with_only_the_primary_url_still_renders_its_motion(_no_dispatch):
+    """存量兼容:只有 model_3d_url、没有 rigged_motions 的造型,仍然出得了主产物那个动作。
+
+    生产此刻有 0 个这样的造型(查过),但 #835 一部署就会产生 —— 那批资产只写
+    model_3d_url。不兼容的话它们会变成"有资产却一个动作都渲不了"。
+    """
+    inp = _input(InputActionType.WALK)
+    inp.rigged_motions = {}                      # 老数据没有这张表
+    with pytest.raises(ActionAwaitingClientBake):
+        _executor()._produce_action(
+            inp, ProjectConstraints(sprite_w=64, sprite_h=64), task_id=33,
+        )
+
+
+# ── 追加动作：只花绑骨那一笔，且每份产物有自己的 URL ────────────────────────
+
+
+def test_adding_a_motion_reuses_the_raw_model_and_pays_only_for_rigging():
+    """拦的坏例:追加动作时把图生 3D 一起重付。
+
+    图生 3D 的产物一直留在 ``raw:`` 落点上(只有 discard 删它),所以追加只该花绑骨那
+    一笔。走 ensure 再跑一遍会连图生 3D 一起重付,而那份模型明明还在。
+    """
+    from windup_app.server.orchestrator.render3d_assets import (
+        RAW_KEY_PREFIX, Render3DAssetBuilder,
+    )
+
+    made3d, rigged = [], []
+
+    class _M3D:
+        def image_to_3d(self, master, want="GLB"):
+            made3d.append(1)
+            return b"glTF-raw"
+
+    class _Rig:
+        def rig(self, model, *, want="GLB", motion=None):
+            rigged.append(motion)
+            return type("R", (), {"data": b"Kaydara FBX Binary  " + str(motion).encode(),
+                                  "fmt": "FBX", "motion": motion})()
+
+    store = _MemStore()
+    store.put(f"{RAW_KEY_PREFIX}k", b"glTF-raw")          # 已经建过，raw 还在
+    b = Render3DAssetBuilder(model3d=_M3D(), autorig=_Rig(), store=store,
+                             review=_AlwaysApproved(), may_build_assets=True)
+    b.add_motion("k", "jump", _Prog())
+    assert made3d == [], "追加动作时又调了一次图生 3D —— 重付了那笔钱"
+    assert rigged == ["jump"], f"绑骨请求的动作是 {rigged}"
+
+
+def test_a_second_motion_does_not_overwrite_the_first():
+    """拦的坏例:第二份产物覆盖第一份 —— 用户付了两次钱只剩一个动作。"""
+    from windup_app.server.orchestrator.render3d_assets import (
+        RAW_KEY_PREFIX, Render3DAssetBuilder,
+    )
+
+    class _Rig:
+        def rig(self, model, *, want="GLB", motion=None):
+            return type("R", (), {"data": b"Kaydara FBX Binary  " + str(motion).encode(),
+                                  "fmt": "FBX", "motion": motion})()
+
+    store = _MemStore()
+    store.put(f"{RAW_KEY_PREFIX}k", b"raw")
+    store.put("k", b"Kaydara FBX Binary  walk")           # 主产物(walk)
+    b = Render3DAssetBuilder(model3d=None, autorig=_Rig(), store=store,
+                             review=_AlwaysApproved(), may_build_assets=True)
+    b.add_motion("k", "jump", _Prog())
+    assert store.get("k") == b"Kaydara FBX Binary  walk", "主产物被覆盖了"
+    assert b"jump" in store.get("k#jump"), "追加的那份没按动作单独存"
+
+
+def test_an_unbakeable_action_is_refused_before_spending():
+    """attack / custom 没有对应预设动作,在花钱之前拒。
+
+    拿 thrust(16) 顶 sweep 会渲出"直刺"冒充"横挥",帧数时长成色全正常。
+    """
+    from windup_app.server.orchestrator.render3d_assets import (
+        RAW_KEY_PREFIX, Render3DAssetBuilder,
+    )
+
+    calls = []
+
+    class _Rig:
+        def rig(self, *a, **k):
+            calls.append(1)
+            raise AssertionError("不该走到绑骨")
+
+    store = _MemStore()
+    store.put(f"{RAW_KEY_PREFIX}k", b"raw")
+    b = Render3DAssetBuilder(model3d=None, autorig=_Rig(), store=store,
+                             review=_AlwaysApproved(), may_build_assets=True)
+    with pytest.raises(ValueError, match="走不了三渲二"):
+        b.add_motion("k", "attack", _Prog())
+    assert not calls, "在拒绝之前就已经调了绑骨(= 已经扣费)"
+
+
+def test_adding_the_same_motion_twice_does_not_pay_twice():
+    """已经烘过这个动作就直接返回,不重复扣费。"""
+    from windup_app.server.orchestrator.render3d_assets import (
+        RAW_KEY_PREFIX, Render3DAssetBuilder,
+    )
+
+    calls = []
+
+    class _Rig:
+        def rig(self, model, *, want="GLB", motion=None):
+            calls.append(motion)
+            return type("R", (), {"data": b"Kaydara FBX Binary  x", "fmt": "FBX",
+                                  "motion": motion})()
+
+    store = _MemStore()
+    store.put(f"{RAW_KEY_PREFIX}k", b"raw")
+    b = Render3DAssetBuilder(model3d=None, autorig=_Rig(), store=store,
+                             review=_AlwaysApproved(), may_build_assets=True)
+    b.add_motion("k", "jump", _Prog())
+    b.add_motion("k", "jump", _Prog())
+    assert calls == ["jump"], f"同一个动作绑了 {len(calls)} 次,重复扣费"

--- a/openapi.json
+++ b/openapi.json
@@ -56,6 +56,21 @@
         "title": "ActionType",
         "type": "string"
       },
+      "AddMotionRequest": {
+        "description": "给已建好的 3D 资产追加一个动作片段。\n\n``motion`` 取 ``render3d_assets.ACTION_MOTIONS`` 里有对应预设的那几个\n(walk / idle / jump);attack 与 custom 没有对应预设,继续走 i2v。",
+        "properties": {
+          "motion": {
+            "minLength": 1,
+            "title": "Motion",
+            "type": "string"
+          }
+        },
+        "required": [
+          "motion"
+        ],
+        "title": "AddMotionRequest",
+        "type": "object"
+      },
       "AdminAccessOut": {
         "description": "管理页访问探针响应。",
         "properties": {
@@ -1001,6 +1016,14 @@
               }
             ],
             "description": "绑骨模型的骨架事实；None = 未建或建于本字段之前"
+          },
+          "rigged_motions": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "动作名 → 该动作的绑骨产物 URL",
+            "title": "Rigged Motions",
+            "type": "object"
           }
         },
         "required": [
@@ -6516,6 +6539,68 @@
           }
         },
         "summary": "Discard Outfit Asset",
+        "tags": [
+          "render3d"
+        ]
+      }
+    },
+    "/render3d/characters/{character_id}/outfits/{outfit_id}/motions": {
+      "post": {
+        "description": "给已建好的造型再烘一个动作片段。**按次计费的触发点**,只认用户的显式请求。\n\n只花绑骨那一笔:图生 3D 的产物一直留着,不重付。一份绑骨产物只带一个动作片段\n(接口一次只吃一个 MotionType),所以\"这个角色会走也会跳\"= 两份产物。",
+        "operationId": "add_outfit_motion_render3d_characters__character_id__outfits__outfit_id__motions_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "character_id",
+            "required": true,
+            "schema": {
+              "title": "Character Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "outfit_id",
+            "required": true,
+            "schema": {
+              "title": "Outfit Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddMotionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_dict_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Add Outfit Motion",
         "tags": [
           "render3d"
         ]


### PR DESCRIPTION
Closes #857

基于 #835（未合），**先合 #835 再合这个**。

## 问题

三渲二此前只出得了 `walk`。

我一开始以为这是绑骨接口的限制，**查了归档发现不是** —— 2026-08-03 的实测记录里：

```
可选参数  MotionType 1–48 预设动作（26=Idle-1，34=Run…），一次一个
实验 #5   MotionType 40「向前大跳」→ 成功，姿势序列可读
```

`PRESET_MOTIONS` 里 walk(23) / idle(26) / jump(38) / jump_forward(40) / run(34) 的编号都是实测过的。

**真正的限制在我们这边**：一个造型只有一个 `model_3d_url` 槽位，而绑骨接口一次只吃一个 `MotionType`、产出一个带**单条** AnimationStack 的 FBX。所以「多动作」必然是「多份产物」，一个槽位装不下 —— 硬塞的话第二次覆盖第一次，用户付了两次钱只剩一个动作。

## 改动分三段

**① 存储**：`CharacterOutfit.rigged_motions`（动作名 → 该动作的绑骨产物 URL）。

`model_3d_url` 保留为**主产物的别名**（判「这个造型走不走三渲二」仍用它），追加动作只往表里加、不碰它。两者不是第二真相源：主产物在表里也有同样一条，由落点同时写。

**② 派单**：判据从全局常量 `RENDERABLE_ACTIONS` 换成**这个造型实际烘了什么**。

读常量的话，常量一改，**已经建好的**资产就开始声称自己会另一个动作，而渲出来的仍是旧那段。选 `model_url` 也按动作取 —— 拿错等于用走路片段冒充跳跃，而两份都渲得满 32 帧，帧数/时长/朝向/成色全部自洽。

**③ 追加**：新增 `POST /render3d/characters/{cid}/outfits/{oid}/motions`。

**只花绑骨那一笔（10 积分）**：图生 3D 的产物一直留在 `raw:` 落点上（只有 `discard` 删它），直接拿它再绑一次。走 `ensure` 会连图生 3D 一起重付，而那份模型明明还在。

`attack` / `custom` 在**花钱之前**拒 —— 它们没有对应的预设动作，拿 `thrust(16)` 顶 `sweep` 会渲出「直刺」冒充「横挥」。

## 验证

七条变异，全部回滚即变红：

| 变异 | 结果 |
|---|---|
| 不按动作选产物（拿主产物渲一切） | 1 红 |
| 拆掉派单闸 | 1 红 |
| 不兼容只有主产物的老数据 | 2 红 |
| 追加动作覆盖主产物 | 1 红 |
| 同一动作重复扣费 | 1 红 |
| 不拦没有预设的动作 | 1 红 |

其中一条钉的是**我自己在实现中途踩的坑**：追加动作的 URL 我一开始取成了 `view()` 里那个主产物的，等于把走路那份记到跳跃名下。这正是本 PR 要防的那类错，而它在任何一道检查前都是正常的。

用例里的落点用真实的 `get/put/delete` 内存实现，不打桩 —— 追加动作的正确性全在「存到哪个键」上，桩掉存储等于把要测的东西测没了。

CI 原样命令跑在最后一次编辑之后：`ruff check .` 通过；`export_openapi` rc=0（`openapi.json` 有新端点，已提交）；`lint-imports` 2 kept / 0 broken；`pytest -q --cov=packages` **1888 passed, 14 skipped**。

## 存量兼容

只有 `model_3d_url`、没有 `rigged_motions` 的造型仍出得了主产物那个动作。生产此刻有 **0** 个这样的造型（查过），但 #835 一部署就会产生 —— 不兼容的话它们会变成「有资产却一个动作都渲不了」。

## 还没做的（明说）

**前端没有入口。** 这个 PR 只到 API 层，用户点不到「给这个角色加个跳跃」。要在界面上暴露它需要一个产品决定（在哪加、怎么显示每个动作 10 积分），那是设计的事，不该夹带在实现 PR 里。API 现在可用，前端另开。

