### PR TITLE
feat(workflow-editor): 上传的参考图本身就是一个可选母版

### DIFF
--- a/frontend/src/pages/workflow-editor/index.test.tsx
+++ b/frontend/src/pages/workflow-editor/index.test.tsx
@@ -154,6 +154,18 @@ describe('WorkflowEditorPage real runtime boundary', () => {
     )
   })
 
+  it('上传过参考图时，它本身就是一个可选母版', async () => {
+    // 用户手上已经有成品角色图时，再生成一遍只会更差。此前「直接用我这张」是个
+    // 不存在的选项——只能眼看着系统拿它去重画，然后从重画的结果里挑。
+    const session = createSession(selectingMasterWithReferenceWorkflow())
+    defaultSessionLoader.mockResolvedValue(session)
+    renderEditor('/workflow-editor/42')
+
+    const own = await screen.findByRole('button', { name: '选择我上传的参考图' })
+    fireEvent.click(own)
+    expect(own.getAttribute('aria-pressed')).toBe('true')
+  })
+
   it('角色母版微调失败时保留输入草稿以便重试', async () => {
     const session = createSession(completedTemplateWorkflow('42'))
     vi.spyOn(session.controller, 'regenerateCharacterTemplate').mockRejectedValueOnce(
@@ -2419,6 +2431,41 @@ function workflowFixture(): WorkflowRun {
         type: 'character-template',
         status: 'locked',
         phase: 'ready',
+        dependsOnNodeIds: ['character-setup'],
+        generations: [],
+        error: null,
+        selectedImageUrl: null,
+      },
+    ],
+  }
+}
+
+/** 母版节点正在选候选，且用户上传过参考图——「直接用我上传那张」的判定发生在这一步。 */
+function selectingMasterWithReferenceWorkflow(): WorkflowRun {
+  return {
+    id: '42',
+    projectId: '1',
+    version: 3,
+    storageStatus: 'active',
+    nodes: [
+      {
+        id: 'character-setup',
+        type: 'character-setup',
+        status: 'passed',
+        phase: 'completed',
+        dependsOnNodeIds: [],
+        generations: [],
+        error: null,
+        input: {
+          prompt: '一头橙色卡通小牛',
+          referenceMedia: ['https://cdn.test/my-cow.png' as unknown as MediaReference],
+        },
+      },
+      {
+        id: 'character-template',
+        type: 'character-template',
+        status: 'active',
+        phase: 'selecting',
         dependsOnNodeIds: ['character-setup'],
         generations: [],
         error: null,

--- a/frontend/src/pages/workflow-editor/index.tsx
+++ b/frontend/src/pages/workflow-editor/index.tsx
@@ -834,7 +834,18 @@ function CharacterTemplateContent({
       }
     })
     if (!masterConfirmed) {
-      const images = groups[0]?.images ?? []
+      const generated = groups[0]?.images ?? []
+      // 用户上传的参考图也是一个候选。他手上已经有成品图时，再生成一遍只会更差 ——
+      // 而「直接用我这张」此前是个不存在的选项，只能眼看着系统拿它去重画。
+      const setupNode = findDependency(input.run, node, 'character-setup')
+      const uploaded = setupNode?.input.referenceMedia?.[0]
+      const uploadedUrl = uploaded ? String(uploaded) : null
+      const images = uploadedUrl
+        ? [
+            { url: uploadedUrl, uploaded: true },
+            ...generated.map((i) => ({ ...i, uploaded: false })),
+          ]
+        : generated.map((i) => ({ ...i, uploaded: false }))
       const selectedImageUrl =
         images.find(
           (image) => image.url === input.selectedImages[selectionKey(node.id, anchorDirection)],
@@ -847,7 +858,7 @@ function CharacterTemplateContent({
                 type="button"
                 key={image.url}
                 className={THUMB_BUTTON}
-                aria-label={`选择角色候选 ${index + 1}`}
+                aria-label={image.uploaded ? '选择我上传的参考图' : `选择角色候选 ${index + 1}`}
                 aria-pressed={
                   input.selectedImages[selectionKey(node.id, anchorDirection)] === image.url
                 }
@@ -858,7 +869,16 @@ function CharacterTemplateContent({
                   }))
                 }
               >
-                <WorkflowImage src={image.url} alt={`角色候选 ${index + 1}`} variant="thumbnail" />
+                <WorkflowImage
+                  src={image.url}
+                  alt={image.uploaded ? '我上传的参考图' : `角色候选 ${index + 1}`}
+                  variant="thumbnail"
+                />
+                {image.uploaded ? (
+                  <small className="mt-[3px] block text-[9px] font-[750] text-app-accent">
+                    我上传的图
+                  </small>
+                ) : null}
               </button>
             ))}
           </div>
@@ -871,7 +891,9 @@ function CharacterTemplateContent({
               branchBusy={branchBusy}
             />
           ) : (
-            <p className={CARD_TEXT}>先选一张候选，再决定是否把它定为母版。</p>
+            <p className={CARD_TEXT}>
+              先选一张，再决定是否把它定为母版。已上传的参考图也可以直接选。
+            </p>
           )}
         </div>
       )


### PR DESCRIPTION
Closes #908

母版节点此前只渲染生成出来的候选，用户上传的参考图不在其中——手上已经有成品角色图时，只能从重画的结果里挑，而重画往往不如原图。

后端不存在这个限制：`confirmCharacterTemplate(nodeId, selectedImageUrl, ...)` 收任意 URL、只做非空校验。补的是前端入口。

上传那张会标注「我上传的图」并排在首位，避免与生成候选混淆。

## 触发场景

横版项目的母版必然是侧视——`SIDE` 的定义就是「横版侧视，角色朝画面右侧行进（母版也须朝侧向）」。而走三渲二需要正面 T-Pose，用户上传的恰好就是，却用不上。

## 验证

前端 format / lint / typecheck / **1368 passed** / build 全过。

新增一条用例，变异测试红：把 `uploadedUrl` 恒设为 null（退回今天的行为），用例会红。