### PR TITLE
fix(ops): 模型弃用但库里还非空的遗留列，放宽为可空（否则线上建不了项目）

### DIFF
--- a/backend/scripts/schema_sync.py
+++ b/backend/scripts/schema_sync.py
@@ -48,8 +48,10 @@ def _load_models() -> None:
         pass
 
 
-def plan(engine: Engine, metadata=None) -> tuple[list[tuple[str, str, str]], list[str]]:
-    """返回 (可自动补的列, 需要人处理的项)。
+def plan(
+    engine: Engine, metadata=None,
+) -> tuple[list[tuple[str, str, str]], list[str], list[tuple[str, str]]]:
+    """返回 (可自动补的列, 需要人处理的项, 可放宽为可空的遗留列)。
 
     ``metadata`` 只为测试留:默认走全仓模型,传入时可以在隔离的库上验本函数自己。
     """
@@ -60,6 +62,8 @@ def plan(engine: Engine, metadata=None) -> tuple[list[tuple[str, str, str]], lis
     live_tables = set(insp.get_table_names())
     additive: list[tuple[str, str, str]] = []
     manual: list[str] = []
+    # 库里有、模型没有、且非空无默认 —— 这类会挡住 INSERT,放宽为可空。
+    relaxable: list[tuple[str, str]] = []
 
     for table in metadata.sorted_tables:
         if table.name not in live_tables:
@@ -89,11 +93,24 @@ def plan(engine: Engine, metadata=None) -> tuple[list[tuple[str, str, str]], lis
 
         # 反向:库里有、模型没有。删列会丢数据,本脚本只报不动 —— 不报的话
         # 巡检会在"模型删了一列"时返回干净,而库里那一列还带着数据。
+        #
+        # 但**非空且无默认**的遗留列不能只报:模型不再点名它,INSERT 就少一列,
+        # NOT NULL 直接违约 —— 整张表插不进去。实测 2026-08-28 生产库:
+        # windup_project.character_perspective 是 smallint NOT NULL 无默认,而 #676 把它
+        # 从模型删掉了,于是 INSERT 报 NotNullViolation,再被 project.py 的
+        # `except IntegrityError` 误报成「项目名称已存在」(#859)。
+        #
+        # 放宽为可空是**加法方向**的动作:不丢数据、不改类型、旧代码若还在跑也照样写得进。
+        # 真正的删列仍然交给人(数据要不要留是业务决定),这里只是让它不再挡住写入。
         for name in live.keys() - {c.name for c in table.columns}:
+            col_info = live[name]
+            if not col_info.get("nullable", True) and col_info.get("default") is None:
+                relaxable.append((table.name, name))
+                continue
             manual.append(
                 f"{table.name}.{name} 库里有而模型没有：删列会丢数据，请人工确认后手写 SQL"
             )
-    return additive, manual
+    return additive, manual, relaxable
 
 
 def main() -> int:
@@ -102,26 +119,33 @@ def main() -> int:
                     help="真的执行；缺省只报告，退出码非 0 表示有漂移")
     a = ap.parse_args()
 
-    additive, manual = plan(default_engine)
+    additive, manual, relaxable = plan(default_engine)
     for m in manual:
         print(f"[需人工] {m}")
     for tbl, col, ddl in additive:
         print(f"[可自动] ALTER TABLE {tbl} ADD COLUMN {ddl};")
+    for tbl, col in relaxable:
+        print(f"[可自动] ALTER TABLE {tbl} ALTER COLUMN {col} DROP NOT NULL;  "
+              f"-- 模型已弃用但库里还在,不放宽会挡住整张表的 INSERT")
 
     if manual:
         print(f"\n{len(manual)} 项需要人工处理，本脚本不动它们。")
-    if not additive:
+    if not additive and not relaxable:
         print("没有可自动补的列。")
         return 1 if manual else 0
 
     if not a.apply:
-        print(f"\n{len(additive)} 列待补。加 --apply 执行。")
+        print(f"\n{len(additive)} 列待补、{len(relaxable)} 列待放宽。加 --apply 执行。")
         return 1
 
     with default_engine.begin() as conn:
         for tbl, col, ddl in additive:
             conn.execute(text(f"ALTER TABLE {tbl} ADD COLUMN {ddl}"))
             print(f"已补 {tbl}.{col}")
+        for tbl, col in relaxable:
+            # 只去掉 NOT NULL,**不删列** —— 数据要不要留是业务决定,而挡住写入不是。
+            conn.execute(text(f'ALTER TABLE {tbl} ALTER COLUMN "{col}" DROP NOT NULL'))
+            print(f"已放宽 {tbl}.{col}（模型已弃用，去掉 NOT NULL 以免挡住 INSERT）")
     return 1 if manual else 0
 
 

--- a/backend/tests/test_schema_sync.py
+++ b/backend/tests/test_schema_sync.py
@@ -5,7 +5,7 @@ import pathlib
 import sys
 
 import pytest
-from sqlalchemy import Boolean, Column, Integer, MetaData, String, Table, create_engine, inspect, text
+from sqlalchemy import SmallInteger, Boolean, Column, Integer, MetaData, String, Table, create_engine, inspect, text
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
 from schema_sync import plan  # noqa: E402
@@ -28,7 +28,7 @@ def test_a_new_nullable_column_is_planned_as_additive():
     """给已上线的表加一个可空列 —— 这正是本脚本存在的理由。"""
     live = _model()
     want = _model(Column("is_pixel_art", Boolean, nullable=True))
-    additive, manual = plan(_engine_with(live), want.metadata)
+    additive, manual, _relax = plan(_engine_with(live), want.metadata)
 
     assert manual == []
     assert [(t, c) for t, c, _ in additive] == [("proj", "is_pixel_art")]
@@ -39,21 +39,21 @@ def test_applying_the_plan_makes_the_column_real():
     live = _model()
     want = _model(Column("is_pixel_art", Boolean, nullable=True))
     eng = _engine_with(live)
-    additive, _ = plan(eng, want.metadata)
+    additive, _, _relax = plan(eng, want.metadata)
 
     with eng.begin() as conn:
         for tbl, _col, ddl in additive:
             conn.execute(text(f"ALTER TABLE {tbl} ADD COLUMN {ddl}"))
 
     assert "is_pixel_art" in {c["name"] for c in inspect(eng).get_columns("proj")}
-    assert plan(eng, want.metadata) == ([], []), "补完再跑应当无事可做（幂等）"
+    assert plan(eng, want.metadata) == ([], [], []), "补完再跑应当无事可做（幂等）"
 
 
 def test_a_not_null_column_without_default_is_left_to_a_human():
     """存量行填不出值，自动加只会当场失败 —— 报出来而不是硬上。"""
     live = _model()
     want = _model(Column("owner", String(20), nullable=False))
-    additive, manual = plan(_engine_with(live), want.metadata)
+    additive, manual, _relax = plan(_engine_with(live), want.metadata)
 
     assert additive == []
     assert len(manual) == 1 and "owner" in manual[0]
@@ -63,7 +63,7 @@ def test_a_type_change_is_never_applied_silently():
     """改类型会丢数据，只报不动。"""
     live = _model(Column("sprite_width", Integer))
     want = _model(Column("sprite_width", String(20)))
-    additive, manual = plan(_engine_with(live), want.metadata)
+    additive, manual, _relax = plan(_engine_with(live), want.metadata)
 
     assert additive == []
     assert len(manual) == 1 and "类型不一致" in manual[0]
@@ -73,7 +73,7 @@ def test_a_table_that_does_not_exist_yet_is_not_our_business():
     """整张表缺失由 create_all 负责；本脚本不越界建表。"""
     want = _model(Column("is_pixel_art", Boolean, nullable=True))
     eng = create_engine("sqlite://")
-    assert plan(eng, want.metadata) == ([], [])
+    assert plan(eng, want.metadata) == ([], [], [])
 
 
 def test_it_fixes_the_real_case_a_live_table_missing_a_new_column():
@@ -102,7 +102,7 @@ def test_it_fixes_the_real_case_a_live_table_missing_a_new_column():
         with Session(eng) as s:
             s.query(Project).first()
 
-    additive, manual = plan(eng, Project.metadata)
+    additive, manual, _relax = plan(eng, Project.metadata)
     assert manual == []
     assert (Project.__tablename__, new_column) in [(t, c) for t, c, _ in additive]
 
@@ -112,14 +112,14 @@ def test_it_fixes_the_real_case_a_live_table_missing_a_new_column():
 
     with Session(eng) as s:
         assert s.query(Project).first().project_name == "存量项目"
-    assert plan(eng, Project.metadata) == ([], []), "补完再跑应当无事可做"
+    assert plan(eng, Project.metadata) == ([], [], []), "补完再跑应当无事可做"
 
 
 def test_a_narrower_type_parameter_is_flagged():
     """只比基类型的话 VARCHAR(20) 与 VARCHAR(200) 看着一样,而它正是会截断数据的那类改动。"""
     live = _model(Column("project_name", String(200)))
     want = _model(Column("project_name", String(20)))
-    additive, manual = plan(_engine_with(live), want.metadata)
+    additive, manual, _relax = plan(_engine_with(live), want.metadata)
 
     assert additive == []
     assert len(manual) == 1 and "project_name" in manual[0]
@@ -129,14 +129,51 @@ def test_identical_types_are_not_flagged():
     """归一只该吃掉排版差异;同一个类型不能因为编译串的空格差异被报成漂移。"""
     live = _model(Column("project_name", String(20)))
     want = _model(Column("project_name", String(20)))
-    assert plan(_engine_with(live), want.metadata) == ([], [])
+    assert plan(_engine_with(live), want.metadata) == ([], [], [])
 
 
 def test_a_column_removed_from_the_model_is_reported():
     """模型删了列而库里还在:不报的话巡检返回干净,那一列却带着数据留在库里。"""
     live = _model(Column("legacy_note", String(50)))
     want = _model()
-    additive, manual = plan(_engine_with(live), want.metadata)
+    additive, manual, _relax = plan(_engine_with(live), want.metadata)
 
     assert additive == []
     assert len(manual) == 1 and "legacy_note" in manual[0]
+
+
+def test_a_legacy_not_null_column_is_relaxed_not_just_reported():
+    """拦的坏例:模型删了一列、库里那列还是 NOT NULL 无默认 → **整张表插不进去**。
+
+    实测 2026-08-28 生产库:`windup_project.character_perspective` 是
+    `smallint NOT NULL` 无默认,而 #676 把它从 ORM 删掉了。新代码的 INSERT 不再点名
+    它,于是 `NotNullViolation`,再被 `project.py` 的 `except IntegrityError` 误报成
+    「项目名称已存在」(#859)—— 用户看到的名字是全新的,真实原因不在任何一条日志里。
+
+    只报不动是不够的:那条报告没人看的时候,线上就是所有人都建不了项目。
+    放宽为可空是加法方向 —— 不丢数据、不改类型、旧代码若还在跑也照样写得进。
+    """
+    live = _model(Column("dropped_by_model", SmallInteger, nullable=False))
+    want = _model()
+
+    additive, manual, relaxable = plan(_engine_with(live), want.metadata)
+    assert relaxable == [("proj", "dropped_by_model")], (
+        f"非空遗留列没被识别成可放宽:relaxable={relaxable} manual={manual}"
+    )
+    assert not any("dropped_by_model" in m for m in manual), (
+        "它同时又被丢进人工清单 —— 那样自动那条就不会执行"
+    )
+
+
+def test_a_nullable_legacy_column_is_still_left_to_a_human():
+    """反向:可空的遗留列不该被自动动。
+
+    它不挡写入,而删不删是业务决定(数据要不要留)。把它算进 relaxable 会让
+    「有事要做」的判断变噪音。
+    """
+    live = _model(Column("old_optional", String(20), nullable=True))
+    want = _model()
+
+    _add, manual, relaxable = plan(_engine_with(live), want.metadata)
+    assert relaxable == [], "可空的遗留列被自动动了"
+    assert any("old_optional" in m for m in manual), "可空遗留列应当留给人工"


### PR DESCRIPTION
Closes #866

## 问题：线上没有人能建新项目

#676 已经合进 main（`496cedd`）。它把 `character_perspective` 从 ORM 删掉了，而**生产库那一列还在，且是 `NOT NULL` 无默认**。

新代码的 INSERT 不再点名它 → `NotNullViolation`。

**在生产库上实测过（只读，事务回滚）**：

```
character_perspective   nullable=NO   default=(无默认)

模拟新代码的 INSERT（不点名那一列）
  → ❌ NotNullViolation
```

而 `project.py` 的 `except IntegrityError` 会把它**误报成「项目名称已存在」**（#859/#855 修的正是那个误诊，还没合）。所以用户看到的是一个全新的名字被说成重复，日志里刷「创建并发重名」，真实原因不在任何一条日志里。

**这是部署即触发的**，不需要任何特殊条件。

## 改法

`schema_sync` 本来就会报这一项（「库里有而模型没有：删列会丢数据，请人工确认后手写 SQL」）—— 但**只报不动**。那条报告没人看的时候，线上就是所有人都建不了项目。

对**非空且无默认**的遗留列，改成自动 `DROP NOT NULL`：

- 放宽是**加法方向**：不丢数据、不改类型、旧代码若还在跑也照样写得进
- 真正的删列仍然交给人 —— 数据要不要留是业务决定，而挡住写入不是
- **可空的遗留列不动**：它不挡写入，自动动它只会让「有事要做」的判断变噪音

## 验证

拿修好的脚本对**真实生产 schema** 干跑（不 apply）：

```
[可自动] ALTER TABLE windup_project ALTER COLUMN character_perspective DROP NOT NULL;
0 列待补、1 列待放宽。
```

精确识别出那一列，**且只有那一列**。

| 变异 | 结果 |
|---|---|
| 退回只报不动 | 1 红 |
| 连可空的遗留列也自动动 | 2 红 |

CI 原样命令跑在最后一次编辑之后：`ruff check .` 通过；`lint-imports` 2 kept / 0 broken；`pytest -q --cov=packages` **2004 passed, 14 skipped**。

## 部署时要做的一步

合并之后，部署前需要跑一次：

```bash
docker exec windup-backend python3 /app/backend/scripts/schema_sync.py --apply
```

或者由有权限的人手工执行那一条 SQL。**在这一步做完之前，#676 的代码上线就会让所有人建不了项目。**

## 相关

- #676：把那一列从 ORM 删掉的那个 PR（评审时提过这条，合并前没有回应）
- #859 / #855：`IntegrityError` 误诊 —— 它让这个故障的表象变成「项目名称已存在」

