### PR TITLE
fix(character): 多方向资产发布时未写入 character_data.version=2

### DIFF
--- a/frontend/src/entities/character/directional-asset.test.ts
+++ b/frontend/src/entities/character/directional-asset.test.ts
@@ -6,7 +6,11 @@ import {
   type Action,
   type CharacterTemplate,
 } from '.'
-import { validateDirectionalAsset } from './directional-asset'
+import {
+  assertMultiDirectionAssetPublishable,
+  characterDataVersionForWrite,
+  validateDirectionalAsset,
+} from './directional-asset'
 
 function realTemplate(direction: CharacterTemplate['direction']): CharacterTemplate {
   return {
@@ -225,5 +229,31 @@ describe('validateDirectionalAsset', () => {
         '单向资产包含无效方向：north',
       ],
     })
+  })
+})
+
+describe('characterDataVersionForWrite', () => {
+  it('keeps version 1 for east/west-only assets', () => {
+    expect(
+      characterDataVersionForWrite(1, [realTemplate('east')], [realAction(['east', 'west'])]),
+    ).toBe(1)
+  })
+
+  it('stamps version 2 when a four-way sequence is present', () => {
+    expect(
+      characterDataVersionForWrite(1, [realTemplate('east')], [realAction(['east', 'north'])]),
+    ).toBe(2)
+  })
+})
+
+describe('assertMultiDirectionAssetPublishable', () => {
+  it('does not block single-direction publishes', () => {
+    expect(() => assertMultiDirectionAssetPublishable(1, 'single', [], [])).not.toThrow()
+  })
+
+  it('raises the first completeness problem after stamping version 2', () => {
+    expect(() =>
+      assertMultiDirectionAssetPublishable(2, 'four-way', [realTemplate('east')], []),
+    ).toThrow('角色母版缺少真实方向：north、south')
   })
 })

--- a/frontend/src/entities/character/directional-asset.ts
+++ b/frontend/src/entities/character/directional-asset.ts
@@ -3,9 +3,41 @@ import type { DirectionalMovement } from '../project'
 import type { Action, CharacterTemplate } from '.'
 import { getDirectionProfile, type ActionDirection } from './directions'
 
+/** 可发布的多方向资产结构版本；east/west 旧镜像合同为 1。 */
+export const MULTI_DIRECTION_CHARACTER_DATA_VERSION = 2
+
+const SINGLE_CONTRACT_DIRECTIONS = new Set<ActionDirection>(['east', 'west'])
+
 export interface DirectionalAssetValidation {
   readonly complete: boolean
   readonly problems: readonly string[]
+}
+
+export function characterDataVersionForWrite(
+  dataVersion: number,
+  templates: readonly CharacterTemplate[],
+  actions: readonly Action[],
+): number {
+  const current = dataVersion >= 1 ? dataVersion : 1
+  const directions = [
+    ...templates.map((template) => template.direction),
+    ...actions.flatMap((action) => (action.sequences ?? []).map((sequence) => sequence.direction)),
+  ]
+  if (directions.every((direction) => SINGLE_CONTRACT_DIRECTIONS.has(direction))) return current
+  return Math.max(current, MULTI_DIRECTION_CHARACTER_DATA_VERSION)
+}
+
+export function assertMultiDirectionAssetPublishable(
+  version: number,
+  movement: DirectionalMovement,
+  templates: readonly CharacterTemplate[],
+  actions: readonly Action[],
+): void {
+  if (movement === 'single') return
+  const validation = validateDirectionalAsset(version, movement, templates, actions)
+  if (!validation.complete) {
+    throw new Error(validation.problems[0] ?? '多方向资产不完整')
+  }
 }
 
 function realDirections(

--- a/frontend/src/entities/character/index.test.ts
+++ b/frontend/src/entities/character/index.test.ts
@@ -355,6 +355,44 @@ describe('characterApis', () => {
     })
   })
 
+  it('stamps character_data.version 2 when PATCHing a version 1 multi-direction asset', async () => {
+    let request: Request | undefined
+    const legacyDto = structuredClone(characterDto)
+    legacyDto.character_data.version = 1
+    const characterApis = await loadCharacterApis(async (input, init) => {
+      request = new Request(input, init)
+      return jsonResponse(legacyDto)
+    })
+    const character = await characterApis.get('51')
+
+    await characterApis.update(character)
+
+    expect(character.dataVersion).toBe(1)
+    await expect(request?.json()).resolves.toMatchObject({
+      character_data: { version: 2 },
+    })
+  })
+
+  it('keeps character_data.version 1 when PATCHing an east/west-only asset', async () => {
+    let request: Request | undefined
+    const legacyDto = structuredClone(characterDto)
+    legacyDto.character_data.version = 1
+    legacyDto.character_data.templates = legacyDto.character_data.templates.filter(
+      (template) => template.direction === 'east' || template.direction === 'west',
+    )
+    const characterApis = await loadCharacterApis(async (input, init) => {
+      request = new Request(input, init)
+      return jsonResponse(legacyDto)
+    })
+    const character = await characterApis.get('51')
+
+    await characterApis.update(character)
+
+    await expect(request?.json()).resolves.toMatchObject({
+      character_data: { version: 1 },
+    })
+  })
+
   it('preserves directional action sequences across GET and PATCH', async () => {
     let request: Request | undefined
     const directionalDto = structuredClone(characterDto)

--- a/frontend/src/entities/character/index.ts
+++ b/frontend/src/entities/character/index.ts
@@ -7,11 +7,25 @@ import {
   resolveActionDirection,
   type ActionDirection,
 } from './directions'
+import {
+  assertMultiDirectionAssetPublishable,
+  characterDataVersionForWrite,
+  MULTI_DIRECTION_CHARACTER_DATA_VERSION,
+  validateDirectionalAsset,
+  type DirectionalAssetValidation,
+} from './directional-asset'
 
 export type { ActionDirection } from './directions'
 export { getDirectionGridLayout } from './directions'
 export type { DirectionGridLayout } from './directions'
-export { validateDirectionalAsset, type DirectionalAssetValidation } from './directional-asset'
+
+export {
+  assertMultiDirectionAssetPublishable,
+  characterDataVersionForWrite,
+  MULTI_DIRECTION_CHARACTER_DATA_VERSION,
+  validateDirectionalAsset,
+}
+export type { DirectionalAssetValidation }
 
 /** PR #75 将动作类型定义为字符串；已知类型之外的后端扩展也应原样保留。 */
 export type ActionType = string
@@ -90,7 +104,7 @@ export interface Character {
   referenceImageUrl: string | null
   /** 后续新增动作时恢复各方向输入，避免用 east 母版生成其他朝向。 */
   templates?: CharacterTemplate[]
-  /** character_data.version，更新整棵资产树时必须原样带回。 */
+  /** character_data.version。多方向合同写入时升到 2；单向旧资产保持 1。 */
   dataVersion: number
   status: CharacterStatus
   outfits: Outfit[]
@@ -604,7 +618,11 @@ export const characterApis: CharacterApis & CharacterSummaryApis = {
           description: character.description,
           reference_image_url: character.referenceImageUrl,
           character_data: {
-            version: character.dataVersion,
+            version: characterDataVersionForWrite(
+              character.dataVersion,
+              character.templates ?? [],
+              character.outfits.flatMap((outfit) => outfit.actions),
+            ),
             templates: (character.templates ?? []).map((template) => ({
               direction: template.direction,
               source_direction: template.sourceDirection,

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -75,10 +75,13 @@ export type {
 } from './character'
 export {
   CHARACTER_STATUS,
+  assertMultiDirectionAssetPublishable,
   characterApis,
+  characterDataVersionForWrite,
   characterTemplateImages,
   characterTemplatesFromImages,
   characterTemplatesFromViewSheetCells,
+  validateDirectionalAsset,
 } from './character'
 export {
   ACTION_DIRECTIONS,

--- a/frontend/src/features/export/index.test.ts
+++ b/frontend/src/features/export/index.test.ts
@@ -107,7 +107,16 @@ describe('Character asset publisher', () => {
     ]
 
     const published = await publisher.publishReviewedAction({
-      character: characterFixture(),
+      character: {
+        ...characterFixture(),
+        templates: fourWayTemplates(),
+        outfits: [
+          {
+            ...characterFixture().outfits[0]!,
+            actions: [],
+          },
+        ],
+      },
       workflow,
       reviewNodeId: 'action-walk:review',
       generations: [
@@ -117,6 +126,8 @@ describe('Character asset publisher', () => {
       ],
       directionalMovement: 'four-way',
     })
+
+    expect(published.dataVersion).toBe(2)
 
     expect(published.outfits[0]?.actions.at(-1)?.sequences).toEqual([
       {
@@ -249,6 +260,40 @@ describe('Character asset publisher', () => {
       }),
     ).rejects.toThrow('完整动画方向 east 的生成结果不可发布')
   })
+
+  it('rejects a four-way publish when character templates are still incomplete', async () => {
+    const publisher = (
+      exportFeature as unknown as ExportFeatureModule
+    ).createCharacterAssetPublisher({
+      async update() {
+        throw new Error('不应写入 Character')
+      },
+    })
+    const workflow = workflowFixture()
+    const fullFrame = workflow.nodes.find((node) => node.type === 'action-full-frame')!
+    fullFrame.generations = [
+      { taskId: 'generation-east', role: 'complete_animation', direction: 'east' },
+      { taskId: 'generation-north', role: 'complete_animation', direction: 'north' },
+      { taskId: 'generation-south', role: 'complete_animation', direction: 'south' },
+    ]
+
+    await expect(
+      publisher.publishReviewedAction({
+        character: {
+          ...characterFixture(),
+          outfits: [{ ...characterFixture().outfits[0]!, actions: [] }],
+        },
+        workflow,
+        reviewNodeId: 'action-walk:review',
+        generations: [
+          directionalAnimationFixture('generation-east', 'east', 'east'),
+          directionalAnimationFixture('generation-north', 'north', 'north'),
+          directionalAnimationFixture('generation-south', 'south', 'south'),
+        ],
+        directionalMovement: 'four-way',
+      }),
+    ).rejects.toThrow('角色母版缺少真实方向')
+  })
 })
 
 function createRejectingPublisher() {
@@ -257,6 +302,15 @@ function createRejectingPublisher() {
       throw new Error('不应写入 Character')
     },
   })
+}
+
+function fourWayTemplates(): NonNullable<Character['templates']> {
+  return [
+    { direction: 'east', sourceDirection: null, mirrorX: false, imageUrl: 'east.png' },
+    { direction: 'west', sourceDirection: 'east', mirrorX: true, imageUrl: null },
+    { direction: 'north', sourceDirection: null, mirrorX: false, imageUrl: 'north.png' },
+    { direction: 'south', sourceDirection: null, mirrorX: false, imageUrl: 'south.png' },
+  ]
 }
 
 function characterFixture(): Character {

--- a/frontend/src/features/export/index.ts
+++ b/frontend/src/features/export/index.ts
@@ -1,14 +1,16 @@
-import type {
-  Action,
-  ActionSequence,
-  Character,
-  CharacterApis,
-  DirectionalMovement,
-  Generation,
-  WorkflowNode,
-  WorkflowRun,
+import {
+  assertMultiDirectionAssetPublishable,
+  characterDataVersionForWrite,
+  getDirectionProfile,
+  type Action,
+  type ActionSequence,
+  type Character,
+  type CharacterApis,
+  type DirectionalMovement,
+  type Generation,
+  type WorkflowNode,
+  type WorkflowRun,
 } from '@/entities'
-import { getDirectionProfile } from '@/entities'
 
 export interface PublishReviewedActionInput {
   character: Character
@@ -105,8 +107,21 @@ export function createCharacterAssetPublisher(
 
       const outfits = [...character.outfits]
       outfits[outfitIndex] = { ...targetOutfit, actions }
+      const nextActions = outfits.flatMap((outfit) => outfit.actions)
+      const dataVersion = characterDataVersionForWrite(
+        character.dataVersion,
+        character.templates ?? [],
+        nextActions,
+      )
+      assertMultiDirectionAssetPublishable(
+        dataVersion,
+        directionalMovement,
+        character.templates ?? [],
+        nextActions,
+      )
       return characterApis.update({
         ...character,
+        dataVersion,
         outfits,
       })
     },

--- a/frontend/src/pages/quick-start/service.test.ts
+++ b/frontend/src/pages/quick-start/service.test.ts
@@ -106,6 +106,15 @@ function fourViewSheet(southImageUrl: string): CharacterViewSheetCandidate {
   }
 }
 
+function fourWayTemplates(): NonNullable<Character['templates']> {
+  return [
+    { direction: 'east', sourceDirection: null, mirrorX: false, imageUrl: 'east-sheet.png' },
+    { direction: 'west', sourceDirection: 'east', mirrorX: true, imageUrl: null },
+    { direction: 'north', sourceDirection: null, mirrorX: false, imageUrl: 'north-sheet.png' },
+    { direction: 'south', sourceDirection: null, mirrorX: false, imageUrl: 'south-sheet.png' },
+  ]
+}
+
 function automaticDeliveryGenerationApis(): GenerationApis {
   const tasks = new Map<string, Awaited<ReturnType<GenerationApis['create']>>>()
   tasks.set('task-template', {
@@ -1830,6 +1839,7 @@ describe('createQuickStartService', () => {
       subscribe: vi.fn(() => () => undefined),
     }
     let character = characterWithDefaultOutfit(run.id)
+    character.templates = fourWayTemplates()
     const characterApis = mutableCharacterApis(
       () => character,
       (value) => (character = value),

--- a/frontend/src/pages/quick-start/service.ts
+++ b/frontend/src/pages/quick-start/service.ts
@@ -7,6 +7,8 @@ import {
   workflowRunApis,
   characterTemplatesFromImages,
   characterTemplatesFromViewSheetCells,
+  characterDataVersionForWrite,
+  assertMultiDirectionAssetPublishable,
   getDirectionProfile,
   type Action,
   type Character,
@@ -1316,16 +1318,30 @@ export function createQuickStartService({
           frames: eastSequence.frames,
           sequences,
         }
+        const publishedOutfits = character.outfits.map((outfit) =>
+          outfit.id === info.outfitId
+            ? {
+                ...outfit,
+                actions: [...outfit.actions.filter((item) => item.id !== action.id), action],
+              }
+            : outfit,
+        )
+        const nextActions = publishedOutfits.flatMap((outfit) => outfit.actions)
+        const dataVersion = characterDataVersionForWrite(
+          character.dataVersion,
+          character.templates ?? [],
+          nextActions,
+        )
+        assertMultiDirectionAssetPublishable(
+          dataVersion,
+          directionalMovement,
+          character.templates ?? [],
+          nextActions,
+        )
         const publishedCharacter = await characterApis.update({
           ...character,
-          outfits: character.outfits.map((outfit) =>
-            outfit.id === info.outfitId
-              ? {
-                  ...outfit,
-                  actions: [...outfit.actions.filter((item) => item.id !== action.id), action],
-                }
-              : outfit,
-          ),
+          dataVersion,
+          outfits: publishedOutfits,
         })
         if (review.status === 'active') {
           try {

--- a/frontend/src/pages/workflow-editor/runtime.test.ts
+++ b/frontend/src/pages/workflow-editor/runtime.test.ts
@@ -715,13 +715,13 @@ describe('createRealWorkflowEditorSession', () => {
       },
       characterApis: {
         listByProject: vi.fn().mockResolvedValue({
-          items: [characterWithOutfitFixture()],
+          items: [fourWayCharacterFixture()],
           total: 1,
           page: 1,
           pageSize: 100,
         }),
         create: vi.fn(),
-        get: vi.fn().mockResolvedValue(characterWithOutfitFixture()),
+        get: vi.fn().mockResolvedValue(fourWayCharacterFixture()),
         update: vi.fn(async (character) => structuredClone(character)),
         remove: vi.fn(),
       },
@@ -1265,6 +1265,18 @@ function characterWithOutfitFixture(): Character {
         model3dUrl: null,
         actions: [],
       },
+    ],
+  }
+}
+
+function fourWayCharacterFixture(): Character {
+  return {
+    ...characterWithOutfitFixture(),
+    templates: [
+      { direction: 'east', sourceDirection: null, mirrorX: false, imageUrl: 'east.png' },
+      { direction: 'west', sourceDirection: 'east', mirrorX: true, imageUrl: null },
+      { direction: 'north', sourceDirection: null, mirrorX: false, imageUrl: 'north.png' },
+      { direction: 'south', sourceDirection: null, mirrorX: false, imageUrl: 'south.png' },
     ],
   }
 }


### PR DESCRIPTION
## Summary
- 写入多方向 sequences/templates 时把 `character_data.version` 升到 2，避免四向/八向 PATCH 被后端当成旧版镜像资产拒绝
- 发布前调用已有的方向完整性校验，缺母版时直接报缺方向，而不是先撞上「旧版镜像资产不能作为完整的多方向资产发布」
- 单向 east/west 旧资产仍保持 version 1

Closes #863

## Test plan
- [x] `vitest`：directional-asset / character API / export publisher / workflow-editor runtime（74 passed）
- [x] 四向项目里对 version 1 角色发布完整动作，`PATCH /characters/{id}` 成功且 `character_data.version === 2`
- [x] 单向项目里 version 1 旧资产仍可更新/发布
- [x] 四向项目里缺 north/south 母版时，客户端报「角色母版缺少真实方向」，而不是旧版镜像那句 400