### PR TITLE
fix(generation): 四向/八向动作首帧独立类型，按朝向立绘出首帧

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
@@ -4,7 +4,12 @@ from .actions import build_attack_prompt, build_idle_prompt
 from .custom import MAX_ACTION_CHARS, build_custom_prompt
 from .jump import JUMP_PHASES, build_jump_prompt
 from .presets import ACTION_PRESETS, ActionPreset
-from .view_sheet import VIEW_SHEET_PROMPT_VERSION, build_view_sheet_prompt
+from .view_sheet import (
+    VIEW_SHEET_PROMPT_VERSION,
+    build_oriented_first_frame_prompt,
+    build_view_sheet_prompt,
+    view_for_perspective,
+)
 from .walk import build_walk_prompt
 
 # 改动本包任何一个 build_*_prompt 的输出(包括 prompts/*.md 模板)都必须连带把这个
@@ -24,5 +29,7 @@ __all__ = [
     "ActionPreset",
     "PROMPT_VERSION",
     "VIEW_SHEET_PROMPT_VERSION",
+    "build_oriented_first_frame_prompt",
     "build_view_sheet_prompt",
+    "view_for_perspective",
 ]

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/view_sheet.md
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/view_sheet.md
@@ -18,20 +18,19 @@ Same idle pose, same scale, same costume, same character.
 ## identity.first_frame
 
 ```text
-This is an image-to-image task. The attached image is the confirmed FRONT-VIEW character master.
-Preserve that identity exactly: the same face, hairstyle, body proportions, outfit, colors,
-accessories, and silhouette. Rotate only the camera azimuth around the same figure to the
-compass heading below. Keep that camera lock: do not let the character turn independently of it.
-The pose is the action first frame described after the camera heading, not the idle standing pose.
-Same scale, same costume, same character.
+This is an image-to-image task. The attached image is the confirmed character already facing
+the requested compass heading. Preserve that identity exactly: the same face, hairstyle, body
+proportions, outfit, colors, accessories, and silhouette. Keep this camera azimuth and heading
+locked: do not turn the character toward another direction. Change only the pose to the action
+first frame described after the camera heading. Same scale, same costume, same character.
 ```
 
 ## first_frame.pose_lock
 
 ```text
 The pose is the action first frame described next, not idle standing. Keep the camera azimuth
-and compass heading above for the whole figure. Do not face another direction. Same identity
-as the front-view master.
+and compass heading of the attached image. Do not face another direction. Same identity as
+the attached heading master.
 ```
 
 ## pose

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/view_sheet.md
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/view_sheet.md
@@ -15,6 +15,25 @@ accessories, and silhouette. Change only the camera azimuth around the same stan
 Same idle pose, same scale, same costume, same character.
 ```
 
+## identity.first_frame
+
+```text
+This is an image-to-image task. The attached image is the confirmed FRONT-VIEW character master.
+Preserve that identity exactly: the same face, hairstyle, body proportions, outfit, colors,
+accessories, and silhouette. Rotate only the camera azimuth around the same figure to the
+compass heading below. Keep that camera lock: do not let the character turn independently of it.
+The pose is the action first frame described after the camera heading, not the idle standing pose.
+Same scale, same costume, same character.
+```
+
+## first_frame.pose_lock
+
+```text
+The pose is the action first frame described next, not idle standing. Keep the camera azimuth
+and compass heading above for the whole figure. Do not face another direction. Same identity
+as the front-view master.
+```
+
 ## pose
 
 ```text

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/view_sheet.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/view_sheet.py
@@ -11,10 +11,26 @@ from windup_common.models import CharacterView
 
 from windup_ai_engine.prompt._md import load_section
 
-__all__ = ["VIEW_SHEET_PROMPT_VERSION", "build_view_sheet_prompt"]
+__all__ = [
+    "VIEW_SHEET_PROMPT_VERSION",
+    "build_oriented_first_frame_prompt",
+    "build_view_sheet_prompt",
+    "view_for_perspective",
+]
 
 _DOC = "view_sheet.md"
 VIEW_SHEET_PROMPT_VERSION = "v1"
+
+_PERSPECTIVE_TO_VIEW = {
+    1: CharacterView.SIDE,
+    2: CharacterView.TOP_DOWN,
+    3: CharacterView.ISOMETRIC,
+}
+
+
+def view_for_perspective(perspective: int) -> CharacterView:
+    """项目 ``character_perspective`` → 立绘 / 首帧用的仰角模板。"""
+    return _PERSPECTIVE_TO_VIEW.get(perspective, CharacterView.SIDE)
 
 
 def build_view_sheet_prompt(
@@ -42,3 +58,32 @@ def build_view_sheet_prompt(
     if extra_text:
         parts.append(extra_text)
     return " ".join(parts)
+
+
+def build_oriented_first_frame_prompt(
+    direction: ActionDirection | str,
+    *,
+    view: CharacterView | str = CharacterView.TOP_DOWN,
+    action_prompt: str,
+) -> str:
+    """从正视母版锁相机方位,再换成动作首帧姿态。
+
+    复用 sheet 的朝向 / 仰角 / 构图节;身份与姿态改成允许动,不能沿用 idle standing。
+    ``action_prompt`` 必须有正文:空描述会让方位锁后面没有姿态,模型容易站着不动。
+    """
+
+    azimuth = ActionDirection(direction)
+    perspective = CharacterView(view)
+    action = action_prompt.strip()
+    if not action:
+        raise ValueError("动作首帧必须提供动作描述")
+    return " ".join(
+        [
+            load_section(_DOC, "identity.first_frame"),
+            load_section(_DOC, azimuth.value),
+            load_section(_DOC, f"elevation.{perspective.value}"),
+            load_section(_DOC, "framing"),
+            load_section(_DOC, "first_frame.pose_lock"),
+            action,
+        ]
+    )

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/view_sheet.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/view_sheet.py
@@ -66,9 +66,9 @@ def build_oriented_first_frame_prompt(
     view: CharacterView | str = CharacterView.TOP_DOWN,
     action_prompt: str,
 ) -> str:
-    """从正视母版锁相机方位,再换成动作首帧姿态。
+    """以该朝向立绘为参考,锁住朝向后换成动作首帧姿态。
 
-    复用 sheet 的朝向 / 仰角 / 构图节;身份与姿态改成允许动,不能沿用 idle standing。
+    复用 sheet 的朝向 / 仰角 / 构图节当方位锁;身份锚是附上的那张朝向图,不从 south 转相机。
     ``action_prompt`` 必须有正文:空描述会让方位锁后面没有姿态,模型容易站着不动。
     """
 

--- a/backend/packages/app/src/windup_app/bootstrap/worker.py
+++ b/backend/packages/app/src/windup_app/bootstrap/worker.py
@@ -24,6 +24,7 @@ from windup_app.server.orchestrator.executor import (
     run_direction_set_task,
 )
 from windup_app.server.orchestrator.view_sheet_executor import run_view_sheet_task
+from windup_app.server.orchestrator.first_frame_executor import run_first_frame_task
 from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
 from windup_app.worker.consumer import StreamConsumer, start_delayed_loop, start_relay_loop
 from windup_app.worker.pending_timeout import release_stale_pending_tasks
@@ -80,6 +81,7 @@ def main() -> None:
             run_action_task=run_action_task,
             run_direction_set_task=run_direction_set_task,
             run_view_sheet_task=run_view_sheet_task,
+            run_first_frame_task=run_first_frame_task,
             stop_event=stop_event,
             resume_action_poll=resume_action_poll,
             resume_action_client_bake=resume_action_client_bake,
@@ -92,6 +94,7 @@ def main() -> None:
             run_action_task=run_action_task,
             run_direction_set_task=run_direction_set_task,
             run_view_sheet_task=run_view_sheet_task,
+            run_first_frame_task=run_first_frame_task,
             stop_event=stop_event,
         ),
         _generation_consumer(generation_image_stream_spec()),

--- a/backend/packages/app/src/windup_app/server/mq/catalog.py
+++ b/backend/packages/app/src/windup_app/server/mq/catalog.py
@@ -165,7 +165,10 @@ def msg_type_for_generation(task_type: str) -> str:
         "character_direction_set",
         "character_four_view",
         "character_eight_view",
+        "character_first_frame",
     ):
+        # 与单张立绘同一图像并发池。payload.task_type 才是执行器分叉,
+        # 不要另开 TypeSpec,否则会把线程池和信号量再加一倍。
         # 与单张立绘同一图像并发池。payload.task_type 才是执行器分叉,
         # 不要另开 TypeSpec,否则会把线程池和信号量再加一倍。
         return MSG_TYPE_CHARACTER_IMAGE

--- a/backend/packages/app/src/windup_app/server/orchestrator/billing.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/billing.py
@@ -44,6 +44,7 @@ def prepaid_cost(task_type: GenerationType, model_calls: int) -> int:
         GenerationType.CHARACTER_DIRECTION_SET,
         GenerationType.CHARACTER_FOUR_VIEW,
         GenerationType.CHARACTER_EIGHT_VIEW,
+        GenerationType.CHARACTER_FIRST_FRAME,
     ):
         return quota_settings.generate_image_cost * model_calls
     if task_type is GenerationType.CHARACTER_ACTION:

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -25,6 +25,10 @@ from typing import TYPE_CHECKING
 from sqlalchemy.orm import Session
 
 from windup_ai_engine.ports import PromptRejected
+from windup_ai_engine.prompt import (
+    build_oriented_first_frame_prompt,
+    view_for_perspective,
+)
 from windup_ai_engine.slicing.quality import subject_blobs
 from windup_common.directions import direction_prompt
 from windup_common.enums import ArtStyle
@@ -1191,7 +1195,9 @@ class ImageTaskExecutor:
         # 2. 风格参考图(项目级,有 sprite_sample_url 时走图生图模式)
         style_url = (cons.sprite_sample_url or "").strip()
         want_char = _is_url(char_url)
-        want_style = _is_url(style_url)
+        # 锁定朝向只吃正视母版,不再叠项目风格图:第二张图会让
+        # "attached image is the FRONT-VIEW master" 对不上。
+        want_style = (not input.lock_from_south) and _is_url(style_url)
 
         def _fetch_style(url: str) -> bytes | None:
             try:
@@ -1217,39 +1223,48 @@ class ImageTaskExecutor:
                     refs.append(style_bytes)
                     has_style_ref = True
 
-        # 3. 构建提示词
-        base = (
-            input.prompt
-            or "Clean full-body character reference of the figure in the image."
-        )
-        parts = [
-            base,
-            _image_view_prompt(cons),
-            direction_prompt(input.direction),
-        ]
-        if cons.style:
-            parts.append(f"Art style: {cons.style}.")
-        parts.append("Plain light-gray background, no shadow.")
-
-        # 图生图模式:明确标注参考图用途。只有角色母版、没有项目风格图时同样必须写明
-        # 身份约束，否则 Provider 虽收到图片，仍可能把它当普通构图参考重新设计角色。
-        if want_char and has_style_ref:
-            prefix = (
-                "This is an image-to-image task. "
-                "The first image is the CHARACTER reference — preserve its identity. "
-                "The second image is the STYLE reference — follow its art style, "
-                "color palette, and rendering technique. "
+        if input.lock_from_south:
+            if not want_char:
+                raise ValueError("锁定朝向的动作首帧必须绑定正视母版")
+            prompt = build_oriented_first_frame_prompt(
+                input.direction,
+                view=view_for_perspective(cons.perspective),
+                action_prompt=input.prompt,
             )
-            parts.insert(0, prefix)
-        elif want_char:
-            parts.insert(
-                0,
-                "This is an image-to-image task. The first image is the confirmed "
-                "CHARACTER master — preserve its identity, face, body proportions, "
-                "outfit, colors, and accessories exactly. ",
+        else:
+            # 3. 构建提示词
+            base = (
+                input.prompt
+                or "Clean full-body character reference of the figure in the image."
             )
+            parts = [
+                base,
+                _image_view_prompt(cons),
+                direction_prompt(input.direction),
+            ]
+            if cons.style:
+                parts.append(f"Art style: {cons.style}.")
+            parts.append("Plain light-gray background, no shadow.")
 
-        prompt = " ".join(parts)
+            # 图生图模式:明确标注参考图用途。只有角色母版、没有项目风格图时同样必须写明
+            # 身份约束，否则 Provider 虽收到图片，仍可能把它当普通构图参考重新设计角色。
+            if want_char and has_style_ref:
+                prefix = (
+                    "This is an image-to-image task. "
+                    "The first image is the CHARACTER reference — preserve its identity. "
+                    "The second image is the STYLE reference — follow its art style, "
+                    "color palette, and rendering technique. "
+                )
+                parts.insert(0, prefix)
+            elif want_char:
+                parts.insert(
+                    0,
+                    "This is an image-to-image task. The first image is the confirmed "
+                    "CHARACTER master — preserve its identity, face, body proportions, "
+                    "outfit, colors, and accessories exactly. ",
+                )
+
+            prompt = " ".join(parts)
 
         import io
 

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -1195,9 +1195,9 @@ class ImageTaskExecutor:
         # 2. 风格参考图(项目级,有 sprite_sample_url 时走图生图模式)
         style_url = (cons.sprite_sample_url or "").strip()
         want_char = _is_url(char_url)
-        # 锁定朝向只吃正视母版,不再叠项目风格图:第二张图会让
-        # "attached image is the FRONT-VIEW master" 对不上。
-        want_style = (not input.lock_from_south) and _is_url(style_url)
+        # 锁定朝向只吃该朝向立绘,不再叠项目风格图:第二张图会让
+        # "attached image is already facing this heading" 对不上。
+        want_style = (not input.lock_orientation) and _is_url(style_url)
 
         def _fetch_style(url: str) -> bytes | None:
             try:
@@ -1223,9 +1223,9 @@ class ImageTaskExecutor:
                     refs.append(style_bytes)
                     has_style_ref = True
 
-        if input.lock_from_south:
+        if input.lock_orientation:
             if not want_char:
-                raise ValueError("锁定朝向的动作首帧必须绑定正视母版")
+                raise ValueError("锁定朝向的动作首帧必须绑定该朝向立绘")
             prompt = build_oriented_first_frame_prompt(
                 input.direction,
                 view=view_for_perspective(cons.perspective),

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -25,10 +25,6 @@ from typing import TYPE_CHECKING
 from sqlalchemy.orm import Session
 
 from windup_ai_engine.ports import PromptRejected
-from windup_ai_engine.prompt import (
-    build_oriented_first_frame_prompt,
-    view_for_perspective,
-)
 from windup_ai_engine.slicing.quality import subject_blobs
 from windup_common.directions import direction_prompt
 from windup_common.enums import ArtStyle
@@ -1195,9 +1191,7 @@ class ImageTaskExecutor:
         # 2. 风格参考图(项目级,有 sprite_sample_url 时走图生图模式)
         style_url = (cons.sprite_sample_url or "").strip()
         want_char = _is_url(char_url)
-        # 锁定朝向只吃该朝向立绘,不再叠项目风格图:第二张图会让
-        # "attached image is already facing this heading" 对不上。
-        want_style = (not input.lock_orientation) and _is_url(style_url)
+        want_style = _is_url(style_url)
 
         def _fetch_style(url: str) -> bytes | None:
             try:
@@ -1223,48 +1217,39 @@ class ImageTaskExecutor:
                     refs.append(style_bytes)
                     has_style_ref = True
 
-        if input.lock_orientation:
-            if not want_char:
-                raise ValueError("锁定朝向的动作首帧必须绑定该朝向立绘")
-            prompt = build_oriented_first_frame_prompt(
-                input.direction,
-                view=view_for_perspective(cons.perspective),
-                action_prompt=input.prompt,
-            )
-        else:
-            # 3. 构建提示词
-            base = (
-                input.prompt
-                or "Clean full-body character reference of the figure in the image."
-            )
-            parts = [
-                base,
-                _image_view_prompt(cons),
-                direction_prompt(input.direction),
-            ]
-            if cons.style:
-                parts.append(f"Art style: {cons.style}.")
-            parts.append("Plain light-gray background, no shadow.")
+        # 3. 构建提示词
+        base = (
+            input.prompt
+            or "Clean full-body character reference of the figure in the image."
+        )
+        parts = [
+            base,
+            _image_view_prompt(cons),
+            direction_prompt(input.direction),
+        ]
+        if cons.style:
+            parts.append(f"Art style: {cons.style}.")
+        parts.append("Plain light-gray background, no shadow.")
 
-            # 图生图模式:明确标注参考图用途。只有角色母版、没有项目风格图时同样必须写明
-            # 身份约束，否则 Provider 虽收到图片，仍可能把它当普通构图参考重新设计角色。
-            if want_char and has_style_ref:
-                prefix = (
-                    "This is an image-to-image task. "
-                    "The first image is the CHARACTER reference — preserve its identity. "
-                    "The second image is the STYLE reference — follow its art style, "
-                    "color palette, and rendering technique. "
-                )
-                parts.insert(0, prefix)
-            elif want_char:
-                parts.insert(
-                    0,
-                    "This is an image-to-image task. The first image is the confirmed "
-                    "CHARACTER master — preserve its identity, face, body proportions, "
-                    "outfit, colors, and accessories exactly. ",
-                )
+        # 图生图模式:明确标注参考图用途。只有角色母版、没有项目风格图时同样必须写明
+        # 身份约束，否则 Provider 虽收到图片，仍可能把它当普通构图参考重新设计角色。
+        if want_char and has_style_ref:
+            prefix = (
+                "This is an image-to-image task. "
+                "The first image is the CHARACTER reference — preserve its identity. "
+                "The second image is the STYLE reference — follow its art style, "
+                "color palette, and rendering technique. "
+            )
+            parts.insert(0, prefix)
+        elif want_char:
+            parts.insert(
+                0,
+                "This is an image-to-image task. The first image is the confirmed "
+                "CHARACTER master — preserve its identity, face, body proportions, "
+                "outfit, colors, and accessories exactly. ",
+            )
 
-            prompt = " ".join(parts)
+        prompt = " ".join(parts)
 
         import io
 
@@ -1573,3 +1558,6 @@ def bind_matte(matte: MatteProvider) -> None:
     from windup_app.server.orchestrator.view_sheet_executor import view_sheet_executor
 
     view_sheet_executor._matte = matte
+    from windup_app.server.orchestrator.first_frame_executor import first_frame_executor
+
+    first_frame_executor._matte = matte

--- a/backend/packages/app/src/windup_app/server/orchestrator/first_frame_executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/first_frame_executor.py
@@ -1,0 +1,205 @@
+"""四向 / 八向动作首帧编排。
+
+以该朝向已确认立绘为唯一参考图,锁住方位后换成动作起手姿态。
+不经过 ``ImageTaskExecutor._produce_image``。
+
+web **不得 import 本模块**(与 ``executor`` 同门禁:会牵出 ai_engine)。
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import threading
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from PIL import Image
+from sqlalchemy.orm import Session
+
+from windup_ai_engine.prompt import build_oriented_first_frame_prompt, view_for_perspective
+from windup_ai_engine.slicing.quality import subject_blobs
+from windup_framework.gateway import bind_call_context, fresh_gateway_request
+
+from windup_app.server.orchestrator import generation_io, task_repo
+from windup_app.server.orchestrator._failure import user_message
+from windup_app.server.orchestrator._fetch import fetch_own_media
+from windup_app.server.orchestrator.executor import (
+    ProjectConstraints,
+    _close_failed,
+    _fit_to,
+    _load_constraints,
+    _settle_credit,
+)
+from windup_app.server.orchestrator.model import (
+    CharacterFirstFrameInput,
+    GenerationType,
+    TaskStatus,
+)
+
+if TYPE_CHECKING:
+    from windup_framework.providers import MatteProvider
+
+logger = logging.getLogger("windup.generation.first_frame")
+
+_RESULT = GenerationType.CHARACTER_FIRST_FRAME.value
+
+
+class FirstFrameTaskExecutor:
+    """跑锁定朝向的动作首帧:该朝向立绘 + 方位锁提示词 → 图生图 → 上传。"""
+
+    def __init__(
+        self,
+        *,
+        image=None,
+        matte: MatteProvider | None = None,
+        upload: Callable[[bytes], str] | None = None,
+        fetch_ref: Callable[[str], bytes] | None = None,
+        session_factory: Callable[[], Session] | None = None,
+    ) -> None:
+        self._image = image
+        self._matte = matte
+        self._upload = upload
+        self._fetch_ref = fetch_ref
+        self._session_factory = session_factory
+        self._assembly_lock = threading.Lock()
+
+    def run_first_frame_task(
+        self,
+        task_id: int,
+        input: CharacterFirstFrameInput,
+        project_id: int | None = None,
+        *,
+        session: Session | None = None,
+    ) -> None:
+        reset = None
+        try:
+
+            def _mark_running(s: Session) -> ProjectConstraints:
+                task_repo.update_status(s, task_id, TaskStatus.RUNNING)
+                return _load_constraints(s, project_id)
+
+            cons = generation_io.using_session(session, self._make_session, _mark_running)
+            reset = bind_call_context(task_id=str(task_id))
+            urls, quality = self._produce_first_frame(input, cons)
+
+            def _complete(s: Session) -> None:
+                task_repo.update_result(
+                    s,
+                    task_id,
+                    _RESULT,
+                    {
+                        "type": _RESULT,
+                        "direction": input.direction.value,
+                        "image_urls": urls,
+                        "quality": quality,
+                    },
+                )
+                _settle_credit(s, task_id, success=True)
+
+            generation_io.using_session(session, self._make_session, _complete)
+        except Exception as exc:  # noqa: BLE001 —— 兜底
+            logger.exception("动作首帧任务 %s 失败", task_id)
+            if session is not None:
+                session.rollback()
+            error_message = user_message(exc)
+
+            def _fail(s: Session) -> None:
+                _close_failed(s, task_id, error_message)
+
+            generation_io.using_session(session, self._make_session, _fail)
+        finally:
+            if reset is not None:
+                reset()
+
+    def _produce_first_frame(
+        self, input: CharacterFirstFrameInput, cons: ProjectConstraints
+    ) -> tuple[list[str], dict]:
+        fetch = self._fetch_ref or self._download
+        heading_png = fetch(input.reference_image_url)
+        prompt = build_oriented_first_frame_prompt(
+            input.direction,
+            view=view_for_perspective(cons.perspective),
+            action_prompt=input.prompt,
+        )
+        image_gen = self._get_image()
+        matte = self._get_matte()
+        upload = self._upload or self._upload_image
+        refs = [heading_png]
+        n_images = max(1, input.num_images or 1)
+
+        from windup_framework.gateway.registry import ModelRegistry, candidate_models
+        from windup_framework.gateway.types import Scene
+
+        spread = candidate_models(
+            ModelRegistry.from_settings().chain(Scene.CHARACTER_IMAGE),
+            n_images,
+        )
+
+        def _gen_one(i: int) -> bytes:
+            reset_call = fresh_gateway_request(start_from_model=spread[i])
+            try:
+                return image_gen.gen_image(prompt, refs)
+            finally:
+                reset_call()
+
+        raws = generation_io.io_map(_gen_one, range(n_images))
+        cut: list[Image.Image] = []
+        pngs: list[bytes] = []
+        for img in raws:
+            png = _fit_to(
+                matte.cutout(img),
+                input.width,
+                input.height,
+                smooth=cons.stylize != "pixel",
+            )
+            cut.append(Image.open(io.BytesIO(png)).convert("RGBA"))
+            pngs.append(png)
+        urls = generation_io.upload_frames(upload, pngs)
+        return urls, {"subject_blobs": list(subject_blobs(cut))}
+
+    def _get_image(self):
+        if self._image is not None:
+            return self._image
+        with self._assembly_lock:
+            if self._image is None:
+                from windup_framework.gateway import build_image_gateway
+
+                self._image = build_image_gateway()
+            return self._image
+
+    def _get_matte(self):
+        if self._matte is not None:
+            return self._matte
+        with self._assembly_lock:
+            if self._matte is None:
+                from windup_framework.providers import get_matte_provider
+
+                self._matte = get_matte_provider()
+            return self._matte
+
+    def _download(self, url: str) -> bytes:
+        return fetch_own_media(url)
+
+    def _upload_image(self, png: bytes) -> str:
+        from windup_app.server.media.model import MediaCategory, MediaUploadInput
+        from windup_app.server.media.service import service as media_service
+
+        meta = MediaUploadInput(
+            filename="first-frame.png",
+            content_type="image/png",
+            size=len(png),
+            category=MediaCategory.ACTION_FRAME,
+        )
+        return media_service.upload(png, meta).url
+
+    def _make_session(self) -> Session:
+        if self._session_factory is not None:
+            return self._session_factory()
+        from windup_framework.db.session import SessionLocal
+
+        return SessionLocal()
+
+
+first_frame_executor = FirstFrameTaskExecutor()
+run_first_frame_task = first_frame_executor.run_first_frame_task

--- a/backend/packages/app/src/windup_app/server/orchestrator/interface.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/interface.py
@@ -6,7 +6,8 @@ API 层只依赖本模块定义的抽象。具体实现（AI 引擎调用、任�
 调用流程
 --------
 1. 前端调用 ``generate_character_image`` / ``generate_character_four_view`` /
-   ``generate_character_eight_view`` / ``generate_character_action`` 提交任务，
+   ``generate_character_eight_view`` / ``generate_character_first_frame`` /
+   ``generate_character_action`` 提交任务，
    拿到 ``task_id``。
 2. 前端通过 SSE 订阅任务状态变更,无需轮询。
    web 层提供 ``GET /generation/tasks/{task_id}/stream`` 端点,
@@ -20,6 +21,7 @@ API 层只依赖本模块定义的抽象。具体实现（AI 引擎调用、任�
        CharacterImageOutput.image_urls[]  → Character.reference_image_url
        CharacterViewSheetOutput.sheets[]          → 3×3 sheet_url + 各方向 image_url
                                                     (四向十字、八向八角;确认后源方向回填 templates[])
+       CharacterFirstFrameOutput.image_urls[] → 该朝向动作首帧候选
        CharacterActionOutput.frames[]  → character_data.outfits[].actions[].frames[]
 """
 
@@ -30,6 +32,7 @@ from sqlalchemy.orm import Session
 from windup_app.server.orchestrator.model import (
     CharacterActionInput,
     CharacterDirectionSetInput,
+    CharacterFirstFrameInput,
     CharacterImageInput,
     CharacterViewSheetInput,
     GenerationTask,
@@ -76,6 +79,20 @@ class GenerationService(ABC):
 
         必须绑定已确认的正视母版（south）；出参为 ``CharacterViewSheetOutput``
         （每张候选 = 1 张 3×3 十字 sheet_url + 4 张方向原图 URL）。
+        """
+
+    @abstractmethod
+    def generate_character_first_frame(
+        self,
+        session: Session,
+        *,
+        user_id: int,
+        project_id: int,
+        input: CharacterFirstFrameInput,
+    ) -> GenerationTask:
+        """提交锁定朝向的动作首帧。
+
+        参考图是该朝向已确认立绘；出参为 ``CharacterFirstFrameOutput``。
         """
 
     @abstractmethod

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -86,17 +86,17 @@ class CharacterImageInput:
     # 而不是各个构造点:MQ 重建时若另写一份默认值,缺省就会从 2 变成另一份数。
     num_images: int | None = None
     direction: ActionDirection = ActionDirection.EAST
-    # 四向 / 八向动作首帧:参考图必须是正视母版,提示词走 view_sheet 方位角锁。
+    # 四向 / 八向动作首帧:参考图是该朝向已确认立绘,提示词走 view_sheet 方位锁。
     # 默认 False,``/generation/image`` 与 MQ 里旧任务都没有这个字段。
-    lock_from_south: bool = False
+    lock_orientation: bool = False
 
     def __post_init__(self) -> None:
         if self.num_images is None:
             self.num_images = 2
-        if self.lock_from_south:
+        if self.lock_orientation:
             self.reference_image_url = (self.reference_image_url or "").strip() or None
             if not self.reference_image_url:
-                raise ValueError("锁定朝向的动作首帧必须绑定正视母版")
+                raise ValueError("锁定朝向的动作首帧必须绑定该朝向立绘")
             if not (self.prompt or "").strip():
                 raise ValueError("锁定朝向的动作首帧必须提供动作描述")
 

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -28,6 +28,7 @@ class GenerationType(StrEnum):
     CHARACTER_DIRECTION_SET = "character_direction_set"  # 一次生成项目所需全部母版方向
     CHARACTER_FOUR_VIEW = "character_four_view"  # 四向立绘 sheet
     CHARACTER_EIGHT_VIEW = "character_eight_view"  # 八向立绘 sheet
+    CHARACTER_FIRST_FRAME = "character_first_frame"  # 四向 / 八向动作首帧
     CHARACTER_ACTION = "character_action"  # 角色动作帧序列
 
 
@@ -86,19 +87,10 @@ class CharacterImageInput:
     # 而不是各个构造点:MQ 重建时若另写一份默认值,缺省就会从 2 变成另一份数。
     num_images: int | None = None
     direction: ActionDirection = ActionDirection.EAST
-    # 四向 / 八向动作首帧:参考图是该朝向已确认立绘,提示词走 view_sheet 方位锁。
-    # 默认 False,``/generation/image`` 与 MQ 里旧任务都没有这个字段。
-    lock_orientation: bool = False
 
     def __post_init__(self) -> None:
         if self.num_images is None:
             self.num_images = 2
-        if self.lock_orientation:
-            self.reference_image_url = (self.reference_image_url or "").strip() or None
-            if not self.reference_image_url:
-                raise ValueError("锁定朝向的动作首帧必须绑定该朝向立绘")
-            if not (self.prompt or "").strip():
-                raise ValueError("锁定朝向的动作首帧必须提供动作描述")
 
 
 @dataclass
@@ -158,6 +150,31 @@ class CharacterViewSheetInput:
             raise ValueError("立绘 sheet 锚点必须是 south（正视图）")
         if self.num_images is None:
             self.num_images = 1
+
+
+@dataclass
+class CharacterFirstFrameInput:
+    """四向 / 八向动作首帧:以该朝向立绘为参考,锁住朝向后换成动作起手姿态。"""
+
+    character_id: int
+    reference_image_url: str
+    prompt: str
+    direction: ActionDirection
+    action_type: ActionType
+    negative_prompt: str = ""
+    width: int = 1024
+    height: int = 1024
+    num_images: int | None = None
+
+    def __post_init__(self) -> None:
+        self.reference_image_url = (self.reference_image_url or "").strip()
+        if not self.reference_image_url:
+            raise ValueError("动作首帧必须提供该朝向已确认的立绘")
+        self.prompt = (self.prompt or "").strip()
+        if not self.prompt:
+            raise ValueError("动作首帧必须提供动作描述")
+        if self.num_images is None:
+            self.num_images = 3
 
 
 @dataclass
@@ -226,6 +243,16 @@ class CharacterImageOutput:
     # 出图当场量的主体数(``ai_engine.slicing.quality.subject_blobs`` 的逐张读数)。与动作
     # 结果那份 ``quality`` 同键同语义:只落库、不参与前端回填,本层不据此判成败。
     # ``None`` = **没量过**,不是"量了没问题"。
+    quality: dict | None = None
+
+
+@dataclass
+class CharacterFirstFrameOutput:
+    """四向 / 八向动作首帧结果。前端按方向选一张写入首帧节点。"""
+
+    type: str = "character_first_frame"
+    image_urls: list[str] = field(default_factory=list)
+    direction: ActionDirection = ActionDirection.EAST
     quality: dict | None = None
 
 
@@ -382,6 +409,7 @@ class GenerationTask:
     input_payload: dict | None = None
     result: (
         CharacterImageOutput
+        | CharacterFirstFrameOutput
         | CharacterDirectionSetOutput
         | CharacterViewSheetOutput
         | CharacterActionOutput

--- a/backend/packages/app/src/windup_app/server/orchestrator/model.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/model.py
@@ -86,10 +86,19 @@ class CharacterImageInput:
     # 而不是各个构造点:MQ 重建时若另写一份默认值,缺省就会从 2 变成另一份数。
     num_images: int | None = None
     direction: ActionDirection = ActionDirection.EAST
+    # 四向 / 八向动作首帧:参考图必须是正视母版,提示词走 view_sheet 方位角锁。
+    # 默认 False,``/generation/image`` 与 MQ 里旧任务都没有这个字段。
+    lock_from_south: bool = False
 
     def __post_init__(self) -> None:
         if self.num_images is None:
             self.num_images = 2
+        if self.lock_from_south:
+            self.reference_image_url = (self.reference_image_url or "").strip() or None
+            if not self.reference_image_url:
+                raise ValueError("锁定朝向的动作首帧必须绑定正视母版")
+            if not (self.prompt or "").strip():
+                raise ValueError("锁定朝向的动作首帧必须提供动作描述")
 
 
 @dataclass

--- a/backend/packages/app/src/windup_app/server/orchestrator/service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/service.py
@@ -19,6 +19,7 @@ from windup_app.server.orchestrator.model import (
     CharacterActionInput,
     CharacterDirectionSetInput,
     CharacterDirectionSetOutput,
+    CharacterFirstFrameInput,
     CharacterImageInput,
     CharacterViewSheetInput,
     EIGHT_VIEW_MODEL_CALLS_PER_SHEET,
@@ -109,6 +110,35 @@ class AiGenerationService(GenerationService):
             task_type=GenerationType.CHARACTER_EIGHT_VIEW,
             model_calls_per_sheet=EIGHT_VIEW_MODEL_CALLS_PER_SHEET,
         )
+
+    def generate_character_first_frame(
+        self,
+        session: Session,
+        *,
+        user_id: int,
+        project_id: int,
+        input: CharacterFirstFrameInput,
+    ) -> GenerationTask:
+        self._assert_clean(
+            user_id=user_id,
+            source="generation.first_frame",
+            texts=(input.prompt, input.negative_prompt),
+        )
+        task = task_repo.create_task(
+            session,
+            user_id=user_id,
+            project_id=project_id,
+            task_type=GenerationType.CHARACTER_FIRST_FRAME,
+            input_payload=dataclasses.asdict(input),
+        )
+        billing.reserve_for_task(
+            session,
+            user_id=user_id,
+            task_id=task.id,
+            task_type=task.task_type,
+            model_calls=max(1, input.num_images or 1),
+        )
+        return task
 
     def _submit_view_sheet(
         self,

--- a/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/task_repo.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from windup_app.server.orchestrator.model import (
     CharacterActionOutput,
     CharacterDirectionSetOutput,
+    CharacterFirstFrameOutput,
     CharacterImageOutput,
     CharacterViewSheetCandidate,
     CharacterViewSheetCell,
@@ -370,6 +371,7 @@ def _deserialize_result(
     raw: dict | None,
 ) -> (
     CharacterImageOutput
+    | CharacterFirstFrameOutput
     | CharacterDirectionSetOutput
     | CharacterViewSheetOutput
     | CharacterActionOutput
@@ -381,6 +383,13 @@ def _deserialize_result(
     if result_type == "character_image":
         return CharacterImageOutput(
             type=raw.get("type", "character_image"),
+            image_urls=raw.get("image_urls", []),
+            direction=ActionDirection(raw.get("direction", ActionDirection.EAST.value)),
+            quality=raw.get("quality"),
+        )
+    if result_type == GenerationType.CHARACTER_FIRST_FRAME.value:
+        return CharacterFirstFrameOutput(
+            type=raw.get("type", GenerationType.CHARACTER_FIRST_FRAME.value),
             image_urls=raw.get("image_urls", []),
             direction=ActionDirection(raw.get("direction", ActionDirection.EAST.value)),
             quality=raw.get("quality"),

--- a/backend/packages/app/src/windup_app/server/orchestrator/view_sheet_executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/view_sheet_executor.py
@@ -18,10 +18,9 @@ from typing import TYPE_CHECKING
 from PIL import Image
 from sqlalchemy.orm import Session
 
-from windup_ai_engine.prompt import build_view_sheet_prompt
+from windup_ai_engine.prompt import build_view_sheet_prompt, view_for_perspective
 from windup_ai_engine.slicing.quality import subject_blobs
 from windup_common.directions import ActionDirection
-from windup_common.models import CharacterView
 from windup_framework.gateway import bind_call_context, fresh_gateway_request
 
 from windup_app.server.orchestrator import generation_io, task_repo
@@ -71,11 +70,6 @@ _CELL_GRID: dict[ActionDirection, tuple[int, int]] = {
     ActionDirection.SOUTH_WEST: (0, 2),
     ActionDirection.SOUTH: (1, 2),
     ActionDirection.SOUTH_EAST: (2, 2),
-}
-_PERSPECTIVE_TO_VIEW = {
-    1: CharacterView.SIDE,
-    2: CharacterView.TOP_DOWN,
-    3: CharacterView.ISOMETRIC,
 }
 
 
@@ -241,7 +235,7 @@ class ViewSheetTaskExecutor:
             n_sheets,
         )
         jobs = [(sheet_i, direction) for sheet_i in range(n_sheets) for direction in sources]
-        view = _PERSPECTIVE_TO_VIEW.get(cons.perspective, CharacterView.SIDE)
+        view = view_for_perspective(cons.perspective)
         extra = (input.prompt or "").strip()
         image_gen = self._get_image()
         matte = self._get_matte()

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -53,6 +53,7 @@ from windup_app.server.orchestrator.model import (
     ActionType,
     CharacterActionInput,
     CharacterDirectionSetInput,
+    CharacterFirstFrameInput,
     CharacterImageInput,
     CharacterViewSheetInput,
     GenerationTask,
@@ -345,6 +346,7 @@ class CharacterFirstFrameGenerateRequest(BaseModel):
     height: int = Field(default=1024, ge=64, le=2048)
     num_images: int = Field(default=3, ge=1, le=4)
     direction: ActionDirection
+    action_type: ActionType
 
     @model_validator(mode="after")
     def require_prompt_and_heading_template(self):
@@ -841,7 +843,8 @@ def submit_first_frame_generation(
     _validate_project_size(project, body.width, body.height)
     _validate_project_direction(project, body.direction)
     _get_character_or_raise(session, body.character_id, body.project_id)
-    input_data = CharacterImageInput(
+    input_data = CharacterFirstFrameInput(
+        character_id=body.character_id,
         reference_image_url=body.reference_image_url,
         prompt=body.prompt,
         negative_prompt=body.negative_prompt,
@@ -849,9 +852,9 @@ def submit_first_frame_generation(
         height=body.height,
         num_images=body.num_images,
         direction=body.direction,
-        lock_orientation=True,
+        action_type=body.action_type,
     )
-    task = generation_service.generate_character_image(
+    task = generation_service.generate_character_first_frame(
         session,
         user_id=user_id,
         project_id=body.project_id,

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -8,6 +8,7 @@
 POST /generation/image                     提交角色图片生成任务
 POST /generation/four-view                 提交四向立绘 sheet
 POST /generation/eight-view                提交八向立绘 sheet
+POST /generation/first-frame               提交锁定朝向的动作首帧
 POST /generation/action                    提交角色动作生成任务
 GET  /generation/tasks/{task_id}           查询任务状态
 GET  /generation/tasks/{task_id}/stream    SSE 订阅任务进度
@@ -329,6 +330,28 @@ class CharacterViewSheetGenerateRequest(BaseModel):
     height: int = Field(default=1024, ge=64, le=2048)
     # sheet 比单张立绘贵,默认 1,不沿用 image 的 3。
     num_images: int = Field(default=1, ge=1, le=4)
+
+
+class CharacterFirstFrameGenerateRequest(BaseModel):
+    """四向 / 八向动作首帧:正视母版锁朝向后出该方向的动作起手姿态。"""
+
+    model_config = ConfigDict(extra="forbid")
+    project_id: int = Field(gt=0)
+    character_id: int = Field(gt=0)
+    prompt: str
+    negative_prompt: str = ""
+    width: int = Field(default=1024, ge=64, le=2048)
+    height: int = Field(default=1024, ge=64, le=2048)
+    num_images: int = Field(default=3, ge=1, le=4)
+    direction: ActionDirection
+
+    @model_validator(mode="after")
+    def require_action_prompt(self):
+        prompt = (self.prompt or "").strip()
+        if not prompt:
+            raise ValueError("动作首帧必须提供动作描述")
+        self.prompt = prompt
+        return self
 
 
 class CharacterActionGenerateRequest(BaseModel):
@@ -794,6 +817,51 @@ def submit_eight_view_generation(
         label="八向",
         submit=generation_service.generate_character_eight_view,
     )
+
+
+@router.post("/first-frame", response_model=Response[GenerationTaskOut])
+def submit_first_frame_generation(
+    body: CharacterFirstFrameGenerateRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> Response[GenerationTaskOut]:
+    """提交锁定朝向的动作首帧:正视母版转相机,再换成动作起手姿态。"""
+    user_id = request.state.current_user.id
+    project = _get_project_or_raise(session, body.project_id, user_id)
+    if project.directional_movement not in (2, 3):
+        raise BizException(
+            "锁定朝向的动作首帧只用于四向或八向项目",
+            code=BizCode.BAD_REQUEST,
+        )
+    _validate_project_size(project, body.width, body.height)
+    _validate_project_direction(project, body.direction)
+    character = _get_character_or_raise(session, body.character_id, body.project_id)
+    confirmed_master = (character.reference_image_url or "").strip()
+    if not confirmed_master:
+        raise BizException("请先选择并确认角色母版", code=BizCode.BAD_REQUEST)
+    input_data = CharacterImageInput(
+        reference_image_url=confirmed_master,
+        prompt=body.prompt,
+        negative_prompt=body.negative_prompt,
+        width=body.width,
+        height=body.height,
+        num_images=body.num_images,
+        direction=body.direction,
+        lock_from_south=True,
+    )
+    task = generation_service.generate_character_image(
+        session,
+        user_id=user_id,
+        project_id=body.project_id,
+        input=input_data,
+    )
+    _publish_generation_after_commit(
+        session,
+        request.app.state.mq_publisher,
+        task_id=task.id,
+        task_type=task.task_type.value,
+    )
+    return Response.success(_task_to_out(session, task), message="任务已提交")
 
 
 @router.post("/action", response_model=Response[GenerationTaskOut])

--- a/backend/packages/app/src/windup_app/web/api/generation.py
+++ b/backend/packages/app/src/windup_app/web/api/generation.py
@@ -333,11 +333,12 @@ class CharacterViewSheetGenerateRequest(BaseModel):
 
 
 class CharacterFirstFrameGenerateRequest(BaseModel):
-    """四向 / 八向动作首帧:正视母版锁朝向后出该方向的动作起手姿态。"""
+    """四向 / 八向动作首帧:以该朝向立绘为参考,锁住朝向后出动作起手姿态。"""
 
     model_config = ConfigDict(extra="forbid")
     project_id: int = Field(gt=0)
     character_id: int = Field(gt=0)
+    reference_image_url: str
     prompt: str
     negative_prompt: str = ""
     width: int = Field(default=1024, ge=64, le=2048)
@@ -346,11 +347,15 @@ class CharacterFirstFrameGenerateRequest(BaseModel):
     direction: ActionDirection
 
     @model_validator(mode="after")
-    def require_action_prompt(self):
+    def require_prompt_and_heading_template(self):
         prompt = (self.prompt or "").strip()
         if not prompt:
             raise ValueError("动作首帧必须提供动作描述")
         self.prompt = prompt
+        url = (self.reference_image_url or "").strip()
+        if not url:
+            raise ValueError("动作首帧必须提供该朝向已确认的立绘")
+        self.reference_image_url = url
         return self
 
 
@@ -825,7 +830,7 @@ def submit_first_frame_generation(
     request: Request,
     session: Session = Depends(get_session),
 ) -> Response[GenerationTaskOut]:
-    """提交锁定朝向的动作首帧:正视母版转相机,再换成动作起手姿态。"""
+    """提交锁定朝向的动作首帧:以该朝向立绘为参考,锁住朝向后换成动作起手姿态。"""
     user_id = request.state.current_user.id
     project = _get_project_or_raise(session, body.project_id, user_id)
     if project.directional_movement not in (2, 3):
@@ -835,19 +840,16 @@ def submit_first_frame_generation(
         )
     _validate_project_size(project, body.width, body.height)
     _validate_project_direction(project, body.direction)
-    character = _get_character_or_raise(session, body.character_id, body.project_id)
-    confirmed_master = (character.reference_image_url or "").strip()
-    if not confirmed_master:
-        raise BizException("请先选择并确认角色母版", code=BizCode.BAD_REQUEST)
+    _get_character_or_raise(session, body.character_id, body.project_id)
     input_data = CharacterImageInput(
-        reference_image_url=confirmed_master,
+        reference_image_url=body.reference_image_url,
         prompt=body.prompt,
         negative_prompt=body.negative_prompt,
         width=body.width,
         height=body.height,
         num_images=body.num_images,
         direction=body.direction,
-        lock_from_south=True,
+        lock_orientation=True,
     )
     task = generation_service.generate_character_image(
         session,

--- a/backend/packages/app/src/windup_app/worker/consumer.py
+++ b/backend/packages/app/src/windup_app/worker/consumer.py
@@ -62,6 +62,7 @@ class StreamConsumer:
         resume_action_client_bake: Callable[..., Any] | None = None,
         run_direction_set_task: Callable[..., Any] | None = None,
         run_view_sheet_task: Callable[..., Any] | None = None,
+        run_first_frame_task: Callable[..., Any] | None = None,
     ) -> None:
         self._config = config
         self._run_image_task = run_image_task
@@ -70,6 +71,7 @@ class StreamConsumer:
         self._resume_action_client_bake = resume_action_client_bake
         self._run_direction_set_task = run_direction_set_task
         self._run_view_sheet_task = run_view_sheet_task
+        self._run_first_frame_task = run_first_frame_task
         self._stop = stop_event
         self._consumer_name = f"{socket.gethostname()}-{threading.get_ident()}"
         self._executors: dict[str, ThreadPoolExecutor] = {}
@@ -293,6 +295,7 @@ class StreamConsumer:
                 resume_action_client_bake=self._resume_action_client_bake,
                 run_direction_set_task=self._run_direction_set_task,
                 run_view_sheet_task=self._run_view_sheet_task,
+                run_first_frame_task=self._run_first_frame_task,
             )
 
             session = SessionLocal()

--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -88,6 +88,7 @@ def _image_input(payload: dict) -> CharacterImageInput:
         height=int(payload.get("height") or 1024),
         num_images=int(raw_num_images) if raw_num_images is not None else None,
         direction=ActionDirection(payload.get("direction") or ActionDirection.EAST.value),
+        lock_from_south=bool(payload.get("lock_from_south")),
     )
 
 

--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -88,7 +88,7 @@ def _image_input(payload: dict) -> CharacterImageInput:
         height=int(payload.get("height") or 1024),
         num_images=int(raw_num_images) if raw_num_images is not None else None,
         direction=ActionDirection(payload.get("direction") or ActionDirection.EAST.value),
-        lock_from_south=bool(payload.get("lock_from_south")),
+        lock_orientation=bool(payload.get("lock_orientation")),
     )
 
 

--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -22,6 +22,7 @@ from windup_app.server.orchestrator.model import (
     ActionType,
     CharacterActionInput,
     CharacterDirectionSetInput,
+    CharacterFirstFrameInput,
     CharacterImageInput,
     CharacterViewSheetInput,
     GenerationType,
@@ -88,7 +89,6 @@ def _image_input(payload: dict) -> CharacterImageInput:
         height=int(payload.get("height") or 1024),
         num_images=int(raw_num_images) if raw_num_images is not None else None,
         direction=ActionDirection(payload.get("direction") or ActionDirection.EAST.value),
-        lock_orientation=bool(payload.get("lock_orientation")),
     )
 
 
@@ -155,6 +155,23 @@ def _view_sheet_input(payload: dict) -> CharacterViewSheetInput:
     )
 
 
+def _first_frame_input(payload: dict) -> CharacterFirstFrameInput:
+    raw_num_images = payload.get("num_images")
+    raw_type = payload.get("action_type")
+    action_type = raw_type if isinstance(raw_type, ActionType) else ActionType(raw_type)
+    return CharacterFirstFrameInput(
+        character_id=int(payload["character_id"]),
+        reference_image_url=str(payload.get("reference_image_url") or ""),
+        prompt=payload.get("prompt") or "",
+        negative_prompt=payload.get("negative_prompt") or "",
+        width=int(payload.get("width") or 1024),
+        height=int(payload.get("height") or 1024),
+        num_images=int(raw_num_images) if raw_num_images is not None else None,
+        direction=ActionDirection(payload.get("direction") or ActionDirection.EAST.value),
+        action_type=action_type,
+    )
+
+
 def handle_generation(
     payload: dict[str, Any],
     *,
@@ -162,6 +179,7 @@ def handle_generation(
     run_action_task: Callable[..., Any],
     run_direction_set_task: Callable[..., Any] | None = None,
     run_view_sheet_task: Callable[..., Any] | None = None,
+    run_first_frame_task: Callable[..., Any] | None = None,
 ) -> None:
     task_id = int(payload["task_id"])
     task_type = str(payload.get("task_type") or "")
@@ -212,6 +230,10 @@ def handle_generation(
             GenerationType(task_type),
             project_id,
         )
+    elif task_type == GenerationType.CHARACTER_FIRST_FRAME.value:
+        if run_first_frame_task is None:
+            raise RuntimeError("未注入 run_first_frame_task")
+        run_first_frame_task(task_id, _first_frame_input(input_payload), project_id)
     elif task_type == GenerationType.CHARACTER_ACTION.value:
         try:
             run_action_task(task_id, _action_input(input_payload), project_id)
@@ -297,6 +319,7 @@ def dispatch_handler(
     resume_action_client_bake: Callable[..., Any] | None = None,
     run_direction_set_task: Callable[..., Any] | None = None,
     run_view_sheet_task: Callable[..., Any] | None = None,
+    run_first_frame_task: Callable[..., Any] | None = None,
 ) -> None:
     handler = HANDLERS.get(msg_type)
     if handler is None:
@@ -309,6 +332,7 @@ def dispatch_handler(
         resume_action_client_bake=resume_action_client_bake,
         run_direction_set_task=run_direction_set_task,
         run_view_sheet_task=run_view_sheet_task,
+        run_first_frame_task=run_first_frame_task,
     )
 
 
@@ -323,6 +347,7 @@ def _dispatch_generation(
     run_action_task: Callable[..., Any],
     run_direction_set_task: Callable[..., Any] | None = None,
     run_view_sheet_task: Callable[..., Any] | None = None,
+    run_first_frame_task: Callable[..., Any] | None = None,
     **_deps: Any,
 ) -> None:
     handle_generation(
@@ -331,6 +356,7 @@ def _dispatch_generation(
         run_action_task=run_action_task,
         run_direction_set_task=run_direction_set_task,
         run_view_sheet_task=run_view_sheet_task,
+        run_first_frame_task=run_first_frame_task,
     )
 
 

--- a/backend/tests/test_first_frame_executor.py
+++ b/backend/tests/test_first_frame_executor.py
@@ -1,0 +1,80 @@
+"""四向 / 八向动作首帧执行器:该朝向立绘为唯一参考,锁方位后换姿态。"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+from PIL import Image
+
+from windup_app.server.orchestrator.executor import ProjectConstraints
+from windup_app.server.orchestrator.first_frame_executor import FirstFrameTaskExecutor
+from windup_app.server.orchestrator.model import ActionType, CharacterFirstFrameInput
+from windup_common.directions import ActionDirection
+
+_BG = (200, 200, 200)
+
+
+def _master(size: int = 64) -> bytes:
+    arr = np.zeros((size, size, 4), "uint8")
+    arr[:, :, :3] = _BG
+    arr[:, :, 3] = 255
+    arr[20:44, 20:38, :3] = (30, 60, 200)
+    buf = io.BytesIO()
+    Image.fromarray(arr, "RGBA").save(buf, "PNG")
+    return buf.getvalue()
+
+
+class _BackgroundMatte:
+    def cutout(self, png: bytes) -> bytes:
+        arr = np.asarray(Image.open(io.BytesIO(png)).convert("RGBA")).copy()
+        bg = np.all(np.abs(arr[:, :, :3].astype(int) - np.array(_BG)) <= 8, axis=-1)
+        arr[bg, 3] = 0
+        buf = io.BytesIO()
+        Image.fromarray(arr, "RGBA").save(buf, "PNG")
+        return buf.getvalue()
+
+
+def test_first_frame_keeps_attached_heading_and_skips_style_ref():
+    master = _master()
+    seen: dict[str, object] = {}
+
+    class _RecordingGen:
+        def gen_image(self, prompt, refs):
+            seen["prompt"] = prompt
+            seen["n_refs"] = len(refs)
+            return master
+
+    FirstFrameTaskExecutor(
+        image=_RecordingGen(),
+        matte=_BackgroundMatte(),
+        upload=lambda _png: "https://cdn.example.com/result.png",
+        fetch_ref=lambda _url: master,
+    )._produce_first_frame(
+        CharacterFirstFrameInput(
+            character_id=7,
+            reference_image_url="https://cdn.example.com/east.png",
+            prompt="walk cycle first frame, left foot forward",
+            width=64,
+            height=64,
+            num_images=1,
+            direction=ActionDirection.EAST,
+            action_type=ActionType.WALK,
+        ),
+        ProjectConstraints(
+            directions=4,
+            perspective=2,
+            view="top-down view",
+            sprite_w=64,
+            sprite_h=64,
+            sprite_sample_url="https://cdn.example.com/style.png",
+        ),
+    )
+
+    prompt = str(seen["prompt"]).lower()
+    assert "already facing the requested compass heading" in prompt
+    assert "ninety-degree" in prompt
+    assert "walk cycle first frame" in prompt
+    assert "rotate the character, not the camera" not in prompt
+    assert "front-view character master" not in prompt
+    assert seen["n_refs"] == 1

--- a/backend/tests/test_generation_api.py
+++ b/backend/tests/test_generation_api.py
@@ -473,6 +473,7 @@ def _first_frame_payload(project_id: int, character_id: int, **overrides) -> dic
         "width": 64,
         "height": 64,
         "direction": "east",
+        "action_type": "walk",
     }
     payload.update(overrides)
     return payload
@@ -494,14 +495,15 @@ def test_first_frame_uses_heading_template_not_south_master(auth_client):
     ).json()
 
     assert body["code"] == 200
-    assert body["data"]["task_type"] == "character_image"
+    assert body["data"]["task_type"] == "character_first_frame"
     assert body["data"]["status"] == "pending"
     assert body["data"]["input_payload"]["reference_image_url"] == _EAST_TEMPLATE_URL
     assert body["data"]["input_payload"]["direction"] == "east"
-    assert body["data"]["input_payload"]["lock_orientation"] is True
+    assert body["data"]["input_payload"]["action_type"] == "walk"
+    assert "lock_orientation" not in body["data"]["input_payload"]
     assert body["data"]["input_payload"]["prompt"] == "walk first frame, left foot forward"
     assert publisher.enqueue.call_args.kwargs["msg_type"] == "character_image"
-    assert publisher.enqueue.call_args.kwargs["payload"]["task_type"] == "character_image"
+    assert publisher.enqueue.call_args.kwargs["payload"]["task_type"] == "character_first_frame"
     assert publisher.enqueue.call_args.kwargs["stream"] == "windup:stream:generation-image"
 
 

--- a/backend/tests/test_generation_api.py
+++ b/backend/tests/test_generation_api.py
@@ -70,6 +70,7 @@ def _direction_set_payload(project_id: int, character_id: int, **overrides) -> d
 
 
 _MASTER_URL = "https://cdn.example.com/masters/hero.png"
+_EAST_TEMPLATE_URL = "https://cdn.example.com/masters/hero-east.png"
 
 
 def _action_payload(project_id: int, character_id: int, **overrides) -> dict:
@@ -467,6 +468,7 @@ def _first_frame_payload(project_id: int, character_id: int, **overrides) -> dic
     payload = {
         "project_id": project_id,
         "character_id": character_id,
+        "reference_image_url": _EAST_TEMPLATE_URL,
         "prompt": "walk first frame, left foot forward",
         "width": 64,
         "height": 64,
@@ -476,7 +478,7 @@ def _first_frame_payload(project_id: int, character_id: int, **overrides) -> dic
     return payload
 
 
-def test_first_frame_binds_south_master_and_shares_image_queue(auth_client):
+def test_first_frame_uses_heading_template_not_south_master(auth_client):
     project = _create_project(auth_client)
     character = _create_character(
         auth_client,
@@ -494,28 +496,30 @@ def test_first_frame_binds_south_master_and_shares_image_queue(auth_client):
     assert body["code"] == 200
     assert body["data"]["task_type"] == "character_image"
     assert body["data"]["status"] == "pending"
-    assert body["data"]["input_payload"]["reference_image_url"] == _MASTER_URL
+    assert body["data"]["input_payload"]["reference_image_url"] == _EAST_TEMPLATE_URL
     assert body["data"]["input_payload"]["direction"] == "east"
-    assert body["data"]["input_payload"]["lock_from_south"] is True
+    assert body["data"]["input_payload"]["lock_orientation"] is True
     assert body["data"]["input_payload"]["prompt"] == "walk first frame, left foot forward"
     assert publisher.enqueue.call_args.kwargs["msg_type"] == "character_image"
     assert publisher.enqueue.call_args.kwargs["payload"]["task_type"] == "character_image"
     assert publisher.enqueue.call_args.kwargs["stream"] == "windup:stream:generation-image"
 
 
-def test_first_frame_without_confirmed_master_is_rejected_before_queueing(auth_client):
+def test_first_frame_without_heading_template_is_rejected_before_queueing(auth_client):
     project = _create_project(auth_client)
-    character = _create_character(auth_client, project["id"])
+    character = _create_character(
+        auth_client, project["id"], reference_image_url=_MASTER_URL,
+    )
     publisher = auth_client.app.state.mq_publisher
     publisher.reset_mock()
 
     response = auth_client.post(
         "/generation/first-frame",
-        json=_first_frame_payload(project["id"], character["id"]),
+        json=_first_frame_payload(project["id"], character["id"], reference_image_url=""),
     )
 
     assert response.json()["code"] == 400
-    assert "请先选择并确认角色母版" in response.json()["message"]
+    assert "该朝向已确认的立绘" in response.json()["message"]
     publisher.enqueue.assert_not_called()
 
 
@@ -552,29 +556,6 @@ def test_first_frame_rejects_west_for_four_way_project(auth_client):
 
     assert body["code"] == 400
     assert "west" in body["message"]
-    publisher.enqueue.assert_not_called()
-
-
-def test_first_frame_rejects_client_supplied_reference_url(auth_client):
-    project = _create_project(auth_client)
-    character = _create_character(
-        auth_client, project["id"], reference_image_url=_MASTER_URL,
-    )
-    publisher = auth_client.app.state.mq_publisher
-    publisher.reset_mock()
-
-    response = auth_client.post(
-        "/generation/first-frame",
-        json=_first_frame_payload(
-            project["id"],
-            character["id"],
-            reference_image_url="https://evil.example/not-the-master.png",
-        ),
-    )
-
-    body = response.json()
-    assert body["code"] == 400
-    assert "reference_image_url" in body["message"] or "Extra" in body["message"]
     publisher.enqueue.assert_not_called()
 
 

--- a/backend/tests/test_generation_api.py
+++ b/backend/tests/test_generation_api.py
@@ -463,6 +463,121 @@ def test_view_sheet_rejects_client_supplied_reference_url(auth_client):
     publisher.enqueue.assert_not_called()
 
 
+def _first_frame_payload(project_id: int, character_id: int, **overrides) -> dict:
+    payload = {
+        "project_id": project_id,
+        "character_id": character_id,
+        "prompt": "walk first frame, left foot forward",
+        "width": 64,
+        "height": 64,
+        "direction": "east",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_first_frame_binds_south_master_and_shares_image_queue(auth_client):
+    project = _create_project(auth_client)
+    character = _create_character(
+        auth_client,
+        project["id"],
+        reference_image_url=_MASTER_URL,
+    )
+    publisher = auth_client.app.state.mq_publisher
+    publisher.reset_mock()
+
+    body = auth_client.post(
+        "/generation/first-frame",
+        json=_first_frame_payload(project["id"], character["id"]),
+    ).json()
+
+    assert body["code"] == 200
+    assert body["data"]["task_type"] == "character_image"
+    assert body["data"]["status"] == "pending"
+    assert body["data"]["input_payload"]["reference_image_url"] == _MASTER_URL
+    assert body["data"]["input_payload"]["direction"] == "east"
+    assert body["data"]["input_payload"]["lock_from_south"] is True
+    assert body["data"]["input_payload"]["prompt"] == "walk first frame, left foot forward"
+    assert publisher.enqueue.call_args.kwargs["msg_type"] == "character_image"
+    assert publisher.enqueue.call_args.kwargs["payload"]["task_type"] == "character_image"
+    assert publisher.enqueue.call_args.kwargs["stream"] == "windup:stream:generation-image"
+
+
+def test_first_frame_without_confirmed_master_is_rejected_before_queueing(auth_client):
+    project = _create_project(auth_client)
+    character = _create_character(auth_client, project["id"])
+    publisher = auth_client.app.state.mq_publisher
+    publisher.reset_mock()
+
+    response = auth_client.post(
+        "/generation/first-frame",
+        json=_first_frame_payload(project["id"], character["id"]),
+    )
+
+    assert response.json()["code"] == 400
+    assert "请先选择并确认角色母版" in response.json()["message"]
+    publisher.enqueue.assert_not_called()
+
+
+def test_first_frame_rejects_unidirectional_project(auth_client):
+    project = _create_project(auth_client, name="单向", directional_movement=1)
+    character = _create_character(
+        auth_client, project["id"], reference_image_url=_MASTER_URL,
+    )
+    publisher = auth_client.app.state.mq_publisher
+    publisher.reset_mock()
+
+    response = auth_client.post(
+        "/generation/first-frame",
+        json=_first_frame_payload(project["id"], character["id"]),
+    )
+
+    assert response.json()["code"] == 400
+    assert "只用于四向或八向" in response.json()["message"]
+    publisher.enqueue.assert_not_called()
+
+
+def test_first_frame_rejects_west_for_four_way_project(auth_client):
+    project = _create_project(auth_client)
+    character = _create_character(
+        auth_client, project["id"], reference_image_url=_MASTER_URL,
+    )
+    publisher = auth_client.app.state.mq_publisher
+    publisher.reset_mock()
+
+    body = auth_client.post(
+        "/generation/first-frame",
+        json=_first_frame_payload(project["id"], character["id"], direction="west"),
+    ).json()
+
+    assert body["code"] == 400
+    assert "west" in body["message"]
+    publisher.enqueue.assert_not_called()
+
+
+def test_first_frame_rejects_client_supplied_reference_url(auth_client):
+    project = _create_project(auth_client)
+    character = _create_character(
+        auth_client, project["id"], reference_image_url=_MASTER_URL,
+    )
+    publisher = auth_client.app.state.mq_publisher
+    publisher.reset_mock()
+
+    response = auth_client.post(
+        "/generation/first-frame",
+        json=_first_frame_payload(
+            project["id"],
+            character["id"],
+            reference_image_url="https://evil.example/not-the-master.png",
+        ),
+    )
+
+    body = response.json()
+    assert body["code"] == 400
+    assert "reference_image_url" in body["message"] or "Extra" in body["message"]
+    publisher.enqueue.assert_not_called()
+
+
 def test_action_character_must_belong_to_requested_project(auth_client):
     first_project = _create_project(auth_client, "项目一")
     second_project = _create_project(auth_client, "项目二")

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -477,6 +477,7 @@ def test_prepaid_cost_scales_with_model_calls():
     assert billing.prepaid_cost(GenerationType.CHARACTER_IMAGE, 3) == unit * 3
     assert billing.prepaid_cost(GenerationType.CHARACTER_FOUR_VIEW, 2) == unit * 2
     assert billing.prepaid_cost(GenerationType.CHARACTER_EIGHT_VIEW, 4) == unit * 4
+    assert billing.prepaid_cost(GenerationType.CHARACTER_FIRST_FRAME, 3) == unit * 3
     assert billing.prepaid_cost(GenerationType.CHARACTER_ACTION, 1) == quota_settings.generate_action_cost
     with pytest.raises(ValueError, match="model_calls"):
         billing.prepaid_cost(GenerationType.CHARACTER_IMAGE, 0)

--- a/backend/tests/test_master_cutout.py
+++ b/backend/tests/test_master_cutout.py
@@ -201,50 +201,6 @@ def test_confirmed_master_is_sent_as_identity_reference_without_style_sample():
     assert "preserve its identity" in str(seen["prompt"])
 
 
-def test_lock_orientation_first_frame_keeps_attached_heading():
-    master = _master()
-    seen: dict[str, object] = {}
-
-    class _RecordingGen:
-        def gen_image(self, prompt, refs):
-            seen["prompt"] = prompt
-            seen["n_refs"] = len(refs)
-            return master
-
-    ImageTaskExecutor(
-        image=_RecordingGen(),
-        matte=_BackgroundMatte(),
-        upload=lambda _png: "https://cdn.example.com/result.png",
-        fetch_ref=lambda _url: master,
-    )._produce_image(
-        CharacterImageInput(
-            reference_image_url="https://cdn.example.com/east.png",
-            prompt="walk cycle first frame, left foot forward",
-            width=64,
-            height=64,
-            num_images=1,
-            direction=ActionDirection.EAST,
-            lock_orientation=True,
-        ),
-        ProjectConstraints(
-            directions=4,
-            perspective=2,
-            view="top-down view",
-            sprite_w=64,
-            sprite_h=64,
-            sprite_sample_url="https://cdn.example.com/style.png",
-        ),
-    )
-
-    prompt = str(seen["prompt"]).lower()
-    assert "already facing the requested compass heading" in prompt
-    assert "ninety-degree" in prompt
-    assert "walk cycle first frame" in prompt
-    assert "rotate the character, not the camera" not in prompt
-    assert "front-view character master" not in prompt
-    assert seen["n_refs"] == 1
-
-
 @pytest.mark.parametrize(
     ("direction", "heading"),
     [

--- a/backend/tests/test_master_cutout.py
+++ b/backend/tests/test_master_cutout.py
@@ -201,6 +201,49 @@ def test_confirmed_master_is_sent_as_identity_reference_without_style_sample():
     assert "preserve its identity" in str(seen["prompt"])
 
 
+def test_lock_from_south_first_frame_uses_view_sheet_camera_not_character_turn():
+    master = _master()
+    seen: dict[str, object] = {}
+
+    class _RecordingGen:
+        def gen_image(self, prompt, refs):
+            seen["prompt"] = prompt
+            seen["n_refs"] = len(refs)
+            return master
+
+    ImageTaskExecutor(
+        image=_RecordingGen(),
+        matte=_BackgroundMatte(),
+        upload=lambda _png: "https://cdn.example.com/result.png",
+        fetch_ref=lambda _url: master,
+    )._produce_image(
+        CharacterImageInput(
+            reference_image_url="https://cdn.example.com/south.png",
+            prompt="walk cycle first frame, left foot forward",
+            width=64,
+            height=64,
+            num_images=1,
+            direction=ActionDirection.EAST,
+            lock_from_south=True,
+        ),
+        ProjectConstraints(
+            directions=4,
+            perspective=2,
+            view="top-down view",
+            sprite_w=64,
+            sprite_h=64,
+            sprite_sample_url="https://cdn.example.com/style.png",
+        ),
+    )
+
+    prompt = str(seen["prompt"]).lower()
+    assert "front-view character master" in prompt
+    assert "ninety-degree" in prompt
+    assert "walk cycle first frame" in prompt
+    assert "rotate the character, not the camera" not in prompt
+    assert seen["n_refs"] == 1
+
+
 @pytest.mark.parametrize(
     ("direction", "heading"),
     [

--- a/backend/tests/test_master_cutout.py
+++ b/backend/tests/test_master_cutout.py
@@ -201,7 +201,7 @@ def test_confirmed_master_is_sent_as_identity_reference_without_style_sample():
     assert "preserve its identity" in str(seen["prompt"])
 
 
-def test_lock_from_south_first_frame_uses_view_sheet_camera_not_character_turn():
+def test_lock_orientation_first_frame_keeps_attached_heading():
     master = _master()
     seen: dict[str, object] = {}
 
@@ -218,13 +218,13 @@ def test_lock_from_south_first_frame_uses_view_sheet_camera_not_character_turn()
         fetch_ref=lambda _url: master,
     )._produce_image(
         CharacterImageInput(
-            reference_image_url="https://cdn.example.com/south.png",
+            reference_image_url="https://cdn.example.com/east.png",
             prompt="walk cycle first frame, left foot forward",
             width=64,
             height=64,
             num_images=1,
             direction=ActionDirection.EAST,
-            lock_from_south=True,
+            lock_orientation=True,
         ),
         ProjectConstraints(
             directions=4,
@@ -237,10 +237,11 @@ def test_lock_from_south_first_frame_uses_view_sheet_camera_not_character_turn()
     )
 
     prompt = str(seen["prompt"]).lower()
-    assert "front-view character master" in prompt
+    assert "already facing the requested compass heading" in prompt
     assert "ninety-degree" in prompt
     assert "walk cycle first frame" in prompt
     assert "rotate the character, not the camera" not in prompt
+    assert "front-view character master" not in prompt
     assert seen["n_refs"] == 1
 
 

--- a/backend/tests/test_mq_catalog.py
+++ b/backend/tests/test_mq_catalog.py
@@ -139,6 +139,7 @@ def test_msg_type_for_generation_skips_poll_types():
     assert msg_type_for_generation("character_direction_set") == MSG_TYPE_CHARACTER_IMAGE
     assert msg_type_for_generation("character_four_view") == MSG_TYPE_CHARACTER_IMAGE
     assert msg_type_for_generation("character_eight_view") == MSG_TYPE_CHARACTER_IMAGE
+    assert msg_type_for_generation("character_first_frame") == MSG_TYPE_CHARACTER_IMAGE
     assert msg_type_for_generation(MSG_TYPE_CHARACTER_ACTION) == MSG_TYPE_CHARACTER_ACTION
     with pytest.raises(ValueError, match="未知任务类型"):
         msg_type_for_generation(MSG_TYPE_CHARACTER_ACTION_POLL)

--- a/backend/tests/test_mq_worker.py
+++ b/backend/tests/test_mq_worker.py
@@ -1452,28 +1452,28 @@ def test_image_input_keeps_explicit_zero_num_images():
     assert rebuilt.num_images == 0
 
 
-def test_image_input_restores_lock_from_south():
+def test_image_input_restores_lock_orientation():
     from windup_app.worker.handlers import _image_input
 
     rebuilt = _image_input(
         {
             "prompt": "walk first frame",
-            "reference_image_url": "https://cdn.example.com/south.png",
+            "reference_image_url": "https://cdn.example.com/east.png",
             "direction": "east",
-            "lock_from_south": True,
+            "lock_orientation": True,
         }
     )
 
-    assert rebuilt.lock_from_south is True
+    assert rebuilt.lock_orientation is True
     assert rebuilt.direction is ActionDirection.EAST
 
 
-def test_image_input_defaults_lock_from_south_off():
+def test_image_input_defaults_lock_orientation_off():
     from windup_app.worker.handlers import _image_input
 
     rebuilt = _image_input({"prompt": "hero"})
 
-    assert rebuilt.lock_from_south is False
+    assert rebuilt.lock_orientation is False
 
 
 def test_warmup_injects_one_matte_into_both_executors(monkeypatch):

--- a/backend/tests/test_mq_worker.py
+++ b/backend/tests/test_mq_worker.py
@@ -163,6 +163,45 @@ def test_handle_generation_dispatches_image_task(db_session, engine, monkeypatch
     assert run_image.call_args.args[1].direction is ActionDirection.NORTH
 
 
+def test_handle_generation_dispatches_first_frame_task(db_session, engine, monkeypatch):
+    from windup_app.server.orchestrator.model import CharacterFirstFrameInput
+
+    _patch_worker_session_local(monkeypatch, engine)
+    seed_credit_account(db_session, 1)
+    db_session.commit()
+
+    service = AiGenerationService()
+    task = service.generate_character_first_frame(
+        db_session,
+        user_id=1,
+        project_id=1,
+        input=CharacterFirstFrameInput(
+            character_id=7,
+            reference_image_url="https://cdn.example.com/east.png",
+            prompt="walk first frame",
+            width=64,
+            height=64,
+            direction=ActionDirection.EAST,
+            action_type=ActionType.WALK,
+        ),
+    )
+    db_session.commit()
+
+    run_first_frame = MagicMock()
+    handle_generation(
+        {"task_id": task.id, "task_type": GenerationType.CHARACTER_FIRST_FRAME.value},
+        run_image_task=MagicMock(),
+        run_action_task=MagicMock(),
+        run_first_frame_task=run_first_frame,
+    )
+    run_first_frame.assert_called_once()
+    assert run_first_frame.call_args.args[0] == task.id
+    rebuilt = run_first_frame.call_args.args[1]
+    assert rebuilt.direction is ActionDirection.EAST
+    assert rebuilt.reference_image_url == "https://cdn.example.com/east.png"
+    assert rebuilt.action_type is ActionType.WALK
+
+
 def test_dispatch_handler_unknown_type_raises():
     with pytest.raises(ValueError, match="未知消息类型"):
         dispatch_handler(
@@ -1452,28 +1491,22 @@ def test_image_input_keeps_explicit_zero_num_images():
     assert rebuilt.num_images == 0
 
 
-def test_image_input_restores_lock_orientation():
-    from windup_app.worker.handlers import _image_input
+def test_first_frame_input_restores_heading_template():
+    from windup_app.worker.handlers import _first_frame_input
 
-    rebuilt = _image_input(
+    rebuilt = _first_frame_input(
         {
+            "character_id": 7,
             "prompt": "walk first frame",
             "reference_image_url": "https://cdn.example.com/east.png",
             "direction": "east",
-            "lock_orientation": True,
+            "action_type": "walk",
         }
     )
 
-    assert rebuilt.lock_orientation is True
     assert rebuilt.direction is ActionDirection.EAST
-
-
-def test_image_input_defaults_lock_orientation_off():
-    from windup_app.worker.handlers import _image_input
-
-    rebuilt = _image_input({"prompt": "hero"})
-
-    assert rebuilt.lock_orientation is False
+    assert rebuilt.action_type is ActionType.WALK
+    assert rebuilt.reference_image_url == "https://cdn.example.com/east.png"
 
 
 def test_warmup_injects_one_matte_into_both_executors(monkeypatch):

--- a/backend/tests/test_mq_worker.py
+++ b/backend/tests/test_mq_worker.py
@@ -1452,6 +1452,30 @@ def test_image_input_keeps_explicit_zero_num_images():
     assert rebuilt.num_images == 0
 
 
+def test_image_input_restores_lock_from_south():
+    from windup_app.worker.handlers import _image_input
+
+    rebuilt = _image_input(
+        {
+            "prompt": "walk first frame",
+            "reference_image_url": "https://cdn.example.com/south.png",
+            "direction": "east",
+            "lock_from_south": True,
+        }
+    )
+
+    assert rebuilt.lock_from_south is True
+    assert rebuilt.direction is ActionDirection.EAST
+
+
+def test_image_input_defaults_lock_from_south_off():
+    from windup_app.worker.handlers import _image_input
+
+    rebuilt = _image_input({"prompt": "hero"})
+
+    assert rebuilt.lock_from_south is False
+
+
 def test_warmup_injects_one_matte_into_both_executors(monkeypatch):
     """预热实例必须交给动作/出图执行器,不能 warmup 完丢掉再各 new 一套。"""
     from windup_app.bootstrap import worker as w

--- a/backend/tests/test_prompt_assets.py
+++ b/backend/tests/test_prompt_assets.py
@@ -38,6 +38,8 @@ SECTIONS = {
     "attack.md": [f"{a.value}.{f}" for a in AttackArchetype for f in ("side", "front")],
     "view_sheet.md": [
         "identity",
+        "identity.first_frame",
+        "first_frame.pose_lock",
         "pose",
         "framing",
         "elevation.side",

--- a/backend/tests/test_view_sheet_prompt.py
+++ b/backend/tests/test_view_sheet_prompt.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from windup_ai_engine.prompt import build_view_sheet_prompt
+from windup_ai_engine.prompt import (
+    build_oriented_first_frame_prompt,
+    build_view_sheet_prompt,
+    view_for_perspective,
+)
 from windup_ai_engine.prompt._md import load_section
 from windup_common.directions import ActionDirection
 from windup_common.models import CharacterView
@@ -65,3 +69,28 @@ def test_illegal_direction_or_view_raises():
         build_view_sheet_prompt("eastt")
     with pytest.raises(ValueError):
         build_view_sheet_prompt(ActionDirection.EAST, view="topdown")
+
+
+def test_first_frame_reuses_camera_lock_and_replaces_idle_pose():
+    text = build_oriented_first_frame_prompt(
+        ActionDirection.EAST,
+        action_prompt="walk cycle first frame, left foot forward",
+    )
+    assert "FRONT-VIEW character master" in text
+    assert "ninety-degree" in text
+    assert "walk cycle first frame, left foot forward" in text
+    assert "Neutral idle standing pose" not in text
+    assert text.index("FRONT-VIEW character master") < text.index("ninety-degree")
+    assert text.endswith("walk cycle first frame, left foot forward")
+
+
+def test_first_frame_blank_action_prompt_raises():
+    with pytest.raises(ValueError, match="动作描述"):
+        build_oriented_first_frame_prompt(ActionDirection.SOUTH, action_prompt="   ")
+
+
+def test_view_for_perspective_maps_project_camera():
+    assert view_for_perspective(1) is CharacterView.SIDE
+    assert view_for_perspective(2) is CharacterView.TOP_DOWN
+    assert view_for_perspective(3) is CharacterView.ISOMETRIC
+    assert view_for_perspective(99) is CharacterView.SIDE

--- a/backend/tests/test_view_sheet_prompt.py
+++ b/backend/tests/test_view_sheet_prompt.py
@@ -71,16 +71,16 @@ def test_illegal_direction_or_view_raises():
         build_view_sheet_prompt(ActionDirection.EAST, view="topdown")
 
 
-def test_first_frame_reuses_camera_lock_and_replaces_idle_pose():
+def test_first_frame_reuses_heading_lock_and_replaces_idle_pose():
     text = build_oriented_first_frame_prompt(
         ActionDirection.EAST,
         action_prompt="walk cycle first frame, left foot forward",
     )
-    assert "FRONT-VIEW character master" in text
+    assert "already facing the requested compass heading" in text
+    assert "FRONT-VIEW character master" not in text
     assert "ninety-degree" in text
     assert "walk cycle first frame, left foot forward" in text
     assert "Neutral idle standing pose" not in text
-    assert text.index("FRONT-VIEW character master") < text.index("ninety-degree")
     assert text.endswith("walk cycle first frame, left foot forward")
 
 

--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -511,6 +511,54 @@ describe('createGenerationApis', () => {
     })
   })
 
+  it('四向动作首帧走锁定朝向端点，由角色正视母版出图', async () => {
+    const request = vi.fn(async (_url: string, _init?: RequestInit) =>
+      success(
+        taskData({
+          input_payload: { num_images: 3, direction: 'east', lock_from_south: true },
+          result: {
+            type: 'character_image',
+            direction: 'east',
+            image_urls: candidateUrls(),
+          },
+        }),
+      ),
+    )
+    const apis = createGenerationApis({
+      baseUrl: '',
+      transport: { request, stream: vi.fn(() => vi.fn()) },
+    })
+
+    const generation = await apis.create({
+      type: 'first_frame',
+      projectId: '42',
+      characterId: '9',
+      actionType: 'walk',
+      prompt: 'left foot forward',
+      referenceMedia: [],
+      spriteWidth: 64,
+      spriteHeight: 96,
+      direction: 'east',
+    })
+
+    expect(request.mock.calls[0]?.[0]).toBe('/generation/first-frame')
+    expect(JSON.parse(String(request.mock.calls[0]?.[1]?.body))).toEqual({
+      project_id: 42,
+      character_id: 9,
+      prompt: 'left foot forward',
+      negative_prompt: '',
+      width: 64,
+      height: 96,
+      num_images: 3,
+      direction: 'east',
+    })
+    expect(generation.result).toEqual({
+      type: 'first_frame',
+      direction: 'east',
+      images: candidates(),
+    })
+  })
+
   it('没有角色母版时拒绝创建动作首帧任务', async () => {
     const apis = createGenerationApis({
       transport: { request: vi.fn(), stream: vi.fn(() => vi.fn()) },

--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -515,9 +515,10 @@ describe('createGenerationApis', () => {
     const request = vi.fn(async (_url: string, _init?: RequestInit) =>
       success(
         taskData({
-          input_payload: { num_images: 3, direction: 'east', lock_orientation: true },
+          task_type: 'character_first_frame',
+          input_payload: { num_images: 3, direction: 'east', action_type: 'walk' },
           result: {
-            type: 'character_image',
+            type: 'character_first_frame',
             direction: 'east',
             image_urls: candidateUrls(),
           },
@@ -552,7 +553,42 @@ describe('createGenerationApis', () => {
       height: 96,
       num_images: 3,
       direction: 'east',
+      action_type: 'walk',
     })
+    expect(generation.result).toEqual({
+      type: 'first_frame',
+      direction: 'east',
+      images: candidates(),
+    })
+  })
+
+  it('查询无期望时按 character_first_frame 恢复为首帧阶段', async () => {
+    const apis = createGenerationApis({
+      transport: {
+        request: vi.fn(async () =>
+          success(
+            taskData({
+              task_type: 'character_first_frame',
+              input_payload: {
+                num_images: 3,
+                direction: 'east',
+                action_type: 'walk',
+              },
+              result: {
+                type: 'character_first_frame',
+                direction: 'east',
+                image_urls: candidateUrls(),
+              },
+            }),
+          ),
+        ),
+        stream: vi.fn(() => vi.fn()),
+      },
+    })
+
+    const generation = await apis.get('42', '91')
+
+    expect(generation.type).toBe('first_frame')
     expect(generation.result).toEqual({
       type: 'first_frame',
       direction: 'east',

--- a/frontend/src/entities/generation/api.test.ts
+++ b/frontend/src/entities/generation/api.test.ts
@@ -511,11 +511,11 @@ describe('createGenerationApis', () => {
     })
   })
 
-  it('四向动作首帧走锁定朝向端点，由角色正视母版出图', async () => {
+  it('四向动作首帧走锁定朝向端点，参考该朝向立绘', async () => {
     const request = vi.fn(async (_url: string, _init?: RequestInit) =>
       success(
         taskData({
-          input_payload: { num_images: 3, direction: 'east', lock_from_south: true },
+          input_payload: { num_images: 3, direction: 'east', lock_orientation: true },
           result: {
             type: 'character_image',
             direction: 'east',
@@ -535,7 +535,7 @@ describe('createGenerationApis', () => {
       characterId: '9',
       actionType: 'walk',
       prompt: 'left foot forward',
-      referenceMedia: [],
+      referenceMedia: [reference('https://cdn.test/east.png')],
       spriteWidth: 64,
       spriteHeight: 96,
       direction: 'east',
@@ -545,6 +545,7 @@ describe('createGenerationApis', () => {
     expect(JSON.parse(String(request.mock.calls[0]?.[1]?.body))).toEqual({
       project_id: 42,
       character_id: 9,
+      reference_image_url: 'https://cdn.test/east.png',
       prompt: 'left foot forward',
       negative_prompt: '',
       width: 64,
@@ -557,6 +558,26 @@ describe('createGenerationApis', () => {
       direction: 'east',
       images: candidates(),
     })
+  })
+
+  it('四向动作首帧缺少该朝向立绘时拒绝提交', async () => {
+    const apis = createGenerationApis({
+      transport: { request: vi.fn(), stream: vi.fn(() => vi.fn()) },
+    })
+
+    await expect(
+      apis.create({
+        type: 'first_frame',
+        projectId: '42',
+        characterId: '9',
+        actionType: 'walk',
+        prompt: 'left foot forward',
+        referenceMedia: [],
+        spriteWidth: 64,
+        spriteHeight: 96,
+        direction: 'east',
+      }),
+    ).rejects.toThrow('动作首帧生成必须提供该朝向已确认的立绘')
   })
 
   it('没有角色母版时拒绝创建动作首帧任务', async () => {

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -66,6 +66,7 @@ type BackendGenerationType =
   | 'character_direction_set'
   | 'character_four_view'
   | 'character_eight_view'
+  | 'character_first_frame'
   | 'character_action'
 
 const TASK_STATUSES = new Set<TaskStatus>(['pending', 'running', 'completed', 'partial', 'failed'])
@@ -130,6 +131,7 @@ function backendTaskType(value: unknown): BackendGenerationType {
     value !== 'character_direction_set' &&
     value !== 'character_four_view' &&
     value !== 'character_eight_view' &&
+    value !== 'character_first_frame' &&
     value !== 'character_action'
   ) {
     throw new GenerationApiError('生成任务 task_type 无效', 200)
@@ -216,8 +218,17 @@ function parseTaskDto(value: unknown): GenerationTaskDto {
 
 function expectedBackendType(type: GenerationTaskType): BackendGenerationType {
   if (type === 'complete_animation') return 'character_action'
+  if (type === 'first_frame') return 'character_first_frame'
   if (type === 'character_four_view' || type === 'character_eight_view') return type
   return type === 'character_direction_set' ? 'character_direction_set' : 'character_image'
+}
+
+function matchesBackendType(type: GenerationTaskType, taskType: BackendGenerationType): boolean {
+  // 单向首帧仍走 /generation/image；四向/八向走 /generation/first-frame。
+  if (type === 'first_frame') {
+    return taskType === 'character_first_frame' || taskType === 'character_image'
+  }
+  return taskType === expectedBackendType(type)
 }
 
 export const IMAGE_CANDIDATE_COUNT = 3
@@ -259,7 +270,11 @@ function mapImageResult(
   expectation: Extract<GenerationExpectation, { type: 'character_template' | 'first_frame' }>,
   expectedCandidateCount?: ImageCandidateCount,
 ): GenerationResult {
-  if (result.type !== 'character_image') {
+  const allowedResultType =
+    expectation.type === 'first_frame'
+      ? result.type === 'character_first_frame' || result.type === 'character_image'
+      : result.type === 'character_image'
+  if (!allowedResultType) {
     throw new GenerationApiError('角色图片结果 type 无效', 200)
   }
   const resultDirection = taskDirection(result.direction, '角色图片结果 direction')
@@ -647,6 +662,18 @@ function inferExpectation(dto: GenerationTaskDto): GenerationExpectation {
   const direction = dto.inputPayload
     ? taskDirection(dto.inputPayload.direction, '生成任务 direction')
     : undefined
+  if (dto.taskType === 'character_first_frame') {
+    if (dto.inputPayload === null) {
+      throw new GenerationApiError('动作首帧任务缺少 input_payload', 200)
+    }
+    const actionType = dto.inputPayload.action_type
+    if (typeof actionType !== 'string' || !ACTION_TYPES.has(actionType)) {
+      throw new GenerationApiError('动作首帧任务 input_payload.action_type 无效', 200)
+    }
+    return direction === undefined
+      ? { type: 'first_frame', actionType }
+      : { type: 'first_frame', actionType, direction }
+  }
   if (dto.taskType === 'character_image') {
     return direction === undefined
       ? { type: 'character_template' }
@@ -679,7 +706,7 @@ function validateTaskIdentity(
   if (expectedTaskId !== undefined && dto.id !== expectedTaskId) {
     throw new GenerationApiError(`生成任务 ID 与请求的 ${expectedTaskId} 不一致`, 200)
   }
-  if (dto.taskType !== expectedBackendType(expectation.type)) {
+  if (!matchesBackendType(expectation.type, dto.taskType)) {
     throw new GenerationApiError(`生成任务类型与 ${expectation.type} 不匹配`, 200)
   }
   validateStatusError(dto.status, dto.errorMessage)
@@ -837,7 +864,7 @@ function mapEvent<TType extends GenerationTaskType>(
       },
     } as GenerationEvent<TType>
   }
-  if (backendTaskType(value.task_type) !== expectedBackendType(expectation.type)) {
+  if (!matchesBackendType(expectation.type, backendTaskType(value.task_type))) {
     throw new GenerationApiError(`task_update 类型与 ${expectation.type} 不匹配`, 200)
   }
   if (
@@ -1013,6 +1040,7 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
             height: inputPositiveInteger(input.spriteHeight, 'spriteHeight'),
             num_images: candidateCount,
             direction: input.direction ?? DEFAULT_DIRECTION,
+            action_type: input.actionType,
           },
           candidateCount,
         )

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -898,6 +898,7 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
       | '/generation/image'
       | '/generation/four-view'
       | '/generation/eight-view'
+      | '/generation/first-frame'
       | '/generation/action',
     projectId: number,
     expectation: Extract<GenerationExpectation, { type: TType }>,
@@ -981,6 +982,37 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
           direction: input.direction ?? DEFAULT_DIRECTION,
         })
         expectations.set(generation.id, expectation)
+        return generation as Generation<T['type']>
+      }
+
+      if (input.type === 'first_frame' && input.characterId) {
+        const expectation = {
+          type: 'first_frame' as const,
+          actionType: input.actionType,
+          ...(input.direction === undefined ? {} : { direction: input.direction }),
+        }
+        const candidateCount = imageCandidateCount(
+          input.candidateCount ?? IMAGE_CANDIDATE_COUNT,
+          'candidateCount',
+        )
+        const generation = await post(
+          '/generation/first-frame',
+          projectId,
+          expectation,
+          {
+            project_id: projectId,
+            character_id: inputPositiveInteger(input.characterId, 'characterId'),
+            prompt: input.prompt ?? '',
+            negative_prompt: '',
+            width: inputPositiveInteger(input.spriteWidth, 'spriteWidth'),
+            height: inputPositiveInteger(input.spriteHeight, 'spriteHeight'),
+            num_images: candidateCount,
+            direction: input.direction ?? DEFAULT_DIRECTION,
+          },
+          candidateCount,
+        )
+        expectations.set(generation.id, expectation)
+        candidateCounts.set(generation.id, candidateCount)
         return generation as Generation<T['type']>
       }
 

--- a/frontend/src/entities/generation/api.ts
+++ b/frontend/src/entities/generation/api.ts
@@ -995,6 +995,10 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
           input.candidateCount ?? IMAGE_CANDIDATE_COUNT,
           'candidateCount',
         )
+        const referenceImageUrl = input.referenceMedia[0] ? String(input.referenceMedia[0]) : null
+        if (!referenceImageUrl) {
+          throw new GenerationApiError('动作首帧生成必须提供该朝向已确认的立绘')
+        }
         const generation = await post(
           '/generation/first-frame',
           projectId,
@@ -1002,6 +1006,7 @@ export function createGenerationApis(config: GenerationApiConfig): GenerationApi
           {
             project_id: projectId,
             character_id: inputPositiveInteger(input.characterId, 'characterId'),
+            reference_image_url: referenceImageUrl,
             prompt: input.prompt ?? '',
             negative_prompt: '',
             width: inputPositiveInteger(input.spriteWidth, 'spriteWidth'),

--- a/frontend/src/entities/generation/index.ts
+++ b/frontend/src/entities/generation/index.ts
@@ -20,8 +20,9 @@ export type TaskStatus = 'pending' | 'running' | 'completed' | 'partial' | 'fail
 
 /**
  * 生成对应的三个前端可见异步步骤。
- * 它是前端工作流粒度，不等于后端 task_type——后端只有 character_image 与
- * character_action 两种，character_template 和 first_frame 都落在 character_image 上。
+ * 它是前端工作流粒度，不等于后端 task_type——后端有 character_image、
+ * character_first_frame、character_action 等；character_template 仍落在
+ * character_image 上，四向/八向动作首帧落在 character_first_frame 上。
  * 完整动画内部可含视频生成、截帧和多次图像处理，但对前端仍是一次 Generation。
  */
 export type ViewSheetGenerationType = 'character_four_view' | 'character_eight_view'
@@ -82,7 +83,8 @@ export interface FirstFrameGenerationInput extends GenerationInputBase {
   /** 首帧必须与角色母版使用同一个真实源方向。 */
   direction?: ActionDirection
   /**
-   * 四向 / 八向锁定朝向时必填。后端走 `/generation/first-frame`，参考图仍是该朝向立绘。
+   * 四向 / 八向锁定朝向时必填。后端走 `/generation/first-frame`，
+   * 任务类型为 `character_first_frame`，参考图仍是该朝向立绘。
    * 单向首帧不传，仍走 `/generation/image`。
    */
   characterId?: string

--- a/frontend/src/entities/generation/index.ts
+++ b/frontend/src/entities/generation/index.ts
@@ -82,7 +82,7 @@ export interface FirstFrameGenerationInput extends GenerationInputBase {
   /** 首帧必须与角色母版使用同一个真实源方向。 */
   direction?: ActionDirection
   /**
-   * 四向 / 八向锁定朝向时必填。后端用角色已确认的正视母版，不再吃各向立绘。
+   * 四向 / 八向锁定朝向时必填。后端走 `/generation/first-frame`，参考图仍是该朝向立绘。
    * 单向首帧不传，仍走 `/generation/image`。
    */
   characterId?: string

--- a/frontend/src/entities/generation/index.ts
+++ b/frontend/src/entities/generation/index.ts
@@ -81,6 +81,11 @@ export interface FirstFrameGenerationInput extends GenerationInputBase {
   spriteHeight: number
   /** 首帧必须与角色母版使用同一个真实源方向。 */
   direction?: ActionDirection
+  /**
+   * 四向 / 八向锁定朝向时必填。后端用角色已确认的正视母版，不再吃各向立绘。
+   * 单向首帧不传，仍走 `/generation/image`。
+   */
+  characterId?: string
   /** 每个方向生成的候选数；缺省为 3，后端允许 1–4。 */
   candidateCount?: ImageCandidateCount
 }

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -35,6 +35,23 @@ function setupNode(
   }
 }
 
+function boundSetup(
+  overrides: Partial<CharacterSetupWorkflowNode> = {},
+): CharacterSetupWorkflowNode {
+  const { input, ...rest } = overrides
+  return setupNode({
+    status: 'passed',
+    phase: 'completed',
+    ...rest,
+    input: {
+      prompt: '像素骑士',
+      referenceMedia: [],
+      characterId: 'character-1',
+      ...input,
+    },
+  })
+}
+
 function templateNode(
   overrides: Partial<CharacterTemplateWorkflowNode> = {},
 ): CharacterTemplateWorkflowNode {
@@ -1451,7 +1468,7 @@ describe('WorkflowController', () => {
 
   it('四向动作只为三个源方向生成并逐方向确认首帧', async () => {
     const run = createRun([
-      setupNode({ status: 'passed', phase: 'completed' }),
+      boundSetup(),
       templateNode({
         status: 'passed',
         phase: 'completed',
@@ -1517,7 +1534,7 @@ describe('WorkflowController', () => {
       },
     })
     const run = createRun([
-      setupNode({ status: 'passed', phase: 'completed' }),
+      boundSetup(),
       templateNode({
         status: 'passed',
         phase: 'completed',
@@ -1539,15 +1556,30 @@ describe('WorkflowController', () => {
 
     expect(generation.apis.create).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ direction: 'east', prompt: '向右行走，保持侧面轮廓' }),
+      expect.objectContaining({
+        direction: 'east',
+        prompt: '向右行走，保持侧面轮廓',
+        characterId: 'character-1',
+        referenceMedia: [],
+      }),
     )
     expect(generation.apis.create).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ direction: 'north', prompt: '背向镜头向上行走' }),
+      expect.objectContaining({
+        direction: 'north',
+        prompt: '背向镜头向上行走',
+        characterId: 'character-1',
+        referenceMedia: [],
+      }),
     )
     expect(generation.apis.create).toHaveBeenNthCalledWith(
       3,
-      expect.objectContaining({ direction: 'south', prompt: '面向镜头向下行走' }),
+      expect.objectContaining({
+        direction: 'south',
+        prompt: '面向镜头向下行走',
+        characterId: 'character-1',
+        referenceMedia: [],
+      }),
     )
   })
 
@@ -2051,9 +2083,9 @@ describe('WorkflowController', () => {
     )
   })
 
-  it('动作首帧只重试失败方向并使用同方向角色母版', async () => {
+  it('动作首帧只重试失败方向并以正视母版锁定朝向', async () => {
     const run = createRun([
-      setupNode({ status: 'passed', phase: 'completed' }),
+      boundSetup(),
       templateNode({
         status: 'passed',
         phase: 'completed',
@@ -2118,8 +2150,9 @@ describe('WorkflowController', () => {
       prompt: '背向镜头向上行走',
       spriteWidth: 64,
       spriteHeight: 64,
-      referenceMedia: ['north-template.png'],
+      referenceMedia: [],
       direction: 'north',
+      characterId: 'character-1',
     })
     const retriedFirstFrame = controller.getWorkflow().nodes[2]
     if (retriedFirstFrame?.type !== 'action-first-frame') {
@@ -4071,9 +4104,9 @@ describe('WorkflowController', () => {
     },
   )
 
-  it('四向动作首帧微调分别使用同方向已确认图片', async () => {
+  it('四向动作首帧微调按方向写提示词，参考图改由正视母版锁定', async () => {
     const run = createRun([
-      setupNode({ status: 'passed', phase: 'completed' }),
+      boundSetup(),
       templateNode({
         status: 'passed',
         phase: 'completed',
@@ -4119,22 +4152,26 @@ describe('WorkflowController', () => {
         direction: input.direction,
         prompt: input.prompt,
         referenceMedia: input.referenceMedia,
+        characterId: 'characterId' in input ? input.characterId : undefined,
       })),
     ).toEqual([
       {
         direction: 'east',
         prompt: '向右行走\n增加轮廓光',
-        referenceMedia: ['east-frame.png'],
+        referenceMedia: [],
+        characterId: 'character-1',
       },
       {
         direction: 'north',
         prompt: '背向镜头行走\n增加轮廓光',
-        referenceMedia: ['north-frame.png'],
+        referenceMedia: [],
+        characterId: 'character-1',
       },
       {
         direction: 'south',
         prompt: '面向镜头行走\n增加轮廓光',
-        referenceMedia: ['south-frame.png'],
+        referenceMedia: [],
+        characterId: 'character-1',
       },
     ])
   })

--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -1560,7 +1560,7 @@ describe('WorkflowController', () => {
         direction: 'east',
         prompt: '向右行走，保持侧面轮廓',
         characterId: 'character-1',
-        referenceMedia: [],
+        referenceMedia: ['https://img/east.png'],
       }),
     )
     expect(generation.apis.create).toHaveBeenNthCalledWith(
@@ -1569,7 +1569,7 @@ describe('WorkflowController', () => {
         direction: 'north',
         prompt: '背向镜头向上行走',
         characterId: 'character-1',
-        referenceMedia: [],
+        referenceMedia: ['https://img/north.png'],
       }),
     )
     expect(generation.apis.create).toHaveBeenNthCalledWith(
@@ -1578,7 +1578,7 @@ describe('WorkflowController', () => {
         direction: 'south',
         prompt: '面向镜头向下行走',
         characterId: 'character-1',
-        referenceMedia: [],
+        referenceMedia: ['https://img/south.png'],
       }),
     )
   })
@@ -2083,7 +2083,7 @@ describe('WorkflowController', () => {
     )
   })
 
-  it('动作首帧只重试失败方向并以正视母版锁定朝向', async () => {
+  it('动作首帧只重试失败方向并以该朝向立绘锁定朝向', async () => {
     const run = createRun([
       boundSetup(),
       templateNode({
@@ -2150,7 +2150,7 @@ describe('WorkflowController', () => {
       prompt: '背向镜头向上行走',
       spriteWidth: 64,
       spriteHeight: 64,
-      referenceMedia: [],
+      referenceMedia: ['north-template.png'],
       direction: 'north',
       characterId: 'character-1',
     })
@@ -4104,7 +4104,7 @@ describe('WorkflowController', () => {
     },
   )
 
-  it('四向动作首帧微调按方向写提示词，参考图改由正视母版锁定', async () => {
+  it('四向动作首帧微调按方向写提示词，参考该朝向已有首帧', async () => {
     const run = createRun([
       boundSetup(),
       templateNode({
@@ -4158,19 +4158,19 @@ describe('WorkflowController', () => {
       {
         direction: 'east',
         prompt: '向右行走\n增加轮廓光',
-        referenceMedia: [],
+        referenceMedia: ['east-frame.png'],
         characterId: 'character-1',
       },
       {
         direction: 'north',
         prompt: '背向镜头行走\n增加轮廓光',
-        referenceMedia: [],
+        referenceMedia: ['north-frame.png'],
         characterId: 'character-1',
       },
       {
         direction: 'south',
         prompt: '面向镜头行走\n增加轮廓光',
-        referenceMedia: [],
+        referenceMedia: ['south-frame.png'],
         characterId: 'character-1',
       },
     ])

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -1028,9 +1028,7 @@ export function createWorkflowController({
                 : nonEmpty(options.prompt, 'prompt'),
           spriteWidth: options.spriteWidth,
           spriteHeight: options.spriteHeight,
-          referenceMedia: lockCharacterId
-            ? []
-            : [sourceImage ?? (characterTemplateReference as MediaReference)],
+          referenceMedia: [sourceImage ?? (characterTemplateReference as MediaReference)],
           direction,
           ...(lockCharacterId === undefined ? {} : { characterId: lockCharacterId }),
           ...(options.candidateCount === undefined
@@ -1427,7 +1425,7 @@ export function createWorkflowController({
                 node.input.name,
               spriteWidth: options.spriteWidth,
               spriteHeight: options.spriteHeight,
-              referenceMedia: characterId ? [] : [templateUrl as MediaReference],
+              referenceMedia: [templateUrl as MediaReference],
               direction: retryDirection,
               ...(characterId === undefined ? {} : { characterId }),
             }

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -990,6 +990,14 @@ export function createWorkflowController({
         throw new Error(`角色母版尚未确认方向 ${direction}`)
       }
     }
+    const lockCharacterId =
+      currentDirectionalMovement === 'single'
+        ? undefined
+        : nonEmpty(
+            findSingleDependencyNode(before, targetTemplate, 'character-setup').input.characterId ??
+              '',
+            'characterId',
+          )
     return submitDirectionalGenerations(
       nodeId,
       'first_frame',
@@ -1020,8 +1028,11 @@ export function createWorkflowController({
                 : nonEmpty(options.prompt, 'prompt'),
           spriteWidth: options.spriteWidth,
           spriteHeight: options.spriteHeight,
-          referenceMedia: [sourceImage ?? (characterTemplateReference as MediaReference)],
+          referenceMedia: lockCharacterId
+            ? []
+            : [sourceImage ?? (characterTemplateReference as MediaReference)],
           direction,
+          ...(lockCharacterId === undefined ? {} : { characterId: lockCharacterId }),
           ...(options.candidateCount === undefined
             ? {}
             : { candidateCount: options.candidateCount }),
@@ -1398,6 +1409,14 @@ export function createWorkflowController({
               retryDirection,
             )
             if (!templateUrl) throw new Error(`角色母版尚未确认方向 ${retryDirection}`)
+            const characterId =
+              currentDirectionalMovement === 'single'
+                ? undefined
+                : nonEmpty(
+                    findSingleDependencyNode(run, templateNode, 'character-setup').input
+                      .characterId ?? '',
+                    'characterId',
+                  )
             const input: FirstFrameGenerationInput = {
               type: 'first_frame',
               projectId: run.projectId,
@@ -1408,8 +1427,9 @@ export function createWorkflowController({
                 node.input.name,
               spriteWidth: options.spriteWidth,
               spriteHeight: options.spriteHeight,
-              referenceMedia: [templateUrl as MediaReference],
+              referenceMedia: characterId ? [] : [templateUrl as MediaReference],
               direction: retryDirection,
+              ...(characterId === undefined ? {} : { characterId }),
             }
             return input
           }

--- a/openapi.json
+++ b/openapi.json
@@ -785,6 +785,63 @@
         "title": "CharacterDirectionSetGenerateRequest",
         "type": "object"
       },
+      "CharacterFirstFrameGenerateRequest": {
+        "additionalProperties": false,
+        "description": "四向 / 八向动作首帧:正视母版锁朝向后出该方向的动作起手姿态。",
+        "properties": {
+          "character_id": {
+            "exclusiveMinimum": 0.0,
+            "title": "Character Id",
+            "type": "integer"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/ActionDirection"
+          },
+          "height": {
+            "default": 1024,
+            "maximum": 2048.0,
+            "minimum": 64.0,
+            "title": "Height",
+            "type": "integer"
+          },
+          "negative_prompt": {
+            "default": "",
+            "title": "Negative Prompt",
+            "type": "string"
+          },
+          "num_images": {
+            "default": 3,
+            "maximum": 4.0,
+            "minimum": 1.0,
+            "title": "Num Images",
+            "type": "integer"
+          },
+          "project_id": {
+            "exclusiveMinimum": 0.0,
+            "title": "Project Id",
+            "type": "integer"
+          },
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "width": {
+            "default": 1024,
+            "maximum": 2048.0,
+            "minimum": 64.0,
+            "title": "Width",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "project_id",
+          "character_id",
+          "prompt",
+          "direction"
+        ],
+        "title": "CharacterFirstFrameGenerateRequest",
+        "type": "object"
+      },
       "CharacterFrame": {
         "description": "动作帧。",
         "properties": {
@@ -5312,6 +5369,48 @@
           }
         },
         "summary": "Submit Eight View Generation",
+        "tags": [
+          "generation"
+        ]
+      }
+    },
+    "/generation/first-frame": {
+      "post": {
+        "description": "提交锁定朝向的动作首帧:正视母版转相机,再换成动作起手姿态。",
+        "operationId": "submit_first_frame_generation_generation_first_frame_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CharacterFirstFrameGenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response_GenerationTaskOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Submit First Frame Generation",
         "tags": [
           "generation"
         ]

--- a/openapi.json
+++ b/openapi.json
@@ -789,6 +789,9 @@
         "additionalProperties": false,
         "description": "四向 / 八向动作首帧:以该朝向立绘为参考,锁住朝向后出动作起手姿态。",
         "properties": {
+          "action_type": {
+            "$ref": "#/components/schemas/ActionType"
+          },
           "character_id": {
             "exclusiveMinimum": 0.0,
             "title": "Character Id",
@@ -842,7 +845,8 @@
           "character_id",
           "reference_image_url",
           "prompt",
-          "direction"
+          "direction",
+          "action_type"
         ],
         "title": "CharacterFirstFrameGenerateRequest",
         "type": "object"

--- a/openapi.json
+++ b/openapi.json
@@ -787,7 +787,7 @@
       },
       "CharacterFirstFrameGenerateRequest": {
         "additionalProperties": false,
-        "description": "四向 / 八向动作首帧:正视母版锁朝向后出该方向的动作起手姿态。",
+        "description": "四向 / 八向动作首帧:以该朝向立绘为参考,锁住朝向后出动作起手姿态。",
         "properties": {
           "character_id": {
             "exclusiveMinimum": 0.0,
@@ -825,6 +825,10 @@
             "title": "Prompt",
             "type": "string"
           },
+          "reference_image_url": {
+            "title": "Reference Image Url",
+            "type": "string"
+          },
           "width": {
             "default": 1024,
             "maximum": 2048.0,
@@ -836,6 +840,7 @@
         "required": [
           "project_id",
           "character_id",
+          "reference_image_url",
           "prompt",
           "direction"
         ],
@@ -5376,7 +5381,7 @@
     },
     "/generation/first-frame": {
       "post": {
-        "description": "提交锁定朝向的动作首帧:正视母版转相机,再换成动作起手姿态。",
+        "description": "提交锁定朝向的动作首帧:以该朝向立绘为参考,锁住朝向后换成动作起手姿态。",
         "operationId": "submit_first_frame_generation_generation_first_frame_post",
         "requestBody": {
           "content": {


### PR DESCRIPTION
## Summary
- 新增 `character_first_frame` 任务类型、`POST /generation/first-frame` 与独立执行器；不改 `generate_character_image`。
- 四向/八向首帧以该朝向已确认立绘为参考，复用 view_sheet 方位锁，只换动作起手姿态。
- 仍入图像 MQ 流（`msg_type=character_image`），由 `payload.task_type` 分叉。单向仍走 `/generation/image`。

Closes #876

## Test plan
- [x] `uv run pytest tests/test_generation_api.py tests/test_first_frame_executor.py tests/test_master_cutout.py tests/test_mq_worker.py tests/test_mq_catalog.py tests/test_view_sheet_prompt.py tests/test_generation_quota.py -q`
- [x] `npm run test -- src/entities/generation/api.test.ts src/features/workflow-controller/controller.test.ts --run`
- [x] 四向项目：确认各向立绘后生成动作首帧，东/北/南分别参考对应朝向模板
- [ ] 单向项目：动作首帧仍走 `/generation/image`，行为不变
- [x] 缺少该朝向立绘 / 提交 west 镜像方向：入队前 400