### PR TITLE
fix(workflow-editor): 建完 3D 资产后重取角色，别让下游看到旧快照

### DIFF
--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -7,10 +7,11 @@ import {
   type NodeProps,
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useLocation, useParams } from 'react-router'
 
 import {
+  characterApis,
   projectApis,
   type ArtStyle,
   type ActionPreset,
@@ -1189,6 +1190,19 @@ function Render3DAssetPanelHost({
 }) {
   const precheck = useMasterPrecheck(input, masterUrl)
   const characterId = input.character?.id
+  // 角色数据上挂着 model_3d_url 与 rigged_motions,而「生产方式」等节点读的是这份数据。
+  // 建资产不在角色数据的更新路径上,所以建完必须把它重取一遍 —— 不重取的话,
+  // 用户刚在这里看到「3D 资产已就绪」,走到下游却被告知「该造型暂无绑骨 3D 模型」。
+  const refreshCharacter = useCallback(() => {
+    if (!characterId) return
+    void characterApis
+      .get(characterId)
+      .then((fresh) => input.setCharacter(fresh))
+      .catch(() => {
+        // 重取失败不该打断建资产那条主线:资产本身已经建成了,这里只是同步一份视图。
+        // 下游最坏退回到"需要刷新页面",与修这条之前一样,不会更糟。
+      })
+  }, [characterId, input])
   if (!characterId) return null
   return (
     <Render3DAssetPanel
@@ -1197,6 +1211,7 @@ function Render3DAssetPanelHost({
       outfitId={outfitId}
       precheck={precheck.status === 'done' ? precheck.report : null}
       disabled={disabled}
+      onAssetChanged={refreshCharacter}
     />
   )
 }

--- a/frontend/src/pages/workflow-editor/render3d-panel.test.tsx
+++ b/frontend/src/pages/workflow-editor/render3d-panel.test.tsx
@@ -182,3 +182,55 @@ describe('3D 资产面板', () => {
     expect(screen.queryByRole('button', { name: /烘入/ })).toBeNull()
   })
 })
+
+describe('资产变化要通知外面', () => {
+  afterEach(cleanup)
+
+  it('模型地址从无到有时通知一次 —— 下游读的是角色数据，不跟着更新就会自相矛盾', async () => {
+    const onAssetChanged = vi.fn()
+    // 建资产是**异步**就绪的（building → rigging → ready），就绪那一刻发生在轮询里，
+    // 不是点击之后。所以这里模拟的是「同一个组件，第二次读到的值变了」。
+    let current = asset({ state: 'rigging', model3dUrl: null })
+    const get = vi.fn(async () => current)
+    const view = render(
+      <Render3DAssetPanel
+        render3d={apis(current, { getOutfitAsset: get })}
+        characterId="7"
+        outfitId="outfit-default"
+        precheck={null}
+        disabled={false}
+        onAssetChanged={onAssetChanged}
+      />,
+    )
+    await waitFor(() => expect(get).toHaveBeenCalled())
+    expect(onAssetChanged).not.toHaveBeenCalled() // 首次读到不算变化
+
+    current = asset({ state: 'ready', model3dUrl: 'https://x/m.glb' })
+    // 轮询间隔 4 秒，默认 1 秒的 waitFor 等不到。
+    // 也**不能改成断言 get 的调用次数** —— StrictMode 下 effect 双跑，
+    // 两次立即调用就把次数满足了，与轮询无关；断言要落在结果上。
+    await waitFor(() => expect(onAssetChanged).toHaveBeenCalledTimes(1), { timeout: 8000 })
+    view.unmount()
+  })
+
+  it('值没变就不通知 —— 轮询期间每一跳都通知会把角色数据打爆', async () => {
+    const onAssetChanged = vi.fn()
+    const current = asset({ state: 'ready', model3dUrl: 'https://x/m.glb' })
+    const get = vi.fn(async () => current)
+    const view = render(
+      <Render3DAssetPanel
+        render3d={apis(current, { getOutfitAsset: get })}
+        characterId="7"
+        outfitId="outfit-default"
+        precheck={null}
+        disabled={false}
+        onAssetChanged={onAssetChanged}
+      />,
+    )
+    await waitFor(() => expect(get).toHaveBeenCalled())
+    // ready 不在 IN_FLIGHT 里,不会再轮询,所以这里等的是"确实没有第二次通知"
+    await new Promise((r) => setTimeout(r, 60))
+    expect(onAssetChanged).not.toHaveBeenCalled()
+    view.unmount()
+  })
+})

--- a/frontend/src/pages/workflow-editor/render3d-panel.tsx
+++ b/frontend/src/pages/workflow-editor/render3d-panel.tsx
@@ -4,7 +4,7 @@
  * 三条约束：金额只从后端 `cost` 读（档位会变，前端抄一份就会分叉）；`awaiting_review`
  * 是人工闸，不提供任何自动放行路径；`error` 直接展示后端文案，不在前端重拼。
  */
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import {
   RENDER3D_MOTION_LABELS,
@@ -109,6 +109,8 @@ export interface Render3DAssetPanelProps {
   /** 母版预检结果。不过检就不给建 —— 重出母版比重建模型便宜一个量级。 */
   precheck: MasterPrecheckReport | null
   disabled: boolean
+  /** 模型地址或已烘动作发生变化时调用。角色数据上挂着同一份信息，别处在读，得跟着更新。 */
+  onAssetChanged?: () => void
 }
 
 export function Render3DAssetPanel({
@@ -117,6 +119,7 @@ export function Render3DAssetPanel({
   outfitId,
   precheck,
   disabled,
+  onAssetChanged,
 }: Render3DAssetPanelProps) {
   const [refreshKey, setRefreshKey] = useState(0)
   const [busy, setBusy] = useState(false)
@@ -124,6 +127,22 @@ export function Render3DAssetPanel({
   const [confirming, setConfirming] = useState(false)
   const [stance, setStance] = useState<CharacterStance>('biped')
   const state = useRender3DAsset(render3d, characterId, outfitId, refreshKey)
+
+  // 资产就绪发生在**轮询里**，不是点击之后（build → awaiting_review → rigging → ready）。
+  // 所以盯的是观察到的值本身变化，而不是在动作回调里通知——只在点击后通知的话，
+  // 建资产那一路（异步就绪）永远不会触发，而那正是最需要通知的一路。
+  const observed =
+    state.status === 'done'
+      ? `${state.asset.model3dUrl ?? ''}|${[...state.asset.bakedMotions].sort().join(',')}`
+      : null
+  const lastObserved = useRef<string | null>(null)
+  useEffect(() => {
+    if (observed === null) return
+    const previous = lastObserved.current
+    lastObserved.current = observed
+    // 首次读到不算变化：那是页面本来就有的状态，不需要惊动别人。
+    if (previous !== null && previous !== observed) onAssetChanged?.()
+  }, [observed, onAssetChanged])
 
   if (state.status === 'loading') {
     return (


### PR DESCRIPTION
Closes #900

## 问题

同一个造型，两个节点给出相反的结论：**02 身份母版**说「3D 资产已就绪」、待机/跳跃/走路三个动作全部就绪；**04 生产方式**说「该造型暂无绑骨 3D 模型」，按钮置灰。

实测角色 151（项目 205，run 197），数据本身是对的：

    character_data.outfits[0]
      id             'outfit-default'
      model_3d_url   已写入
      rigged_motions ['idle', 'jump', 'walk']

工作流节点里 `action-first-frame.input.outfitId = 'outfit-default'`，也对得上。

## 根因

两个节点读的不是同一个源：

    02  Render3DAssetPanel → 实时查 GET /render3d/.../outfits/{oid}     ← 活的
    04  Boolean(outfit?.model3dUrl)，outfit 来自 input.character 快照      ← 死的

`Render3DAssetPanelHost` 没有任何回调，建完 3D 资产不通知任何人，角色快照因此停在建资产之前。用户只有刷新整个页面才能解开。

## 改法

面板新增 `onAssetChanged`，Host 收到后重取角色并 `setCharacter`。

**关键是通知的触发点：盯观察到的值本身变化，而不是挂在动作回调上。** 资产就绪发生在轮询里（building → awaiting_review → rigging → ready），只在点击后通知的话，建资产那一路永远不会触发——而那正是最需要通知的一路。首次读到不算变化，否则轮询期间每一跳都会去重取角色。

重取失败不打断主线：资产本身已经建成了，这里只是同步一份视图，最坏退回到"需要刷新页面"，与修这条之前一样。

## 验证

前端 format / lint / typecheck / **1365 passed** / build 全过。

新增两条用例，变异测试两个方向都红：根本不通知、首次读到也通知。

写用例时踩到一个坑记下来：**不能断言 `getOutfitAsset` 的调用次数**——StrictMode 下 effect 双跑，两次立即调用就把 `toHaveBeenCalledTimes(2)` 满足了，与轮询无关。断言要落在结果上。
