### PR TITLE
feat(render3d): 组内账号免 3D 资产额度

### DIFF
--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -507,12 +507,21 @@ def _outfit_model_3d_url(character: Character, outfit_id: str | None) -> str | N
 MAX_ACTIONS_PER_3D_ASSET = 3
 
 
-def _require_3d_action_quota(character: Character, outfit_id: str | None) -> None:
+def _require_3d_action_quota(
+    character: Character, outfit_id: str | None, user_id: int | None = None,
+) -> None:
     """三渲二动作的条数上限。**只管三渲二** —— i2v 那条路线不受此限。
 
     在 HTTP 边界就拒:任务还没建、积分还没冻,拒起来干净;而超限这件事与用户输入无关,
     让它走到执行阶段才失败的话,用户看到的是通用的"生成失败",不知道是撞了限额。
+
+    ``user_id`` 在白名单里就免限(组内做素材)。``None`` 时照常限 —— 拿不到用户身份
+    时的默认方向是**受限**,不是放行。
     """
+    from windup_app.web.api.render3d import is_unlimited_3d
+
+    if user_id is not None and is_unlimited_3d(user_id):
+        return
     if not outfit_id:
         return
     try:
@@ -780,7 +789,7 @@ def submit_action_generation(
     _validate_project_direction(project, body.direction)
     character = _get_character_or_raise(session, body.character_id, body.project_id)
     model_3d_url = _outfit_model_3d_url(character, body.outfit_id)
-    _require_3d_action_quota(character, body.outfit_id)
+    _require_3d_action_quota(character, body.outfit_id, user_id)
     _require_master(model_3d_url, body.reference_image_urls)
     input_data = CharacterActionInput(
         character_id=body.character_id,

--- a/backend/packages/app/src/windup_app/web/api/render3d.py
+++ b/backend/packages/app/src/windup_app/web/api/render3d.py
@@ -75,6 +75,27 @@ def _precheck(request: Request):
 MAX_ASSETS_PER_USER = 2
 
 
+def _unlimited_3d_user_ids() -> frozenset[int]:
+    """不受 3D 额度限制的用户(组内做素材)。配置里写坏的条目跳过,不让它变成"对所有人开放"。
+
+    与 veo 白名单**分开一个字段**:两件事的开关合并的话,给某人开 veo 会连带解掉他的
+    3D 额度,而那两笔钱的量级完全不同(veo 按秒计费,3D 是每资产 30 积分且可无限累积)。
+    """
+    from windup_framework.config.provider import settings as _cfg
+
+    out = set()
+    for part in str(getattr(_cfg, "render3d_unlimited_user_ids", "") or "").split(","):
+        part = part.strip()
+        if part.isdigit():
+            out.add(int(part))
+    return frozenset(out)
+
+
+def is_unlimited_3d(user_id: int) -> bool:
+    """这个账号免 3D 额度吗。**空名单时对谁都不成立** —— 判据的默认方向是"受限"。"""
+    return user_id in _unlimited_3d_user_ids()
+
+
 def _owned_asset_count(session: Session, user_id: int) -> int:
     """该用户名下已经建成的 3D 资产数。
 
@@ -194,7 +215,7 @@ def build_outfit_asset(
     character = get_character_with_auth(session, character_id, user_id)
     outfit = _outfit_or_raise(character, outfit_id)
     owned = _owned_asset_count(session, user_id)
-    if owned >= MAX_ASSETS_PER_USER:
+    if owned >= MAX_ASSETS_PER_USER and not is_unlimited_3d(user_id):
         raise BizException(
             f"每个账号最多同时持有 {MAX_ASSETS_PER_USER} 个 3D 角色，你已经有 {owned} 个。"
             "弃掉其中一个就能再建。",

--- a/backend/packages/framework/src/windup_framework/config/provider.py
+++ b/backend/packages/framework/src/windup_framework/config/provider.py
@@ -56,6 +56,12 @@ class AIProviderSettings(BaseSettings):
     # 逗号分隔的用户 id,如 "1,7,12"。
     video_veo_user_ids: str = ""
 
+    # 不受 3D 资产额度限制的用户。用途与 ``video_veo_user_ids`` 一样是**组内做素材**,
+    # 但**单独一个字段** —— 两件事的开关合并的话,给某人开 veo 会连带解掉他的 3D 额度,
+    # 而那两笔钱的量级完全不同(veo 按秒计费,3D 是每资产 30 积分且可无限累积)。
+    # 空值 = 所有人都受额度限制(默认)。逗号分隔的用户 id,如 "1,2,3"。
+    render3d_unlimited_user_ids: str = ""
+
     chat_fallbacks: str = ""
     image_fallbacks: str = "gemini-3.1-flash-image-preview"
     video_fallbacks: str = ""

--- a/backend/tests/test_render3d_unlimited_users.py
+++ b/backend/tests/test_render3d_unlimited_users.py
@@ -1,0 +1,113 @@
+"""组内账号免 3D 额度(用来做高质量素材)。
+
+两道额度都要免,漏一道就等于没免:
+  MAX_ASSETS_PER_USER       每人最多同时持有几个 3D 角色
+  MAX_ACTIONS_PER_3D_ASSET  每个 3D 角色最多几个动作
+
+判据的**默认方向是受限**:空名单、拿不到用户身份时一律照常限。反过来(默认放行)
+的代价是所有人都能无限建资产,而每个是 30 积分。
+"""
+from __future__ import annotations
+
+import pytest
+
+from windup_app.web.api.render3d import _unlimited_3d_user_ids, is_unlimited_3d
+
+
+@pytest.fixture
+def _ids(monkeypatch):
+    def _set(value: str):
+        from windup_framework.config.provider import settings as cfg
+
+        monkeypatch.setattr(cfg, "render3d_unlimited_user_ids", value, raising=False)
+    return _set
+
+
+def test_an_empty_allowlist_exempts_nobody(_ids):
+    """拦的坏例:默认放行。空名单时所有人都能无限建资产,每个 30 积分。"""
+    _ids("")
+    assert _unlimited_3d_user_ids() == frozenset()
+    for uid in (1, 2, 3, 99):
+        assert not is_unlimited_3d(uid)
+
+
+def test_the_listed_users_are_exempt(_ids):
+    _ids("1,2,3")
+    assert _unlimited_3d_user_ids() == frozenset({1, 2, 3})
+    assert all(is_unlimited_3d(u) for u in (1, 2, 3))
+    assert not is_unlimited_3d(4)
+
+
+@pytest.mark.parametrize("raw", ["1, 2 ,3", " 1,2,3 ", "1,,2,3,"])
+def test_whitespace_and_empty_entries_are_tolerated(_ids, raw):
+    """部署时手写的配置会有空格和多余逗号,不该因此少放一个人。"""
+    _ids(raw)
+    assert _unlimited_3d_user_ids() == frozenset({1, 2, 3})
+
+
+def test_a_malformed_entry_is_skipped_not_treated_as_everyone(_ids):
+    """拦的坏例:写坏一个条目就"对所有人开放"。
+
+    与 veo 白名单同一条判据:坏条目跳过,不放大授权范围。
+    """
+    _ids("1,abc,3,,x7")
+    assert _unlimited_3d_user_ids() == frozenset({1, 3})
+    assert not is_unlimited_3d(7), "写坏的 x7 被当成了 7"
+
+
+def test_the_asset_count_gate_honours_the_allowlist(_ids, monkeypatch):
+    """第一道额度:持有数。免限的用户建到第 3 个也不该被拒。"""
+    from windup_app.web.api import render3d as r3d
+
+    _ids("2")
+    monkeypatch.setattr(r3d, "_owned_asset_count", lambda *a, **k: 99)
+    # 直接验判据本身:超额 + 在名单里 → 不拦
+    assert 99 >= r3d.MAX_ASSETS_PER_USER
+    assert r3d.is_unlimited_3d(2)
+    assert not r3d.is_unlimited_3d(5)
+
+
+def test_the_action_quota_gate_honours_the_allowlist(_ids):
+    """第二道额度:每资产的动作数。漏这道的话免限用户建得了资产、加不了动作。"""
+    from windup_app.web.api.generation import _require_3d_action_quota
+    from windup_app.web.api.generation import BizException
+
+    _ids("2")
+
+    class _Char:
+        id = 1
+        character_data = {
+            "version": 1, "templates": [],
+            "outfits": [{
+                "id": "o1", "name": "默认", "model_3d_url": "https://x/m.glb",
+                "actions": [
+                    {"id": f"a{i}", "type": "walk", "name": "走", "frame_count": 1,
+                     "frames": []} for i in range(9)
+                ],
+            }],
+        }
+
+    # 不在名单里 → 撞额度
+    with pytest.raises(BizException):
+        _require_3d_action_quota(_Char(), "o1", user_id=5)
+    # 在名单里 → 放行
+    _require_3d_action_quota(_Char(), "o1", user_id=2)
+
+
+def test_no_user_id_still_enforces_the_quota(_ids):
+    """拿不到用户身份时照常限 —— 默认方向是受限,不是放行。"""
+    from windup_app.web.api.generation import _require_3d_action_quota, BizException
+
+    _ids("2")
+
+    class _Char:
+        id = 1
+        character_data = {
+            "version": 1, "templates": [],
+            "outfits": [{"id": "o1", "name": "默认", "model_3d_url": "https://x/m.glb",
+                         "actions": [{"id": f"a{i}", "type": "walk", "name": "走",
+                                      "frame_count": 1, "frames": []} for i in range(9)]}],
+        }
+
+    with pytest.raises(BizException):
+        _require_3d_action_quota(_Char(), "o1", user_id=None)


### PR DESCRIPTION
Closes #869

## 需求

组内那三个做高质量素材的账号要**不受 3D 额度限制**。现在有两道，都会挡住他们：

```
MAX_ASSETS_PER_USER       = 2   每人最多同时持有 2 个 3D 角色
MAX_ACTIONS_PER_3D_ASSET  = 3   每个 3D 角色最多 3 个动作
```

**两道都免** —— 漏一道等于没免（建得了资产、加不了动作）。

## 三个判断

**① 单独一个配置字段，不复用 `video_veo_user_ids`。**

两件事的开关合并的话，给某人开 veo 会连带解掉他的 3D 额度，而那两笔钱的量级完全不同 —— veo 按秒计费，3D 是每资产 30 积分（图生 3D 20 + 绑骨 10）且**可无限累积**。

**② 默认方向是受限。**

空名单、拿不到用户身份（`user_id is None`）时一律照常限。反过来（默认放行）的代价是所有人都能无限建资产。

**③ 写坏的条目跳过，不放大授权范围。**

配置写成 `1,abc,3,,x7` 时解析出的是 `1` 和 `3` 两个 —— 那个 `x7` 不会被当成 7。与 veo 白名单同一条判据。

## 验证

| 变异 | 结果 |
|---|---|
| 对所有人放行 | 5 红 |
| 动作额度那道漏掉豁免 | 1 红 |
| 拿不到用户身份就放行 | 1 红 |
| 坏条目不跳过 | 1 红 |

CI 原样命令跑在最后一次编辑之后：`ruff check .` 通过；`export_openapi` rc=0；`lint-imports` 2 kept / 0 broken；`pytest -q --cov=packages` **2027 passed, 14 skipped**。

## 部署时要做的

合并后在生产 `.env` 加一行（值与 `AI_VIDEO_VEO_USER_IDS` 相同，但**是两个独立开关**）：

```
AI_RENDER3D_UNLIMITED_USER_IDS=1,2,3
```

不加这一行的话，本 PR 的效果是零 —— 空名单对谁都不免限，行为与现在完全一致。
