### PR TITLE
fix(quick-start): 完善历史消息栏展示

### DIFF
--- a/frontend/src/pages/quick-start/history-sidebar.tsx
+++ b/frontend/src/pages/quick-start/history-sidebar.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useState } from 'react'
-import {
-  ChatCircle,
-  ClockCounterClockwise,
-  NotePencil,
-  SidebarSimple,
-  X,
-} from '@phosphor-icons/react'
+import { ClockCounterClockwise, Note, NotePencil, SidebarSimple, X } from '@phosphor-icons/react'
 import { Link } from 'react-router'
 
 import type { QuickStartEntryService, QuickStartHistoryItem } from './service'
@@ -138,13 +132,14 @@ export function QuickStartHistorySidebar({
                           : 'text-app-ink-soft hover:bg-app-surface-muted'
                       }`}
                     >
-                      <ChatCircle
+                      <Note
                         aria-hidden="true"
+                        data-icon="history-entry"
                         size={17}
                         weight={current ? 'fill' : 'regular'}
                         className={current ? 'text-app-accent' : 'text-app-faint'}
                       />
-                      <span className="truncate">{item.title}</span>
+                      <span className="min-w-0 flex-1 truncate">{item.title}</span>
                     </Link>
                   </li>
                 )

--- a/frontend/src/pages/quick-start/index.test.tsx
+++ b/frontend/src/pages/quick-start/index.test.tsx
@@ -762,6 +762,26 @@ describe('QuickStartPage', () => {
     expect(service.open).toHaveBeenLastCalledWith('run-old')
   })
 
+  it('让超长历史标题占用剩余宽度并稳定省略', async () => {
+    const longTitle = '披白羽斗篷、戴月牙面具并携带星盘的占星师'
+    renderAt(
+      '/quick-start/run-current',
+      serviceFor(workflow(setupAndTemplate(), 'run-current'), {
+        listHistory: vi.fn(async () => [{ runId: 'run-current', title: longTitle }]),
+      }),
+    )
+
+    const history = await screen.findByRole('navigation', { name: '创作历史' })
+    const link = within(history).getByRole('link', { name: longTitle })
+    const title = within(link).getByText(longTitle)
+
+    expect(link.getAttribute('title')).toBe(longTitle)
+    expect(title.className).toContain('min-w-0')
+    expect(title.className).toContain('flex-1')
+    expect(title.className).toContain('truncate')
+    expect(link.querySelector('svg')?.getAttribute('data-icon')).toBe('history-entry')
+  })
+
   it('keeps the main export capability available in the conversation UI', async () => {
     const run = workflow(setupAndTemplate({ selectedImageUrl: '/master.png' }))
     const model: ExportPackageModel = {


### PR DESCRIPTION
## Summary

- 调整 Quick Start 历史记录的消息入口图标
- 对超长会话标题增加稳定截断，避免挤压侧栏布局
- 增加长标题回归测试

## Verification

- `npm test -- --run src/pages/quick-start/index.test.tsx`（131 passed）
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Refs #783