### PR TITLE
fix(render3d): 绑骨上传取 .url，别把整个 MediaUploadResult 返回出去

### DIFF
--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -409,18 +409,25 @@ class _MediaModelUploader:
     _NAME = {"model/gltf-binary": "rig-input.glb", "application/x-fbx": "rig-input.fbx"}
 
     def upload(self, model: bytes, content_type: str) -> str:
-        from windup_app.server.media.model import MediaUploadInput
+        from windup_app.server.media.model import MediaCategory, MediaUploadInput
         from windup_app.server.media.service import service as media_service
 
+        # **取 .url**:``media_service.upload`` 返回的是 ``MediaUploadResult`` 对象,
+        # 不是字符串。返回整个对象的话,``_upload`` 那道"必须是 http(s) URL"的断言会拒,
+        # 而那发生在**图生 3D 已经付过 20 积分之后**、绑骨提交之前 ——
+        # 用户卡在"模型建好了但绑不了骨"的中间态(2026-08-28 生产实测踩到)。
+        #
+        # 分类取枚举成员而不是字面量:与 ``_publish_model`` 同一条理由 ——
+        # 字面量打错会在两笔钱都花完之后才炸,而错误文本只说"输入不合法"。
         return media_service.upload(
             model,
             MediaUploadInput(
                 filename=self._NAME.get(content_type, "rig-input.bin"),
                 content_type=content_type,
                 size=len(model),
-                category="model-3d",
+                category=MediaCategory.MODEL_3D,
             ),
-        )
+        ).url
 
 
 def _publish_model(data: bytes) -> str:

--- a/backend/tests/test_rig_upload_target.py
+++ b/backend/tests/test_rig_upload_target.py
@@ -67,7 +67,20 @@ def test_the_uploader_returns_a_public_http_url():
             seen["filename"] = spec.filename
             seen["category"] = spec.category
             seen["size"] = spec.size
-            return "https://media.example.com/media/model-3d/abc.glb"
+            # **返回真实类型**,不是字符串。第一版这里桩了个 str,于是
+            # "忘了取 .url" 这个 bug 被测试完美地放过去了 —— 断言的是自己写的桩的
+            # 行为,而生产上 upload() 返回的是 MediaUploadResult 对象。
+            # 2026-08-28 生产实测:图生 3D 付完 20 积分后绑骨报
+            # ModelNotPublicError,用户卡在"模型建好了但绑不了骨"。
+            from windup_app.server.media.model import MediaUploadResult
+
+            return MediaUploadResult(
+                url="https://media.example.com/media/model-3d/abc.glb",
+                object_key="media/model-3d/abc.glb",
+                filename=spec.filename,
+                content_type=spec.content_type,
+                size=spec.size,
+            )
 
     import windup_app.server.media.service as ms
     real = ms.service
@@ -77,8 +90,17 @@ def test_the_uploader_returns_a_public_http_url():
     finally:
         ms.service = real
 
+    assert isinstance(url, str), f"返回的不是字符串而是 {type(url).__name__} —— 忘了取 .url"
     assert url.startswith("https://")
-    assert seen["category"] == "model-3d", "分类错了会走回 MediaCategory 那个老坑(#834②)"
+    # 分类必须是 model-3d。**这一条只断言取值**,不断言"是不是枚举成员" ——
+    # MediaUploadInput 是 pydantic 模型,字面量在构造时就被转成枚举了,
+    # 断言 `is MediaCategory.MODEL_3D` 对两种写法都成立(试过,变异不红)。
+    # 用字面量的真实风险是**打错字**,而那由下面这条覆盖:打错就不等于 "model-3d"。
+    from windup_app.server.media.model import MediaCategory
+
+    assert seen["category"] == MediaCategory.MODEL_3D, (
+        f"分类是 {seen['category']!r} —— 不是 model-3d 就会走回 #834② 那个老坑"
+    )
     assert seen["size"] == 104, "size 要报真实字节数"
 
 


### PR DESCRIPTION
Closes #872

## 线上 3D 建资产在绑骨那一步必失败

生产实测（2026-08-28，全程走真实端点）：

```
① 图生 3D   成功，18.4MB glTF2，三视图核对过
② 绑骨      ❌ ModelNotPublicError: uploader 必须返回 http(s) 公网 URL
```

## 原因

`_MediaModelUploader.upload()` 直接返回了 `media_service.upload(...)`，而那个函数返回的是 **`MediaUploadResult` 对象**，不是字符串 —— 忘了取 `.url`。

同一文件里的 `_publish_model` 是对的（末尾有 `.url`），我在 #856 里照抄时漏了那一行。

失败发生在**图生 3D 已经付过 20 积分之后**、绑骨提交之前 —— 用户卡在「模型建好了但绑不了骨」的中间态。

## 为什么原来那条测试没拦住 —— 它是假的

```python
class _FakeMedia:
    def upload(self, data, spec):
        return "https://media.example.com/..."   # 返回字符串
```

**桩返回字符串，而真实的返回对象**，于是「忘了取 .url」被完美放过。这是「断言的是自己写的桩的行为」那一类。改成桩返回真实的 `MediaUploadResult`。

## 顺带修了第二条没牙的断言

分类那条原本写的是 `assert seen["category"] is MediaCategory.MODEL_3D`。做变异时发现它对**两种写法都成立** —— `MediaUploadInput` 是 pydantic 模型，字面量在构造时就被转成枚举了，所以断言「是不是枚举成员」测不出任何东西。

改成断言取值。真实风险是**打错字**，那条变异现在会红。

## 验证

| 变异 | 结果 |
|---|---|
| 拿掉 `.url`（就是这个 bug） | 1 红 |
| 分类打错（`GENERAL` 而非 `MODEL_3D`） | 1 红 |

CI 原样命令跑在最后一次编辑之后：`ruff check .` 通过；`lint-imports` 2 kept / 0 broken；`pytest -q --cov=packages` **2025 passed, 14 skipped**。

## 部署后要做的

这个修复合并部署之后，3D 端到端才第一次有机会跑通 —— **③ 落库和 ④ 出帧目前在生产上仍是零次成功**，因为链路在 ② 就断了。
