### PR TITLE
fix(render3d): 绑骨的模型上传改走自家对象存储，不再走走不通的腾讯 COS

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -339,15 +339,52 @@ class _LazyAutoRig:
         self._allow_spend = allow_spend
 
     def rig(self, model: bytes, *, want: str = "GLB", motion=None):
-        from windup_framework.providers.render3d import (
-            TencentAutoRigProvider,
-            TencentCosModelUploader,
-        )
+        from windup_framework.providers.render3d import TencentAutoRigProvider
 
         provider = TencentAutoRigProvider(
-            TencentCosModelUploader(), allow_spend=self._allow_spend
+            _MediaModelUploader(), allow_spend=self._allow_spend
         )
         return provider.rig(model, want=want, motion=motion)
+
+
+class _MediaModelUploader:
+    """把模型放到**我们自己的**对象存储,拿绑骨服务器取得到的公网 URL。
+
+    原先走 ``TencentCosModelUploader``(先传腾讯 COS 再提交)。那条路在生产部署机上
+    走不通 —— 2026-08-28 实测:
+
+        部署机 → 腾讯 COS          64KB 通(52MB/s) │ 256KB 超时 │ 1MB BrokenPipe
+        部署机 → 自家对象存储       1MB 0.32s
+        部署机 → 上游 API 网关      1MB 0.23s
+
+    只有 COS 这一条链路超过约 64KB 就断,别的目标 1MB 秒传;18MB 的模型死在
+    ``ssl.sendall``,而失败发生在 ``_upload``,``_submit`` 从没执行(所以没扣费,
+    但也永远建不成资产)。
+
+    换成自家存储还顺带省掉一次 18MB 上传:``_publish_model`` 本来就要把模型传到
+    同一个地方,原先等于同一份文件传两遍、第二遍还传到一条走不通的链路上。
+
+    腾讯认这个 URL —— 同一份模型、同一个接口,实测提交成功
+    (JobId=1484789196060876800,产物 20.4MB FBX、2 个 AnimationStack)。
+    用控制样本区分过错误码:URL 取不到时腾讯报 ``DownloadError: 文件下载失败``,
+    与我们遇到的 ``ServerError`` / ``RequestTimeout`` 是不同的错,后两者重试即过。
+    """
+
+    _NAME = {"model/gltf-binary": "rig-input.glb", "application/x-fbx": "rig-input.fbx"}
+
+    def upload(self, model: bytes, content_type: str) -> str:
+        from windup_app.server.media.model import MediaUploadInput
+        from windup_app.server.media.service import service as media_service
+
+        return media_service.upload(
+            model,
+            MediaUploadInput(
+                filename=self._NAME.get(content_type, "rig-input.bin"),
+                content_type=content_type,
+                size=len(model),
+                category="model-3d",
+            ),
+        )
 
 
 def _publish_model(data: bytes) -> str:

--- a/backend/tests/test_rig_upload_target.py
+++ b/backend/tests/test_rig_upload_target.py
@@ -1,0 +1,97 @@
+"""绑骨的模型上传走**我们自己的**对象存储,不走腾讯 COS。
+
+拦的坏例:18MB 的模型死在 ``ssl.sendall``,资产永远建不成。
+
+2026-08-28 在生产部署机上实测的链路：
+
+    部署机 → 腾讯 COS         64KB 通(52MB/s) │ 256KB 超时 │ 1MB BrokenPipe
+    部署机 → 自家对象存储      1MB 0.32s
+    部署机 → 上游 API 网关     1MB 0.23s
+
+只有 COS 这一条超过约 64KB 就断。失败发生在 ``_upload``、``_submit`` 从没执行 ——
+所以不扣费,但也永远建不成资产,而错误信息是一句 ``URLError: write operation timed
+out``,看不出是哪条链路。
+
+换成自家存储还顺带省掉一次 18MB 上传:``_publish_model`` 本来就要把模型传到同一个
+地方,原先等于同一份文件传两遍、第二遍还传到一条走不通的链路上。
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_the_rig_uploader_is_not_the_cos_one():
+    """拦的坏例:退回 ``TencentCosModelUploader``。
+
+    判据是**实际注入的那个对象的类型**,不是源码里有没有某个名字 —— 后者在把
+    import 挪个位置时就会误判。
+    """
+    from windup_app.server.orchestrator import render3d_service as svc
+
+    calls = []
+
+    class _FakeProvider:
+        def __init__(self, uploader, *, allow_spend=False):
+            calls.append(uploader)
+
+        def rig(self, model, *, want="GLB", motion=None):
+            return object()
+
+    import windup_framework.providers.render3d as r3d
+    real = r3d.TencentAutoRigProvider
+    r3d.TencentAutoRigProvider = _FakeProvider
+    try:
+        svc._LazyAutoRig(allow_spend=False).rig(b"x", motion="walk")
+    finally:
+        r3d.TencentAutoRigProvider = real
+
+    assert calls, "没构造 provider"
+    assert type(calls[0]).__name__ != "TencentCosModelUploader", (
+        "又走回腾讯 COS 了 —— 生产部署机到 COS 的上行超过约 64KB 就断"
+    )
+    assert isinstance(calls[0], svc._MediaModelUploader)
+
+
+def test_the_uploader_returns_a_public_http_url():
+    """绑骨服务器要能取到这个 URL。
+
+    ``TencentAutoRigProvider._upload`` 自己也会校验(非 http(s) 就在提交前炸),
+    这条钉的是我们这一侧真的给得出。
+    """
+    from windup_app.server.orchestrator import render3d_service as svc
+
+    seen = {}
+
+    class _FakeMedia:
+        def upload(self, data, spec):
+            seen["filename"] = spec.filename
+            seen["category"] = spec.category
+            seen["size"] = spec.size
+            return "https://media.example.com/media/model-3d/abc.glb"
+
+    import windup_app.server.media.service as ms
+    real = ms.service
+    ms.service = _FakeMedia()
+    try:
+        url = svc._MediaModelUploader().upload(b"glTF" + b"\0" * 100, "model/gltf-binary")
+    finally:
+        ms.service = real
+
+    assert url.startswith("https://")
+    assert seen["category"] == "model-3d", "分类错了会走回 MediaCategory 那个老坑(#834②)"
+    assert seen["size"] == 104, "size 要报真实字节数"
+
+
+@pytest.mark.parametrize(
+    "ct,want",
+    [("model/gltf-binary", ".glb"), ("application/x-fbx", ".fbx")],
+)
+def test_the_filename_extension_follows_the_content_type(ct, want):
+    """后缀跟着 content-type 走。
+
+    绑骨接口按 ``Type`` 判格式、而两个出帧台宿主按 URL 后缀挑 loader ——
+    FBX 挂成 .glb 会走 GLTFLoader 报 "Bad glTF"(#834③)。
+    """
+    from windup_app.server.orchestrator.render3d_service import _MediaModelUploader
+
+    assert _MediaModelUploader._NAME[ct].endswith(want)


### PR DESCRIPTION
Closes #858

## 问题

**生产上第一次真跑三渲二的花钱两段时撞到的。** 图生 3D 成功了，绑骨死在上传：

```
URLError: <urlopen error The write operation timed out>
  tencent.py:432  rig
  tencent.py:453  _upload          ← 死在这
  tencent.py:226  upload → cos_request → ssl.sendall
```

在部署机上实测三条链路（每条发同样大小的数据）：

```
→ 腾讯 COS           64KB 通(52MB/s) │ 256KB 超时 │ 1MB BrokenPipe
→ 自家对象存储        1MB 0.32s  ✅
→ 上游 API 网关       1MB 0.23s  ✅
```

**只有腾讯 COS 这一条超过约 64KB 就断**，别的目标 1MB 秒传。这是这台机器到腾讯云的链路问题，不是我们超时设小了（那里本来就是 300 秒）。

失败发生在 `_upload`、`_submit` 从没执行 —— **所以不扣费，但资产永远建不成**，而错误信息看不出是哪条链路出的问题。

## 改法

`_upload` 走的是注入的 uploader，结构上本来就支持换目标。换成走 `media_service.upload`（和 `_publish_model` 同一个地方）。

**顺带省掉一次 18MB 上传**：`_publish_model` 本来就要把模型传到那里，原先等于同一份文件传两遍、第二遍还传到一条走不通的链路上。

## 实证：腾讯认这个 URL

同一份模型、同一个接口，只换来源，**提交成功**：

```
JobId = 1484789196060876800
产物  = 20.4MB FBX，AnimationStack × 2
骨骼  = Hips / Spine / Neck / Head / LeftFoot / RightHand 齐全
```

前两次提交报的是 `ServerError: 算法服务异常` 和 `RequestTimeout: 后端服务超时`，第三次成功。用**控制样本**确认这不是「URL 不被接受」：故意提交一个不存在的 URL，腾讯报的是 `DownloadError: 文件下载失败` —— **三个不同的错**，说明我们那个 URL 被接受了、文件被下载了，前两次是上游瞬时故障。

## 验证

| 变异 | 结果 |
|---|---|
| 退回 `TencentCosModelUploader` | 1 红 |
| 分类写成 `general`（走回 #834② 那个坑） | 1 红 |

判据取**实际注入对象的类型**，不是源码里有没有某个名字 —— 后者在把 import 挪个位置时就会误判。

CI 原样命令跑在最后一次编辑之后：`ruff check .` 通过；`export_openapi` rc=0 无漂移；`lint-imports` 2 kept / 0 broken；`pytest -q --cov=packages` **1991 passed, 14 skipped**。

## 附：#834 四条根因在真实产物上的实证

这次跑通顺带把 #835 修的四条在**生产真实产物**上逐条验了：

| 根因 | 实证 |
|---|---|
| ① 绑骨不带 motion → 零动画 | `AnimationStack = 2`（带 motion 之后不再是 0） |
| ② `MediaCategory` 缺 `model-3d` | 上传成功，URL 是 `media/model-3d/....glb` |
| ③ 要 GLB 却返回 FBX | 声明 `Type=FBX`、magic 是 `Kaydara FBX Binary` —— 按 magic 定后缀才不会被挂成 `.glb` 走 GLTFLoader |
| ④ 片段名对不上 | 产物里恰好一个可用片段，走「只有一个就用它」那条 |

