### PR TITLE
fix(workflow): 完善多方向角色立绘生成与重试

### DIFF
--- a/frontend/src/features/client-bake/index.test.ts
+++ b/frontend/src/features/client-bake/index.test.ts
@@ -166,7 +166,7 @@ describe('浏览器出帧驱动', () => {
 
     expect(stage.setups.map(([clip]) => clip)).toEqual([HASHED, HASHED])
     // 交回的仍是**登记的那个名字** —— 后端按它对账,换成真实片段名会被判成交错了片段。
-    expect(completed).toEqual({ clip: 'walk', sampleTimes: [0, 0.1] })
+    expect(completed).toMatchObject({ clip: 'walk', sampleTimes: [0, 0.1] })
   })
 
   it('一个片段都没有时说清是绑骨没带动作', async () => {

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -599,6 +599,62 @@ describe('WorkflowController', () => {
     })
   })
 
+  it.each([
+    ['four-way', 'character_four_view'],
+    ['eight-way', 'character_eight_view'],
+  ] as const)('%s sheet 失败后保留 south 母版并重新提交整张 sheet', async (movement, role) => {
+    const run = createRun([
+      setupNode({
+        status: 'passed',
+        phase: 'completed',
+        input: {
+          prompt: '多向像素骑士',
+          referenceMedia: [],
+          characterId: '7',
+        },
+      }),
+      templateNode({
+        status: 'failed',
+        phase: 'generating',
+        error: 'sheet provider failed',
+        selectedImageUrl: 'https://img/south.png',
+        selectedImages: { south: 'https://img/south.png' },
+        generations: [
+          { taskId: 'template-south', role: 'character_template', direction: 'south' },
+          { taskId: 'sheet-old', role },
+        ],
+      }),
+    ])
+    const { controller, generation } = createController(run, movement)
+
+    await controller.retryGenerationDirection('template-1', 'east', {
+      spriteWidth: 64,
+      spriteHeight: 96,
+    })
+
+    expect(generation.apis.create).toHaveBeenCalledWith({
+      type: role,
+      projectId: '1',
+      characterId: '7',
+      prompt: '多向像素骑士',
+      referenceMedia: [],
+      spriteWidth: 64,
+      spriteHeight: 96,
+      candidateCount: 1,
+    })
+    expect(controller.getWorkflow().nodes[1]).toMatchObject({
+      status: 'active',
+      phase: 'generating',
+      selectedImageUrl: 'https://img/south.png',
+      selectedImages: { south: 'https://img/south.png' },
+      generations: expect.arrayContaining([
+        { taskId: 'template-south', role: 'character_template', direction: 'south' },
+        { taskId: 'task-1', role, direction: 'east' },
+      ]),
+      error: null,
+    })
+  })
+
   it('未注入项目准备能力时拒绝 Quick Start 生成命令', async () => {
     const { controller } = createController()
 
@@ -1307,43 +1363,41 @@ describe('WorkflowController', () => {
     })
   })
 
-  it.each([
-    ['four-way', ['east', 'north', 'south']],
-    ['eight-way', ['east', 'north', 'south', 'north_east', 'south_east']],
-  ] as const)('按项目方向为 %s 创建全部源方向的候选任务', async (movement, directions) => {
-    const { controller, generation } = createController(createRun(), movement)
+  it.each(['four-way', 'eight-way'] as const)(
+    '%s 未显式指定方向时也只生成 south 身份锚',
+    async (movement) => {
+      const { controller, generation } = createController(createRun(), movement)
 
-    await controller.generateCharacterTemplate('setup-1', {
-      spriteWidth: 64,
-      spriteHeight: 64,
-    })
+      await controller.generateCharacterTemplate('setup-1', {
+        spriteWidth: 64,
+        spriteHeight: 64,
+      })
 
-    expect(generation.apis.create).toHaveBeenCalledTimes(directions.length)
-    for (const [index, direction] of directions.entries()) {
+      expect(generation.apis.create).toHaveBeenCalledTimes(1)
+      expect(generation.apis.create).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'character_template', direction: 'south' }),
+      )
       generation.emit({
-        taskId: `task-${index + 1}`,
+        taskId: 'task-1',
         type: 'character_template',
         status: 'completed',
         result: {
           type: 'character_template',
-          direction,
-          images: imageCandidates(direction),
+          direction: 'south',
+          images: imageCandidates('south'),
         },
         error: null,
       })
-    }
-    await flushAsyncWork()
+      await flushAsyncWork()
 
-    const template = controller.getWorkflow().nodes[1]
-    expect(template).toMatchObject({
-      phase: 'selecting',
-      status: 'active',
-      generations: directions.map((_, index) => ({
-        taskId: `task-${index + 1}`,
-        role: 'character_template',
-      })),
-    })
-  })
+      const template = controller.getWorkflow().nodes[1]
+      expect(template).toMatchObject({
+        phase: 'selecting',
+        status: 'active',
+        generations: [{ taskId: 'task-1', role: 'character_template', direction: 'south' }],
+      })
+    },
+  )
 
   it('一个方向提交失败时先保留其它已创建任务，重试只补缺失方向', async () => {
     const { controller, generation } = createController(createRun(), 'four-way')
@@ -1362,6 +1416,7 @@ describe('WorkflowController', () => {
     const generationRequest = controller.generateCharacterTemplate('setup-1', {
       spriteWidth: 64,
       spriteHeight: 64,
+      directions: ['east', 'north', 'south'],
     })
     let requestState: 'pending' | 'rejected' = 'pending'
     void generationRequest.catch(() => {
@@ -1386,6 +1441,7 @@ describe('WorkflowController', () => {
     await controller.generateCharacterTemplate('setup-1', {
       spriteWidth: 64,
       spriteHeight: 64,
+      directions: ['east', 'north', 'south'],
     })
 
     expect(create).toHaveBeenCalledTimes(4)
@@ -1720,6 +1776,7 @@ describe('WorkflowController', () => {
     await controller.generateCharacterTemplate('setup-1', {
       spriteWidth: 64,
       spriteHeight: 64,
+      directions: ['east', 'north', 'south'],
     })
     generation.emit({
       taskId: 'task-1',
@@ -1910,6 +1967,7 @@ describe('WorkflowController', () => {
     await controller.generateCharacterTemplate('setup-1', {
       spriteWidth: 64,
       spriteHeight: 64,
+      directions: ['east', 'north', 'south'],
     })
     for (const [index, direction] of ['east', 'north', 'south'].entries()) {
       generation.emit({
@@ -2715,7 +2773,7 @@ describe('WorkflowController', () => {
     expect(generation.apis.create).not.toHaveBeenCalled()
   })
 
-  it('四向微调在重启节点前拒绝缺失的同方向参考图', async () => {
+  it('四向母版微调在重启节点前拒绝缺失的 south 身份锚', async () => {
     const templateRun = createRun([
       setupNode({ status: 'passed', phase: 'completed' }),
       templateNode({
@@ -2725,7 +2783,6 @@ describe('WorkflowController', () => {
         selectedImages: {
           east: 'east-template.png',
           west: 'west-template.png',
-          south: 'south-template.png',
         },
       }),
     ])
@@ -2738,7 +2795,7 @@ describe('WorkflowController', () => {
         mode: 'refine',
         adjustmentPrompt: '加强阴影',
       }),
-    ).rejects.toThrow('角色母版尚未确认方向 north')
+    ).rejects.toThrow('角色母版方向 south 不能为空')
     expect(template.generation.apis.create).not.toHaveBeenCalled()
     expect(template.controller.getWorkflow()).toEqual(templateBefore)
 
@@ -3970,40 +4027,49 @@ describe('WorkflowController', () => {
     })
   })
 
-  it('四向角色母版微调分别使用同方向已确认图片', async () => {
-    const run = createRun([
-      setupNode({ status: 'passed', phase: 'completed' }),
-      templateNode({
-        status: 'passed',
-        phase: 'completed',
-        selectedImageUrl: 'east-template.png',
-        selectedImages: {
-          east: 'east-template.png',
-          north: 'north-template.png',
-          south: 'south-template.png',
-        },
-      }),
-    ])
-    const { controller, generation } = createController(run, 'four-way')
+  it.each(['four-way', 'eight-way'] as const)(
+    '%s 角色母版微调只重做 south 身份锚，不回退到逐方向 character_template',
+    async (movement) => {
+      const run = createRun([
+        setupNode({ status: 'passed', phase: 'completed' }),
+        templateNode({
+          status: 'passed',
+          phase: 'completed',
+          selectedImageUrl: 'south-template.png',
+          selectedImages: {
+            east: 'east-template.png',
+            north: 'north-template.png',
+            south: 'south-template.png',
+            ...(movement === 'eight-way'
+              ? {
+                  north_east: 'north-east-template.png',
+                  south_east: 'south-east-template.png',
+                }
+              : {}),
+          },
+        }),
+      ])
+      const { controller, generation } = createController(run, movement)
 
-    await controller.regenerateCharacterTemplate('template-1', {
-      spriteWidth: 64,
-      spriteHeight: 96,
-      mode: 'refine',
-      adjustmentPrompt: '增加轮廓光',
-    })
+      await controller.regenerateCharacterTemplate('template-1', {
+        spriteWidth: 64,
+        spriteHeight: 96,
+        mode: 'refine',
+        adjustmentPrompt: '增加轮廓光',
+      })
 
-    expect(
-      vi.mocked(generation.apis.create).mock.calls.map(([input]) => ({
-        direction: input.direction,
-        referenceMedia: input.referenceMedia,
-      })),
-    ).toEqual([
-      { direction: 'east', referenceMedia: ['east-template.png'] },
-      { direction: 'north', referenceMedia: ['north-template.png'] },
-      { direction: 'south', referenceMedia: ['south-template.png'] },
-    ])
-  })
+      expect(vi.mocked(generation.apis.create)).toHaveBeenCalledTimes(1)
+      expect(generation.apis.create).toHaveBeenCalledWith({
+        type: 'character_template',
+        projectId: '1',
+        prompt: '像素骑士\n增加轮廓光',
+        referenceMedia: ['south-template.png'],
+        spriteWidth: 64,
+        spriteHeight: 96,
+        direction: 'south',
+      })
+    },
+  )
 
   it('四向动作首帧微调分别使用同方向已确认图片', async () => {
     const run = createRun([

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -51,13 +51,13 @@ export interface GenerateCharacterTemplateOptions {
   spriteHeight: number
   /** 重生成时用上一版图片约束本次结果；不覆盖角色设定中的原始参考素材。 */
   sourceImageUrl?: GeneratedImage['url']
-  /** 多方向微调时，每个源方向必须使用自己上一版的已确认图片。 */
+  /** 调用方显式补方向时，为该方向提供上一版已确认图片。 */
   sourceImageUrls?: Partial<Record<ActionDirection, GeneratedImage['url']>>
   /** 只影响本次请求的 prompt 覆盖值；不改写角色设定节点的原始输入。 */
   prompt?: string
   /** 手动编辑器提交时覆盖 configuring 节点的初始输入；节点通过后不再改写。 */
   input?: WorkflowCharacterInput
-  /** 只提交本阶段需要的真实源方向；缺省仍按项目完整方向集生成。 */
+  /** 只提交本阶段需要的方向；缺省使用项目身份锚（单向 east，多向 south）。 */
   directions?: readonly ActionDirection[]
   /** 本阶段每个方向的候选数；母版三选一，派生方向通常每向一张。 */
   candidateCount?: ImageCandidateCount
@@ -659,7 +659,9 @@ export function createWorkflowController({
             )
           })
     const templateNode = findSingleDependentNode(advanced, nodeId, 'character-template')
-    const requestedDirections = options.directions ?? generationDirections
+    const requestedDirections = options.directions ?? [
+      currentDirectionalMovement === 'single' ? 'east' : 'south',
+    ]
     for (const direction of requestedDirections) {
       assertGenerationDirection(direction, generationDirections)
     }
@@ -1086,23 +1088,24 @@ export function createWorkflowController({
     }
     const setupNode = findSingleDependencyNode(before, templateNode, 'character-setup')
     const prompt = adjustedPrompt(setupNode.input.prompt, options)
+    const anchorDirection: ActionDirection =
+      currentDirectionalMovement === 'single' ? 'east' : 'south'
     const sourceImageUrls =
       options.mode === 'refine'
         ? isCandidateSelection
-          ? { east: nonEmpty(options.sourceImageUrl ?? '', 'sourceImageUrl') }
-          : Object.fromEntries(
-              generationDirections.map((direction) => {
-                const imageUrl = selectedDirectionUrl(
+          ? { [anchorDirection]: nonEmpty(options.sourceImageUrl ?? '', 'sourceImageUrl') }
+          : {
+              [anchorDirection]: nonEmpty(
+                selectedDirectionUrl(
                   templateNode.selectedImages,
                   templateNode.selectedImageUrl,
-                  direction,
-                )
-                if (!imageUrl) throw new Error(`角色母版尚未确认方向 ${direction}`)
-                return [direction, imageUrl]
-              }),
-            )
+                  anchorDirection,
+                ) ?? '',
+                `角色母版方向 ${anchorDirection}`,
+              ),
+            }
         : undefined
-    const requestedDirections = isCandidateSelection ? (['east'] as const) : generationDirections
+    const requestedDirections = [anchorDirection]
     const keys = requestedDirections.map((direction) =>
       generationKey(nodeId, 'character_template', direction),
     )
@@ -1304,6 +1307,15 @@ export function createWorkflowController({
       const node = findNode(run, nodeId)
       const generations = node.generations.filter((item) => item.taskId !== reference.taskId)
       if (node.type === 'character-template') {
+        if (role === 'character_four_view' || role === 'character_eight_view') {
+          return replaceNode(run, {
+            ...node,
+            status: 'active',
+            phase: 'generating',
+            generations,
+            error: null,
+          })
+        }
         const selectedImages = { ...(node.selectedImages ?? {}) }
         delete selectedImages[direction]
         return replaceNode(run, {
@@ -1348,6 +1360,23 @@ export function createWorkflowController({
         (run, node, retryDirection) => {
           if (node.type === 'character-template') {
             const setupNode = findSingleDependencyNode(run, node, 'character-setup')
+            if (role === 'character_four_view' || role === 'character_eight_view') {
+              if (!node.selectedImageUrl || !node.selectedImages?.south) {
+                throw new Error('必须先确认南向正视母版')
+              }
+              const characterId = nonEmpty(setupNode.input.characterId ?? '', 'characterId')
+              const input: CharacterViewSheetGenerationInput = {
+                type: role,
+                projectId: run.projectId,
+                characterId,
+                prompt: setupNode.input.prompt,
+                referenceMedia: [],
+                spriteWidth: options.spriteWidth,
+                spriteHeight: options.spriteHeight,
+                candidateCount: 1,
+              }
+              return input
+            }
             const confirmedMaster = generatedImageReference(node.selectedImageUrl ?? undefined)
             const input: CharacterTemplateGenerationInput = {
               type: 'character_template',

--- a/frontend/src/pages/workflow-editor/character-template-confirmation.ts
+++ b/frontend/src/pages/workflow-editor/character-template-confirmation.ts
@@ -12,6 +12,7 @@ import type { WorkflowController } from '@/features/workflow-controller'
 interface CharacterTemplateConfirmerDependencies {
   controller: WorkflowController
   characterApis: Pick<CharacterApis, 'create' | 'update' | 'remove'>
+  referenceDirection: ActionDirection
   getCurrentCharacter(): Character | null
   setCurrentCharacter(character: Character): void
   shouldRollbackWorkflowChange(isPersisted: (latest: WorkflowRun) => boolean): Promise<boolean>
@@ -55,7 +56,12 @@ export function createCharacterTemplateConfirmer(
     }
 
     try {
-      await prepareCharacter(dependencies.characterApis, context, write)
+      await prepareCharacter(
+        dependencies.characterApis,
+        dependencies.referenceDirection,
+        context,
+        write,
+      )
       await dependencies.controller.confirmCharacterTemplate(
         nodeId,
         context.imageUrl,
@@ -107,6 +113,7 @@ function resolveCharacterTemplateContext(
 
 async function prepareCharacter(
   characterApis: CharacterTemplateConfirmerDependencies['characterApis'],
+  referenceDirection: ActionDirection,
   context: CharacterTemplateContext,
   write: CharacterWrite,
 ) {
@@ -122,7 +129,10 @@ async function prepareCharacter(
   const templateUrl = context.selectedImages.east ?? context.imageUrl
   write.next = await characterApis.update({
     ...write.next,
-    referenceImageUrl: write.next.referenceImageUrl ?? templateUrl,
+    referenceImageUrl:
+      context.direction === referenceDirection
+        ? context.imageUrl
+        : (write.next.referenceImageUrl ?? templateUrl),
     templates: characterTemplatesFromImages(context.selectedImages),
     outfits:
       write.next.outfits.length > 0

--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -765,6 +765,43 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     expect(screen.queryByRole('button', { name: /选择.*角色候选/ })).toBeNull()
   })
 
+  it('四向 sheet 生成中在母版节点渲染方向立绘进度而不是身份母版进度', async () => {
+    const workflow = selectingTemplateWorkflow(5, 'template-south')
+    workflow.nodes[1] = {
+      ...(workflow.nodes[1] as CharacterTemplateWorkflowNode),
+      phase: 'generating',
+      selectedImageUrl: 'https://assets.windup.test/south.png',
+      selectedImages: { south: 'https://assets.windup.test/south.png' },
+      generations: [
+        { taskId: 'template-south', role: 'character_template', direction: 'south' },
+        { taskId: 'view-sheet', role: 'character_four_view' },
+      ],
+    }
+    const session = createSession(workflow, {
+      project: { ...projectFixture(), directionalMovement: 'four-way' },
+      generationApis: generationApisFixture({
+        get: vi.fn(async (_projectId: string, taskId: string) =>
+          taskId === 'view-sheet'
+            ? {
+                id: taskId,
+                projectId: '1',
+                type: 'character_four_view' as const,
+                status: 'running' as const,
+                result: null,
+                error: null,
+              }
+            : directionalCharacterGeneration('south'),
+        ) as GenerationApis['get'],
+      }),
+    })
+    defaultSessionLoader.mockResolvedValue(session)
+
+    renderEditor('/workflow-editor/42')
+
+    expect(await screen.findByLabelText('方向立绘生成进度')).toBeTruthy()
+    expect(screen.queryByLabelText('身份母版生成进度')).toBeNull()
+  })
+
   it('四向 sheet 的四张独立图片在一个方向集合中展示并一次确认', async () => {
     const workflow = selectingTemplateWorkflow(4, 'template-south')
     workflow.nodes[1] = {
@@ -932,6 +969,59 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     expect(screen.queryByRole('button', { name: '重试东方向' })).toBeNull()
     expect(screen.queryByRole('button', { name: '重试南方向' })).toBeNull()
     expect(retry).toHaveBeenCalledWith('character-template', 'north', {
+      spriteWidth: 64,
+      spriteHeight: 64,
+    })
+  })
+
+  it.each([
+    ['four-way', 'character_four_view'],
+    ['eight-way', 'character_eight_view'],
+  ] as const)('%s 方向 sheet 失败时保留母版并提供整张 sheet 重试入口', async (movement, role) => {
+    const workflow = selectingTemplateWorkflow(5, 'template-south')
+    const template = workflow.nodes.find((node) => node.id === 'character-template')
+    if (!template || template.type !== 'character-template') throw new Error('missing template')
+    Object.assign(template, {
+      status: 'failed',
+      phase: 'generating',
+      error: 'sheet provider failed',
+      selectedImageUrl: 'https://assets.windup.test/south.png',
+      selectedImages: { south: 'https://assets.windup.test/south.png' },
+      generations: [
+        {
+          taskId: 'template-south',
+          role: 'character_template' as const,
+          direction: 'south' as const,
+        },
+        { taskId: 'view-sheet', role },
+      ],
+    })
+    const generationApis = generationApisFixture({
+      get: vi.fn(async (_projectId, taskId) =>
+        taskId === 'view-sheet'
+          ? {
+              id: taskId,
+              projectId: '1',
+              type: role,
+              status: 'failed' as const,
+              result: null,
+              error: 'sheet provider failed',
+            }
+          : directionalCharacterGeneration('south'),
+      ) as GenerationApis['get'],
+    })
+    const session = createSession(workflow, {
+      generationApis,
+      project: { ...projectFixture(), directionalMovement: movement },
+    })
+    const retry = vi.spyOn(session.controller, 'retryGenerationDirection').mockResolvedValue()
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    fireEvent.click(await screen.findByRole('button', { name: '重新生成整张方向立绘' }))
+
+    expect(screen.queryByRole('button', { name: '从此节点重做' })).toBeNull()
+    expect(retry).toHaveBeenCalledWith('character-template', 'east', {
       spriteWidth: 64,
       spriteHeight: 64,
     })

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -2083,19 +2083,32 @@ function WorkflowCard({ data, selected }: NodeProps<WorkflowCardNode>) {
 function StatusText({ node, input }: { node: WorkflowNode; input: ProjectionInput }) {
   const branchKey = branchKeyOf(node, input)
   const branchBusy = input.busyBranches.has(branchKey)
-  const generationRole =
+  const viewSheetRole =
     node.type === 'character-template'
+      ? (node.generations.find(
+          (reference) =>
+            reference.role === 'character_four_view' || reference.role === 'character_eight_view',
+        )?.role ?? null)
+      : null
+  const generationRole =
+    viewSheetRole ??
+    (node.type === 'character-template'
       ? 'character_template'
       : node.type === 'action-first-frame'
         ? 'first_frame'
         : node.type === 'action-full-frame'
           ? 'complete_animation'
-          : null
+          : null)
   const failedDirections = generationRole
-    ? getDirectionProfile(input.project.directionalMovement).generationDirections.filter(
-        (direction) =>
-          input.generations[generationKey(node.id, generationRole, direction)]?.status === 'failed',
-      )
+    ? viewSheetRole
+      ? input.generations[generationKey(node.id, viewSheetRole, 'east')]?.status === 'failed'
+        ? (['east'] as const)
+        : []
+      : getDirectionProfile(input.project.directionalMovement).generationDirections.filter(
+          (direction) =>
+            input.generations[generationKey(node.id, generationRole, direction)]?.status ===
+            'failed',
+        )
     : []
   const resumeBlocked =
     input.resumeBlocked && node.status === 'active' && node.phase === 'generating'
@@ -2105,7 +2118,23 @@ function StatusText({ node, input }: { node: WorkflowNode; input: ProjectionInpu
         <p className={CARD_SUMMARY}>
           {node.status === 'failed' ? (node.error ?? '生成失败') : '生成任务恢复失败'}
         </p>
-        {failedDirections.length > 0 ? (
+        {viewSheetRole && failedDirections.length > 0 ? (
+          <button
+            type="button"
+            className={CARD_BUTTON}
+            disabled={branchBusy}
+            onClick={() =>
+              input.runCommand(branchKey, () =>
+                input.controller.retryGenerationDirection(node.id, 'east', {
+                  spriteWidth: input.project.spriteSize.width,
+                  spriteHeight: input.project.spriteSize.height,
+                }),
+              )
+            }
+          >
+            重新生成整张方向立绘
+          </button>
+        ) : failedDirections.length > 0 ? (
           failedDirections.map((direction) => (
             <button
               type="button"
@@ -2141,8 +2170,15 @@ function StatusText({ node, input }: { node: WorkflowNode; input: ProjectionInpu
     )
   }
   if (node.phase === 'generating') {
-    const feedback =
-      node.type === 'character-template'
+    const generatingViewSheet =
+      node.type === 'character-template' &&
+      node.generations.some(
+        (reference) =>
+          reference.role === 'character_four_view' || reference.role === 'character_eight_view',
+      )
+    const feedback = generatingViewSheet
+      ? (['character-view-sheet', '方向立绘生成进度', '方向立绘生成预览'] as const)
+      : node.type === 'character-template'
         ? (['character-template', '身份母版生成进度', '身份母版生成预览'] as const)
         : node.type === 'action-first-frame'
           ? (['action-first-frame', '动作首帧生成进度', '动作首帧生成预览'] as const)

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -494,6 +494,46 @@ describe('createRealWorkflowEditorSession', () => {
     ).toMatchObject({ status: 'passed', phase: 'completed' })
   })
 
+  it('四向已有旧母版时确认新的南向定妆会覆盖角色身份锚', async () => {
+    const existing = {
+      ...characterWithOutfitFixture(),
+      referenceImageUrl: 'https://assets.windup.test/old-south.png',
+    }
+    const { session, update } = await createCharacterTemplateSession({
+      characters: [existing],
+      directionalMovement: 'four-way',
+    })
+
+    const character = await session.confirmCharacterTemplate(
+      'template',
+      'https://assets.windup.test/new-south.png',
+      'south',
+    )
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        referenceImageUrl: 'https://assets.windup.test/new-south.png',
+      }),
+    )
+    expect(character.referenceImageUrl).toBe('https://assets.windup.test/new-south.png')
+  })
+
+  it('单向已有旧母版时确认新的东向定妆会覆盖角色身份锚', async () => {
+    const existing = {
+      ...characterWithOutfitFixture(),
+      referenceImageUrl: 'https://assets.windup.test/old-east.png',
+    }
+    const { session } = await createCharacterTemplateSession({ characters: [existing] })
+
+    const character = await session.confirmCharacterTemplate(
+      'template',
+      'https://assets.windup.test/new-east.png',
+      'east',
+    )
+
+    expect(character.referenceImageUrl).toBe('https://assets.windup.test/new-east.png')
+  })
+
   it('已有 Character 新增造型后 Run 冲突时恢复修改前的角色资产', async () => {
     const existing = characterFixture()
     const updates: Character[] = []

--- a/frontend/src/pages/workflow-editor/runtime.ts
+++ b/frontend/src/pages/workflow-editor/runtime.ts
@@ -158,6 +158,7 @@ export async function createRealWorkflowEditorSession(
   const confirmCharacterTemplate = createCharacterTemplateConfirmer({
     controller,
     characterApis: dependencies.characterApis,
+    referenceDirection: project.directionalMovement === 'single' ? 'east' : 'south',
     getCurrentCharacter: () => currentCharacter,
     setCurrentCharacter: (character) => {
       currentCharacter = character

--- a/frontend/src/shared/ui/generation-progress-copy.tsx
+++ b/frontend/src/shared/ui/generation-progress-copy.tsx
@@ -5,6 +5,7 @@ import './generation-progress-copy.css'
 
 export type GenerationProgressKind =
   | 'character-template'
+  | 'character-view-sheet'
   | 'action-first-frame'
   | 'action-full-frame'
   | 'pixel-perfect'
@@ -18,6 +19,14 @@ const GENERATION_PROGRESS_MESSAGES: Record<GenerationProgressKind, readonly Kine
       { lines: ['添上表情'] },
       { lines: ['处理一下光影'] },
       { lines: ['补齐画面细节'] },
+    ],
+    'character-view-sheet': [
+      { lines: ['按罗盘生成朝向'] },
+      { lines: ['补齐角色侧视'] },
+      { lines: ['校准角色背面'] },
+      { lines: ['保持各方向身份一致'] },
+      { lines: ['整理镜像方向'] },
+      { lines: ['拼成立绘方向集'] },
     ],
     'action-first-frame': [
       { lines: ['摆好动作姿态'] },


### PR DESCRIPTION
## 变更说明

- 四向/八向角色母版统一使用 `south` 身份锚，单向继续使用 `east`
- 重生成与精修不再回退为逐方向 `character_template`，整张方向立绘失败时支持完整重提
- 方向立绘生成展示独立进度，并在确认新锚点时更新 `Character.reference_image_url`
- 补齐四向、八向默认生成、精修、失败重试和旧母版覆盖测试
- 修正最新 `main` 中 client-bake 用例的过度严格对象断言，允许既有 `rig` / `rootMotion` 元数据返回

## 验证

- `npm test -- --maxWorkers=50%`：81 files / 1269 tests passed
- `npm run test:coverage -- --maxWorkers=50%`：81 files / 1269 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- 本 PR 9 个改动文件通过 `npm run format:check`

Closes #783