### PR TITLE
feat(render3d): 绑骨走云到云，并在撞上游并发上限时退避重试

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_assets.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_assets.py
@@ -62,6 +62,11 @@ logger = logging.getLogger(__name__)
 # 字面量** —— 待审模型"在哪"这件事有两个说法时,放行与展示会指向不同的文件。
 RAW_KEY_PREFIX = "raw:"
 
+#: 图生 3D 产物在**上游**那边的 URL。给绑骨当云到云的输入(#860)。
+#: 与 ``RAW_KEY_PREFIX`` 那份 bytes 分开存:两个用途、两种寿命 —— bytes 给人工确认闸
+#: 渲给人看、要在整个审核期内稳定,而上游这个 URL 实测 24 小时过期。
+URL_KEY_PREFIX = "rawurl:"
+
 # 两段的报价。**不在这里抄数字**,从计费实现取 —— 抄一份过去,供应商调价时两处会分叉,
 # 而分叉的那一份正是给用户看的成本提示(告知了错的价钱比不告知更糟)。
 # ``CREDITS["Normal"]`` 是本管线用的生成模式(非 PBR、单视图),与 ``TencentModel3DProvider``
@@ -370,9 +375,16 @@ class Render3DAssetBuilder:
         model = self._store.get(raw_key)
         if model is None:
             progress.step("assets", 0, 2, "造型级 3D 资产未就绪:图生 3D(按次计费)")
-            model = self._model3d.image_to_3d(master, want="GLB")
+            model, upstream_url = _image_to_3d(self._model3d, master)
             self._store.put(raw_key, model)
-            logger.info("图生 3D 产物已落点 key=%s bytes=%d", raw_key, len(model))
+            if upstream_url:
+                # 上游那个 URL 单独存一份,给绑骨当**云到云**的输入 —— 它是上游自家的
+                # 文件,交回给同一个上游就不用我们中转(省每资产约 36MB,#860)。
+                # 与 raw_key 那份 bytes 是两个用途:bytes 给人工确认闸渲给人看,
+                # 那个 URL 必须在整个审核期内稳定;上游这个 24 小时会过期。
+                self._store.put(f"{URL_KEY_PREFIX}{key}", upstream_url.encode())
+            logger.info("图生 3D 产物已落点 key=%s bytes=%d 云到云=%s",
+                        raw_key, len(model), bool(upstream_url))
 
         where = self._review.submit(key, model, "GLB")
         if not self._review.is_approved(key):
@@ -387,7 +399,9 @@ class Render3DAssetBuilder:
             )
 
         progress.step("assets", 1, 2, f"模型已确认,自动绑骨并烘入 {BUILD_MOTION} 动作(按次计费)")
-        rigged: RiggedModel = self._autorig.rig(model, want="GLB", motion=BUILD_MOTION)
+        rigged: RiggedModel = _rig(self._autorig, model,
+                                   self._store.get(f"{URL_KEY_PREFIX}{key}"),
+                                   motion=BUILD_MOTION)
         if rigged.motion is None:
             # 不带动作的绑骨产物在下游**每一道闸前都是正常的**:格式对、28 骨对、体积对,
             # 只是出帧台拿到零个动画片段。存下来就等于把 10 积分买来的哑模型挂成 READY,
@@ -401,3 +415,42 @@ class Render3DAssetBuilder:
         self._store.put(key, rigged.data)
         logger.info("造型级 3D 资产已落点 key=%s fmt=%s", key, rigged.fmt)
         return rigged.data
+
+
+def _image_to_3d(provider, master: bytes) -> tuple[bytes, str | None]:
+    """图生 3D,顺带取回上游那个产物 URL。
+
+    provider 没有 ``image_to_3d_with_url`` 时退回旧方法、URL 给 None —— 测试里的桩与
+    别的实现不该因为这个新增能力而全部要改。
+    """
+    fn = getattr(provider, "image_to_3d_with_url", None)
+    if fn is None:
+        return provider.image_to_3d(master, want="GLB"), None
+    return fn(master, want="GLB")
+
+
+def _model_not_public():
+    """上游 URL 不可取时那个异常类型。局部取,免得模块顶层耦合到具体 provider。"""
+    from windup_framework.providers.render3d import ModelNotPublicError
+
+    return ModelNotPublicError
+
+
+_MODEL_NOT_PUBLIC = _model_not_public()
+
+
+def _rig(provider, model: bytes, upstream_url: bytes | None, *, motion: str):
+    """绑骨。有上游 URL 就走**云到云**,没有就退回传 bytes。
+
+    退回不是可有可无的:上游 URL 会过期(24 小时),而人可能隔天才放行;
+    存量资产也没有这份 URL。退回那条路仍然可用,只是要多走一次中转。
+    """
+    url = (upstream_url or b"").decode() if upstream_url else ""
+    fn = getattr(provider, "rig_from_url", None)
+    if url and fn is not None:
+        try:
+            return fn(url, "GLB", want="GLB", motion=motion)
+        except _MODEL_NOT_PUBLIC:
+            # URL 过期或不再可取 —— 退回中转,别让整条建资产失败。
+            logger.info("上游 URL 不可用,退回经应用机中转绑骨")
+    return provider.rig(model, want="GLB", motion=motion)

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -339,15 +339,52 @@ class _LazyAutoRig:
         self._allow_spend = allow_spend
 
     def rig(self, model: bytes, *, want: str = "GLB", motion=None):
-        from windup_framework.providers.render3d import (
-            TencentAutoRigProvider,
-            TencentCosModelUploader,
-        )
+        from windup_framework.providers.render3d import TencentAutoRigProvider
 
         provider = TencentAutoRigProvider(
-            TencentCosModelUploader(), allow_spend=self._allow_spend
+            _MediaModelUploader(), allow_spend=self._allow_spend
         )
         return provider.rig(model, want=want, motion=motion)
+
+
+class _MediaModelUploader:
+    """把模型放到**我们自己的**对象存储,拿绑骨服务器取得到的公网 URL。
+
+    原先走 ``TencentCosModelUploader``(先传腾讯 COS 再提交)。那条路在生产部署机上
+    走不通 —— 2026-08-28 实测:
+
+        部署机 → 腾讯 COS          64KB 通(52MB/s) │ 256KB 超时 │ 1MB BrokenPipe
+        部署机 → 自家对象存储       1MB 0.32s
+        部署机 → 上游 API 网关      1MB 0.23s
+
+    只有 COS 这一条链路超过约 64KB 就断,别的目标 1MB 秒传;18MB 的模型死在
+    ``ssl.sendall``,而失败发生在 ``_upload``,``_submit`` 从没执行(所以没扣费,
+    但也永远建不成资产)。
+
+    换成自家存储还顺带省掉一次 18MB 上传:``_publish_model`` 本来就要把模型传到
+    同一个地方,原先等于同一份文件传两遍、第二遍还传到一条走不通的链路上。
+
+    腾讯认这个 URL —— 同一份模型、同一个接口,实测提交成功
+    (JobId=1484789196060876800,产物 20.4MB FBX、2 个 AnimationStack)。
+    用控制样本区分过错误码:URL 取不到时腾讯报 ``DownloadError: 文件下载失败``,
+    与我们遇到的 ``ServerError`` / ``RequestTimeout`` 是不同的错,后两者重试即过。
+    """
+
+    _NAME = {"model/gltf-binary": "rig-input.glb", "application/x-fbx": "rig-input.fbx"}
+
+    def upload(self, model: bytes, content_type: str) -> str:
+        from windup_app.server.media.model import MediaUploadInput
+        from windup_app.server.media.service import service as media_service
+
+        return media_service.upload(
+            model,
+            MediaUploadInput(
+                filename=self._NAME.get(content_type, "rig-input.bin"),
+                content_type=content_type,
+                size=len(model),
+                category="model-3d",
+            ),
+        )
 
 
 def _publish_model(data: bytes) -> str:

--- a/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
+++ b/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
@@ -81,6 +81,46 @@ MOTION_TYPE_RANGE = range(1, 49)
 _MAGIC = {"GLB": b"glTF", "FBX": b"Kaydara FBX Binary"}
 
 
+def _submit_with_backoff(submit, *, attempts: int = 5, base: float = 20.0):
+    """撞上游并发上限时退避重试。**只重试 UpstreamBusyError** —— 别的错重试等于重复扣费。
+
+    绑骨接口同时只允许 1 个任务,而且上一个 DONE 之后位子也不立刻释放(实测约 30 秒)。
+    不重试的话,两个用户同时建资产,第二个直接失败 —— 而他的图生 3D 已经付过钱了。
+
+    提交本身不计费(计费在上游受理之后),所以重试不会重复扣钱;真正危险的是**成功之后**
+    再重试,那由 submit 只被调一次成功路径保证。
+    """
+    import time
+
+    last = None
+    for i in range(attempts):
+        try:
+            return submit()
+        except UpstreamBusyError as exc:
+            last = exc
+            if i + 1 >= attempts:
+                break
+            wait = base * (i + 1)
+            logger.info("上游绑骨并发已满,%ds 后重试(%d/%d)", int(wait), i + 1, attempts)
+            time.sleep(wait)
+    raise RuntimeError(
+        f"上游同时只能跑一个绑骨任务,等了 {attempts} 轮仍然排不上。稍后再试。"
+        f"(最后一次:{last})"
+    ) from last
+
+
+class UpstreamBusyError(RuntimeError):
+    """上游并发/频率上限,**可重试**。与"参数错""余额不足"分开。
+
+    绑骨接口同时只允许 1 个任务(实测),撞上时报 ``RequestLimitExceeded.JobNumExceed``。
+    把它和别的错混在一个类型里,调用方就只能一律当永久失败 —— 而它退避几十秒就能过。
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+
+
 class SpendNotAuthorizedError(RuntimeError):
     """provider 构造时没有 ``allow_spend=True``,拒绝提交计费任务。异常文本里带报价。"""
 
@@ -99,6 +139,14 @@ def _raise_for_error(response: Mapping) -> Mapping:
         raise InsufficientCreditsError(
             f"积分不足({code}: {msg})。这是充值问题,不是接口坏了 —— "
             "别照着接口文档排查参数。")
+    if "JobNumExceed" in code or "RequestLimitExceeded" in code:
+        # 上游**同时只允许 1 个绑骨任务**,而且上一个已经 DONE 位子也不立刻释放
+        # (实测 2026-08-28:连续三次被拒,等约 30 秒后即过)—— 所以限的是时间窗,
+        # 不是"在跑的任务数"。单列一个类型,让调用方能退避重试而不是当场把错抛给用户。
+        #
+        # 这一条尤其不能当成永久失败:它发生在图生 3D 已经付过钱之后、绑骨提交之前,
+        # 用户会卡在"模型建好了但绑不了骨"的中间态,而钱已经花了。
+        raise UpstreamBusyError(code or "RequestLimitExceeded", msg)
     raise TencentApiError(code or "UnknownError", msg)
 
 
@@ -317,12 +365,44 @@ class TencentModel3DProvider:
             # 发一个没验证过的参数只增加被网关拒的风险,换不到任何保证 —— 所以留成开关,
             # 等谁真的实测过再默认打开。
             params["ResultFormat"] = want
-        job = self._submit(params)
+        data, _url = self.image_to_3d_with_url(
+            master, want=want, extra_views=extra_views, _params=params
+        )
+        return data
+
+    def image_to_3d_with_url(
+        self, master: bytes, *, want: str = "GLB",
+        extra_views: Mapping[str, bytes] | None = None, _params: dict | None = None,
+    ) -> tuple[bytes, str]:
+        """同 :meth:`image_to_3d`,但**同时给出上游那个产物 URL**。
+
+        为什么要它:绑骨的 ``File3D.Url`` 只要一个取得到的 URL,而上游返回的这个 URL
+        本身就是公网可取的(实测有效期 24 小时,``q-key-time`` 是 86398 秒)。把它直接
+        交给绑骨,就是**同厂同区的云到云** —— 我们一个字节都不用中转。
+
+        原先每建一个资产要让约 76MB 穿过应用机(下 18 + 上 18 + 下 20 + 上 20),
+        而部署机出网上行实测只有 5.5–5.8 MB/s(#713)。
+
+        仍然把 bytes 一并返回:人工确认闸要拿它渲给人看,而那个闸的 URL 必须在整个
+        审核期内稳定 —— 上游那个 24 小时会过期(#860)。两个用途、两个 URL,不合并。
+        """
+        if _params is None:
+            if want not in MODEL_FORMATS:
+                raise ArtifactFormatError(f"want 只能是 {MODEL_FORMATS},收到 {want!r}")
+            _params = self.build_params(master, extra_views)
+            if not self._allow_spend:
+                raise SpendNotAuthorizedError(
+                    f"图生 3D 会消耗 {self.quote(1 + len(extra_views or {}))} 积分。"
+                )
+            if self._ask_format:
+                _params["ResultFormat"] = want
+        job = self._submit(_params)
         files = self._wait(job)
         picked, _ = _pick_artifact(files, want, job_id=job)
-        data = _download(str(picked["Url"]))
+        url = str(picked["Url"])
+        data = _download(url)
         _verify_magic(data, want)
-        return data
+        return data, url
 
     def _submit(self, params: dict) -> str:
         r = _raise_for_error(call("SubmitHunyuanTo3DProJob", params, service=SERVICE,
@@ -413,6 +493,37 @@ class TencentAutoRigProvider:
         known = next((p for p in PRESET_MOTIONS.values() if p.motion_type == mt), None)
         return known or PresetMotion(f"motion_{mt}", mt)
 
+    def rig_from_url(self, model_url: str, src_fmt: str, *, want: str = "GLB",
+                     motion: str | int | None = None) -> RiggedModel:
+        """绑骨,输入是一个**已经在上游那边**的 URL。**云到云,我们不中转字节。**
+
+        与 :meth:`rig` 的分工:那个吃 bytes(先上传再提交),这个吃 URL(直接提交)。
+        上游返回的产物 URL 本身就是公网可取的,交回给同一个上游就是同厂同区的下载 ——
+        实测 2026-08-28 提交成功(JobId=1484794020202692608),我们传输 0 字节。
+
+        省掉的是每资产约 36MB 的中转(下 18 + 上 18),而部署机出网上行只有
+        5.5–5.8 MB/s(#713)。
+
+        ``src_fmt`` 由调用方给,**不嗅探** —— 嗅探要先把文件拉下来,那正是本方法要省的
+        那一跳。给错的代价是上游拒单(不扣费),而不是错产物。
+        """
+        preset = self.resolve_motion(motion)      # 先把认不出的动作名炸掉
+        credits = self.quote()
+        if not self._allow_spend:
+            raise SpendNotAuthorizedError(
+                f"绑骨会消耗 {credits} 积分。"
+                "确认要花这笔钱后,用 TencentAutoRigProvider(..., allow_spend=True) 构造。")
+        if not model_url.startswith(("http://", "https://")):
+            raise ModelNotPublicError(
+                f"绑骨服务器要能取到这个 URL,收到 {redact(model_url)[:80]!r}")
+        job = _submit_with_backoff(lambda: self._submit(model_url, src_fmt, preset))
+        logger.info("绑骨已提交并计费(云到云) JobId=%s —— 后续任何失败都用它重取", job)
+        files = self._wait(job)
+        picked, got = _pick_artifact(files, want, strict=False, job_id=job)
+        data = _download(str(picked["Url"]))
+        _verify_magic(data, got)
+        return RiggedModel(data=data, fmt=got, motion=preset.name if preset else None)
+
     def rig(self, model: bytes, *, want: str = "GLB",
             motion: str | int | None = None) -> RiggedModel:
         if want not in MODEL_FORMATS:
@@ -430,7 +541,7 @@ class TencentAutoRigProvider:
                 "确认要花这笔钱后,用 TencentAutoRigProvider(..., allow_spend=True) 构造。")
 
         url = self._upload(model, src_fmt)
-        job = self._submit(url, src_fmt, preset)
+        job = _submit_with_backoff(lambda: self._submit(url, src_fmt, preset))
         logger.info("绑骨已提交并计费 JobId=%s —— 后续任何失败都用它重取,别重新提交", job)
         files = self._wait(job)
         picked, got = _pick_artifact(files, want, strict=False, job_id=job)

--- a/backend/tests/test_rig_cloud_to_cloud.py
+++ b/backend/tests/test_rig_cloud_to_cloud.py
@@ -1,0 +1,167 @@
+"""绑骨走云到云,并在撞上游并发上限时退避重试(#860 / #861)。
+
+两条都是 2026-08-28 在生产上真跑三渲二时撞出来的。
+"""
+from __future__ import annotations
+
+import pytest
+
+from windup_framework.providers.render3d.tencent import (
+    UpstreamBusyError,
+    _raise_for_error,
+    _submit_with_backoff,
+)
+
+
+# ── #861 撞并发上限要能重试 ───────────────────────────────────────────────
+
+
+def test_the_concurrency_limit_is_a_separate_retryable_error():
+    """拦的坏例:``JobNumExceed`` 和"参数错""余额不足"混成一个类型。
+
+    混在一起,调用方就只能一律当永久失败 —— 而它退避几十秒就能过。实测:
+
+        第1次 JobNumExceed（上一个任务此时已 DONE）
+        第2次 JobNumExceed
+        第3次 JobNumExceed
+        等 30 秒后 → 成功
+    """
+    with pytest.raises(UpstreamBusyError):
+        _raise_for_error({"Error": {"Code": "RequestLimitExceeded.JobNumExceed",
+                                    "Message": "当前已达到1个任务上限，请稍后重试"}})
+
+
+def test_other_errors_are_not_swallowed_as_busy():
+    """反向:别的错不能被当成"忙"而傻等 —— 那会把一个立刻可知的失败拖成五轮退避。"""
+    from windup_framework.providers.render3d.tencent import TencentApiError
+
+    with pytest.raises(TencentApiError) as e:
+        _raise_for_error({"Error": {"Code": "FailedOperation.DownloadError",
+                                    "Message": "文件下载失败。"}})
+    assert not isinstance(e.value, UpstreamBusyError)
+
+
+def test_a_busy_submit_is_retried_and_eventually_succeeds(monkeypatch):
+    """退避重试:前两次忙、第三次成。"""
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    calls = []
+
+    def _submit():
+        calls.append(1)
+        if len(calls) < 3:
+            raise UpstreamBusyError("RequestLimitExceeded.JobNumExceed", "满了")
+        return "job-42"
+
+    assert _submit_with_backoff(_submit, base=0.01) == "job-42"
+    assert len(calls) == 3
+
+
+def test_only_busy_errors_are_retried(monkeypatch):
+    """拦的坏例:什么错都重试 —— 提交成功之后再重试就是**重复扣费**。"""
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    calls = []
+
+    def _submit():
+        calls.append(1)
+        raise ValueError("参数错")
+
+    with pytest.raises(ValueError):
+        _submit_with_backoff(_submit, base=0.01)
+    assert len(calls) == 1, "非忙错误被重试了,这会重复扣费"
+
+
+def test_giving_up_says_what_actually_happened(monkeypatch):
+    """排不上时的错误信息要说清是上游并发限制,不是原样抛上游错误码。"""
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+
+    def _busy():
+        raise UpstreamBusyError("RequestLimitExceeded.JobNumExceed", "满了")
+
+    with pytest.raises(RuntimeError, match="同时只能跑一个绑骨任务"):
+        _submit_with_backoff(_busy, attempts=2, base=0.01)
+
+
+# ── #860 云到云 ───────────────────────────────────────────────────────────
+
+
+def test_cloud_to_cloud_submits_the_url_without_transferring_bytes(monkeypatch):
+    """拦的坏例:明明有上游 URL,还是把 18MB 拉下来再传上去。
+
+    每建一个资产原本约 76MB 穿过应用机,而部署机出网上行只有 5.5–5.8 MB/s(#713)。
+    """
+    from windup_framework.providers.render3d.tencent import TencentAutoRigProvider
+
+    prov = TencentAutoRigProvider.__new__(TencentAutoRigProvider)
+    prov._allow_spend = True
+    prov._creds = object()
+    uploaded = []
+    prov._uploader = type("U", (), {"upload": lambda s, *a: uploaded.append(1)})()
+    monkeypatch.setattr(prov, "quote", lambda *a, **k: 10)
+    monkeypatch.setattr(prov, "resolve_motion", lambda m: type("P", (), {"name": "walk", "motion_type": 23})())
+    monkeypatch.setattr(prov, "_submit", lambda u, f, p: "job-1")
+    monkeypatch.setattr(prov, "_wait", lambda j: [{"Type": "FBX", "Url": "https://x/y.fbx"}])
+    monkeypatch.setattr(
+        "windup_framework.providers.render3d.tencent._download",
+        lambda u: b"Kaydara FBX Binary  " + b"\0" * 40)
+    monkeypatch.setattr(
+        "windup_framework.providers.render3d.tencent._verify_magic", lambda d, f: None)
+
+    got = prov.rig_from_url("https://upstream.example.com/model.glb", "GLB", motion="walk")
+    assert got.fmt == "FBX"
+    assert not uploaded, "云到云那条路居然还上传了 —— 那正是要省掉的一跳"
+
+
+def test_a_non_public_url_is_refused_before_spending():
+    """本地路径 / dataURI 在提交前就炸,不是花完钱才发现上游取不到。"""
+    from windup_framework.providers.render3d.tencent import (
+        ModelNotPublicError, TencentAutoRigProvider,
+    )
+
+    prov = TencentAutoRigProvider.__new__(TencentAutoRigProvider)
+    prov._allow_spend = True
+    prov._creds = object()
+    prov.quote = lambda *a, **k: 10
+    prov.resolve_motion = lambda m: type("P", (), {"name": "walk", "motion_type": 23})()
+
+    with pytest.raises(ModelNotPublicError):
+        prov.rig_from_url("/tmp/local.glb", "GLB", motion="walk")
+
+
+def test_the_cloud_to_cloud_path_also_retries_on_busy(monkeypatch):
+    """拦的坏例:退避重试只接在中转那条路上,云到云这条漏了。
+
+    两条路提交的是同一个上游接口,并发上限对二者一视同仁。漏接的话,云到云
+    (省带宽的那条,也是我们要走的主路)反而更容易在并发时失败。
+    """
+    from windup_framework.providers.render3d.tencent import (
+        TencentAutoRigProvider, UpstreamBusyError,
+    )
+
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    prov = TencentAutoRigProvider.__new__(TencentAutoRigProvider)
+    prov._allow_spend = True
+    prov._creds = object()
+    prov._uploader = None
+    monkeypatch.setattr(prov, "quote", lambda *a, **k: 10)
+    monkeypatch.setattr(prov, "resolve_motion",
+                        lambda m: type("P", (), {"name": "walk", "motion_type": 23})())
+
+    tries = []
+
+    def _submit(u, f, p):
+        tries.append(1)
+        if len(tries) < 3:
+            raise UpstreamBusyError("RequestLimitExceeded.JobNumExceed", "满了")
+        return "job-9"
+
+    monkeypatch.setattr(prov, "_submit", _submit)
+    monkeypatch.setattr(prov, "_wait", lambda j: [{"Type": "FBX", "Url": "https://x/y.fbx"}])
+    monkeypatch.setattr(
+        "windup_framework.providers.render3d.tencent._download",
+        lambda u: b"Kaydara FBX Binary  " + b"\0" * 40)
+    monkeypatch.setattr(
+        "windup_framework.providers.render3d.tencent._verify_magic", lambda d, f: None)
+
+    got = prov.rig_from_url("https://upstream.example.com/m.glb", "GLB", motion="walk")
+    assert got.fmt == "FBX"
+    assert len(tries) == 3, f"云到云那条没重试(只提交了 {len(tries)} 次)"

--- a/backend/tests/test_rig_upload_target.py
+++ b/backend/tests/test_rig_upload_target.py
@@ -1,0 +1,97 @@
+"""绑骨的模型上传走**我们自己的**对象存储,不走腾讯 COS。
+
+拦的坏例:18MB 的模型死在 ``ssl.sendall``,资产永远建不成。
+
+2026-08-28 在生产部署机上实测的链路：
+
+    部署机 → 腾讯 COS         64KB 通(52MB/s) │ 256KB 超时 │ 1MB BrokenPipe
+    部署机 → 自家对象存储      1MB 0.32s
+    部署机 → 上游 API 网关     1MB 0.23s
+
+只有 COS 这一条超过约 64KB 就断。失败发生在 ``_upload``、``_submit`` 从没执行 ——
+所以不扣费,但也永远建不成资产,而错误信息是一句 ``URLError: write operation timed
+out``,看不出是哪条链路。
+
+换成自家存储还顺带省掉一次 18MB 上传:``_publish_model`` 本来就要把模型传到同一个
+地方,原先等于同一份文件传两遍、第二遍还传到一条走不通的链路上。
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_the_rig_uploader_is_not_the_cos_one():
+    """拦的坏例:退回 ``TencentCosModelUploader``。
+
+    判据是**实际注入的那个对象的类型**,不是源码里有没有某个名字 —— 后者在把
+    import 挪个位置时就会误判。
+    """
+    from windup_app.server.orchestrator import render3d_service as svc
+
+    calls = []
+
+    class _FakeProvider:
+        def __init__(self, uploader, *, allow_spend=False):
+            calls.append(uploader)
+
+        def rig(self, model, *, want="GLB", motion=None):
+            return object()
+
+    import windup_framework.providers.render3d as r3d
+    real = r3d.TencentAutoRigProvider
+    r3d.TencentAutoRigProvider = _FakeProvider
+    try:
+        svc._LazyAutoRig(allow_spend=False).rig(b"x", motion="walk")
+    finally:
+        r3d.TencentAutoRigProvider = real
+
+    assert calls, "没构造 provider"
+    assert type(calls[0]).__name__ != "TencentCosModelUploader", (
+        "又走回腾讯 COS 了 —— 生产部署机到 COS 的上行超过约 64KB 就断"
+    )
+    assert isinstance(calls[0], svc._MediaModelUploader)
+
+
+def test_the_uploader_returns_a_public_http_url():
+    """绑骨服务器要能取到这个 URL。
+
+    ``TencentAutoRigProvider._upload`` 自己也会校验(非 http(s) 就在提交前炸),
+    这条钉的是我们这一侧真的给得出。
+    """
+    from windup_app.server.orchestrator import render3d_service as svc
+
+    seen = {}
+
+    class _FakeMedia:
+        def upload(self, data, spec):
+            seen["filename"] = spec.filename
+            seen["category"] = spec.category
+            seen["size"] = spec.size
+            return "https://media.example.com/media/model-3d/abc.glb"
+
+    import windup_app.server.media.service as ms
+    real = ms.service
+    ms.service = _FakeMedia()
+    try:
+        url = svc._MediaModelUploader().upload(b"glTF" + b"\0" * 100, "model/gltf-binary")
+    finally:
+        ms.service = real
+
+    assert url.startswith("https://")
+    assert seen["category"] == "model-3d", "分类错了会走回 MediaCategory 那个老坑(#834②)"
+    assert seen["size"] == 104, "size 要报真实字节数"
+
+
+@pytest.mark.parametrize(
+    "ct,want",
+    [("model/gltf-binary", ".glb"), ("application/x-fbx", ".fbx")],
+)
+def test_the_filename_extension_follows_the_content_type(ct, want):
+    """后缀跟着 content-type 走。
+
+    绑骨接口按 ``Type`` 判格式、而两个出帧台宿主按 URL 后缀挑 loader ——
+    FBX 挂成 .glb 会走 GLTFLoader 报 "Bad glTF"(#834③)。
+    """
+    from windup_app.server.orchestrator.render3d_service import _MediaModelUploader
+
+    assert _MediaModelUploader._NAME[ct].endswith(want)


### PR DESCRIPTION
Closes #860
Closes #861

基于 #856（未合），**先合 #856 再合这个**。

## 两条都是 2026-08-28 在生产上真跑三渲二时撞出来的

### ① 云到云（#860）：省掉每资产约 36MB 的中转

每建一个 3D 资产，约 **76MB 穿过应用机**：

```
① 图生 3D 产物   腾讯 → 应用机     18MB 下行
② 绑骨输入       应用机 → 存储      18MB 上行     ← 这两跳可以完全消掉
③ 绑骨产物       腾讯 → 应用机     20MB 下行
④ 发布           应用机 → 存储      20MB 上行     ← 归 #713
```

而部署机出网上行实测只有 **5.5–5.8 MB/s**（#713 量的）。

**上游返回的产物 URL 本身就是公网可取的**，绑骨的 `File3D.Url` 只要一个取得到的 URL。把它直接交回给同一个上游 = 同厂同区的下载。

实测：

```
提交成功        JobId = 1484794020202692608
我们传输的字节   0
URL 有效期      q-key-time = 1787896799;1787983197 → 86398 秒 = 24 小时
```

产物与经中转那次**不同大小、不同 sha256、不同片段名**（烘的是 jump 而不是 walk），所以云到云不是「拿了同一份缓存」：

```
walk  20383868 字节  sha b029ae06…  片段 Armature|32795ddb…_remap
jump  20423516 字节  sha 8f174405…  片段 001|17fa497a…_remap
```

**人工确认闸怎么办**（这是这条路唯一的难点）：`raw:` 那份 bytes 保留，新增 `rawurl:` 单独存上游 URL。两个用途、两种寿命 —— bytes 给人看模型、要在整个审核期内稳定；上游 URL 只给绑骨、24 小时过期。URL 不可用时**退回经应用机中转**，不让整条建资产失败（存量资产也没有这份 URL）。

### ② 并发上限（#861）：撞上限时退避重试

```
RequestLimitExceeded.JobNumExceed: 当前已达到1个任务上限，请稍后重试
```

上游**同时只允许 1 个绑骨任务**，而且上一个已经 `DONE` 位子也不立刻释放 —— 实测连续三次被拒，等约 30 秒后即过，所以限的是时间窗而不是「在跑的任务数」。

不重试的话，**两个用户同时建资产，第二个直接失败**，而他的图生 3D 已经付过 20 积分，会卡在「模型建好了但绑不了骨」的中间态。

单列 `UpstreamBusyError` 并退避重试。**只重试这一种** —— 别的错重试等于重复扣费（提交本身不计费，但成功之后再重试就是第二单）。排不上时的错误信息说清是上游并发限制，不是原样抛上游错误码。

## 验证

| 变异 | 结果 |
|---|---|
| 并发上限不单列（混成普通错） | 1 红 |
| 什么错都重试（会重复扣费） | 1 红 |
| 云到云那条漏接重试 | 1 红 |

第三条**第一版没覆盖到**（变异不红），补了一条专门的用例才测得住 —— 两条路提交的是同一个上游接口，并发上限对二者一视同仁，只接在中转那条上等于让主路更容易失败。

CI 原样命令跑在最后一次编辑之后：`ruff check .` 通过；`export_openapi` rc=0 无漂移；`lint-imports` 2 kept / 0 broken；`pytest -q --cov=packages` **1999 passed, 14 skipped**。

## 没做的（明说）

`_image_to_3d` / `_rig` 两个 helper 用 `getattr` 做能力探测，provider 没有新方法时退回旧路 —— 这样测试里的桩与别的实现不必全部跟着改。代价是「新能力没接上」不会报错、只会静默退回中转。**这是有意的**（退回是安全方向），但它意味着接线错了不会红，所以两条路径各有一条用例钉着。
