### PR TITLE
feat(render3d): 图生 3D 接入多视图与建模参数

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,14 @@ AI_VIDEO_VEO_USER_IDS=
 # (veo 按秒计费，3D 是每资产 30 积分且可无限累积)。
 # 空 = 所有人都受额度限制(默认每人最多同时持有 2 个 3D 资产)。
 AI_RENDER3D_UNLIMITED_USER_IDS=
+# 图生 3D 的三个建模参数。留空 = 沿用代码里的构造默认，行为与接出来之前一致。
+# GenerateType：Normal 20 / Geometry 15 / LowPoly 25 / Sketch 25 积分
+AI_RENDER3D_GENERATE_TYPE=
+# 面数。默认 150000；实测线上产物 45 万顶点、FBX 20.7MB，而出帧只渲成平面精灵，
+# 面数用不上，却要用户在浏览器里全下下来。0 = 不覆盖。
+AI_RENDER3D_FACE_COUNT=
+# PBR 材质，开启 +10 积分。出帧走平面着色，用不上，默认关。
+AI_RENDER3D_ENABLE_PBR=
 # 留空即按型号查上游牌价（美元）；配了它就整条链共用这一个价，跨型号时会算错。
 AI_IMAGE_UNIT_COST=
 AI_VIDEO_UNIT_COST_PER_SECOND=

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_assets.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_assets.py
@@ -342,7 +342,8 @@ class Render3DAssetBuilder:
         self._store.delete(f"{RAW_KEY_PREFIX}{outfit_key}")
         self._review.discard(outfit_key)
 
-    def ensure(self, outfit_key: str, master: bytes, progress: ProgressPort) -> bytes:
+    def ensure(self, outfit_key: str, master: bytes, progress: ProgressPort,
+               extra_views: Mapping[str, bytes] | None = None) -> bytes:
         """取该造型的绑骨模型;没有且获准时才现建。
 
         建一次的计费 = 图生 3D + 绑骨,取值见本模块顶部常量,**每造型一次性**。
@@ -364,10 +365,11 @@ class Render3DAssetBuilder:
                 f"绑骨 {AUTORIG_CREDITS})。要现建请显式授权花钱,"
                 "或先把资产备好,或改走 video_i2v。"
             )
-        return self._build(outfit_key, master, progress)
+        return self._build(outfit_key, master, progress, extra_views)
 
     # ── 内部 ─────────────────────────────────────────────────────────────
-    def _build(self, key: str, master: bytes, progress: ProgressPort) -> bytes:
+    def _build(self, key: str, master: bytes, progress: ProgressPort,
+               extra_views: Mapping[str, bytes] | None = None) -> bytes:
         """① 图生 3D →(人工确认)→ ② 绑骨并烘入 :data:`BUILD_MOTION`。**按次计费,每造型一次性。**
 
         中间那道人工确认是硬停点,原因见 :class:`ModelReviewGate`:模型不可事后修改,
@@ -385,7 +387,7 @@ class Render3DAssetBuilder:
         model = self._store.get(raw_key)
         if model is None:
             progress.step("assets", 0, 2, "造型级 3D 资产未就绪:图生 3D(按次计费)")
-            model, upstream_url = _image_to_3d(self._model3d, master)
+            model, upstream_url = _image_to_3d(self._model3d, master, extra_views)
             self._store.put(raw_key, model)
             if upstream_url:
                 # 上游那个 URL 单独存一份,给绑骨当**云到云**的输入 —— 它是上游自家的
@@ -480,16 +482,20 @@ class Render3DAssetBuilder:
         logger.info("造型追加动作已落点 key=%s motion=%s", motion_key, want)
         return rigged.data
 
-def _image_to_3d(provider, master: bytes) -> tuple[bytes, str | None]:
+def _image_to_3d(provider, master: bytes,
+                 extra_views: Mapping[str, bytes] | None = None) -> tuple[bytes, str | None]:
     """图生 3D,顺带取回上游那个产物 URL。
 
     provider 没有 ``image_to_3d_with_url`` 时退回旧方法、URL 给 None —— 测试里的桩与
     别的实现不该因为这个新增能力而全部要改。
     """
     fn = getattr(provider, "image_to_3d_with_url", None)
+    # 没有多视图时**不传这个关键字** —— 不接它的实现(测试替身、别家 provider)
+    # 收到就是 TypeError,而那时它本来就没这件事要做。
+    kw = {"extra_views": extra_views} if extra_views else {}
     if fn is None:
-        return provider.image_to_3d(master, want="GLB"), None
-    return fn(master, want="GLB")
+        return provider.image_to_3d(master, want="GLB", **kw), None
+    return fn(master, want="GLB", **kw)
 
 
 def _model_not_public():

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -22,7 +22,7 @@ import logging
 import os
 import pathlib
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 
 from windup_ai_engine.master_check import check_master
@@ -226,7 +226,8 @@ class Render3DAssetOperations:
         }
 
     # ── 三个动作 ─────────────────────────────────────────────────────────
-    def build(self, outfit_key: str, master_url: str, stance: CharacterStance) -> dict:
+    def build(self, outfit_key: str, master_url: str, stance: CharacterStance,
+              extra_view_urls: Mapping[str, str] | None = None) -> dict:
         """① 图生 3D。**这一步开始花钱**,所以只在三个前提都成立时才起:
         该造型确实还什么都没有、体型能绑骨、且母版过得了零成本预检。
 
@@ -258,8 +259,23 @@ class Render3DAssetOperations:
         if not report["accepted"]:
             raise MasterPrecheckFailed(report)
 
-        self._start(outfit_key, PHASE_BUILDING, master)
+        views = self._resolve_views(extra_view_urls)
+        self._start(outfit_key, PHASE_BUILDING, master, views)
         return self.view(outfit_key)
+
+    def _resolve_views(self, urls: Mapping[str, str] | None) -> dict[str, bytes] | None:
+        """多视图 URL → 字节。**认不出的视角名在花钱之前就拒**,不静默丢掉 ——
+        丢掉的后果是用户按多视图付了钱、拿到的却是单图重建的模型。"""
+        if not urls:
+            return None
+        from windup_framework.providers.render3d import VIEW_TYPES
+
+        bad = sorted(set(urls) - set(VIEW_TYPES))
+        if bad:
+            raise ValueError(
+                f"视角名只能取 {sorted(VIEW_TYPES)},收到 {bad}。正面走母版,不在这里传。"
+            )
+        return {k: self._fetch(v) for k, v in urls.items()}
 
     def approve(self, outfit_key: str, master_url: str) -> dict:
         """人点头 → ② 绑骨。**这道闸不会自己点头**,只有本方法能放行,而它只挂在
@@ -314,10 +330,11 @@ class Render3DAssetOperations:
         return self.view(outfit_key)
 
     # ── 内部 ─────────────────────────────────────────────────────────────
-    def _start(self, outfit_key: str, phase: str, master: bytes) -> None:
+    def _start(self, outfit_key: str, phase: str, master: bytes,
+               extra_views: Mapping[str, bytes] | None = None) -> None:
         with self._lock:
             self._jobs[outfit_key] = _Job(phase)
-        self._spawn(lambda: self._run(outfit_key, master))
+        self._spawn(lambda: self._run(outfit_key, master, extra_views))
 
     def _publish_for_review(self, outfit_key: str) -> None:
         """把待审模型也放到对象存储上。
@@ -336,14 +353,15 @@ class Render3DAssetOperations:
         except Exception:                              # noqa: BLE001 - 看不了不等于建失败
             logger.exception("[WINDUP] 待审模型上传失败 | outfit=%s", outfit_key)
 
-    def _run(self, outfit_key: str, master: bytes) -> None:
+    def _run(self, outfit_key: str, master: bytes,
+             extra_views: Mapping[str, bytes] | None = None) -> None:
         """两段付费调用共用这一条:``ensure`` 自己知道该走 ① 还是 ②。
 
         ``ModelAwaitingReview`` 不是失败,是 ① 干完了、停在闸上 —— 把它当失败会让
         用户看到一条红色报错,而实际上该看到的是"去看模型"。
         """
         try:
-            rigged = self._builder.ensure(outfit_key, master, _SilentProgress())
+            rigged = self._builder.ensure(outfit_key, master, _SilentProgress(), extra_views)
         except ModelAwaitingReview:
             self._publish_for_review(outfit_key)
             with self._lock:
@@ -389,12 +407,31 @@ class _LazyModel3D:
     def __init__(self, allow_spend: bool) -> None:
         self._allow_spend = allow_spend
 
-    def image_to_3d(self, master: bytes, *, want: str = "GLB") -> bytes:
+    def image_to_3d(self, master: bytes, *, want: str = "GLB",
+                    extra_views: Mapping[str, bytes] | None = None) -> bytes:
+        return self._provider().image_to_3d(master, want=want, extra_views=extra_views)
+
+    def image_to_3d_with_url(self, master: bytes, *, want: str = "GLB",
+                             extra_views: Mapping[str, bytes] | None = None):
+        """建资产实际走的是这一条(要顺带拿上游产物 URL 做云到云)。
+        多视图必须在这里也接上 —— 只接上面那条的话,生产路径上多视图会被悄悄丢掉。"""
+        return self._provider().image_to_3d_with_url(
+            master, want=want, extra_views=extra_views
+        )
+
+    def _provider(self):
+        """按配置构造。空值一律沿用 provider 的构造默认 —— 没配过的部署行为不变。"""
+        from windup_framework.config.provider import settings as cfg
         from windup_framework.providers.render3d import TencentModel3DProvider
 
-        return TencentModel3DProvider(allow_spend=self._allow_spend).image_to_3d(
-            master, want=want
-        )
+        kw: dict = {"allow_spend": self._allow_spend}
+        if getattr(cfg, "render3d_generate_type", ""):
+            kw["generate_type"] = cfg.render3d_generate_type
+        if int(getattr(cfg, "render3d_face_count", 0) or 0) > 0:
+            kw["face_count"] = int(cfg.render3d_face_count)
+        if getattr(cfg, "render3d_enable_pbr", False):
+            kw["enable_pbr"] = True
+        return TencentModel3DProvider(**kw)
 
 
 class _LazyAutoRig:

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -565,8 +565,9 @@ class _LazyOperations:
     def view(self, outfit_key: str) -> dict:
         return self._ops().view(outfit_key)
 
-    def build(self, outfit_key: str, master_url: str, stance: CharacterStance) -> dict:
-        return self._ops().build(outfit_key, master_url, stance)
+    def build(self, outfit_key: str, master_url: str, stance: CharacterStance,
+              extra_view_urls: Mapping[str, str] | None = None) -> dict:
+        return self._ops().build(outfit_key, master_url, stance, extra_view_urls)
 
     def approve(self, outfit_key: str, master_url: str) -> dict:
         return self._ops().approve(outfit_key, master_url)

--- a/backend/packages/app/src/windup_app/web/api/render3d.py
+++ b/backend/packages/app/src/windup_app/web/api/render3d.py
@@ -42,6 +42,13 @@ class BuildAssetRequest(BaseModel):
     """
 
     stance: CharacterStance
+    # 多视图重建的附加参考图:视角名 → 自家对象存储 URL。正面走造型母版,不在这里传。
+    # 视角名的合法取值由编排层校验(web 层不 import render3d 常量,那会经它连到
+    # ai_engine,破坏「入口层不经 ai_engine 直连」那条 import 契约)。
+    #
+    # 硬前提:各视图必须是**同一个角色、同一姿势、同一尺度**。侧/背视要以正面母版
+    # 做参考图 i2i 出来,各自文生等于送了三个人进去。传多少个视角计费都是统一 +10。
+    extra_view_urls: dict[str, str] | None = None
 
 
 class MasterPrecheckRequest(BaseModel):
@@ -245,7 +252,8 @@ def build_outfit_asset(
     try:
         return Response.success(
             operations.build(_asset_key(character_id, outfit_id),
-                             _master_url_or_raise(outfit), body.stance),
+                             _master_url_or_raise(outfit), body.stance,
+                             body.extra_view_urls),
             message="已开始生成 3D 模型",
         )
     except ValueError as exc:

--- a/backend/packages/framework/src/windup_framework/config/provider.py
+++ b/backend/packages/framework/src/windup_framework/config/provider.py
@@ -62,6 +62,16 @@ class AIProviderSettings(BaseSettings):
     # 空值 = 所有人都受额度限制(默认)。逗号分隔的用户 id,如 "1,2,3"。
     render3d_unlimited_user_ids: str = ""
 
+    # ── 图生 3D 的三个建模参数 ────────────────────────────────────────────
+    # 接出来是因为原先它们只有构造默认值,部署上改不动 —— 而其中 face_count 直接决定
+    # 用户要下多大的模型:实测线上产物 45 万顶点、FBX 20.7MB,而出帧最终只渲成
+    # 1536x2560 的平面精灵,面数用不上。降不降、降到多少要靠实测,前提是得能改。
+    #
+    # 空值 = 沿用 provider 的构造默认(Normal / 150000 / 关),行为与接出来之前一致。
+    render3d_generate_type: str = ""      # Normal 20 / Geometry 15 / LowPoly 25 / Sketch 25 积分
+    render3d_face_count: int = 0          # 0 = 不覆盖
+    render3d_enable_pbr: bool = False     # 开启 +10 积分。出帧走平面着色,PBR 材质用不上
+
     chat_fallbacks: str = ""
     image_fallbacks: str = "gemini-3.1-flash-image-preview"
     video_fallbacks: str = ""

--- a/backend/tests/test_render3d_route_and_assets.py
+++ b/backend/tests/test_render3d_route_and_assets.py
@@ -833,3 +833,47 @@ def test_a_job_that_never_comes_back_is_eventually_given_up_on(tmp_path):
     builder.ensure(OUTFIT, _png(), _NullProgress())   # 第 RIGJOB_MAX_RESUMES 轮:放弃并重提
     assert rig.submits == 2, "续了这么多轮还不放弃,资产永远建不出来"
     assert store.get(f"{RIGJOB_KEY_PREFIX}{OUTFIT}#walk") is None
+
+
+# ══ 多视图与建模参数:provider 早就支持,应用层此前一个都用不到 ══════════
+
+
+class _ViewRecordingModel3D(_FakeModel3D):
+    """记下拿到的多视图。不传时**不该收到这个关键字** —— 不接它的实现会 TypeError。"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.views: dict | None = None
+        self.saw_kwarg = False
+
+    def image_to_3d(self, master, *, want="GLB", **kw):
+        self.saw_kwarg = "extra_views" in kw
+        self.views = kw.get("extra_views")
+        return super().image_to_3d(master, want=want)
+
+
+def test_extra_views_reach_the_provider(tmp_path):
+    """多视图要一路走到 provider。中间任何一层漏接,用户按多视图付了钱,
+    拿到的却是单图重建的模型 —— 而每一道闸都正常。"""
+    m = _ViewRecordingModel3D()
+    builder = Render3DAssetBuilder(
+        model3d=m, autorig=_FakeAutoRig(), store=LocalDirAssetStore(tmp_path),
+        review=_AutoApproveReview(), may_build_assets=True,
+    )
+    builder.ensure(OUTFIT, _png(), _NullProgress(), {"back": b"BACK", "left": b"LEFT"})
+    assert m.views == {"back": b"BACK", "left": b"LEFT"}
+
+
+def test_no_views_means_the_keyword_is_not_passed_at_all(tmp_path):
+    """没有多视图时连关键字都不传。
+
+    传 ``extra_views=None`` 会让不接它的实现当场 TypeError —— 测试替身、别家 provider
+    都在此列,而那时它们本来就没有这件事要做。
+    """
+    m = _ViewRecordingModel3D()
+    builder = Render3DAssetBuilder(
+        model3d=m, autorig=_FakeAutoRig(), store=LocalDirAssetStore(tmp_path),
+        review=_AutoApproveReview(), may_build_assets=True,
+    )
+    builder.ensure(OUTFIT, _png(), _NullProgress())
+    assert m.saw_kwarg is False, "没有多视图却把关键字传下去了"

--- a/backend/tests/test_render3d_route_and_assets.py
+++ b/backend/tests/test_render3d_route_and_assets.py
@@ -877,3 +877,26 @@ def test_no_views_means_the_keyword_is_not_passed_at_all(tmp_path):
     )
     builder.ensure(OUTFIT, _png(), _NullProgress())
     assert m.saw_kwarg is False, "没有多视图却把关键字传下去了"
+
+
+def test_the_lazy_facade_accepts_every_argument_the_endpoint_passes():
+    """生产装的是 ``_LazyOperations`` 门面,不是 ``Render3DAssetOperations`` 本身。
+
+    端点按位置传参,门面少一个形参就是每一次建资产请求当场 500 —— 而全树 2000+ 条
+    用例一条都不会红,因为它们打的都是里面那个具体实现。这条专门打门面。
+    """
+    import inspect
+
+    from windup_app.server.orchestrator.render3d_service import (
+        Render3DAssetOperations,
+        _LazyOperations,
+    )
+
+    for name in ("view", "build", "approve", "discard", "add_motion"):
+        real = getattr(Render3DAssetOperations, name, None)
+        facade = getattr(_LazyOperations, name, None)
+        if real is None or facade is None:
+            continue
+        assert inspect.signature(real) == inspect.signature(facade), (
+            f"门面 {name} 的签名与实现对不上 —— 端点按位置传参,少一个形参就是线上 500"
+        )

--- a/openapi.json
+++ b/openapi.json
@@ -316,6 +316,20 @@
       "BuildAssetRequest": {
         "description": "建 3D 资产的入参。\n\n``stance`` 必填、无默认:自动绑骨只支持双足,而四足/无肢从模型几何判不出来\n(实测归档模型的包围盒比例完全重叠)。给默认值等于把「没声明」当成「双足」放行。",
         "properties": {
+          "extra_view_urls": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra View Urls"
+          },
           "stance": {
             "$ref": "#/components/schemas/CharacterStance"
           }


### PR DESCRIPTION
Closes #898

`TencentModel3DProvider` 支持的四项能力，应用层此前一项都用不到。

## 改了什么

**多视图**：`POST .../build` 新增可选 `extra_view_urls`（视角名 → 自家对象存储 URL），从 HTTP 入参贯通到 provider 消费点。

    web/api/render3d.py:51 extra_view_urls
      → :256 body.extra_view_urls
      → render3d_service.py:230 build(..., extra_view_urls)
      → :262 _resolve_views  取字节 + 视角名校验
      → :337 _start → :364 builder.ensure(..., extra_views)
      → render3d_assets.py:389 _build → :494 provider.image_to_3d(extra_views=...)

`image_to_3d_with_url` 那条也接了——**生产实际走的正是这一条**（要顺带拿上游产物 URL 做云到云），只接另一条的话多视图会被悄悄丢掉。

**三个建模参数**接到 `AI_RENDER3D_GENERATE_TYPE` / `_FACE_COUNT` / `_ENABLE_PBR`，空值一律沿用构造默认，没配过的部署行为不变。已补进 `.env.example`。

## 两个刻意的决定

**没有多视图时不传这个关键字。** 传 `extra_views=None` 会让不接它的实现当场 TypeError（测试替身、别家 provider 都在此列），而那时它们本来就没这件事要做。有用例焊住这条，把它改成无条件传会红。

**视角名非法在花钱之前拒，不静默忽略。** 静默丢掉的后果是用户按多视图付了钱、拿到的却是单图重建的模型——而每一道闸都正常。

## 关于 face_count

`150000` 这个默认值没有任何注释说明依据。实测线上产物 **45 万顶点、FBX 20.7MB**，而出帧最终只渲成 1536×2560 的平面精灵，面数用不上，却要用户在浏览器里全下下来。本 PR 只让它可配，**不改默认值**——降到多少要靠实测。

## 验证

后端 `uv run pytest` **2070 passed** / ruff / import-linter 2 kept 0 broken / openapi 已同步。

新增两条用例，变异测试两个方向都红：多视图在 builder 里被吞掉、无多视图时也传关键字。

## 前端待接

后端收的是通用的 view→url 映射（back / left / right 任选，可只传一个），前端怎么给都不用再改后端。界面上的上传槽另开 issue。
