### PR TITLE
fix(i2v): 动作失败终态不释放在途名额，全站动作任务空转排队

### DIFF
--- a/backend/packages/app/src/windup_app/server/mq/i2v_admit.py
+++ b/backend/packages/app/src/windup_app/server/mq/i2v_admit.py
@@ -196,6 +196,19 @@ def has_claim(task_id: int) -> bool:
     return bool(get_redis().sismember(INFLIGHT_KEY, _task_member(task_id)))
 
 
+def claimed_ids() -> tuple[int, ...]:
+    """全局索引 ∪ 各车道 SET。终态对账时两边都要扫，避免只清了一边。"""
+    redis_client = get_redis()
+    ids: set[int] = set()
+    keys = (INFLIGHT_KEY, *(_lane_inflight(lane) for lane in lane_ids()))
+    for key in keys:
+        for raw in redis_client.smembers(key) or ():
+            text = raw.decode() if isinstance(raw, bytes) else str(raw)
+            if text.isdigit():
+                ids.add(int(text))
+    return tuple(sorted(ids))
+
+
 def can_submit(task_id: int) -> bool:
     """该任务所在车道健康时可并行；冷却期内等到点且只能一枪。"""
     lane = _bound_lane(task_id) or lane_ids()[0]

--- a/backend/packages/app/src/windup_app/server/orchestrator/executor.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/executor.py
@@ -416,6 +416,10 @@ class ActionTaskExecutor:
                 task_repo.fail_task(s, task_id, error_message=error_message)
 
             generation_io.using_session(session, self._make_session, _reject)
+            try:
+                i2v_admit.release(task_id)
+            except Exception:
+                logger.exception("释放 i2v 在途名额失败 | task_id=%s", task_id)
         except UpstreamExhaustedError as exc:
             i2v_admit.release(task_id)
             if not exc.is_free_retryable:

--- a/backend/packages/app/src/windup_app/server/orchestrator/recover.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/recover.py
@@ -73,6 +73,20 @@ def recover_orphaned_generation_tasks(
             _fail_interrupted(session, task)
             continue
         _requeue_pending(session, publisher, task)
+    try:
+        _release_stale_i2v_claims(session)
+    except Exception:
+        logger.exception("清理终态 i2v 在途名额失败")
+
+
+def _release_stale_i2v_claims(session: Session) -> None:
+    """FAILED/COMPLETED/失踪任务仍占坑时清掉。SET 无 TTL，漏一次就永久堵闸。"""
+    for task_id in i2v_admit.claimed_ids():
+        task = task_repo.get_task(session, task_id)
+        if task is not None and not task.is_terminal:
+            continue
+        i2v_admit.release(task_id)
+        logger.info("终态或失踪任务已释放 i2v 名额 | task_id=%s", task_id)
 
 
 def _fail_unrecoverable(session: Session, task: GenerationTask) -> None:

--- a/backend/tests/test_generation_orchestration.py
+++ b/backend/tests/test_generation_orchestration.py
@@ -553,6 +553,62 @@ def test_action_task_prompt_rejected_leaves_no_result(session_factory):
     assert payload["error_message"]
 
 
+def test_action_task_prompt_rejected_releases_i2v_claim(session_factory, monkeypatch):
+    """占坑后被措辞门禁拒绝，必须把名额还回去，否则 failed 任务永久堵闸。"""
+    from windup_ai_engine.ports import PromptRejectCode, PromptRejected
+
+    released: list[int] = []
+
+    class _RejectGen:
+        def start_video(self, *args, **kwargs):
+            raise PromptRejected(PromptRejectCode.NEGATION, "描述里不要写否定词")
+
+        def generate(self, *args, **kwargs):
+            raise AssertionError("有 start_video 时不该走阻塞 generate")
+
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.executor.i2v_admit.try_acquire",
+        lambda _task_id: True,
+    )
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.executor.i2v_admit.can_submit",
+        lambda _task_id: True,
+    )
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.executor.i2v_admit.retry_state",
+        lambda _task_id: (0, 0),
+    )
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.executor.i2v_admit.release",
+        lambda task_id: released.append(task_id),
+    )
+    service = AiGenerationService()
+    executor = ActionTaskExecutor(
+        generator=_RejectGen(),
+        fetch_master=lambda _input: _tiny_png(),
+        session_factory=session_factory,
+        fetch_constraints=lambda _s, _pid: ProjectConstraints(sprite_w=64, sprite_h=96),
+    )
+    action_input = CharacterActionInput(
+        character_id=1,
+        action_type=ActionType.CUSTOM,
+        custom_prompt="不要扬尘",
+        num_frames=4,
+    )
+    with session_factory() as s:
+        task = service.generate_character_action(s, user_id=1, input=action_input)
+        s.commit()
+        task_id = task.id
+
+    executor.run_action_task(task_id, action_input)
+
+    assert released == [task_id]
+    with session_factory() as s:
+        done = service.get_task(s, project_id=1, task_id=task_id)
+    assert done.status is TaskStatus.FAILED
+    assert done.error_message and "动作描述没通过检查" in done.error_message
+
+
 def test_fail_task_clears_stale_result(session_factory):
     from windup_app.server.orchestrator import task_repo
 

--- a/backend/tests/test_generation_quota.py
+++ b/backend/tests/test_generation_quota.py
@@ -429,6 +429,57 @@ def test_recover_requeues_pending_tasks_with_open_freeze(session_factory):
         assert _account(session, 1).frozen == quota_settings.generate_action_cost
 
 
+def test_recover_releases_i2v_claim_for_failed_and_missing_tasks(
+    session_factory, monkeypatch,
+):
+    from windup_app.server.mq import i2v_admit
+    from windup_app.server.orchestrator import task_repo
+    from windup_app.server.orchestrator.recover import recover_orphaned_generation_tasks
+
+    publisher, _enqueued = _tracking_publisher()
+    released: list[int] = []
+
+    with session_factory() as session:
+        _seed_account(session, 1)
+        session.commit()
+
+    service = AiGenerationService()
+    action_input = CharacterActionInput(
+        character_id=1, action_type=ActionType.WALK, num_frames=2,
+    )
+    with session_factory() as session:
+        failed = service.generate_character_action(
+            session, user_id=1, project_id=7, input=action_input,
+        )
+        live = service.generate_character_action(
+            session, user_id=1, project_id=7, input=action_input,
+        )
+        task_repo.update_status(session, failed.id, TaskStatus.FAILED)
+        task_repo.update_status(session, live.id, TaskStatus.RUNNING)
+        session.commit()
+        failed_id, live_id = failed.id, live.id
+
+    monkeypatch.setattr(i2v_admit, "rebuild", lambda: None)
+    monkeypatch.setattr(
+        i2v_admit, "claimed_ids", lambda: (failed_id, live_id, 99999),
+    )
+    monkeypatch.setattr(i2v_admit, "release", lambda task_id: released.append(task_id))
+    monkeypatch.setattr(i2v_admit, "has_claim", lambda task_id: task_id == live_id)
+    monkeypatch.setattr(i2v_admit, "schedule_retry", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "windup_app.server.orchestrator.recover.reschedule_if_waiting",
+        lambda *_a, **_k: False,
+    )
+
+    with session_factory() as session:
+        recover_orphaned_generation_tasks(session, publisher=publisher)
+        session.commit()
+
+    assert failed_id in released
+    assert 99999 in released
+    assert live_id not in released
+
+
 def test_recover_fails_and_unfreezes_running_orphans(session_factory):
     from datetime import datetime, timedelta, timezone
 

--- a/backend/tests/test_i2v_admit.py
+++ b/backend/tests/test_i2v_admit.py
@@ -46,6 +46,9 @@ class _MemRedis:
     def sismember(self, key, member):
         return 1 if str(member) in self.sets.get(key, set()) else 0
 
+    def smembers(self, key):
+        return set(self.sets.get(key, set()))
+
     def scard(self, key):
         return len(self.sets.get(key, set()))
 
@@ -145,6 +148,14 @@ def _patch_redis(
     monkeypatch.setattr("windup_app.server.mq.i2v_admit.get_redis", lambda: mem)
     monkeypatch.setattr("windup_app.server.mq.i2v_admit.lane_ids", lambda: lanes)
     return mem
+
+
+def test_claimed_ids_unions_global_and_lane_sets(monkeypatch):
+    mem = _patch_redis(monkeypatch, lanes=("primary.key0", "primary.key1"))
+    mem.sadd("windup:i2v:gate:inflight", "632")
+    mem.sadd("windup:i2v:gate:inflight:primary.key0", "632")
+    mem.sadd("windup:i2v:gate:inflight:primary.key1", "710")
+    assert admit.claimed_ids() == (632, 710)
 
 
 def test_third_acquire_is_rejected(monkeypatch):


### PR DESCRIPTION
## Summary
- 措辞门禁 `PromptRejected` 与轮询失败对称：标 FAILED 后立刻 `i2v_admit.release`，避免无 TTL 的在途 SET 被幽灵任务占满。
- Worker 启动对账在 `rebuild` 之后扫全局/车道 inflight，清掉已终态或不存在的成员。
- 补回归：占坑后被门禁拒绝必须还坑；recover 只释放 failed/失踪，不动仍在 RUNNING 的 claim。

Closes #894

## Test plan
- [x] `uv run pytest tests/test_i2v_admit.py tests/test_generation_orchestration.py tests/test_generation_quota.py tests/test_mq_worker.py -q --no-cov`（109 passed）
- [ ] 现网：对已 FAILED 却仍在 `windup:i2v:gate:inflight` 的 id 做一次 SREM（或等 worker 重启走 recover）；795/801/802/803 应出现「已提交 i2v」
- [ ] 再提交一条会被门禁拦住的动作描述，确认任务 failed 后 Redis 名额被清掉，其它动作仍能建单