### PR TITLE
fix(render3d): 退避日志带上上游真实 code，别把超时说成并发已满

### DIFF
--- a/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
+++ b/backend/packages/framework/src/windup_framework/providers/render3d/tencent.py
@@ -81,10 +81,20 @@ MOTION_TYPE_RANGE = range(1, 49)
 _MAGIC = {"GLB": b"glTF", "FBX": b"Kaydara FBX Binary"}
 
 
-def _submit_with_backoff(submit, *, attempts: int = 5, base: float = 20.0):
+def _submit_with_backoff(submit, *, attempts: int = 8, base: float = 30.0):
     """撞上游并发上限时退避重试。**只重试 UpstreamBusyError** —— 别的错重试等于重复扣费。
 
-    绑骨接口同时只允许 1 个任务,而且上一个 DONE 之后位子也不立刻释放(实测约 30 秒)。
+    绑骨接口同时只允许 1 个任务,而且上一个 DONE 之后位子也不立刻释放。
+
+    **窗口比一开始记的长得多。** 首次实测是"单发等约 30 秒即过",据此把参数定成
+    5 轮 × 20 秒基数(总计约 5 分钟)。2026-08-28 生产端到端里连着退了 20/40/60/80 秒
+    共 200 秒仍然排不上,而占位的那个任务此时**早已 DONE** —— 印证了限的是时间窗、
+    不是"在跑的任务数",而那个窗口远超 30 秒。
+
+    改成 8 轮 × 30 秒基数(30+60+90+…+240,总计约 18 分钟)。为什么敢等这么久:
+    这一步发生在图生 3D **已经付过 20 积分之后**,等 18 分钟换一次成功,
+    比当场失败、让那 20 积分白花划算得多;而它是后台线程,不占用户的等待。
+
     不重试的话,两个用户同时建资产,第二个直接失败 —— 而他的图生 3D 已经付过钱了。
 
     提交本身不计费(计费在上游受理之后),所以重试不会重复扣钱;真正危险的是**成功之后**
@@ -101,11 +111,19 @@ def _submit_with_backoff(submit, *, attempts: int = 5, base: float = 20.0):
             if i + 1 >= attempts:
                 break
             wait = base * (i + 1)
-            logger.info("上游绑骨并发已满,%ds 后重试(%d/%d)", int(wait), i + 1, attempts)
+            # **把上游的原始 code 打出来。** 写死一句"并发已满"会让所有可重试的故障
+            # 长成同一个样子 —— 2026-08-28 实测:五轮退避的日志全是"并发已满",
+            # 而最后一次的真实错误是 RequestTimeout(上游持续超时),完全是另一回事。
+            # 我照着那句日志排查了整整五轮"位子被谁占了",方向从一开始就是错的。
+            logger.info(
+                "上游暂时不可用(%s),%ds 后重试(%d/%d)",
+                getattr(exc, "code", "?"), int(wait), i + 1, attempts,
+            )
             time.sleep(wait)
     raise RuntimeError(
-        f"上游同时只能跑一个绑骨任务,等了 {attempts} 轮仍然排不上。稍后再试。"
-        f"(最后一次:{last})"
+        # 同理:结论里不预设原因。它可能是并发上限,也可能是上游超时或算法服务异常,
+        # 而这三种的下一步动作不同(等一等 vs 查上游状态 vs 换个时间再来)。
+        f"上游连续 {attempts} 轮不可用,最后一次:{last}"
     ) from last
 
 

--- a/backend/tests/test_rig_cloud_to_cloud.py
+++ b/backend/tests/test_rig_cloud_to_cloud.py
@@ -78,13 +78,18 @@ def test_only_busy_errors_are_retried(monkeypatch):
 
 
 def test_giving_up_says_what_actually_happened(monkeypatch):
-    """排不上时的错误信息要说清是上游并发限制,不是原样抛上游错误码。"""
+    """放弃时的错误信息要带上**上游的真实 code**,而不是预设一个原因。
+
+    原先这条断言的是「说清是上游并发限制」,而那正是 2026-08-28 把我带偏的东西:
+    三种可重试故障被写死成同一句「只能跑一个绑骨任务」,于是 RequestTimeout
+    也长成了并发问题的样子。判据改成「带上真实 code」。
+    """
     monkeypatch.setattr("time.sleep", lambda _s: None)
 
     def _busy():
         raise UpstreamBusyError("RequestLimitExceeded.JobNumExceed", "满了")
 
-    with pytest.raises(RuntimeError, match="同时只能跑一个绑骨任务"):
+    with pytest.raises(RuntimeError, match="JobNumExceed"):
         _submit_with_backoff(_busy, attempts=2, base=0.01)
 
 
@@ -309,3 +314,59 @@ def test_polling_still_reports_a_real_upstream_failure(monkeypatch):
     prov._max_min = 1
     with pytest.raises(t.JobFailedError, match="绑骨失败"):
         prov._wait("job-2")
+
+
+def test_the_backoff_window_covers_the_measured_upstream_hold():
+    """拦的坏例：退避窗口比上游实际的占位窗口短，等于没重试。
+
+    2026-08-28 生产实测：连着退了 20/40/60/80 秒共 **200 秒仍然排不上**，
+    而占位的那个绑骨任务此时早已 `DONE` —— 上游限的是时间窗，不是「在跑的任务数」。
+
+    首版参数（5 轮 × 20 秒基数 ≈ 5 分钟）是照「单发等约 30 秒即过」定的，那次测量
+    没有覆盖连续提交的场合。这条把**实测下限**钉住：总等待必须显著超过 200 秒。
+    """
+    import inspect
+
+    from windup_framework.providers.render3d.tencent import _submit_with_backoff
+
+    sig = inspect.signature(_submit_with_backoff)
+    attempts = sig.parameters["attempts"].default
+    base = sig.parameters["base"].default
+    total = sum(base * (i + 1) for i in range(attempts - 1))
+    assert total >= 600, (
+        f"总退避 {total:.0f}s 不够 —— 实测 200s 都排不上，而这一步发生在"
+        f"图生 3D 已付 20 积分之后，等不起就是那笔钱白花"
+    )
+
+
+def test_the_retry_log_names_the_real_upstream_code(caplog):
+    """拦的坏例：退避日志写死一句「并发已满」，把所有可重试故障说成同一件事。
+
+    2026-08-28 实测：五轮退避的日志全是「上游绑骨并发已满」，而最后一次的真实错误是
+    `RequestTimeout`（上游持续超时）—— 完全是另一回事。照着那句日志排查「位子被谁
+    占了」，方向从一开始就是错的，而真相就在被丢掉的那个 code 里。
+
+    三种可重试故障的下一步动作并不相同：
+      JobNumExceed    等一等（别人在用）
+      RequestTimeout  上游在抖，换个时间
+      ServerError     上游算法服务异常
+    """
+    import logging
+
+    from windup_framework.providers.render3d.tencent import (
+        UpstreamBusyError, _submit_with_backoff,
+    )
+
+    def _busy():
+        raise UpstreamBusyError("FailedOperation.RequestTimeout", "后端服务超时。")
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(RuntimeError) as err:
+            _submit_with_backoff(_busy, attempts=2, base=0.01)
+
+    logged = " ".join(r.getMessage() for r in caplog.records)
+    assert "RequestTimeout" in logged, f"日志里没有真实 code：{logged}"
+    assert "并发已满" not in logged, "又把超时说成了并发已满"
+    # 最终错误也不该预设原因
+    assert "只能跑一个" not in str(err.value), f"结论里预设了原因：{err.value}"
+    assert "RequestTimeout" in str(err.value)


### PR DESCRIPTION
Closes #879

## 这条是被自己的日志误导出来的

五轮退避日志全是「上游绑骨并发已满」,而最后一次的真实错误是 `FailedOperation.RequestTimeout`。那句文案写死在 `_submit_with_backoff` 里,`UpstreamBusyError` 捕获之后无论 code 是什么都说并发已满。

我照着它排查了整整五轮「位子被谁占了」—— 查上一个 job 是不是还在跑(DONE)、查时间窗多长、准备调大轮数。**方向从一开始就错**,真相就在被丢掉的那个 code 里。

## 顺带排除的三个假设,都不成立

```
我们的 URL 取不到?   HEAD 200 / 18366000 字节 / 0.2s
文件太大下不动?      公网实测 4.92 MB/s,18MB 约需 4s
上游解析不了?        小文件提交报 InvalidParameter(能取能解析)
```

## 改动

日志带真实 code;最终错误不预设原因;退避参数按实测从 5×20s(≈5min) 调到 8×30s(≈18min) —— 首版是照「单发等约 30 秒即过」定的,那次测量没覆盖连续提交,实测连退 200 秒仍排不上。

回写一条过期断言:原先有用例断言「说清是上游并发限制」,那正是把我带偏的东西。

变异验过:写死成「并发已满」→ 2 红;退回旧参数 → 1 红。

CI: ruff 通过 / lint-imports 2 kept 0 broken / pytest **2045 passed**