### PR TITLE
fix(render3d): 上游三种瞬时故障纳入重试，它们重发就过

### DIFF
--- a/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
+++ b/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
@@ -139,6 +139,22 @@ def _raise_for_error(response: Mapping) -> Mapping:
         raise InsufficientCreditsError(
             f"积分不足({code}: {msg})。这是充值问题,不是接口坏了 —— "
             "别照着接口文档排查参数。")
+    # 上游自己的瞬时故障。**都可重试** —— 2026-08-28 一次端到端里三种都撞到过,
+    # 而每一次都是「同一个请求原样再发一遍就过」:
+    #
+    #   FailedOperation.ServerError      算法服务异常     重试即过
+    #   FailedOperation.RequestTimeout   后端服务超时     重试即过
+    #   FailedOperation.DownloadError    文件下载失败     ← 这个最误导
+    #
+    # DownloadError 字面看像"我们的 URL 取不到",实测不是:同一个 18MB URL 在报了
+    # DownloadError 之后原样重发就成功了(JobId=1484843892775575552),而那个 URL
+    # 我们自己 HEAD 过 —— 206、18366000 字节、content-type 正确。
+    # 它照字面排查会把人引到"是不是对象存储坏了",而真因在上游那一侧。
+    #
+    # 不重试的代价:这三种都发生在**图生 3D 已经付过 20 积分之后**,用户卡在
+    # 「模型建好了但绑不了骨」,钱花了、资产建不成。
+    if any(x in code for x in ("ServerError", "RequestTimeout", "DownloadError")):
+        raise UpstreamBusyError(code or "FailedOperation", msg)
     if "JobNumExceed" in code or "RequestLimitExceeded" in code:
         # 上游**同时只允许 1 个绑骨任务**,而且上一个已经 DONE 位子也不立刻释放
         # (实测 2026-08-28:连续三次被拒,等约 30 秒后即过)—— 所以限的是时间窗,

--- a/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
+++ b/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
@@ -421,17 +421,28 @@ class TencentModel3DProvider:
         return data, url
 
     def _submit(self, params: dict) -> str:
-        r = _raise_for_error(call("SubmitHunyuanTo3DProJob", params, service=SERVICE,
-                                  version=VERSION, creds=self._creds))
+        # 与绑骨提交同一条理由:上游那三种瞬时故障重发就过,而这里失败虽然还没扣钱,
+        # 却会让用户在"点了建资产、什么都没发生"之间反复试(#874 评审指出本处遗漏)。
+        r = _submit_with_backoff(lambda: _raise_for_error(
+            call("SubmitHunyuanTo3DProJob", params, service=SERVICE,
+                 version=VERSION, creds=self._creds)))
         if "JobId" not in r:
             raise JobFailedError(redact(f"提交图生 3D 没拿到 JobId: {r}"))
         return str(r["JobId"])
 
     def _wait(self, job_id: str) -> list:
         for _ in range(max(1, int(self._max_min * 60 // self._poll))):
-            r = _raise_for_error(call("QueryHunyuanTo3DProJob", {"JobId": job_id},
-                                      service=SERVICE, version=VERSION, creds=self._creds,
-                                      idempotent=True))
+            # 轮询撞上游瞬时故障时**继续下一轮**,不抛 —— 任务在云上还在跑,
+            # JobId 也还在,抛出去等于把一次已经付过钱的图生 3D作废
+            # (#874 评审指出本处遗漏)。真正的终态由下面的 Status 判定。
+            try:
+                r = _raise_for_error(call("QueryHunyuanTo3DProJob", {"JobId": job_id},
+                                          service=SERVICE, version=VERSION, creds=self._creds,
+                                          idempotent=True))
+            except UpstreamBusyError as exc:
+                logger.info("轮询撞上游瞬时故障,继续等 JobId=%s(%s)", job_id, exc)
+                time.sleep(self._poll)
+                continue
             status = str(r.get("Status") or "")
             if status == "DONE":
                 files = r.get("ResultFile3Ds") or r.get("ResultFile3D") or []
@@ -598,9 +609,17 @@ class TencentAutoRigProvider:
 
     def _wait(self, job_id: str) -> list:
         for _ in range(max(1, int(self._max_min * 60 // self._poll))):
-            r = _raise_for_error(call("DescribeAutoRiggingJob", {"JobId": job_id},
-                                      service=SERVICE, version=VERSION, creds=self._creds,
-                                      idempotent=True))
+            # 轮询撞上游瞬时故障时**继续下一轮**,不抛 —— 任务在云上还在跑,
+            # JobId 也还在,抛出去等于把一次已经付过钱的绑骨作废
+            # (#874 评审指出本处遗漏)。真正的终态由下面的 Status 判定。
+            try:
+                r = _raise_for_error(call("DescribeAutoRiggingJob", {"JobId": job_id},
+                                          service=SERVICE, version=VERSION, creds=self._creds,
+                                          idempotent=True))
+            except UpstreamBusyError as exc:
+                logger.info("轮询撞上游瞬时故障,继续等 JobId=%s(%s)", job_id, exc)
+                time.sleep(self._poll)
+                continue
             status = str(r.get("Status") or "")
             if status == "DONE":
                 files = r.get("ResultFile3Ds") or []

--- a/backend/tests/test_rig_cloud_to_cloud.py
+++ b/backend/tests/test_rig_cloud_to_cloud.py
@@ -32,12 +32,19 @@ def test_the_concurrency_limit_is_a_separate_retryable_error():
 
 
 def test_other_errors_are_not_swallowed_as_busy():
-    """反向:别的错不能被当成"忙"而傻等 —— 那会把一个立刻可知的失败拖成五轮退避。"""
+    """反向:别的错不能被当成"忙"而傻等 —— 那会把一个立刻可知的失败拖成五轮退避。
+
+    **原本这条拿 DownloadError 当例子,2026-08-28 的实测推翻了它** ——
+    同一个 18MB URL 报了 DownloadError 之后原样重发就成功(JobId=1484843892775575552),
+    而那个 URL 我们自己 HEAD 过:206、18366000 字节、content-type 正确。
+    所以它属于上游瞬时故障、可重试(见下面那组用例),不是"立刻可知的失败"。
+    这里换成参数错 —— 那才是重试没有意义的那类。
+    """
     from windup_framework.providers.render3d.tencent import TencentApiError
 
     with pytest.raises(TencentApiError) as e:
-        _raise_for_error({"Error": {"Code": "FailedOperation.DownloadError",
-                                    "Message": "文件下载失败。"}})
+        _raise_for_error({"Error": {"Code": "InvalidParameterValue",
+                                    "Message": "File3D.Url 不合法"}})
     assert not isinstance(e.value, UpstreamBusyError)
 
 
@@ -165,3 +172,54 @@ def test_the_cloud_to_cloud_path_also_retries_on_busy(monkeypatch):
     got = prov.rig_from_url("https://upstream.example.com/m.glb", "GLB", motion="walk")
     assert got.fmt == "FBX"
     assert len(tries) == 3, f"云到云那条没重试(只提交了 {len(tries)} 次)"
+
+
+# ── 上游瞬时故障也要重试（#874）─────────────────────────────────────────────
+#
+# 2026-08-28 一次端到端里三种都撞到过，而每一次都是「原样再发一遍就过」。
+# 不重试的代价：它们都发生在图生 3D 已经付过 20 积分之后。
+
+
+@pytest.mark.parametrize(
+    "code,msg",
+    [
+        ("FailedOperation.ServerError", "算法服务异常"),
+        ("FailedOperation.RequestTimeout", "后端服务超时。"),
+        ("FailedOperation.DownloadError", "文件下载失败。"),
+    ],
+)
+def test_transient_upstream_failures_are_retryable(code, msg):
+    """拦的坏例：把上游的瞬时故障当成永久失败，直接把钱和状态都卡死。
+
+    `DownloadError` 尤其误导 —— 字面看像「我们的 URL 取不到」。实测不是：同一个
+    18MB URL 报了 DownloadError 之后原样重发就成功了
+    （JobId=1484843892775575552），而那个 URL 我们自己 HEAD 过：
+    206、18366000 字节、content-type 正确。
+    """
+    with pytest.raises(UpstreamBusyError):
+        _raise_for_error({"Error": {"Code": code, "Message": msg}})
+
+
+def test_a_genuinely_bad_url_is_retried_too_and_that_is_the_tradeoff():
+    """诚实说明这条判据的边界 —— 它**不区分**两种 DownloadError。
+
+    URL 真的取不到时上游报的也是 `DownloadError`（今天用不存在的 URL 做过控制样本）。
+    所以真取不到的场合会被多重试几轮，代价是多等几十秒；而反过来（不重试）的代价是
+    一次已付费的资产永久建不成。取舍取在这一侧。
+
+    要真区分，得我们自己先 HEAD 一次那个 URL —— 那是另一件事，没做。
+    本条只钉住「现在的行为是重试」，免得将来有人以为它已经区分了。
+    """
+    with pytest.raises(UpstreamBusyError):
+        _raise_for_error({
+            "Error": {"Code": "FailedOperation.DownloadError", "Message": "文件下载失败。"}
+        })
+
+
+def test_a_parameter_error_is_still_permanent():
+    """反向：参数错这类不该重试 —— 重试五轮只是把一个立刻可知的失败拖长。"""
+    from windup_framework.providers.render3d.tencent import TencentApiError
+
+    with pytest.raises(TencentApiError) as e:
+        _raise_for_error({"Error": {"Code": "InvalidParameter", "Message": "参数不合法"}})
+    assert not isinstance(e.value, UpstreamBusyError)

--- a/backend/tests/test_rig_cloud_to_cloud.py
+++ b/backend/tests/test_rig_cloud_to_cloud.py
@@ -223,3 +223,89 @@ def test_a_parameter_error_is_still_permanent():
     with pytest.raises(TencentApiError) as e:
         _raise_for_error({"Error": {"Code": "InvalidParameter", "Message": "参数不合法"}})
     assert not isinstance(e.value, UpstreamBusyError)
+
+
+# ── 退避要接到**实际受影响的流程**上，不只是改异常类型（#874 评审）──────────
+#
+# `_raise_for_error` 被六处调用：图生 3D 的提交与轮询、绑骨的提交与轮询，以及取
+# AppId。只把异常类型改掉、而没有调用方捕获重发的话，用户侧的行为一个字都没变 ——
+# 仍然是「已扣 20 积分后立即失败」。
+
+
+def test_image_to_3d_submit_retries_transient_failures(monkeypatch):
+    """拦的坏例：只有绑骨提交接了退避，图生 3D 提交没接。
+
+    图生 3D 提交失败时还没扣钱，但用户会在「点了建资产、什么都没发生」之间反复试，
+    而每一次都是原样重发就能过。
+    """
+    from windup_framework.providers.render3d import tencent as t
+
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    calls = []
+
+    def _fake_call(action, params, **kw):
+        calls.append(action)
+        if action == "SubmitHunyuanTo3DProJob" and len(calls) < 3:
+            return {"Error": {"Code": "FailedOperation.ServerError", "Message": "算法服务异常"}}
+        return {"JobId": "job-3d"}
+
+    monkeypatch.setattr(t, "call", _fake_call)
+    prov = t.TencentModel3DProvider.__new__(t.TencentModel3DProvider)
+    prov._creds = object()
+    assert prov._submit({"x": 1}) == "job-3d"
+    assert calls.count("SubmitHunyuanTo3DProJob") == 3, (
+        f"只提交了 {calls.count('SubmitHunyuanTo3DProJob')} 次 —— 没接退避"
+    )
+
+
+@pytest.mark.parametrize(
+    "cls_name,api,attr",
+    [
+        ("TencentModel3DProvider", "QueryHunyuanTo3DProJob", "ResultFile3Ds"),
+        ("TencentAutoRigProvider", "DescribeAutoRiggingJob", "ResultFile3Ds"),
+    ],
+)
+def test_polling_survives_a_transient_failure(monkeypatch, cls_name, api, attr):
+    """拦的坏例：轮询撞上游瞬时故障就抛，把一次**已经付过钱**的任务作废。
+
+    任务在云上还在跑、JobId 也还在 —— 抛出去等于钱花了、产物取不回来。
+    """
+    from windup_framework.providers.render3d import tencent as t
+
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    seen = []
+
+    def _fake_call(action, params, **kw):
+        seen.append(action)
+        if len(seen) < 3:
+            return {"Error": {"Code": "FailedOperation.RequestTimeout", "Message": "后端服务超时。"}}
+        return {"Status": "DONE", attr: [{"Type": "FBX", "Url": "https://x/y.fbx"}]}
+
+    monkeypatch.setattr(t, "call", _fake_call)
+    prov = getattr(t, cls_name).__new__(getattr(t, cls_name))
+    prov._creds = object()
+    prov._poll = 1
+    prov._max_min = 1
+    files = prov._wait("job-1")
+    assert files and files[0]["Type"] == "FBX"
+    assert len(seen) == 3, f"轮询只调了 {len(seen)} 次 —— 瞬时故障把它打断了"
+
+
+def test_polling_still_reports_a_real_upstream_failure(monkeypatch):
+    """反向：上游明确说 FAIL 时要抛，不能一直等到超时。
+
+    没有这条的话，把「继续等」写成「什么都不管」也能让上面那条绿 ——
+    而那会把一次真失败拖满整个轮询预算。
+    """
+    from windup_framework.providers.render3d import tencent as t
+
+    monkeypatch.setattr("time.sleep", lambda _s: None)
+    monkeypatch.setattr(
+        t, "call",
+        lambda *a, **k: {"Status": "FAIL", "ErrorMessage": "模型不合规"})
+    prov = t.TencentAutoRigProvider.__new__(t.TencentAutoRigProvider)
+    prov._creds = object()
+    prov._poll = 1
+    prov._max_min = 1
+    with pytest.raises(t.JobFailedError, match="绑骨失败"):
+        prov._wait("job-2")


### PR DESCRIPTION
Closes #874

详见 issue。要点:

三种瞬时故障(ServerError / RequestTimeout / DownloadError)实测都是原样重发就过,而现在的重试只覆盖 JobNumExceed。它们都发生在图生 3D 已付 20 积分之后 —— 不重试就是钱花了、资产建不成。

DownloadError 最误导:字面像「我们的 URL 取不到」,实测同一个 18MB URL 重发即成功(JobId=1484843892775575552),而那个 URL 我们自己 HEAD 过 206/18366000 字节/content-type 正确。

顺带回写一条被实测推翻的旧判断:原先有条用例拿 DownloadError 当「不该重试」的例子,换成参数错。

取舍写明:真取不到时上游报的也是 DownloadError(控制样本验过),本判据不区分两者 —— 多重试几轮 vs 一次已付费资产永久建不成,取舍在后者。

CI: ruff 通过 / lint-imports 2 kept 0 broken / pytest **2039 passed, 14 skipped**