### PR TITLE
fix(account): 优化账号菜单和表单提示

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 
@@ -480,7 +480,32 @@ describe('AppHeader', () => {
 
     const accountMenu = await screen.findByRole('button', { name: '打开账号菜单' })
     expect(accountMenu.textContent).toContain('reader@example.com')
-    expect(accountMenu.textContent).toContain('r')
+    expect(within(accountMenu).getByTestId('default-account-avatar').getAttribute('src')).toBe(
+      '/windup-mark.svg',
+    )
+  })
+
+  it('账号菜单在点击外部、按 Escape 或指针移出账号区域时关闭', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    renderHeader('/workspace')
+
+    const trigger = await screen.findByRole('button', { name: '打开账号菜单' })
+    const menu = screen.getByTestId('account-menu')
+    const accountRegion = screen.getByLabelText('账号')
+
+    fireEvent.click(trigger)
+    fireEvent.pointerDown(document.body)
+    expect(menu.getAttribute('data-state')).toBe('closing')
+    fireEvent.animationEnd(menu)
+
+    fireEvent.click(trigger)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(menu.getAttribute('data-state')).toBe('closing')
+    fireEvent.animationEnd(menu)
+
+    fireEvent.click(trigger)
+    fireEvent.pointerLeave(accountRegion)
+    expect(menu.getAttribute('data-state')).toBe('closing')
   })
 
   it('让登录用户从 Header 的账号信息进入账号中心', async () => {

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 
 import { quotaApis as defaultQuotaApis } from '@/entities'
@@ -120,6 +120,9 @@ export function AppHeader({
   const navigate = useNavigate()
   const session = useAuthSession()
   const accountMenu = useProductPopoverMotion()
+  const closeAccountMenu = accountMenu.close
+  const accountMenuExpanded = accountMenu.expanded
+  const accountRegionRef = useRef<HTMLDivElement>(null)
   const [inviteHintVisible, setInviteHintVisible] = useState(false)
   const creditBalance = useQuotaBalance(
     accountMenu.mounted && session.state.status === 'authenticated',
@@ -161,6 +164,24 @@ export function AppHeader({
 
     return () => window.clearTimeout(timer)
   }, [pathname, session.state.status])
+
+  useEffect(() => {
+    if (!accountMenuExpanded) return
+
+    function closeOnOutsidePointer(event: PointerEvent) {
+      if (!accountRegionRef.current?.contains(event.target as Node)) closeAccountMenu()
+    }
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') closeAccountMenu()
+    }
+
+    document.addEventListener('pointerdown', closeOnOutsidePointer)
+    document.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsidePointer)
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [accountMenuExpanded, closeAccountMenu])
 
   function signOut() {
     window.sessionStorage.removeItem(inviteHintStorageKey)
@@ -327,7 +348,17 @@ export function AppHeader({
           })}
         </nav>
 
-        <div aria-label="账号" className="relative col-start-3 ml-auto shrink-0">
+        <div
+          ref={accountRegionRef}
+          aria-label="账号"
+          onPointerLeave={accountMenu.close}
+          onBlur={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+              accountMenu.close()
+            }
+          }}
+          className="relative col-start-3 ml-auto shrink-0"
+        >
           {session.state.status === 'booting' ? (
             <span
               aria-label="正在恢复登录状态"
@@ -394,7 +425,13 @@ export function AppHeader({
                     accountMenu.expanded ? 'scale-110' : 'scale-100'
                   }`}
                 >
-                  {(session.state.user.nickname || session.state.user.email).slice(0, 1)}
+                  <img
+                    data-testid="default-account-avatar"
+                    src="/windup-mark.svg"
+                    alt=""
+                    aria-hidden="true"
+                    className="h-5 w-5 object-contain"
+                  />
                 </span>
                 <span className="hidden truncate sm:inline">
                   {session.state.user.nickname || session.state.user.email}

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -132,13 +132,23 @@ describe('AccountPage', () => {
     fireEvent.click(badgeButton)
     expect(badgeButton.className).toContain('account-badge-shake')
     expect(screen.getByRole('navigation', { name: '账号设置' })).toBeTruthy()
+    expect(screen.getByRole('navigation', { name: '账号设置' }).parentElement?.className).toContain(
+      'md:sticky',
+    )
     expect(screen.getByRole('heading', { name: '个人资料' })).toBeTruthy()
+    expect(screen.getByLabelText('昵称').getAttribute('placeholder')).toBe('输入昵称')
+    expect(screen.getByTestId('account-profile-default-avatar').getAttribute('src')).toBe(
+      '/windup-mark.svg',
+    )
     expect(screen.queryByLabelText('邮箱验证码')).toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: '修改密码' }))
     expect(screen.getByRole('heading', { name: '修改密码' })).toBeTruthy()
     const code = screen.getByLabelText('邮箱验证码')
     const newPassword = screen.getByLabelText('新密码')
+    expect(code.getAttribute('placeholder')).toBe('6 位验证码')
+    expect(newPassword.getAttribute('placeholder')).toBe('8–128 位新密码')
+    expect(screen.getByLabelText('确认新密码').getAttribute('placeholder')).toBe('再次输入新密码')
     expect(code).toBeTruthy()
     expect(screen.getByText('reader@example.com')).toBeTruthy()
     expect(screen.queryByLabelText('当前密码')).toBeNull()

--- a/frontend/src/pages/account/index.tsx
+++ b/frontend/src/pages/account/index.tsx
@@ -641,7 +641,6 @@ export function AccountPage() {
 
   const hasPassword = currentUser.hasPassword
   const displayName = currentUser.nickname || currentUser.email.split('@')[0]
-  const initial = Array.from(displayName)[0]?.toUpperCase() ?? 'W'
   const cooldownSeconds = securityCooldownSeconds()
 
   return (
@@ -688,7 +687,7 @@ export function AccountPage() {
           data-account-layout="settings"
           className="grid gap-6 md:grid-cols-[14rem_minmax(0,1fr)] md:gap-[clamp(2rem,4vw,4.5rem)]"
         >
-          <aside className="flex flex-col">
+          <aside className="flex flex-col md:sticky md:top-24 md:self-start">
             <nav aria-label="账号设置" className="grid gap-1 border-t border-app-line pt-4">
               {(
                 [
@@ -734,8 +733,14 @@ export function AccountPage() {
                 </header>
 
                 <div className="mt-5 flex items-center gap-4 border-b border-app-line pb-5">
-                  <span className="grid size-14 shrink-0 place-items-center rounded-full bg-app-accent-soft font-serif text-2xl text-app-accent">
-                    {initial}
+                  <span className="grid size-14 shrink-0 place-items-center rounded-full bg-app-accent-soft">
+                    <img
+                      data-testid="account-profile-default-avatar"
+                      src="/windup-mark.svg"
+                      alt=""
+                      aria-hidden="true"
+                      className="size-9 object-contain"
+                    />
                   </span>
                   <div className="min-w-0">
                     <p className="truncate text-base font-semibold text-app-ink-soft">
@@ -758,6 +763,7 @@ export function AccountPage() {
                       type="text"
                       autoComplete="nickname"
                       value={profile.nickname}
+                      placeholder="输入昵称"
                       maxLength={MAX_NICKNAME_LENGTH + 1}
                       disabled={profile.isLoading || profile.isSaving}
                       onChange={(event) =>
@@ -869,6 +875,7 @@ export function AccountPage() {
                       inputMode="numeric"
                       autoComplete="one-time-code"
                       maxLength={6}
+                      placeholder="6 位验证码"
                       value={security.code}
                       disabled={security.isChanging || security.isSendingCode}
                       onChange={(event) =>
@@ -886,6 +893,7 @@ export function AccountPage() {
                       id={newPasswordId}
                       type="password"
                       autoComplete="new-password"
+                      placeholder={hasPassword ? '8–128 位新密码' : '8–128 位密码'}
                       value={security.newPassword}
                       disabled={security.isChanging || security.isSendingCode}
                       onChange={(event) =>
@@ -913,6 +921,7 @@ export function AccountPage() {
                       id={confirmPasswordId}
                       type="password"
                       autoComplete="new-password"
+                      placeholder={hasPassword ? '再次输入新密码' : '再次输入密码'}
                       value={security.confirmPassword}
                       disabled={security.isChanging || security.isSendingCode}
                       onChange={(event) =>


### PR DESCRIPTION
## Summary

- 账号菜单支持点击外部、Escape、失焦和指针离开关闭
- 账号侧栏在桌面端保持稳定定位
- 优化昵称、验证码和密码输入提示，并统一默认头像

## Verification

- `npm test -- --run src/app/layout/app-header.test.tsx src/pages/account/index.test.tsx`（55 passed）
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Refs #783