### PR TITLE
feat(render3d): 绑骨母版由系统自动转 T-Pose，不让用户去写

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
@@ -4,6 +4,7 @@ from .actions import build_attack_prompt, build_idle_prompt
 from .custom import MAX_ACTION_CHARS, build_custom_prompt
 from .jump import JUMP_PHASES, build_jump_prompt
 from .presets import ACTION_PRESETS, ActionPreset
+from .rig_master import RIG_MASTER_PROMPT_VERSION, build_rig_master_prompt
 from .view_sheet import (
     VIEW_SHEET_PROMPT_VERSION,
     build_oriented_first_frame_prompt,
@@ -30,6 +31,8 @@ __all__ = [
     "PROMPT_VERSION",
     "VIEW_SHEET_PROMPT_VERSION",
     "build_oriented_first_frame_prompt",
+    "build_rig_master_prompt",
+    "RIG_MASTER_PROMPT_VERSION",
     "build_view_sheet_prompt",
     "view_for_perspective",
 ]

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/rig_master.md
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/rig_master.md
@@ -1,0 +1,22 @@
+# 绑骨母版
+
+送进图生 3D 的那张图**只为绑骨服务**，不给人看。自动绑骨要求四肢与躯干在空间上
+分得开：手臂贴着身体时,绑骨器分不清哪块是手臂哪块是躯干,蒙皮权重会渗过去 ——
+手臂被焊在躯干上,一摆手躯干跟着变形,而这只有渲出动作才看得见。
+
+与定妆母版分开出的理由:定妆母版还要给用户看、还要给图生视频当输入,
+T-Pose 又不好看又不表达角色气质,不该让所有用户为三渲二这条路线买单。
+
+## tpose
+
+```text
+This is an image-to-image task. The attached image is the confirmed CHARACTER master —
+preserve its identity, face, body proportions, outfit, colors and accessories exactly.
+Change ONLY the pose: put the character in a strict symmetrical T-pose. Both arms fully
+extended straight out to the left and right, horizontal at shoulder height, elbows straight,
+palms down, clearly separated from the torso with visible empty space under both armpits.
+Both legs straight and vertical, feet flat and slightly apart, hips square, head upright
+facing the viewer. Full body from head to feet, character centred in frame, orthographic
+sprite projection, flat even lighting, plain light-gray background, no shadow.
+Exactly one character in the frame. No weapon, no prop, no held object.
+```

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/rig_master.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/rig_master.py
@@ -1,0 +1,27 @@
+"""绑骨母版的图生图提示词。
+
+提示词正文在 ``prompts/rig_master.md``。本模块只做加载。
+
+**与定妆母版分开的理由**在 md 里写了:定妆母版还要给用户看、还要给图生视频当输入,
+而 T-Pose 只对自动绑骨有意义。一张图兼顾两者的结果是两边都不到位 ——
+实测线上产物臂展/身高 0.523,只比闸口下限 0.45 高 0.07,没够到 A-Pose 区间 0.55–0.75。
+"""
+
+from __future__ import annotations
+
+from windup_ai_engine.prompt._md import load_section
+
+__all__ = ["RIG_MASTER_PROMPT_VERSION", "build_rig_master_prompt"]
+
+_DOC = "rig_master.md"
+RIG_MASTER_PROMPT_VERSION = "v1"
+
+
+def build_rig_master_prompt() -> str:
+    """从定妆母版转出 T-Pose 绑骨母版的提示词。
+
+    无参数:身份由附上的定妆母版携带,姿势与构图全部由模板锁死 ——
+    留一个 ``extra`` 口子的话,调用方补进来的站姿描述会和 T-Pose 打架,
+    而打架的结果是"手臂张开了一半",那正好落在闸口最难判的区间。
+    """
+    return load_section(_DOC, "tpose")

--- a/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
+++ b/backend/packages/app/src/windup_app/server/orchestrator/render3d_service.py
@@ -155,12 +155,16 @@ class Render3DAssetOperations:
         *,
         fetch: Callable[[str], bytes] = fetch_own_media,
         spawn: Callable[[Callable[[], None]], None] = _spawn_thread,
+        image=None,
     ) -> None:
         self._builder = builder
         self._store = store
         self._publish = publish
         self._fetch = fetch
         self._spawn = spawn
+        # 生图网关**懒装配**:没配生图凭证的部署不该因为多了这一步就起不来,
+        # 而绑骨母版转不出来时本来就会退回定妆母版。
+        self._image = image
         self._jobs: dict[str, _Job] = {}
         self._lock = threading.Lock()
 
@@ -260,7 +264,11 @@ class Render3DAssetOperations:
             raise MasterPrecheckFailed(report)
 
         views = self._resolve_views(extra_view_urls)
-        self._start(outfit_key, PHASE_BUILDING, master, views)
+        # 送进图生 3D 的不是定妆母版本身,而是从它转出的 T-Pose 绑骨母版。
+        # 定妆母版对姿势没有任何约束(它的提示词里一个字没提姿势),而自动绑骨要求
+        # 四肢与躯干分得开 —— 让用户自己去写「T-pose」是把绑骨的实现细节漏给用户。
+        rig_master = self._rig_master(master)
+        self._start(outfit_key, PHASE_BUILDING, rig_master, views)
         return self.view(outfit_key)
 
     def _resolve_views(self, urls: Mapping[str, str] | None) -> dict[str, bytes] | None:
@@ -276,6 +284,44 @@ class Render3DAssetOperations:
                 f"视角名只能取 {sorted(VIEW_TYPES)},收到 {bad}。正面走母版,不在这里传。"
             )
         return {k: self._fetch(v) for k, v in urls.items()}
+    #: 绑骨母版相对定妆母版,主体宽高比至少要涨这么多。
+    #:
+    #: 张开手臂必然让主体变宽,所以这是个**能证伪的**判据:比值没涨说明那一版根本
+    #: 没照做,而没照做的后果只有渲出动作才看得见(手臂被焊在躯干上、一摆手躯干跟着变形)。
+    #: 取 1.15 而不是更高:定妆母版本身可能已经半张开,留出余量,只拦"完全没动"。
+    RIG_MASTER_MIN_WIDEN = 1.15
+
+    def _rig_master(self, master: bytes) -> bytes:
+        """定妆母版 → T-Pose 绑骨母版。转不出来就用原图,不让整条建资产失败。
+
+        **失败要能退回**:绑骨母版是为了把姿势做对,不是必要条件 —— 转不出来时
+        用定妆母版仍然可能绑成(线上实测 0.523 就是这么过的),而在这里硬拒等于
+        把一条本来能走的路堵死。
+        """
+        from windup_ai_engine.prompt import build_rig_master_prompt
+
+        try:
+            posed = self._image_gateway().gen_image(build_rig_master_prompt(), [master])
+            before = precheck_master_bytes(master)["facts"]["subject_ratio"]
+            after = precheck_master_bytes(posed)["facts"]["subject_ratio"]
+            if after < before * self.RIG_MASTER_MIN_WIDEN:
+                logger.info(
+                    "绑骨母版没把手臂张开(主体宽高比 %.3f → %.3f,不足 %.2f 倍),改用定妆母版",
+                    before, after, self.RIG_MASTER_MIN_WIDEN,
+                )
+                return master
+            logger.info("绑骨母版已转出(主体宽高比 %.3f → %.3f)", before, after)
+            return posed
+        except Exception:                              # noqa: BLE001 —— 尽力而为
+            logger.exception("转绑骨母版失败,改用定妆母版")
+            return master
+
+    def _image_gateway(self):
+        if self._image is None:
+            from windup_framework.gateway import build_image_gateway
+
+            self._image = build_image_gateway()
+        return self._image
 
     def approve(self, outfit_key: str, master_url: str) -> dict:
         """人点头 → ② 绑骨。**这道闸不会自己点头**,只有本方法能放行,而它只挂在

--- a/backend/packages/framework/src/windup_framework/providers/render3d/__init__.py
+++ b/backend/packages/framework/src/windup_framework/providers/render3d/__init__.py
@@ -41,6 +41,7 @@ from .interfaces import (
 from .sprite import DIRECTIONS_4, DIRECTIONS_8, MATERIALS, LocalSpriteRenderProvider
 from .tencent import (
     PRESET_MOTIONS,
+    VIEW_TYPES,
     SpendNotAuthorizedError,
     TencentAutoRigProvider,
     TencentCosModelUploader,
@@ -57,7 +58,8 @@ __all__ = [
     "TencentModel3DProvider", "TencentAutoRigProvider", "TencentCosModelUploader",
     "LocalSpriteRenderProvider",
     # 预检 / 常量
-    "check_model", "sniff_format", "PRESET_MOTIONS", "DIRECTIONS_4", "DIRECTIONS_8",
+    "check_model", "sniff_format", "PRESET_MOTIONS", "VIEW_TYPES",
+    "DIRECTIONS_4", "DIRECTIONS_8",
     "MATERIALS", "TencentCredentials", "redact",
     # 出错形态
     "ModelRejected", "ArtifactFormatError", "ModelNotPublicError", "JobFailedError",

--- a/backend/tests/test_render3d_asset_endpoints.py
+++ b/backend/tests/test_render3d_asset_endpoints.py
@@ -58,10 +58,12 @@ class _FakeModel3D:
     def __init__(self) -> None:
         self.calls = 0
         self.seen: list[bytes] = []      # 收到的是哪张图 —— 送错图和没送一样致命
+        self.views: dict | None = None   # 多视图有没有真的传下来
 
-    def image_to_3d(self, master: bytes, *, want: str = "GLB") -> bytes:
+    def image_to_3d(self, master: bytes, *, want: str = "GLB", **kw) -> bytes:
         self.calls += 1
         self.seen.append(master)
+        self.views = kw.get("extra_views")
         return b"glTF-fake-model"
 
 
@@ -553,3 +555,22 @@ def test_a_failed_pose_step_does_not_sink_the_whole_build(api, render3d):
     r = api.post(f"{_base()}/build", json=BIPED)
     assert r.status_code == 200, r.json()
     assert render3d.test_model3d.seen == [render3d.test_source["master"]]
+
+
+def test_extra_views_survive_alongside_the_posed_master(api, render3d):
+    """多视图与 T-Pose 绑骨母版**同时生效**。
+
+    两者在 build 里挨着,合并时极易只留一半 —— 而少了哪一半都不报错:
+    丢了多视图就是用户按多视图付了钱拿到单图重建;丢了绑骨母版就是手臂焊在躯干上。
+    这条专门盯那一行同时带两个参数的调用。
+    """
+    posed = _subject_png(240, 120, (40, 90, 200))
+    render3d._image = _PosingImage(posed)
+    render3d.test_source["back"] = b"BACK-VIEW-BYTES"
+    original_fetch = render3d._fetch
+    render3d._fetch = lambda url: (
+        b"BACK-VIEW-BYTES" if url == "https://cdn.windup.test/back.png" else original_fetch(url)
+    )
+    api.post(f"{_base()}/build", json={**BIPED, "extra_view_urls": {"back": "https://cdn.windup.test/back.png"}})
+    assert render3d.test_model3d.seen == [posed], "送进图生 3D 的不是 T-Pose 绑骨母版"
+    assert render3d.test_model3d.views == {"back": b"BACK-VIEW-BYTES"}, "多视图没传下去"

--- a/backend/tests/test_render3d_asset_endpoints.py
+++ b/backend/tests/test_render3d_asset_endpoints.py
@@ -57,9 +57,11 @@ class _FakeModel3D:
 
     def __init__(self) -> None:
         self.calls = 0
+        self.seen: list[bytes] = []      # 收到的是哪张图 —— 送错图和没送一样致命
 
     def image_to_3d(self, master: bytes, *, want: str = "GLB") -> bytes:
         self.calls += 1
+        self.seen.append(master)
         return b"glTF-fake-model"
 
 
@@ -479,3 +481,75 @@ def test_discarding_frees_a_slot(api, engine, render3d):
 
     data = _data(api.post(f"{_base()}/build", json=BIPED))
     assert data["state"] in {"building", "awaiting_review"}
+
+
+# ══ 绑骨母版:送进图生 3D 的是 T-Pose 转出来的那张,不是定妆母版 ══════════
+
+
+def _subject_png(w: int, h: int, color: tuple[int, int, int]) -> bytes:
+    """指定主体宽高与颜色。**颜色要能区分** —— 两张图字节一样的话,
+    "用了转出来那张"与"退回定妆母版"结果相同,断言分不出来(变异测试逮出来过)。"""
+    img = Image.new("RGBA", (w + 40, h + 40), (0, 0, 0, 0))
+    for x in range(20, 20 + w):
+        for y in range(20, 20 + h):
+            img.putpixel((x, y), (*color, 255))
+    buf = io.BytesIO()
+    img.save(buf, "PNG")
+    return buf.getvalue()
+
+
+class _PosingImage:
+    """生图桩:返回给定的字节,并记下被调了几次、拿到什么提示词。"""
+
+    def __init__(self, out: bytes | None) -> None:
+        self.out = out
+        self.calls = 0
+        self.prompts: list[str] = []
+
+    def gen_image(self, prompt, refs):
+        self.calls += 1
+        self.prompts.append(prompt)
+        if self.out is None:
+            raise RuntimeError("生图网关不可用")
+        return self.out
+
+
+def test_the_posed_master_is_what_goes_into_image_to_3d(api, render3d):
+    """转出来的 T-Pose 母版要**真的被送进去** —— 转了却不用等于白花一次生图。"""
+    posed = _subject_png(240, 120, (40, 90, 200))   # 明显更宽 = 手臂张开了
+    image = _PosingImage(posed)
+    render3d._image = image
+    api.post(f"{_base()}/build", json=BIPED)
+    assert image.calls == 1
+    assert "T-pose" in image.prompts[0]
+    assert render3d.test_model3d.seen == [posed], "送进图生 3D 的不是转出来那张"
+
+
+def test_a_posed_master_that_did_not_widen_is_rejected(api, render3d):
+    """主体没变宽 = 那一版根本没照做。
+
+    张开手臂必然让主体变宽,所以这是个能证伪的判据。用它而不是信任模型照做了 ——
+    没照做的后果只有渲出动作才看得见（手臂焊在躯干上、一摆手躯干跟着变形）。
+    """
+    # 和定妆母版一样宽（= 没张开），但**颜色不同**所以字节不同 ——
+    # 否则两条路产出相同字节，断言恒真。
+    narrow = _master_png(legs_apart=False)
+    assert narrow != render3d.test_source["master"], "两版字节必须不同,否则断言恒真"
+    image = _PosingImage(narrow)
+    render3d._image = image
+    api.post(f"{_base()}/build", json=BIPED)
+    assert render3d.test_model3d.seen == [render3d.test_source["master"]], (
+        "没变宽却仍然用了转出来那张"
+    )
+
+
+def test_a_failed_pose_step_does_not_sink_the_whole_build(api, render3d):
+    """转不出来就退回定妆母版,不让整条建资产失败。
+
+    绑骨母版是为了把姿势做对,不是必要条件——线上实测臂展 0.523 的定妆母版
+    也绑成过。在这里硬拒等于把一条本来能走的路堵死。
+    """
+    render3d._image = _PosingImage(None)       # 生图直接抛
+    r = api.post(f"{_base()}/build", json=BIPED)
+    assert r.status_code == 200, r.json()
+    assert render3d.test_model3d.seen == [render3d.test_source["master"]]


### PR DESCRIPTION
Closes #903

## 问题

送进图生 3D 的是身份母版，而它的提示词里**一个字没提姿势**——姿势全看用户怎么写角色描述。于是用户必须自己知道「走三渲二要在描述里写 T-pose」，否则手臂垂着，绑骨器分不开手臂与躯干，蒙皮权重渗过去，手臂被焊在躯干上。这只有渲出动作才看得见。

实测线上产物臂展/身高 **0.523**，只比 `ARM_SPAN_MIN = 0.45` 高 0.07，没够到 A-Pose 区间 0.55–0.75（本仓唯一一个成功存档是 0.715）。贴着线过的。

## 改法

建资产时从定妆母版 i2i 转一张 T-Pose 绑骨母版，送它进图生 3D。定妆母版不受影响——它还要给用户看、给图生视频当输入。

**转完要验**：主体宽高比至少涨 `RIG_MASTER_MIN_WIDEN = 1.15` 倍。张开手臂必然让主体变宽，所以这是个**能证伪**的判据，而不是信任模型照做了。没涨就退回定妆母版。

转不出来（生图网关不可用等）同样退回，不让整条建资产失败——绑骨母版是把姿势做对，不是必要条件，实测 0.523 的定妆母版也绑成过，硬拒等于堵死一条本来能走的路。

## 验证

后端 ruff / import-linter / **pytest 全绿**。三条新用例，变异测试三个方向都红：不转、不验宽度、转失败就挂掉。

写用例时踩到一个坑记下来：第一版「没变宽要退回」那条是**空的**——桩返回的图和定妆母版字节完全一样，两条路产出相同结果，断言恒真。是变异测试逮出来的，已改成同宽但字节不同的图。