### PR TITLE
fix(project): 优化项目创建表单控件

### DIFF
--- a/frontend/src/pages/project-create/index.test.tsx
+++ b/frontend/src/pages/project-create/index.test.tsx
@@ -47,6 +47,11 @@ function workflowCreationRequests(backend: ReturnType<typeof createProjectAssets
   )
 }
 
+function chooseOption(label: string, option: string) {
+  fireEvent.click(screen.getByRole('combobox', { name: label }))
+  fireEvent.click(screen.getByRole('option', { name: option }))
+}
+
 function installWorkflowBackend(failWorkflowAttempts = 0) {
   const backend = createProjectAssetsBackend()
   const baseFetch = backend.fetch
@@ -151,6 +156,7 @@ describe('ProjectCreatePage', () => {
     await renderWorkflowProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '可重试画布' } })
+    fireEvent.click(screen.getByRole('button', { name: '自定义' }))
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
 
     expect((await screen.findByRole('alert')).textContent).toBe('项目已创建，但工作流暂时无法创建')
@@ -175,10 +181,10 @@ describe('ProjectCreatePage', () => {
     await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
-    fireEvent.change(screen.getByLabelText('游戏视角'), { target: { value: 'top-down' } })
-    fireEvent.change(screen.getByLabelText('朝向'), { target: { value: 'eight-way' } })
+    chooseOption('游戏视角', '俯视')
+    chooseOption('朝向', '八向')
     fireEvent.click(screen.getByRole('button', { name: '512 × 512' }))
-    fireEvent.change(screen.getByLabelText('画风'), { target: { value: 'pixel' } })
+    chooseOption('画风', '像素')
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
 
     expect(await screen.findByRole('heading', { name: '雾港来信' })).toBeTruthy()
@@ -243,11 +249,11 @@ describe('ProjectCreatePage', () => {
     await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '点灯人 · MVP' } })
-    fireEvent.change(screen.getByLabelText('画风'), { target: { value: 'pixel' } })
+    chooseOption('画风', '像素')
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
 
     expect((await screen.findByRole('alert')).textContent).toBe('项目名称已存在')
-    expect((screen.getByLabelText('画风') as HTMLSelectElement).value).toBe('pixel')
+    expect(screen.getByRole('combobox', { name: '画风' }).textContent).toContain('像素')
   })
 
   it('连续点击创建只发出一次请求', async () => {
@@ -277,6 +283,7 @@ describe('ProjectCreatePage', () => {
     await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
+    fireEvent.click(screen.getByRole('button', { name: '自定义' }))
     fireEvent.change(screen.getByLabelText('宽度（像素）'), { target: { value: '16' } })
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
 
@@ -313,6 +320,7 @@ describe('ProjectCreatePage', () => {
     await renderProjectCreate()
 
     fireEvent.change(screen.getByLabelText('项目名称'), { target: { value: '雾港来信' } })
+    fireEvent.click(screen.getByRole('button', { name: '自定义' }))
     fireEvent.change(screen.getByLabelText('宽度（像素）'), { target: { value: '16' } })
     fireEvent.click(screen.getByRole('button', { name: '创建项目' }))
     expect(await screen.findByRole('alert')).toBeTruthy()
@@ -320,5 +328,32 @@ describe('ProjectCreatePage', () => {
     fireEvent.click(screen.getByRole('button', { name: '256 × 256' }))
 
     expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('默认只显示尺寸预设，选择自定义后才显示宽高输入', async () => {
+    installBackend()
+    await renderProjectCreate()
+
+    expect(screen.queryByLabelText('宽度（像素）')).toBeNull()
+    expect(screen.getByRole('button', { name: '256 × 256' }).getAttribute('aria-pressed')).toBe(
+      'true',
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '自定义' }))
+
+    expect(screen.getByLabelText('宽度（像素）')).toBeTruthy()
+    expect(screen.getByLabelText('高度（像素）')).toBeTruthy()
+    expect(screen.getByRole('button', { name: '自定义' }).getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: '128 × 128' }))
+    expect(screen.queryByLabelText('宽度（像素）')).toBeNull()
+  })
+
+  it('游戏视角、朝向和画风使用产品下拉框而不是原生 select', async () => {
+    installBackend()
+    const { container } = await renderProjectCreate()
+
+    expect(container.querySelectorAll('select')).toHaveLength(0)
+    expect(screen.getAllByRole('combobox')).toHaveLength(3)
   })
 })

--- a/frontend/src/pages/project-create/index.tsx
+++ b/frontend/src/pages/project-create/index.tsx
@@ -16,6 +16,7 @@ import {
   type WorkflowNode,
 } from '@/entities'
 import { ApiError, getApiAccessToken } from '@/shared/api'
+import { ProductSelect } from '@/shared/ui'
 import { ProjectCreatePixelMark } from './pixel-mark'
 
 /**
@@ -53,6 +54,7 @@ export function ProjectCreatePage() {
   const [directionalMovement, setDirectionalMovement] = useState<DirectionalMovement>('single')
   const [spriteWidth, setSpriteWidth] = useState('256')
   const [spriteHeight, setSpriteHeight] = useState('256')
+  const [customSpriteSize, setCustomSpriteSize] = useState(false)
   const [gameStyle, setGameStyle] = useState<ArtStyle>('unspecified')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -171,40 +173,38 @@ export function ProjectCreatePage() {
               >
                 游戏视角
               </label>
-              <select
+              <ProductSelect
                 id="project-perspective"
                 value={perspective}
                 disabled={createdProject !== null}
-                onChange={(event) => setPerspective(event.target.value as CharacterPerspective)}
-                className="rounded-xl border border-app-line bg-app-surface px-4 py-3 text-sm outline-none focus-visible:border-app-accent"
-              >
-                {Object.entries(CHARACTER_PERSPECTIVE).map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
+                options={Object.entries(CHARACTER_PERSPECTIVE).map(([value, label]) => ({
+                  value: value as CharacterPerspective,
+                  label,
+                }))}
+                onChange={(value) => {
+                  setPerspective(value)
+                  setError(null)
+                }}
+              />
             </div>
 
             <div className="grid gap-2">
               <label className="text-xs font-semibold text-app-ink-soft" htmlFor="project-movement">
                 朝向
               </label>
-              <select
+              <ProductSelect
                 id="project-movement"
                 value={directionalMovement}
                 disabled={createdProject !== null}
-                onChange={(event) =>
-                  setDirectionalMovement(event.target.value as DirectionalMovement)
-                }
-                className="rounded-xl border border-app-line bg-app-surface px-4 py-3 text-sm outline-none focus-visible:border-app-accent"
-              >
-                {Object.entries(DIRECTIONAL_MOVEMENT).map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
+                options={Object.entries(DIRECTIONAL_MOVEMENT).map(([value, label]) => ({
+                  value: value as DirectionalMovement,
+                  label,
+                }))}
+                onChange={(value) => {
+                  setDirectionalMovement(value)
+                  setError(null)
+                }}
+              />
             </div>
           </div>
 
@@ -219,69 +219,85 @@ export function ProjectCreatePage() {
                   onClick={() => {
                     setSpriteWidth(String(preset))
                     setSpriteHeight(String(preset))
+                    setCustomSpriteSize(false)
                     // 按钮点击不是表单的 change 事件，收不到表单上那个清错误的处理，只能自己清。
                     setError(null)
                   }}
-                  aria-pressed={spriteWidth === String(preset) && spriteHeight === String(preset)}
+                  aria-pressed={
+                    !customSpriteSize &&
+                    spriteWidth === String(preset) &&
+                    spriteHeight === String(preset)
+                  }
                   className="rounded-full border border-app-line px-4 py-1.5 text-xs text-app-ink-soft aria-pressed:border-app-accent aria-pressed:bg-app-accent aria-pressed:text-app-on-accent"
                 >
                   {preset} × {preset}
                 </button>
               ))}
+              <button
+                type="button"
+                disabled={createdProject !== null}
+                aria-pressed={customSpriteSize}
+                onClick={() => {
+                  setCustomSpriteSize(true)
+                  setError(null)
+                }}
+                className="rounded-full border border-app-line px-4 py-1.5 text-xs text-app-ink-soft aria-pressed:border-app-accent aria-pressed:bg-app-accent aria-pressed:text-app-on-accent"
+              >
+                自定义
+              </button>
             </div>
-            <div className="grid gap-5 sm:grid-cols-2">
-              <div className="grid gap-2">
-                <label className="text-[10px] text-app-faint" htmlFor="project-sprite-width">
-                  宽度（像素）
-                </label>
-                <input
-                  id="project-sprite-width"
-                  type="number"
-                  inputMode="numeric"
-                  min={SPRITE_MIN}
-                  max={SPRITE_MAX}
-                  value={spriteWidth}
-                  disabled={createdProject !== null}
-                  onChange={(event) => setSpriteWidth(event.target.value)}
-                  className="rounded-xl border border-app-line bg-app-surface px-4 py-3 text-sm outline-none focus-visible:border-app-accent"
-                />
+            {customSpriteSize ? (
+              <div className="grid gap-5 sm:grid-cols-2">
+                <div className="grid gap-2">
+                  <label className="text-[10px] text-app-faint" htmlFor="project-sprite-width">
+                    宽度（像素）
+                  </label>
+                  <input
+                    id="project-sprite-width"
+                    type="number"
+                    inputMode="numeric"
+                    min={SPRITE_MIN}
+                    max={SPRITE_MAX}
+                    value={spriteWidth}
+                    disabled={createdProject !== null}
+                    onChange={(event) => setSpriteWidth(event.target.value)}
+                    className="rounded-xl border border-app-line bg-app-surface px-4 py-3 text-sm outline-none focus-visible:border-app-accent"
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <label className="text-[10px] text-app-faint" htmlFor="project-sprite-height">
+                    高度（像素）
+                  </label>
+                  <input
+                    id="project-sprite-height"
+                    type="number"
+                    inputMode="numeric"
+                    min={SPRITE_MIN}
+                    max={SPRITE_MAX}
+                    value={spriteHeight}
+                    disabled={createdProject !== null}
+                    onChange={(event) => setSpriteHeight(event.target.value)}
+                    className="rounded-xl border border-app-line bg-app-surface px-4 py-3 text-sm outline-none focus-visible:border-app-accent"
+                  />
+                </div>
               </div>
-              <div className="grid gap-2">
-                <label className="text-[10px] text-app-faint" htmlFor="project-sprite-height">
-                  高度（像素）
-                </label>
-                <input
-                  id="project-sprite-height"
-                  type="number"
-                  inputMode="numeric"
-                  min={SPRITE_MIN}
-                  max={SPRITE_MAX}
-                  value={spriteHeight}
-                  disabled={createdProject !== null}
-                  onChange={(event) => setSpriteHeight(event.target.value)}
-                  className="rounded-xl border border-app-line bg-app-surface px-4 py-3 text-sm outline-none focus-visible:border-app-accent"
-                />
-              </div>
-            </div>
+            ) : null}
           </fieldset>
 
           <div className="grid gap-2">
             <label className="text-xs font-semibold text-app-ink-soft" htmlFor="project-style">
               画风
             </label>
-            <select
+            <ProductSelect
               id="project-style"
               value={gameStyle}
               disabled={createdProject !== null}
-              onChange={(event) => setGameStyle(event.target.value as ArtStyle)}
-              className="rounded-xl border border-app-line bg-app-surface px-4 py-3 text-sm outline-none focus-visible:border-app-accent"
-            >
-              {ART_STYLE_OPTIONS.map((value) => (
-                <option key={value} value={value}>
-                  {ART_STYLE[value]}
-                </option>
-              ))}
-            </select>
+              options={ART_STYLE_OPTIONS.map((value) => ({ value, label: ART_STYLE[value] }))}
+              onChange={(value) => {
+                setGameStyle(value)
+                setError(null)
+              }}
+            />
             <small className="text-[11px] leading-5 text-app-muted">
               {ART_STYLE_HINT[gameStyle]}
             </small>

--- a/frontend/src/shared/ui/index.ts
+++ b/frontend/src/shared/ui/index.ts
@@ -26,3 +26,5 @@ export {
 } from './product-control'
 export type { ProductControlVariant, ProductPopoverMotionState } from './product-control'
 export { useProductPopoverMotion } from './product-popover-motion'
+export { ProductSelect } from './product-select'
+export type { ProductSelectOption, ProductSelectProps } from './product-select'

--- a/frontend/src/shared/ui/product-select.test.tsx
+++ b/frontend/src/shared/ui/product-select.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ProductSelect } from './product-select'
+
+afterEach(cleanup)
+
+describe('ProductSelect', () => {
+  it('用方向键选择选项并在确认后把焦点留在触发器上', () => {
+    const onChange = vi.fn()
+    render(
+      <ProductSelect
+        id="movement"
+        aria-label="朝向"
+        value="single"
+        options={[
+          { value: 'single', label: '单向' },
+          { value: 'four-way', label: '四向' },
+          { value: 'eight-way', label: '八向' },
+        ]}
+        onChange={onChange}
+      />,
+    )
+
+    const trigger = screen.getByRole('combobox', { name: '朝向' })
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+
+    expect(onChange).toHaveBeenCalledWith('four-way')
+    expect(screen.queryByRole('listbox')).toBeNull()
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('按 Escape 或点击组件外部会关闭选项', () => {
+    render(
+      <div>
+        <ProductSelect
+          id="style"
+          aria-label="画风"
+          value="pixel"
+          options={[
+            { value: 'pixel', label: '像素' },
+            { value: 'ink', label: '水墨' },
+          ]}
+          onChange={() => undefined}
+        />
+        <button type="button">外部按钮</button>
+      </div>,
+    )
+
+    const trigger = screen.getByRole('combobox', { name: '画风' })
+    fireEvent.click(trigger)
+    expect(screen.getByRole('listbox')).toBeTruthy()
+    fireEvent.keyDown(trigger, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).toBeNull()
+
+    fireEvent.click(trigger)
+    fireEvent.pointerDown(screen.getByRole('button', { name: '外部按钮' }))
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+})

--- a/frontend/src/shared/ui/product-select.tsx
+++ b/frontend/src/shared/ui/product-select.tsx
@@ -1,0 +1,159 @@
+import { CaretDown, Check } from '@phosphor-icons/react'
+import { useEffect, useRef, useState } from 'react'
+
+import { productMenuItemClass, productPopoverClass } from './product-control'
+
+export interface ProductSelectOption<Value extends string> {
+  value: Value
+  label: string
+}
+
+export interface ProductSelectProps<Value extends string> {
+  id: string
+  value: Value
+  options: readonly ProductSelectOption<Value>[]
+  onChange: (value: Value) => void
+  disabled?: boolean
+  'aria-label'?: string
+}
+
+/** 与产品浮层视觉一致、支持键盘操作的单选下拉框。 */
+export function ProductSelect<Value extends string>({
+  id,
+  value,
+  options,
+  onChange,
+  disabled = false,
+  'aria-label': ariaLabel,
+}: ProductSelectProps<Value>) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((option) => option.value === value),
+  )
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(selectedIndex)
+  const listboxId = `${id}-listbox`
+
+  useEffect(() => {
+    if (!open) return
+    function closeOnOutsidePointer(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    document.addEventListener('pointerdown', closeOnOutsidePointer)
+    return () => document.removeEventListener('pointerdown', closeOnOutsidePointer)
+  }, [open])
+
+  useEffect(() => {
+    if (disabled) setOpen(false)
+  }, [disabled])
+
+  function openMenu() {
+    setActiveIndex(selectedIndex)
+    setOpen(true)
+  }
+
+  function select(index: number) {
+    const option = options[index]
+    if (!option) return
+    onChange(option.value)
+    setOpen(false)
+    triggerRef.current?.focus()
+  }
+
+  function moveActive(step: number) {
+    setActiveIndex((current) => (current + step + options.length) % options.length)
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      if (!open) openMenu()
+      else moveActive(event.key === 'ArrowDown' ? 1 : -1)
+      return
+    }
+    if (event.key === 'Home' && open) {
+      event.preventDefault()
+      setActiveIndex(0)
+      return
+    }
+    if (event.key === 'End' && open) {
+      event.preventDefault()
+      setActiveIndex(options.length - 1)
+      return
+    }
+    if ((event.key === 'Enter' || event.key === ' ') && open) {
+      event.preventDefault()
+      select(activeIndex)
+      return
+    }
+    if (event.key === 'Escape' && open) {
+      event.preventDefault()
+      setOpen(false)
+      triggerRef.current?.focus()
+      return
+    }
+    if (event.key === 'Tab') setOpen(false)
+  }
+
+  const selected = options[selectedIndex]
+
+  return (
+    <div ref={rootRef} className="relative min-w-0">
+      <button
+        ref={triggerRef}
+        id={id}
+        type="button"
+        role="combobox"
+        aria-label={ariaLabel}
+        aria-controls={listboxId}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-activedescendant={open ? `${listboxId}-option-${activeIndex}` : undefined}
+        disabled={disabled}
+        onClick={() => (open ? setOpen(false) : openMenu())}
+        onKeyDown={handleKeyDown}
+        className="flex w-full items-center justify-between gap-3 rounded-xl border border-app-line bg-app-surface px-4 py-3 text-left text-sm outline-none transition-colors hover:border-app-line-strong focus-visible:border-app-accent disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <span className="min-w-0 flex-1 truncate">{selected?.label}</span>
+        <CaretDown
+          aria-hidden="true"
+          size={16}
+          className={`shrink-0 text-app-faint transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open ? (
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label={ariaLabel}
+          className={`${productPopoverClass} absolute inset-x-0 top-[calc(100%+0.4rem)] z-30 grid max-h-64 gap-1 overflow-y-auto p-1.5`}
+        >
+          {options.map((option, index) => {
+            const selectedOption = option.value === value
+            const active = index === activeIndex
+            return (
+              <button
+                id={`${listboxId}-option-${index}`}
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={selectedOption}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => select(index)}
+                className={`${productMenuItemClass} justify-between gap-3 text-left ${
+                  active ? 'bg-app-accent-muted text-app-accent' : 'text-app-ink-soft'
+                }`}
+              >
+                <span>{option.label}</span>
+                {selectedOption ? <Check aria-hidden="true" size={15} weight="bold" /> : null}
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- 用可访问的产品化下拉控件替换原生选择框
- 支持键盘操作、Escape 和点击外部关闭
- 增加自定义精灵尺寸模式，仅在选中后展示宽高输入

## Verification

- `npm test -- --run src/pages/project-create/index.test.tsx src/shared/ui/product-select.test.tsx`（17 passed）
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Refs #783