### PR TITLE
feat(export): 新增 Cocos Creator 无损游戏资产包

### DIFF
--- a/frontend/src/entities/character/frame-timing.ts
+++ b/frontend/src/entities/character/frame-timing.ts
@@ -1,0 +1,86 @@
+export interface AnimationTimingFrame {
+  readonly durationMs: number | null
+}
+
+export interface AnimationTimingAction {
+  readonly type: string
+  readonly loop: boolean
+  readonly fps: number
+}
+
+const DEFAULT_FRAME_DURATION_MS = 100
+const DENSE_GENERATED_TIMING: Readonly<
+  Record<
+    string,
+    {
+      readonly frameCount: number
+      readonly sourceFrameDurationsMs: readonly number[]
+      readonly cycleDurationMs: number
+      readonly loopOnly: boolean
+    }
+  >
+> = {
+  idle: {
+    frameCount: 12,
+    sourceFrameDurationsMs: [125, 450],
+    cycleDurationMs: 1000,
+    loopOnly: true,
+  },
+  walk: {
+    frameCount: 32,
+    sourceFrameDurationsMs: [125],
+    cycleDurationMs: 1000,
+    loopOnly: true,
+  },
+  run: {
+    frameCount: 32,
+    sourceFrameDurationsMs: [90],
+    cycleDurationMs: 720,
+    loopOnly: true,
+  },
+  jump: {
+    frameCount: 32,
+    sourceFrameDurationsMs: [110],
+    cycleDurationMs: 1000,
+    loopOnly: false,
+  },
+  attack: {
+    frameCount: 32,
+    sourceFrameDurationsMs: [90],
+    cycleDurationMs: 1000,
+    loopOnly: false,
+  },
+}
+
+function authoredFrameDuration(durationMs: number | null, fps: number): number {
+  if (durationMs !== null && Number.isFinite(durationMs) && durationMs > 0) {
+    return Math.max(1, durationMs)
+  }
+  if (Number.isFinite(fps) && fps > 0) return Math.max(1, Math.round(1000 / fps))
+  return DEFAULT_FRAME_DURATION_MS
+}
+
+/** 预览、导出和引擎适配共用的唯一逐帧时长解析规则。 */
+export function resolveAnimationFrameDurations(
+  action: AnimationTimingAction,
+  frames: readonly AnimationTimingFrame[],
+): readonly number[] {
+  const durations = frames.map((frame) => authoredFrameDuration(frame.durationMs, action.fps))
+  const denseTiming = DENSE_GENERATED_TIMING[action.type]
+  const sourceFrameDurationMs = frames[0]?.durationMs
+  if (
+    denseTiming === undefined ||
+    (denseTiming.loopOnly && !action.loop) ||
+    frames.length !== denseTiming.frameCount ||
+    !denseTiming.sourceFrameDurationsMs.some(
+      (sourceDurationMs) => sourceFrameDurationMs === sourceDurationMs,
+    ) ||
+    frames.some((frame) => frame.durationMs !== sourceFrameDurationMs)
+  ) {
+    return durations
+  }
+
+  const timingScale =
+    denseTiming.cycleDurationMs / durations.reduce((total, duration) => total + duration, 0)
+  return durations.map((duration) => duration * timingScale)
+}

--- a/frontend/src/entities/character/index.ts
+++ b/frontend/src/entities/character/index.ts
@@ -26,6 +26,8 @@ export {
   validateDirectionalAsset,
 }
 export type { DirectionalAssetValidation }
+export { resolveAnimationFrameDurations } from './frame-timing'
+export type { AnimationTimingAction, AnimationTimingFrame } from './frame-timing'
 
 /** PR #75 将动作类型定义为字符串；已知类型之外的后端扩展也应原样保留。 */
 export type ActionType = string

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -81,8 +81,10 @@ export {
   characterTemplateImages,
   characterTemplatesFromImages,
   characterTemplatesFromViewSheetCells,
+  resolveAnimationFrameDurations,
   validateDirectionalAsset,
 } from './character'
+export type { AnimationTimingAction, AnimationTimingFrame } from './character'
 export {
   ACTION_DIRECTIONS,
   getDirectionGridLayout,

--- a/frontend/src/features/export-package/README.md
+++ b/frontend/src/features/export-package/README.md
@@ -17,7 +17,7 @@
 2. `validateExportPackageModel` 检查角色、画布、生成记录、帧数、质量状态、锚点和脚底线。
 3. `createAssetExportPlan` 为每个动作方向生成稳定目录与三位连续帧名。
 4. `exportGameAssets` 读取透明 PNG，并检查图片尺寸是否与统一画布一致。
-5. 浏览器生成 Sprite Sheet 与逐动作方向 GIF 预览，最后写入动画 `meta.json`、`schema.json`、README 与 ZIP。
+5. 浏览器生成无损 PNG Sprite Sheet 与兼容 GIF 预览，最后写入动画 `meta.json`、`schema.json`、README 与 ZIP。
 6. 可选 target 只在 `targets/<target-id>/` 下追加引擎文件，不修改通用层。
 
 ## 导出结构
@@ -33,22 +33,25 @@ Aster-character-1-Explorer-outfit-1/
   atlas/Walk.png
   preview/Walk.gif
   playtest.json
-  targets/<target-id>/...
+  targets/cocos-creator-3x/
+    atlases/Walk.png
+    atlases/Walk.plist
+    windup-animation.json
 ```
 
 `meta.json` 的坐标原点在左上角，y 轴向下。`anchor` 是 0-1 归一化坐标，`foot_y` 是从画布顶部开始计算的像素值。
 
-`preview/*.gif` 使用动作的逐帧时长和循环设置，只用于快速查看。GIF 最多 256 色且只支持一位透明度，游戏引擎仍应读取 `frames/*.png` 或 `atlas/*.png`。
+`preview/*.gif` 只用于快速查看和旧平台兼容，最多 256 色且只支持一位透明度。正式游戏资产应读取逐帧无损的 `frames/*.png`，或使用 `atlas/*.png` 与 `meta.json` 中的方向、逐帧时长、锚点和图集切分信息。
 
 ## 为什么缺一帧就全部失败
 
 已发布 Character 动作的 `expectedFrameCount` 来自后端声明，不能用 `frames.length` 自己推算；两者不同时导出立即失败。WorkflowRun 中尚未发布的生成结果没有独立的期望总帧数字段，因此当前只能校验帧序从 0 连续，不能识别生成服务在末尾少返回帧。所有阶段遇到图片读取失败、PNG 无透明信息或尺寸不一致都会失败，不会用透明占位掩盖问题。`action-assets` 可保留 `pending` 质量状态供检查；`playtest` 只接受 `passed` 动作。
 
-## Cocos Creator 边界
+## Cocos Creator 3.x
 
-Issue #94 要求先用真实 Cocos Creator 3.x 验证图集切分数据、`.anim`、`.meta`、UUID 与小版本差异。当前仓库没有该实测结论，因此本模块只落地已确定的通用层和 target 扩展接口，不伪造 Cocos 原生文件。
+默认下载包会在 `targets/cocos-creator-3x/` 中追加同名 PNG 与 TexturePacker plist。把 `atlases/` 内的 PNG 和 plist 一起放入 Creator 资源目录，Creator 会把它们导入为 SpriteAtlas 与 SpriteFrame 子资源。`windup-animation.json` 保留每帧时长、循环、方向、锚点和脚底线，供项目侧创建 AnimationClip 或运行时播放器。
 
-Cocos 坐标转换规则已经明确：通用锚点 `(x, y)` 转成 Creator 锚点 `(x, 1-y)`。等实测字段回填后，只需新增一个 `AssetExportTarget`，不改 `meta.json` 与通用打包逻辑。
+本模块不生成 `.meta` 或 `.anim`：这些文件携带由实际 Creator 项目和版本管理的 UUID。Cocos 坐标转换规则是把通用锚点 `(x, y)` 转成 Creator 锚点 `(x, 1-y)`。
 
 ## 验证
 
@@ -59,12 +62,12 @@ npm run lint
 npm run build
 ```
 
-测试覆盖 Schema 校验、连续命名、图集输出、缺帧失败、质量门禁、图片释放和空 target 扩展。
+测试覆盖 Schema 校验、连续命名、图集输出、Cocos PNG/plist、缺帧失败、质量门禁、图片释放和 target 扩展。
 
 ## 当前主线接线
 
 - WorkflowRun 的完整动画结果可在发布前以 `pending` 动作资产导出；Character 资产树中的已发布动作标记为 `passed`。
 - 帧顺序使用后端显式 `Frame.index`，断号或重复序号会在读取图片前失败。
-- `durationMs` 为空时才按 Action FPS 计算，不覆盖后端逐帧时长。
+- 预览与导出共用同一份逐帧时长解析规则；密集生成动作会按规范化周期播放。
 - 锚点和脚线沿用 `ai_engine.align_bottom_center` 的底部居中与 `0.92` 脚线约定。
-- 当前 Character 只表达单方向动作，因此统一导出为 `default`；四向和八向需等待资产契约扩展。
+- 四向和八向导出真实源方向；由东向帧镜像得到的西向在运行时按方向配置处理，避免重复生成源资产。

--- a/frontend/src/features/export-package/asset-export.test.ts
+++ b/frontend/src/features/export-package/asset-export.test.ts
@@ -5,10 +5,11 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   createAssetExportPlan,
   exportGameAssets,
+  palettizeGifFrame,
   type AssetExportRuntime,
   type AssetExportTarget,
 } from './asset-export'
-import { COCOS_TARGET_READINESS, toCocosAnchor } from './cocos-target'
+import { COCOS_CREATOR_TARGET, COCOS_TARGET_READINESS, toCocosAnchor } from './cocos-target'
 import { EXPORT_PACKAGE_JSON_SCHEMA_TEXT, validateExportPackageModel } from './contract'
 import type { ExportAction, ExportFrame, ExportPackageModel } from './model'
 
@@ -190,7 +191,7 @@ describe('asset export', () => {
       new TextDecoder().decode(playtestEntries.get(`${root}/playtest.json`)),
     )
     expect(playtest).toEqual({
-      schema_version: '1.2.0',
+      schema_version: '1.3.0',
       initial_action_id: 'walk-abcdef12',
       action_ids: ['walk-abcdef12'],
     })
@@ -204,11 +205,56 @@ describe('asset export', () => {
     })
   })
 
-  it('明确 Cocos 尚未就绪，并只落地已确认的锚点坐标转换', () => {
-    expect(COCOS_TARGET_READINESS.ready).toBe(false)
+  it('声明 Cocos PNG + plist 目标已就绪，并转换锚点坐标', () => {
+    expect(COCOS_TARGET_READINESS.ready).toBe(true)
     const anchor = toCocosAnchor({ x: 0.5, y: 0.9 })
     expect(anchor.x).toBe(0.5)
     expect(anchor.y).toBeCloseTo(0.1)
+  })
+
+  it('Cocos target 输出同名 PNG/plist 和保留逐帧时长的动画清单', async () => {
+    const entries = await readStoredZip(
+      (
+        await exportGameAssets(model, {
+          runtime: runtime(),
+          targets: [COCOS_CREATOR_TARGET],
+        })
+      ).blob,
+    )
+    const root = 'Aster-character-1-Explorer-outfit-1'
+    const targetRoot = `${root}/targets/cocos-creator-3x`
+    const atlas = entries.get(`${root}/atlas/Walk-Forward-south.png`)
+    const cocosAtlas = entries.get(`${targetRoot}/atlases/Walk-Forward-south.png`)
+    const plist = new TextDecoder().decode(
+      entries.get(`${targetRoot}/atlases/Walk-Forward-south.plist`),
+    )
+    const manifest = JSON.parse(
+      new TextDecoder().decode(entries.get(`${targetRoot}/windup-animation.json`)),
+    )
+
+    expect(cocosAtlas).toEqual(atlas)
+    expect(plist).toContain('<key>Walk-Forward-south_000.png</key>')
+    expect(plist).toContain('<string>{{0,0},{32,40}}</string>')
+    expect(plist).toContain('<key>Walk-Forward-south_008.png</key>')
+    expect(plist).toContain('<string>{{0,40},{32,40}}</string>')
+    expect(plist).toContain('<key>textureFileName</key>')
+    expect(plist).toContain('<string>Walk-Forward-south.png</string>')
+    expect(manifest).toMatchObject({
+      engine: 'cocos-creator-3.x',
+      animations: [
+        {
+          id: 'walk-abcdef12',
+          direction: 'south',
+          loop: true,
+          anchor: { x: 0.5, y: 0.1 },
+        },
+      ],
+    })
+    expect(manifest.animations[0].frames[0]).toEqual({
+      sprite_frame: 'Walk-Forward-south_000.png',
+      duration_ms: 100,
+    })
+    expect(manifest.animations[0].frames).toHaveLength(9)
   })
 
   it('按动作名和方向生成连续三位帧名，并按八列排列图集', () => {
@@ -222,11 +268,55 @@ describe('asset export', () => {
       columns: 8,
       rows: 2,
     })
+    expect(plan[0]).not.toHaveProperty('previewWebpFile')
+    expect(plan[0]).not.toHaveProperty('previewApngFile')
     expect(plan[0]?.frames[0]?.filename).toBe('Walk-Forward-south_000.png')
     expect(plan[0]?.frames[8]?.filename).toBe('Walk-Forward-south_008.png')
   })
 
-  it('为每个动作方向生成可识别的 GIF 预览，并在 meta.json 中声明路径', async () => {
+  it('GIF 为透明像素预留索引，并把多色帧平均通道误差控制在 5 以内', () => {
+    const width = 64
+    const height = 64
+    const rgba = new Uint8ClampedArray(width * height * 4)
+    for (let y = 0; y < height; y += 1) {
+      for (let x = 0; x < width; x += 1) {
+        const pixel = y * width + x
+        rgba[pixel * 4] = Math.round((x / (width - 1)) * 255)
+        rgba[pixel * 4 + 1] = Math.round((y / (height - 1)) * 255)
+        rgba[pixel * 4 + 2] = Math.round((((x + y) % width) / (width - 1)) * 255)
+        rgba[pixel * 4 + 3] = x < 4 ? 0 : 255
+      }
+    }
+
+    const result = palettizeGifFrame(rgba)
+    let absoluteError = 0
+    let opaqueChannels = 0
+    for (let pixel = 0; pixel < width * height; pixel += 1) {
+      if (rgba[pixel * 4 + 3] === 0) {
+        expect(result.indexed[pixel]).toBe(result.transparentIndex)
+        continue
+      }
+      expect(result.indexed[pixel]).not.toBe(result.transparentIndex)
+      const color = result.palette[result.indexed[pixel]!]
+      for (let channel = 0; channel < 3; channel += 1) {
+        absoluteError += Math.abs(rgba[pixel * 4 + channel]! - color![channel]!)
+        opaqueChannels += 1
+      }
+    }
+
+    expect(result.palette.length).toBeLessThanOrEqual(256)
+    expect(absoluteError / opaqueChannels).toBeLessThan(5)
+  })
+
+  it('GIF 全透明帧仍生成有效的单色透明调色板', () => {
+    const result = palettizeGifFrame(new Uint8ClampedArray(4 * 4 * 4))
+
+    expect(result.palette).toEqual([[0, 0, 0]])
+    expect(result.indexed).toEqual(new Uint8Array(16))
+    expect(result.transparentIndex).toBe(0)
+  })
+
+  it('保留原始 PNG、图集和 GIF 预览，并在 meta.json 中声明方向与逐帧时长', async () => {
     const phases: string[] = []
     const result = await exportGameAssets(model, {
       runtime: runtime(),
@@ -243,6 +333,8 @@ describe('asset export', () => {
     expect(names).toContain(`${root}/README.md`)
     expect(names).toContain(`${root}/atlas/Walk-Forward-south.png`)
     expect(names).toContain(`${root}/preview/Walk-Forward-south.gif`)
+    expect(names).not.toContain(`${root}/preview/Walk-Forward-south.webp`)
+    expect(names).not.toContain(`${root}/preview/Walk-Forward-south.apng`)
     expect(names.filter((name) => name.includes('/frames/'))).toHaveLength(9)
 
     const gif = entries.get(`${root}/preview/Walk-Forward-south.gif`)
@@ -253,13 +345,14 @@ describe('asset export', () => {
     const validate = new Ajv2020().compile(schema)
     expect(validate(meta), JSON.stringify(validate.errors)).toBe(true)
     expect(meta).toMatchObject({
-      schema_version: '1.2.0',
+      schema_version: '1.3.0',
       character: { id: 'character-1', name: 'Aster' },
       canvas: { w: 32, h: 40 },
       source: { workflow_run_id: 'run-1', generation_ids: ['generation-1'] },
     })
     expect(meta.actions[0]).toMatchObject({
       name: 'Walk / Forward',
+      direction: 'south',
       fps: 10,
       loop: true,
       anchor: { x: 0.5, y: 0.9 },
@@ -267,6 +360,38 @@ describe('asset export', () => {
       preview_gif: 'preview/Walk-Forward-south.gif',
       atlas: { cols: 8, rows: 2, cell: { w: 32, h: 40 } },
     })
+    expect(meta.actions[0].frames.slice(0, 2)).toEqual([
+      { index: 0, file: 'Walk-Forward-south_000.png', duration_ms: 100 },
+      { index: 1, file: 'Walk-Forward-south_001.png', duration_ms: 100 },
+    ])
+    expect(meta.actions[0]).not.toHaveProperty('preview_webp')
+    expect(meta.actions[0]).not.toHaveProperty('preview_apng')
+  })
+
+  it('接受与预览一致的亚毫秒精度规范化帧时长', async () => {
+    const denseTimingModel: ExportPackageModel = {
+      ...model,
+      actions: [
+        {
+          ...model.actions[0]!,
+          sequences: [
+            {
+              ...model.actions[0]!.sequences[0]!,
+              frames: model.actions[0]!.sequences[0]!.frames.map((currentFrame) => ({
+                ...currentFrame,
+                durationMs: 31.25,
+              })),
+            },
+          ],
+        },
+      ],
+    }
+
+    await expect(exportGameAssets(denseTimingModel, { runtime: runtime() })).resolves.toMatchObject(
+      {
+        filename: 'windup-Aster-character-1-Explorer-outfit-1.zip',
+      },
+    )
   })
 
   it('把 Outfit 标识写入包名，避免同一 Character 的不同造型互相覆盖', async () => {

--- a/frontend/src/features/export-package/asset-export.ts
+++ b/frontend/src/features/export-package/asset-export.ts
@@ -1,4 +1,4 @@
-import { applyPalette, GIFEncoder, quantize } from 'gifenc'
+import { applyPalette, GIFEncoder, quantize, type GifPalette } from 'gifenc'
 
 import {
   EXPORT_PACKAGE_JSON_SCHEMA_TEXT,
@@ -57,6 +57,8 @@ export interface AssetExportTargetContext {
   model: ExportPackageModel
   metadata: GenericExportMetadata
   plan: readonly PlannedSequence[]
+  /** 读取通用包根目录下已经生成的文件，供 target 复用无损图集而不重复渲染。 */
+  readFile(relativePath: string): Uint8Array | null
 }
 
 /** 新引擎只实现 target，不应修改通用 meta.json、frames 与 atlas。 */
@@ -90,6 +92,61 @@ interface LoadedStaticAsset {
 interface ZipEntry {
   name: string
   data: Uint8Array
+}
+
+export interface PalettizedGifFrame {
+  palette: GifPalette
+  indexed: Uint8Array
+  transparentIndex: number
+}
+
+const GIF_ALPHA_THRESHOLD = 127
+
+export function palettizeGifFrame(rgba: Uint8Array | Uint8ClampedArray): PalettizedGifFrame {
+  const pixelCount = rgba.length / 4
+  let opaqueCount = 0
+  for (let pixel = 0; pixel < pixelCount; pixel += 1) {
+    if (rgba[pixel * 4 + 3]! > GIF_ALPHA_THRESHOLD) opaqueCount += 1
+  }
+
+  if (opaqueCount === 0) {
+    return {
+      palette: [[0, 0, 0]],
+      indexed: new Uint8Array(pixelCount),
+      transparentIndex: 0,
+    }
+  }
+
+  const hasTransparency = opaqueCount !== pixelCount
+  const opaqueRgba = new Uint8ClampedArray(opaqueCount * 4)
+  let target = 0
+  for (let pixel = 0; pixel < pixelCount; pixel += 1) {
+    const source = pixel * 4
+    if (rgba[source + 3]! <= GIF_ALPHA_THRESHOLD) continue
+    opaqueRgba[target] = rgba[source]!
+    opaqueRgba[target + 1] = rgba[source + 1]!
+    opaqueRgba[target + 2] = rgba[source + 2]!
+    opaqueRgba[target + 3] = 255
+    target += 4
+  }
+
+  const opaquePalette = quantize(opaqueRgba, hasTransparency ? 255 : 256, {
+    format: 'rgb565',
+  })
+  const opaqueIndexed = applyPalette(rgba, opaquePalette, 'rgb565')
+  if (!hasTransparency) {
+    return { palette: opaquePalette, indexed: opaqueIndexed, transparentIndex: -1 }
+  }
+
+  const indexed = new Uint8Array(pixelCount)
+  for (let pixel = 0; pixel < pixelCount; pixel += 1) {
+    indexed[pixel] = rgba[pixel * 4 + 3]! <= GIF_ALPHA_THRESHOLD ? 0 : opaqueIndexed[pixel]! + 1
+  }
+  return {
+    palette: [[0, 0, 0], ...opaquePalette],
+    indexed,
+    transparentIndex: 0,
+  }
 }
 
 function safeSegment(value: string, fallback: string): string {
@@ -378,9 +435,7 @@ function renderGif(
       context.clearRect(0, 0, canvas.width, canvas.height)
       context.drawImage(frame.decoded.source, 0, 0)
       const rgba = context.getImageData(0, 0, canvas.width, canvas.height).data
-      const palette = quantize(rgba, 256, { format: 'rgba4444', oneBitAlpha: true })
-      const indexed = applyPalette(rgba, palette, 'rgba4444')
-      const transparentIndex = palette.findIndex((color) => color[3] === 0)
+      const { palette, indexed, transparentIndex } = palettizeGifFrame(rgba)
       gif.writeFrame(indexed, canvas.width, canvas.height, {
         palette,
         delay: frame.frame.durationMs,
@@ -425,7 +480,12 @@ function createMetadata(
       fps: item.action.fps,
       loop: item.sequence.loop,
       quality_status: item.sequence.qualityStatus,
-      frames: item.frames.map((frame) => ({ index: frame.index, file: frame.filename })),
+      direction: item.sequence.direction,
+      frames: item.frames.map((frame) => ({
+        index: frame.index,
+        file: frame.filename,
+        duration_ms: frame.frame.durationMs,
+      })),
       anchor: { ...item.sequence.anchor },
       foot_y: item.sequence.footY,
       preview_gif: item.previewGifFile,
@@ -458,7 +518,7 @@ function createReadme(model: ExportPackageModel): string {
 - \`meta.json\`: 动作、帧率、循环、画布、锚点、脚底线、图集与生成记录。
 - \`frames/<action>/\`: 连续编号的透明 PNG 原始帧。
 - \`atlas/<action>.png\`: 按 \`meta.json\` 中 cols、rows 和 cell 切分的图集。
-- \`preview/<action>.gif\`: 按逐帧时长生成的 GIF 快速预览；PNG 原始帧仍是无损源。
+- \`preview/<action>.gif\`: 兼容旧平台的 GIF 预览，颜色可能因格式限制产生损失。
 - \`schema.json\`: 校验 \`meta.json\` 的 JSON Schema。
 - \`targets/<target>/\`: 可选引擎适配器产生的原生文件。
 
@@ -469,8 +529,9 @@ function createReadme(model: ExportPackageModel): string {
 
 ## Cocos Creator 状态
 
-本包没有伪造 .anim 或 .meta。Issue #94 要求先在真实 Creator 3.x 中确认图集切分、UUID 和版本格式；
-验证完成前只能使用通用 frames、atlas 和 meta.json，不能声称“拖入即播放”。
+默认下载会在 targets/cocos-creator-3x/ 中附带同名 PNG + TexturePacker plist，二者一起导入
+Cocos Creator 3.x 后可识别为 SpriteAtlas。windup-animation.json 保存逐帧时长、方向、锚点和循环信息。
+本包不会伪造依赖实际项目 UUID 与 Creator 小版本的 .meta 或 .anim。
 `
 }
 
@@ -645,9 +706,13 @@ export async function exportGameAssets(
     })
   }
 
+  const readFile = (relativePath: string): Uint8Array | null => {
+    const normalized = relativePath.replace(/\\/g, '/').replace(/^\/+/, '')
+    return entries.find((entry) => entry.name === `${root}/${normalized}`)?.data ?? null
+  }
   for (const target of options.targets ?? []) {
     const targetId = safeSegment(target.id, 'target')
-    const files = await target.createFiles({ model, metadata, plan })
+    const files = await target.createFiles({ model, metadata, plan, readFile })
     for (const [index, file] of files.entries()) {
       entries.push({
         name: `${root}/${safeTargetPath(targetId, file.path, index)}`,

--- a/frontend/src/features/export-package/cocos-target.ts
+++ b/frontend/src/features/export-package/cocos-target.ts
@@ -1,15 +1,119 @@
 import type { ExportAnchor } from './model'
+import type { AssetExportTarget, PlannedSequence } from './asset-export'
+import type { GenericExportAction } from './contract'
 
-/**
- * Issue #94 的 Cocos 原生文件格式仍等待真实 Creator 3.x 实测。
- * 这里公开状态，避免页面或调用方把通用包误标成“Cocos 拖入即用包”。
- */
 export const COCOS_TARGET_READINESS = {
-  ready: false,
-  reason: '等待真实 Cocos Creator 3.x 验证 .anim、.meta、UUID 与图集切分格式',
+  ready: true,
+  reason: '输出 Cocos Creator 3.x 文档支持的同名 TexturePacker PNG 与 plist 图集文件',
 } as const
 
 /** 通用层左上原点转为 Cocos Creator 左下原点；x 不变，y 上下翻转。 */
 export function toCocosAnchor(anchor: ExportAnchor): ExportAnchor {
-  return { x: anchor.x, y: 1 - anchor.y }
+  return { x: anchor.x, y: Number((1 - anchor.y).toFixed(6)) }
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function createTexturePackerPlist(
+  item: PlannedSequence,
+  canvas: { width: number; height: number },
+) {
+  const frames = item.frames
+    .map((frame) => {
+      const column = frame.index % item.columns
+      const row = Math.floor(frame.index / item.columns)
+      const x = column * canvas.width
+      const y = row * canvas.height
+      return `    <key>${xmlEscape(frame.filename)}</key>
+    <dict>
+      <key>frame</key><string>{{${x},${y}},{${canvas.width},${canvas.height}}}</string>
+      <key>offset</key><string>{0,0}</string>
+      <key>rotated</key><false/>
+      <key>sourceColorRect</key><string>{{0,0},{${canvas.width},${canvas.height}}}</string>
+      <key>sourceSize</key><string>{${canvas.width},${canvas.height}}</string>
+    </dict>`
+    })
+    .join('\n')
+  const textureName = `${item.exportName}.png`
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>frames</key>
+  <dict>
+${frames}
+  </dict>
+  <key>metadata</key>
+  <dict>
+    <key>format</key><integer>3</integer>
+    <key>realTextureFileName</key><string>${xmlEscape(textureName)}</string>
+    <key>size</key><string>{${item.columns * canvas.width},${item.rows * canvas.height}}</string>
+    <key>textureFileName</key><string>${xmlEscape(textureName)}</string>
+  </dict>
+</dict>
+</plist>
+`
+}
+
+function animationManifest(item: PlannedSequence, action: GenericExportAction) {
+  return {
+    id: action.id,
+    name: action.name,
+    direction: action.direction,
+    loop: action.loop,
+    fps: action.fps,
+    atlas: `atlases/${item.exportName}.png`,
+    plist: `atlases/${item.exportName}.plist`,
+    anchor: toCocosAnchor(action.anchor),
+    foot_y: action.foot_y,
+    frames: action.frames.map((frame) => ({
+      sprite_frame: frame.file,
+      duration_ms: frame.duration_ms,
+    })),
+  }
+}
+
+export const COCOS_CREATOR_TARGET: AssetExportTarget = {
+  id: 'cocos-creator-3x',
+  async createFiles({ model, metadata, plan, readFile }) {
+    const files = plan.flatMap((item) => {
+      const atlas = readFile(item.atlasFile)
+      if (atlas === null) throw new Error(`${item.atlasFile}: Cocos target 找不到通用 PNG 图集`)
+      return [
+        { path: `atlases/${item.exportName}.png`, data: atlas },
+        {
+          path: `atlases/${item.exportName}.plist`,
+          data: createTexturePackerPlist(item, model.canvas),
+        },
+      ]
+    })
+    const animations = plan.map((item) => {
+      const action = metadata.actions.find(
+        (candidate) =>
+          candidate.id === item.action.id && candidate.direction === item.sequence.direction,
+      )
+      if (!action) throw new Error(`${item.exportName}: Cocos target 找不到动作元数据`)
+      return animationManifest(item, action)
+    })
+    files.push({
+      path: 'windup-animation.json',
+      data: JSON.stringify(
+        {
+          engine: 'cocos-creator-3.x',
+          source_schema_version: metadata.schema_version,
+          animations,
+        },
+        null,
+        2,
+      ),
+    })
+    return files
+  },
 }

--- a/frontend/src/features/export-package/contract.ts
+++ b/frontend/src/features/export-package/contract.ts
@@ -2,17 +2,19 @@ import exportSchemaText from './export-package.schema.json?raw'
 import { EXPORT_STAGES } from './model'
 import type { ExportPackageModel } from './model'
 
-export const EXPORT_PACKAGE_SCHEMA_VERSION = '1.2.0'
+export const EXPORT_PACKAGE_SCHEMA_VERSION = '1.3.0'
 export const EXPORT_PACKAGE_JSON_SCHEMA_TEXT = exportSchemaText
 
 export interface GenericExportFrame {
   index: number
   file: string
+  duration_ms: number
 }
 
 export interface GenericExportAction {
   id: string
   name: string
+  direction: string
   fps: number
   loop: boolean
   quality_status: ExportPackageModel['actions'][number]['sequences'][number]['qualityStatus']
@@ -59,6 +61,10 @@ function requireText(field: string, value: string): void {
 
 function requirePositiveInteger(field: string, value: number): void {
   if (!Number.isInteger(value) || value < 1) fail(field, '必须是大于 0 的整数')
+}
+
+function requirePositiveNumber(field: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) fail(field, '必须是大于 0 的数值')
 }
 
 function requireUnitNumber(field: string, value: number): void {
@@ -145,10 +151,7 @@ export function validateExportPackageModel(model: ExportPackageModel): void {
           fail(`${sequenceField}.frames[${frameIndex}].index`, `必须连续且等于 ${frameIndex}`)
         }
         requireText(`${sequenceField}.frames[${frameIndex}].imageUrl`, frame.imageUrl)
-        requirePositiveInteger(
-          `${sequenceField}.frames[${frameIndex}].durationMs`,
-          frame.durationMs,
-        )
+        requirePositiveNumber(`${sequenceField}.frames[${frameIndex}].durationMs`, frame.durationMs)
       })
     })
   })

--- a/frontend/src/features/export-package/export-package.schema.json
+++ b/frontend/src/features/export-package/export-package.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://windup.local/schemas/export-package-1.2.0.json",
+  "$id": "https://windup.local/schemas/export-package-1.3.0.json",
   "title": "Windup Generic Export Package",
   "type": "object",
   "additionalProperties": false,
@@ -16,7 +16,7 @@
     "source"
   ],
   "properties": {
-    "schema_version": { "const": "1.2.0" },
+    "schema_version": { "const": "1.3.0" },
     "stage": { "enum": ["character", "first-frame", "action-assets", "playtest"] },
     "character": {
       "type": "object",
@@ -54,6 +54,7 @@
         "required": [
           "id",
           "name",
+          "direction",
           "fps",
           "loop",
           "quality_status",
@@ -66,6 +67,7 @@
         "properties": {
           "id": { "type": "string", "minLength": 1 },
           "name": { "type": "string", "minLength": 1 },
+          "direction": { "type": "string", "minLength": 1 },
           "fps": { "type": "integer", "minimum": 1 },
           "loop": { "type": "boolean" },
           "quality_status": { "enum": ["passed", "pending", "failed"] },
@@ -75,10 +77,11 @@
             "items": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["index", "file"],
+              "required": ["index", "file", "duration_ms"],
               "properties": {
                 "index": { "type": "integer", "minimum": 0 },
-                "file": { "type": "string", "pattern": "^[^/]+_[0-9]{3}\\.png$" }
+                "file": { "type": "string", "pattern": "^[^/]+_[0-9]{3}\\.png$" },
+                "duration_ms": { "type": "number", "minimum": 1 }
               }
             }
           },

--- a/frontend/src/features/export-package/export-panel.tsx
+++ b/frontend/src/features/export-package/export-panel.tsx
@@ -8,6 +8,7 @@ import {
   useProductPopoverMotion,
 } from '@/shared/ui'
 import type { ExportPackageModel } from './model'
+import { COCOS_CREATOR_TARGET } from './cocos-target'
 import {
   createAssetExportPlan,
   exportGameAssets,
@@ -56,7 +57,8 @@ const STAGE_LABELS: Readonly<Record<ExportPackageModel['stage'], string>> = {
   playtest: 'Playtest 运行包',
 }
 
-const defaultExporter: AssetExporter = (model, onPhase) => exportGameAssets(model, { onPhase })
+const defaultExporter: AssetExporter = (model, onPhase) =>
+  exportGameAssets(model, { onPhase, targets: [COCOS_CREATOR_TARGET] })
 
 interface ExportRequest {
   model: ExportPackageModel

--- a/frontend/src/features/export-package/index.ts
+++ b/frontend/src/features/export-package/index.ts
@@ -22,7 +22,7 @@ export {
   validateExportPackageModel,
   type GenericExportMetadata,
 } from './contract'
-export { COCOS_TARGET_READINESS, toCocosAnchor } from './cocos-target'
+export { COCOS_CREATOR_TARGET, COCOS_TARGET_READINESS, toCocosAnchor } from './cocos-target'
 export {
   createAssetExportPlan,
   exportGameAssets,

--- a/frontend/src/features/export-package/progressive-export.test.ts
+++ b/frontend/src/features/export-package/progressive-export.test.ts
@@ -124,6 +124,44 @@ function actionRunFixture(base: WorkflowRun): WorkflowRun {
 }
 
 describe('createProgressiveExportModel', () => {
+  it('导出与预览共用密集动作的规范化逐帧时长', () => {
+    const denseWalk: Character = {
+      ...character,
+      outfits: [
+        {
+          ...character.outfits[0]!,
+          actions: [
+            {
+              id: 'walk-dense',
+              outfitId: 'outfit-1',
+              name: '行走',
+              type: 'walk',
+              loop: true,
+              fps: 8,
+              frameCount: 32,
+              frames: Array.from({ length: 32 }, (_, index) => ({
+                index,
+                imageUrl: `/walk-${index}.png`,
+                durationMs: 125,
+              })),
+            },
+          ],
+        },
+      ],
+    }
+
+    const model = createProgressiveExportModel({
+      project,
+      character: denseWalk,
+      outfitId: 'outfit-1',
+    })
+    const frames = model.actions[0]!.sequences[0]!.frames
+
+    expect(frames).toHaveLength(32)
+    expect(frames.map((frame) => frame.durationMs)).toEqual(Array.from({ length: 32 }, () => 31.25))
+    expect(frames.reduce((total, frame) => total + frame.durationMs, 0)).toBe(1000)
+  })
+
   it('拒绝把其它 WorkflowRun 的完成度拼到当前角色', () => {
     expect(() =>
       createProgressiveExportModel({
@@ -435,7 +473,11 @@ describe('createProgressiveExportModel', () => {
       error: null,
       result: {
         type: 'complete_animation',
-        frames: [{ index: 0, url: '/walk-0.png', durationMs: 100 }],
+        frames: Array.from({ length: 32 }, (_, index) => ({
+          index,
+          url: `/walk-${index}.png`,
+          durationMs: 125,
+        })),
       },
     } satisfies Generation<'complete_animation'>
 
@@ -451,8 +493,18 @@ describe('createProgressiveExportModel', () => {
     expect(model.actions[0]).toMatchObject({ id: 'walk-full', name: '行走' })
     expect(model.actions[0]?.sequences[0]).toMatchObject({
       qualityStatus: 'pending',
-      frames: [{ index: 0, imageUrl: '/walk-0.png', durationMs: 100 }],
+      frames: Array.from({ length: 32 }, (_, index) => ({
+        index,
+        imageUrl: `/walk-${index}.png`,
+        durationMs: 31.25,
+      })),
     })
+    expect(
+      model.actions[0]?.sequences[0]?.frames.reduce(
+        (total, currentFrame) => total + currentFrame.durationMs,
+        0,
+      ),
+    ).toBe(1000)
   })
 
   it('落位几何取后端报的那份，而不是前端自己按 0.92 算', () => {

--- a/frontend/src/features/export-package/progressive-export.ts
+++ b/frontend/src/features/export-package/progressive-export.ts
@@ -8,7 +8,7 @@ import type {
   WorkflowActionInput,
   WorkflowRun,
 } from '@/entities'
-import { getDirectionProfile } from '@/entities'
+import { getDirectionProfile, resolveAnimationFrameDurations } from '@/entities'
 
 import type {
   ExportAction,
@@ -56,21 +56,33 @@ function orderedFrames(action: Action): readonly Frame[] {
   return frames
 }
 
-function durationMs(frame: Frame, action: Action): number {
-  if (frame.durationMs !== null && Number.isFinite(frame.durationMs) && frame.durationMs > 0) {
-    return Math.round(frame.durationMs)
+function requireExportTiming(
+  actionName: string,
+  fps: number,
+  frames: readonly { durationMs: number | null }[],
+): void {
+  const needsFps = frames.some(
+    (frame) =>
+      frame.durationMs === null || !Number.isFinite(frame.durationMs) || frame.durationMs <= 0,
+  )
+  if (needsFps && (!Number.isFinite(fps) || fps <= 0)) {
+    throw new Error(`${actionName}缺少有效的帧时长和 FPS`)
   }
-  if (!Number.isFinite(action.fps) || action.fps <= 0) {
-    throw new Error(`${action.name}缺少有效的帧时长和 FPS`)
-  }
-  return Math.max(1, Math.round(1000 / action.fps))
 }
 
-function exportFrames(action: Action): readonly ExportFrame[] {
-  return orderedFrames(action).map((frame) => ({
+function exportFrames(
+  action: Action,
+  sourceFrames: readonly Frame[] = orderedFrames(action),
+): readonly ExportFrame[] {
+  const frames = [...sourceFrames].sort((left, right) => left.index - right.index)
+  const invalid = frames.find((frame, index) => frame.index !== index)
+  if (invalid !== undefined) throw new Error(`${action.name}的帧序号必须从 0 连续排列`)
+  requireExportTiming(action.name, action.fps, frames)
+  const durations = resolveAnimationFrameDurations(action, frames)
+  return frames.map((frame, index) => ({
     index: frame.index,
     imageUrl: frame.imageUrl,
-    durationMs: durationMs(frame, action),
+    durationMs: durations[index]!,
   }))
 }
 
@@ -102,18 +114,7 @@ function exportAction(action: Action, project: Project): ExportAction {
           loop: action.loop,
           ...sequenceGeometry(undefined, project.spriteSize.height),
           qualityStatus: 'passed' as const,
-          frames: [...sequence.frames]
-            .sort((left, right) => left.index - right.index)
-            .map((frame, index) => {
-              if (frame.index !== index) {
-                throw new Error(`${action.name}的${sequence.direction}方向帧序号必须从 0 连续排列`)
-              }
-              return {
-                index: frame.index,
-                imageUrl: frame.imageUrl,
-                durationMs: durationMs(frame, action),
-              }
-            }),
+          frames: exportFrames(action, sequence.frames),
         }))
       : [
           {
@@ -232,20 +233,24 @@ function generatedActions(
         ) {
           throw new Error(`${first.input.name}缺少${direction}方向完整动画`)
         }
-        const frames = [...generation.result.frames]
-          .sort((left, right) => left.index - right.index)
-          .map((frame, index) => {
-            if (frame.index !== index) {
-              const directionLabel =
-                project.directionalMovement === 'single' ? '' : `${direction}方向`
-              throw new Error(`${first.input.name}的${directionLabel}帧序号必须从 0 连续排列`)
-            }
-            const durationMs =
-              frame.durationMs !== null && frame.durationMs > 0
-                ? Math.round(frame.durationMs)
-                : Math.max(1, Math.round(1000 / first.input.fps))
-            return { index: frame.index, imageUrl: frame.url, durationMs }
-          })
+        const sourceFrames = [...generation.result.frames].sort(
+          (left, right) => left.index - right.index,
+        )
+        const invalidFrame = sourceFrames.find((frame, index) => frame.index !== index)
+        if (invalidFrame !== undefined) {
+          const directionLabel = project.directionalMovement === 'single' ? '' : `${direction}方向`
+          throw new Error(`${first.input.name}的${directionLabel}帧序号必须从 0 连续排列`)
+        }
+        requireExportTiming(first.input.name, first.input.fps, sourceFrames)
+        const durations = resolveAnimationFrameDurations(
+          { type: first.input.type, loop: true, fps: first.input.fps },
+          sourceFrames,
+        )
+        const frames = sourceFrames.map((frame, index) => ({
+          index: frame.index,
+          imageUrl: frame.url,
+          durationMs: durations[index]!,
+        }))
         return {
           direction: project.directionalMovement === 'single' ? 'default' : direction,
           expectedFrameCount: frames.length,

--- a/frontend/src/pages/guide/content.ts
+++ b/frontend/src/pages/guide/content.ts
@@ -172,7 +172,7 @@ export const guideChapters: readonly GuideChapter[] = [
       {
         title: '根据游戏接入方式选择文件',
         description:
-          '资源包会按角色当前的完成情况整理母版、首帧、透明 PNG、Sprite Sheet、逐动作方向 GIF 预览和动画说明文件。你可以把 PNG 或 Sprite Sheet 接进游戏，也可以先用 GIF 快速和队友确认动作方向与节奏。',
+          '资源包会按角色当前的完成情况整理母版、首帧、透明 PNG、Sprite Sheet 和兼容 GIF 预览。正式接入游戏请使用无损 PNG 帧或 Sprite Sheet；动作方向、逐帧时长、锚点与切分信息都写在元数据中。',
       },
       {
         title: '缺失帧不会被静默忽略',

--- a/frontend/src/pages/playtest/workbench/model.ts
+++ b/frontend/src/pages/playtest/workbench/model.ts
@@ -1,4 +1,10 @@
-import type { ActionDirection, ActionType, Character, Frame } from '@/entities'
+import {
+  resolveAnimationFrameDurations,
+  type ActionDirection,
+  type ActionType,
+  type Character,
+  type Frame,
+} from '@/entities'
 
 export interface PlaytestFrame {
   readonly imageUrl: string
@@ -46,48 +52,6 @@ export type PlaytestModelResult =
   | { readonly ok: true; readonly model: PlaytestModel }
   | { readonly ok: false; readonly reason: 'outfit_not_found' }
 
-const DEFAULT_FRAME_DURATION_MS = 100
-const DENSE_GENERATED_TIMING = {
-  idle: {
-    frameCount: 12,
-    sourceFrameDurationsMs: [125, 450],
-    cycleDurationMs: 1000,
-    loopOnly: true,
-  },
-  walk: {
-    frameCount: 32,
-    sourceFrameDurationsMs: [125],
-    cycleDurationMs: 1000,
-    loopOnly: true,
-  },
-  run: {
-    frameCount: 32,
-    sourceFrameDurationsMs: [90],
-    cycleDurationMs: 720,
-    loopOnly: true,
-  },
-  jump: {
-    frameCount: 32,
-    sourceFrameDurationsMs: [110],
-    cycleDurationMs: 1000,
-    loopOnly: false,
-  },
-  attack: {
-    frameCount: 32,
-    sourceFrameDurationsMs: [90],
-    cycleDurationMs: 1000,
-    loopOnly: false,
-  },
-} as const
-
-function frameDuration(durationMs: number | null, fps: number): number {
-  if (durationMs !== null && Number.isFinite(durationMs) && durationMs > 0) {
-    return Math.max(1, durationMs)
-  }
-  if (Number.isFinite(fps) && fps > 0) return Math.max(1, Math.round(1000 / fps))
-  return DEFAULT_FRAME_DURATION_MS
-}
-
 /**
  * 播放顺序由 Frame.index 决定，不是数组下标。
  * 后端整棵下发资产树，数组顺序没有被契约保证；照数组播的话，顺序一变动画就乱，
@@ -102,39 +66,10 @@ function playtestFrames(
   frames: readonly Frame[],
 ): readonly PlaytestFrame[] {
   const ordered = orderedFrames(frames)
-  const playbackFrames = ordered.map((frame) => ({
+  const durations = resolveAnimationFrameDurations(action, ordered)
+  return ordered.map((frame, index) => ({
     imageUrl: frame.imageUrl,
-    durationMs: frameDuration(frame.durationMs, action.fps),
-  }))
-  const denseTiming =
-    action.type === 'idle' ||
-    action.type === 'walk' ||
-    action.type === 'run' ||
-    action.type === 'jump' ||
-    action.type === 'attack'
-      ? DENSE_GENERATED_TIMING[action.type]
-      : undefined
-  const sourceFrameDurationMs = ordered[0]?.durationMs
-  // 只兼容生成器已知的密集帧形状。默认非走动动作与 walk 共用 1 秒播放周期；
-  // 帧数、循环性或任一原始时值不完全匹配时仍尊重资产合同，避免误改用户编排。
-  if (
-    denseTiming === undefined ||
-    (denseTiming.loopOnly && !action.loop) ||
-    ordered.length !== denseTiming.frameCount ||
-    !denseTiming.sourceFrameDurationsMs.some(
-      (sourceDurationMs) => sourceFrameDurationMs === sourceDurationMs,
-    ) ||
-    ordered.some((frame) => frame.durationMs !== sourceFrameDurationMs)
-  ) {
-    return playbackFrames
-  }
-
-  const timingScale =
-    denseTiming.cycleDurationMs /
-    playbackFrames.reduce((total, frame) => total + frame.durationMs, 0)
-  return playbackFrames.map((frame) => ({
-    ...frame,
-    durationMs: frame.durationMs * timingScale,
+    durationMs: durations[index]!,
   }))
 }
 


### PR DESCRIPTION
## 变更
- 正式游戏资产改为逐帧无损 PNG 与 PNG Sprite Sheet，GIF 仅保留为兼容预览
- 预览、已发布动作和工作流生成结果共用同一份逐帧时序规则，32 帧密集动作导出与预览节奏一致
- meta.json 1.3.0 增加动作方向和逐帧 duration_ms，并允许规范化产生的小数毫秒
- 默认导出 Cocos Creator 3.x target：同名 PNG + TexturePacker plist，以及保留方向、循环、锚点和逐帧时长的 windup-animation.json
- 不生成依赖实际 Creator 项目 UUID/版本的 .meta 或 .anim，移除 WebP/APNG 编码依赖与实现

## 验证
- npm test -- --maxWorkers=50%（81 files / 1281 tests）
- npm run typecheck
- npm run lint
- npx oxfmt --check ...
- npm run build

Refs #783