### PR TITLE
feat(invite): 增加邀请记录明细

### DIFF
--- a/backend/packages/app/src/windup_app/server/quota/interface.py
+++ b/backend/packages/app/src/windup_app/server/quota/interface.py
@@ -14,6 +14,7 @@ from windup_app.server.quota.model import (
     CreditTransactionView,
     InviteCode,
     InviteCodeView,
+    InviteRecordView,
 )
 
 
@@ -118,6 +119,16 @@ class QuotaService(ABC):
     @abstractmethod
     def generate_invite_code(self, session: Session, user_id: int) -> InviteCodeView:
         """签发新邀请码：插入新行，仍有效的旧码立即过期但保留。"""
+
+    @abstractmethod
+    def list_invite_records(
+        self,
+        session: Session,
+        user_id: int,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[InviteRecordView], int]:
+        """分页查询当前用户发出的邀请，返回脱敏明细和总数。"""
 
     @abstractmethod
     def require_active_invite(self, session: Session, code: str) -> InviteCode:

--- a/backend/packages/app/src/windup_app/server/quota/model.py
+++ b/backend/packages/app/src/windup_app/server/quota/model.py
@@ -258,3 +258,14 @@ class InviteCodeView:
     expires_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     create_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     update_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class InviteRecordView:
+    """邀请明细视图；被邀请人身份已脱敏。"""
+
+    id: int
+    invitee: str
+    code: str
+    rewarded: bool
+    create_at: datetime

--- a/backend/packages/app/src/windup_app/server/quota/service.py
+++ b/backend/packages/app/src/windup_app/server/quota/service.py
@@ -36,6 +36,7 @@ from windup_app.server.quota.model import (
     InviteCode,
     InviteCodeView,
     InviteRecord,
+    InviteRecordView,
 )
 from windup_app.server.user.model import User
 from windup_framework.config.quota import settings as quota_settings
@@ -134,6 +135,21 @@ def _to_txn_view(txn: CreditTransaction) -> CreditTransactionView:
         balance_after=txn.balance_after,
         create_at=txn.create_at,
     )
+
+
+def _mask_invitee(user: User | None) -> str:
+    """提供可辨认但不可还原的邀请对象标签。"""
+    if user is None:
+        return "已注销用户"
+    if user.nickname:
+        nickname = user.nickname.strip()
+        if nickname:
+            return f"{nickname[0]}{'*' * max(1, min(len(nickname) - 1, 3))}"
+
+    local, separator, domain = user.email.partition("@")
+    if not separator:
+        return f"{local[:1]}***"
+    return f"{local[:1]}***@{domain}"
 
 
 class SqlAlchemyQuotaService(QuotaService):
@@ -522,6 +538,57 @@ class SqlAlchemyQuotaService(QuotaService):
         session.flush()
         logger.info("[WINDUP] 生成邀请码 | user_id=%s code=%s", user_id, row.code)
         return _to_invite_view(row)
+
+    def list_invite_records(
+        self,
+        session: Session,
+        user_id: int,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[InviteRecordView], int]:
+        total = (
+            session.scalar(
+                select(func.count())
+                .select_from(InviteRecord)
+                .where(InviteRecord.inviter_id == user_id)
+            )
+            or 0
+        )
+        rows = session.execute(
+            select(InviteRecord, User)
+            .outerjoin(User, User.id == InviteRecord.invitee_id)
+            .where(InviteRecord.inviter_id == user_id)
+            .order_by(InviteRecord.create_at.desc(), InviteRecord.id.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        ).all()
+
+        reward_refs = {f"invite:{record.invitee_id}:inviter" for record, _user in rows}
+        rewarded_refs: set[str] = set()
+        if reward_refs:
+            rewarded_refs = set(
+                session.scalars(
+                    select(CreditTransaction.ref_id).where(
+                        CreditTransaction.user_id == user_id,
+                        CreditTransaction.reason == int(CreditReason.INVITE_REWARD),
+                        CreditTransaction.ref_id.in_(reward_refs),
+                    )
+                ).all()
+            )
+
+        return (
+            [
+                InviteRecordView(
+                    id=record.id,
+                    invitee=_mask_invitee(invitee),
+                    code=record.code,
+                    rewarded=f"invite:{record.invitee_id}:inviter" in rewarded_refs,
+                    create_at=record.create_at,
+                )
+                for record, invitee in rows
+            ],
+            total,
+        )
 
     def _allocate_invite_code(self, session: Session) -> str:
         for _ in range(16):

--- a/backend/packages/app/src/windup_app/web/api/quota.py
+++ b/backend/packages/app/src/windup_app/web/api/quota.py
@@ -6,6 +6,7 @@ GET  /quota/balance          查询积分余额
 GET  /quota/transactions     查询积分流水（分页）
 POST /quota/redeem            兑换一次性积分码
 GET  /quota/invite/code      获取我的邀请码
+GET  /quota/invite/records   查询邀请明细
 POST /quota/invite/generate  签发新邀请码
 """
 
@@ -72,6 +73,18 @@ class InviteCodeOut(BaseModel):
     expires_at: datetime
     create_at: datetime
     update_at: datetime
+
+
+class InviteRecordOut(BaseModel):
+    """当前用户发出的单条邀请；身份字段已脱敏。"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    invitee: str
+    code: str
+    rewarded: bool
+    create_at: datetime
 
 
 class RedeemCodeIn(BaseModel):
@@ -193,4 +206,26 @@ def generate_invite_code(
             update_at=view.update_at,
         ),
         message="邀请码已更新",
+    )
+
+
+@router.get("/invite/records", response_model=ListResponse[InviteRecordOut])
+def list_invite_records(
+    request: Request,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    session: Session = Depends(get_session),
+) -> ListResponse[InviteRecordOut]:
+    """分页查询当前登录用户发出的邀请。"""
+    records, total = service.list_invite_records(
+        session,
+        request.state.current_user.id,
+        page=page,
+        page_size=page_size,
+    )
+    return ListResponse.success(
+        [InviteRecordOut.model_validate(record) for record in records],
+        total=total,
+        page=page,
+        page_size=page_size,
     )

--- a/backend/tests/test_quota.py
+++ b/backend/tests/test_quota.py
@@ -856,6 +856,79 @@ class TestInviteCode:
         assert len(second) == 8
         assert auth_quota_client.get("/quota/invite/code").json()["data"]["code"] == second
 
+    def test_list_invite_records_is_private_paginated_and_reports_reward(
+        self, auth_quota_client, db_session, user_with_account
+    ):
+        from datetime import timedelta
+
+        from windup_app.server.quota.model import InviteRecord
+        from windup_app.server.user.model import User
+
+        older = User(email="older@example.com", password_hash="x", nickname="小明")
+        newer = User(email="newer@example.com", password_hash="x")
+        outsider = User(email="outsider@example.com", password_hash="x")
+        outsider_guest = User(email="hidden@example.com", password_hash="x")
+        db_session.add_all([older, newer, outsider, outsider_guest])
+        db_session.flush()
+
+        now = datetime.now(timezone.utc)
+        newer_record = InviteRecord(
+            inviter_id=user_with_account.id,
+            invitee_id=newer.id,
+            code="NEW2CODE",
+            create_at=now,
+        )
+        db_session.add_all(
+            [
+                InviteRecord(
+                    inviter_id=user_with_account.id,
+                    invitee_id=older.id,
+                    code="OLD2CODE",
+                    create_at=now - timedelta(days=1),
+                ),
+                newer_record,
+                InviteRecord(
+                    inviter_id=outsider.id,
+                    invitee_id=outsider_guest.id,
+                    code="HIDDEN22",
+                    create_at=now,
+                ),
+                CreditTransaction(
+                    user_id=user_with_account.id,
+                    delta=quota_settings.invite_reward_amount,
+                    reason=int(CreditReason.INVITE_REWARD),
+                    billing_mode=0,
+                    ref_id=f"invite:{newer.id}:inviter",
+                    balance_after=quota_settings.register_gift_amount
+                    + quota_settings.invite_reward_amount,
+                    create_at=now,
+                ),
+            ]
+        )
+        db_session.commit()
+
+        first_page = auth_quota_client.get(
+            "/quota/invite/records", params={"page": 1, "page_size": 1}
+        ).json()
+        second_page = auth_quota_client.get(
+            "/quota/invite/records", params={"page": 2, "page_size": 1}
+        ).json()
+
+        assert first_page["code"] == 200
+        assert first_page["total"] == 2
+        assert first_page["page"] == 1
+        assert first_page["page_size"] == 1
+        assert first_page["data"][0]["id"] == newer_record.id
+        assert first_page["data"][0]["invitee"] == "n***@example.com"
+        assert first_page["data"][0]["code"] == "NEW2CODE"
+        assert first_page["data"][0]["rewarded"] is True
+        assert first_page["data"][0]["create_at"].startswith(
+            now.replace(tzinfo=None).isoformat()
+        )
+        assert second_page["data"][0]["invitee"] == "小*"
+        assert second_page["data"][0]["rewarded"] is False
+        assert "hidden@example.com" not in str(first_page) + str(second_page)
+
     def test_generate_invite_code_locks_existing_row(
         self, db_session, quota_service, monkeypatch
     ):

--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -56,6 +56,7 @@ function createQuotaMock(): QuotaApis & {
   return {
     getBalance: vi.fn(async () => creditAccount),
     listTransactions: vi.fn(async () => ({ items: [], total: 0, page: 1, pageSize: 20 })),
+    listInviteRecords: vi.fn(async () => ({ items: [], total: 0, page: 1, pageSize: 20 })),
     redeemCode: vi.fn(async () => ({ credited: 1000, account: creditAccount })),
     getInviteCode: vi.fn(async () => ({
       code: 'AB23CD45',

--- a/frontend/src/entities/index.ts
+++ b/frontend/src/entities/index.ts
@@ -16,6 +16,7 @@ export type {
   CreditRedemptionResult,
   CreditTransaction,
   InviteCode,
+  InviteRecord,
   CreditTransactionDirection,
   QuotaApis,
   QuotaTransactionFilters,

--- a/frontend/src/entities/quota/api.test.ts
+++ b/frontend/src/entities/quota/api.test.ts
@@ -107,6 +107,43 @@ describe('createQuotaApis', () => {
     expect(request).toHaveBeenCalledWith('/quota/invite/code')
   })
 
+  it('分页读取并映射当前用户的邀请明细', async () => {
+    requestList.mockResolvedValue({
+      items: [
+        {
+          id: 31,
+          invitee: 'n***@example.com',
+          code: 'AB23CD45',
+          rewarded: true,
+          create_at: '2026-08-29T01:02:03Z',
+        },
+      ],
+      total: 7,
+      page: 2,
+      pageSize: 5,
+    })
+
+    await expect(
+      createQuotaApis({ client }).listInviteRecords({ page: 2, pageSize: 5 }),
+    ).resolves.toEqual({
+      items: [
+        {
+          id: '31',
+          invitee: 'n***@example.com',
+          code: 'AB23CD45',
+          rewarded: true,
+          createdAt: '2026-08-29T01:02:03Z',
+        },
+      ],
+      total: 7,
+      page: 2,
+      pageSize: 5,
+    })
+    expect(requestList).toHaveBeenCalledWith('/quota/invite/records', {
+      query: { page: 2, page_size: 5 },
+    })
+  })
+
   it('轮换邀请码并映射新的有效期', async () => {
     request.mockResolvedValueOnce({
       code: 'XY89KL23',
@@ -179,7 +216,7 @@ describe('createQuotaApis', () => {
     const fetchFn = vi.fn<typeof fetch>(async (input) => {
       const url = String(input)
       let body: unknown
-      if (url.includes('/quota/transactions')) {
+      if (url.includes('/quota/transactions') || url.includes('/quota/invite/records')) {
         body = {
           code: 200,
           message: 'ok',
@@ -220,6 +257,10 @@ describe('createQuotaApis', () => {
         total: 0,
       })
       await expect(quotaApis.getInviteCode()).resolves.toMatchObject({ code: 'AB23CD45' })
+      await expect(quotaApis.listInviteRecords({ page: 1, pageSize: 5 })).resolves.toMatchObject({
+        items: [],
+        total: 0,
+      })
       await expect(quotaApis.generateInviteCode()).resolves.toMatchObject({ code: 'AB23CD45' })
       expect(fetchFn).toHaveBeenCalledWith(
         'https://api.windup.test/quota/balance',
@@ -233,7 +274,10 @@ describe('createQuotaApis', () => {
         'https://api.windup.test/quota/transactions?page=1&page_size=20',
       )
       expect(fetchFn.mock.calls[2]?.[0]).toBe('https://api.windup.test/quota/invite/code')
-      expect(fetchFn.mock.calls[3]?.[0]).toBe('https://api.windup.test/quota/invite/generate')
+      expect(fetchFn.mock.calls[3]?.[0]).toBe(
+        'https://api.windup.test/quota/invite/records?page=1&page_size=5',
+      )
+      expect(fetchFn.mock.calls[4]?.[0]).toBe('https://api.windup.test/quota/invite/generate')
     } finally {
       unregister()
       vi.unstubAllGlobals()

--- a/frontend/src/entities/quota/api.ts
+++ b/frontend/src/entities/quota/api.ts
@@ -2,9 +2,11 @@ import type {
   CreditAccount,
   CreditTransaction,
   InviteCode,
+  InviteRecord,
   QuotaApis,
   QuotaTransactionPageQuery,
 } from './types'
+import type { PageQuery } from '@/shared/pagination'
 
 import { createApiClient, getApiAccessToken } from '@/shared/api'
 import type { ApiClient, ApiClientOptions } from '@/shared/api'
@@ -37,6 +39,14 @@ interface InviteCodeDto {
   expires_at: string
   create_at: string
   update_at: string
+}
+
+interface InviteRecordDto {
+  id: number
+  invitee: string
+  code: string
+  rewarded: boolean
+  create_at: string
 }
 
 interface CreditRedemptionResultDto {
@@ -84,6 +94,16 @@ function toInviteCode(dto: InviteCodeDto): InviteCode {
   }
 }
 
+function toInviteRecord(dto: InviteRecordDto): InviteRecord {
+  return {
+    id: String(dto.id),
+    invitee: dto.invitee,
+    code: dto.code,
+    rewarded: dto.rewarded,
+    createdAt: dto.create_at,
+  }
+}
+
 export function createQuotaApis(options: CreateQuotaApisOptions = {}): QuotaApis {
   const { client, ...clientOptions } = options
   const protectedClient =
@@ -125,6 +145,12 @@ export function createQuotaApis(options: CreateQuotaApisOptions = {}): QuotaApis
     async getInviteCode() {
       return toInviteCode(await protectedClient.request<InviteCodeDto>('/quota/invite/code'))
     },
+    async listInviteRecords(query: PageQuery = {}) {
+      const result = await protectedClient.requestList<InviteRecordDto>('/quota/invite/records', {
+        query: { page: query.page, page_size: query.pageSize },
+      })
+      return { ...result, items: result.items.map(toInviteRecord) }
+    },
     async generateInviteCode() {
       return toInviteCode(
         await protectedClient.request<InviteCodeDto>('/quota/invite/generate', { method: 'POST' }),
@@ -146,5 +172,6 @@ export const quotaApis: QuotaApis = {
   listTransactions: (query) => getDefaultApis().listTransactions(query),
   redeemCode: (code) => getDefaultApis().redeemCode(code),
   getInviteCode: () => getDefaultApis().getInviteCode(),
+  listInviteRecords: (query) => getDefaultApis().listInviteRecords(query),
   generateInviteCode: () => getDefaultApis().generateInviteCode(),
 }

--- a/frontend/src/entities/quota/index.ts
+++ b/frontend/src/entities/quota/index.ts
@@ -5,6 +5,7 @@ export type {
   CreditRedemptionResult,
   CreditTransaction,
   InviteCode,
+  InviteRecord,
   CreditTransactionDirection,
   QuotaApis,
   QuotaTransactionFilters,

--- a/frontend/src/entities/quota/types.ts
+++ b/frontend/src/entities/quota/types.ts
@@ -46,6 +46,15 @@ export interface InviteCode {
   updatedAt: string
 }
 
+/** 当前用户发出的单次邀请；invitee 是后端生成的脱敏身份。 */
+export interface InviteRecord {
+  id: string
+  invitee: string
+  code: string
+  rewarded: boolean
+  createdAt: string
+}
+
 /** 兑换码入账结果；account 是本次事务提交后的最新账户快照。 */
 export interface CreditRedemptionResult {
   credited: number
@@ -57,5 +66,6 @@ export interface QuotaApis {
   listTransactions(query?: QuotaTransactionPageQuery): Promise<Paged<CreditTransaction>>
   redeemCode(code: string): Promise<CreditRedemptionResult>
   getInviteCode(): Promise<InviteCode>
+  listInviteRecords(query?: PageQuery): Promise<Paged<InviteRecord>>
   generateInviteCode(): Promise<InviteCode>
 }

--- a/frontend/src/features/quota/index.test.ts
+++ b/frontend/src/features/quota/index.test.ts
@@ -45,6 +45,7 @@ function createQuotaApis(): QuotaApis & {
       page,
       pageSize,
     })),
+    listInviteRecords: vi.fn(async () => ({ items: [], total: 0, page: 1, pageSize: 20 })),
     redeemCode: vi.fn(async () => ({ credited: 1000, account })),
     getInviteCode: vi.fn(async () => ({
       code: 'AB23CD45',

--- a/frontend/src/pages/account/index.test.tsx
+++ b/frontend/src/pages/account/index.test.tsx
@@ -325,6 +325,12 @@ describe('AccountPage', () => {
       createdAt: '2026-08-12T01:02:03Z',
       updatedAt: '2026-08-17T01:02:03Z',
     })
+    vi.spyOn(quotaApis, 'listInviteRecords').mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 5,
+    })
 
     renderAccount()
     fireEvent.click(await screen.findByRole('button', { name: '邀请奖励' }))
@@ -350,6 +356,12 @@ describe('AccountPage', () => {
       expiresAt: '2026-09-16T01:02:03Z',
       createdAt: '2026-08-12T01:02:03Z',
       updatedAt: '2026-08-17T01:02:03Z',
+    })
+    vi.spyOn(quotaApis, 'listInviteRecords').mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 5,
     })
 
     renderAccount(createApis(), '/account?section=invite')

--- a/frontend/src/pages/invite/index.test.tsx
+++ b/frontend/src/pages/invite/index.test.tsx
@@ -20,6 +20,20 @@ function createApis(): QuotaApis & Record<keyof QuotaApis, ReturnType<typeof vi.
   return {
     getBalance: vi.fn(async () => account),
     listTransactions: vi.fn(async () => ({ items: [], total: 0, page: 1, pageSize: 20 })),
+    listInviteRecords: vi.fn(async () => ({
+      items: [
+        {
+          id: '31',
+          invitee: 'n***@example.com',
+          code: 'AB23CD45',
+          rewarded: true,
+          createdAt: '2026-08-29T01:02:03Z',
+        },
+      ],
+      total: 6,
+      page: 1,
+      pageSize: 5,
+    })),
     redeemCode: vi.fn(async () => ({ credited: 1000, account })),
     getInviteCode: vi.fn(async () => ({
       code: 'AB23CD45',
@@ -77,12 +91,41 @@ describe('InviteSection', () => {
     renderInvite()
 
     expect(await screen.findByText('AB23CD45')).toBeTruthy()
-    expect(screen.getByText('2')).toBeTruthy()
+    expect(screen.getByText('当前码注册').parentElement?.textContent).toContain('2')
     expect(screen.getByText('100')).toBeTruthy()
     expect(screen.getByText('当前码注册')).toBeTruthy()
     expect(screen.getByText(/邀请成功，双方各得 200 积分/)).toBeTruthy()
     expect(screen.getByText(/每日前 3 次邀请可得奖励/)).toBeTruthy()
     expect(screen.getByText('有效至 2026年9月16日')).toBeTruthy()
+  })
+
+  it('展示累计邀请和可分页的邀请明细', async () => {
+    const { apis } = renderInvite()
+
+    expect(await screen.findByText('n***@example.com')).toBeTruthy()
+    expect(screen.getByText('已获得奖励')).toBeTruthy()
+    expect(screen.getByText('累计邀请')).toBeTruthy()
+    expect(screen.getByText('6')).toBeTruthy()
+    expect(screen.getByText(/2026年8月29日/)).toBeTruthy()
+    expect(apis.listInviteRecords).toHaveBeenCalledWith({ page: 1, pageSize: 5 })
+
+    fireEvent.click(screen.getByRole('button', { name: '第 2 页' }))
+    await waitFor(() =>
+      expect(apis.listInviteRecords).toHaveBeenLastCalledWith({ page: 2, pageSize: 5 }),
+    )
+  })
+
+  it('邀请明细加载失败后允许单独重试', async () => {
+    const apis = createApis()
+    apis.listInviteRecords
+      .mockRejectedValueOnce(new Error('邀请记录暂时不可用'))
+      .mockResolvedValueOnce({ items: [], total: 0, page: 1, pageSize: 5 })
+    renderInvite(apis)
+
+    expect((await screen.findByRole('alert')).textContent).toContain('邀请记录暂时不可用')
+    fireEvent.click(screen.getByRole('button', { name: '重新加载邀请记录' }))
+    await waitFor(() => expect(apis.listInviteRecords).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('还没有邀请记录')).toBeTruthy()
   })
 
   it('邀请码有效期异常时使用安全提示', async () => {

--- a/frontend/src/pages/invite/index.tsx
+++ b/frontend/src/pages/invite/index.tsx
@@ -3,8 +3,11 @@ import { Copy } from '@phosphor-icons/react'
 
 import inviteCharacterArtwork from '@/assets/account/illustrations/invite-character.webp'
 import { quotaApis as defaultQuotaApis } from '@/entities'
-import type { InviteCode, QuotaApis } from '@/entities'
+import type { InviteCode, InviteRecord, QuotaApis } from '@/entities'
 import { useQuotaBalance } from '@/features/quota'
+import { Pagination } from '@/shared/ui'
+
+const INVITE_RECORD_PAGE_SIZE = 5
 
 function errorMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : '操作失败，请稍后重试'
@@ -30,6 +33,17 @@ function invitationUrl(code: string): string {
   return `${window.location.origin}/?${query}`
 }
 
+function formatInviteDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '时间未知'
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(date)
+}
+
 export function InviteSection({ apis = defaultQuotaApis }: { apis?: QuotaApis }) {
   const balance = useQuotaBalance(true, apis)
   const [invite, setInvite] = useState<InviteCode | null>(null)
@@ -38,6 +52,12 @@ export function InviteSection({ apis = defaultQuotaApis }: { apis?: QuotaApis })
   const [inviteRequestVersion, setInviteRequestVersion] = useState(0)
   const [notice, setNotice] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
+  const [records, setRecords] = useState<InviteRecord[]>([])
+  const [recordsTotal, setRecordsTotal] = useState<number | null>(null)
+  const [recordsPage, setRecordsPage] = useState(1)
+  const [recordsLoading, setRecordsLoading] = useState(true)
+  const [recordsError, setRecordsError] = useState<string | null>(null)
+  const [recordsRequestVersion, setRecordsRequestVersion] = useState(0)
 
   useEffect(() => {
     let active = true
@@ -60,6 +80,28 @@ export function InviteSection({ apis = defaultQuotaApis }: { apis?: QuotaApis })
       active = false
     }
   }, [apis, inviteRequestVersion])
+
+  useEffect(() => {
+    let active = true
+    setRecordsLoading(true)
+    setRecordsError(null)
+    void apis.listInviteRecords({ page: recordsPage, pageSize: INVITE_RECORD_PAGE_SIZE }).then(
+      (result) => {
+        if (!active) return
+        setRecords(result.items)
+        setRecordsTotal(result.total)
+        setRecordsLoading(false)
+      },
+      (error: unknown) => {
+        if (!active) return
+        setRecordsError(errorMessage(error))
+        setRecordsLoading(false)
+      },
+    )
+    return () => {
+      active = false
+    }
+  }, [apis, recordsPage, recordsRequestVersion])
 
   const shareLink = useMemo(() => (invite ? invitationUrl(invite.code) : ''), [invite])
 
@@ -85,6 +127,12 @@ export function InviteSection({ apis = defaultQuotaApis }: { apis?: QuotaApis })
         </div>
 
         <dl className="flex items-center gap-5 text-right">
+          <div>
+            <dt className="text-xs text-app-faint">累计邀请</dt>
+            <dd className="mt-1 font-mono text-2xl font-semibold text-app-ink">
+              {recordsTotal ?? '—'}
+            </dd>
+          </div>
           <div>
             <dt className="text-xs text-app-faint">当前码注册</dt>
             <dd className="mt-1 font-mono text-2xl font-semibold text-app-ink">
@@ -179,6 +227,84 @@ export function InviteSection({ apis = defaultQuotaApis }: { apis?: QuotaApis })
             style={{ imageRendering: 'pixelated' }}
           />
         </div>
+      </section>
+
+      <section
+        className="mt-8 border-t border-app-line pt-6"
+        aria-labelledby="invite-records-title"
+      >
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h3 id="invite-records-title" className="text-base font-semibold text-app-ink-soft">
+              邀请记录
+            </h3>
+            <p className="mt-1 text-sm text-app-muted">仅展示脱敏身份和你的奖励到账状态。</p>
+          </div>
+          {recordsTotal !== null && (
+            <span className="text-xs tabular-nums text-app-faint">共 {recordsTotal} 条</span>
+          )}
+        </div>
+
+        <div className="mt-4 min-h-24">
+          {recordsLoading ? (
+            <p role="status" className="py-6 text-sm text-app-muted">
+              正在加载邀请记录…
+            </p>
+          ) : recordsError ? (
+            <div className="flex flex-wrap items-center gap-3 py-4">
+              <p role="alert" className="text-sm text-app-danger">
+                {recordsError}
+              </p>
+              <button
+                type="button"
+                onClick={() => setRecordsRequestVersion((version) => version + 1)}
+                className="min-h-9 rounded-lg border border-app-line bg-app-surface-raised px-3 text-sm font-semibold text-app-ink-soft hover:border-app-accent/30"
+              >
+                重新加载邀请记录
+              </button>
+            </div>
+          ) : records.length === 0 ? (
+            <p className="rounded-xl border border-dashed border-app-line px-4 py-7 text-center text-sm text-app-muted">
+              还没有邀请记录
+            </p>
+          ) : (
+            <ul className="divide-y divide-app-line rounded-xl border border-app-line">
+              {records.map((record) => (
+                <li
+                  key={record.id}
+                  className="flex flex-wrap items-center justify-between gap-3 px-4 py-3.5"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-app-ink-soft">
+                      {record.invitee}
+                    </p>
+                    <p className="mt-1 text-xs text-app-faint">
+                      {formatInviteDate(record.createdAt)} · 邀请码 {record.code}
+                    </p>
+                  </div>
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-xs font-medium ${
+                      record.rewarded
+                        ? 'bg-app-accent-soft text-app-accent'
+                        : 'bg-app-surface-muted text-app-muted'
+                    }`}
+                  >
+                    {record.rewarded ? '已获得奖励' : '未获得奖励'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <Pagination
+          page={recordsPage}
+          pageSize={INVITE_RECORD_PAGE_SIZE}
+          total={recordsTotal ?? 0}
+          disabled={recordsLoading}
+          showPageNumbers
+          onPageChange={setRecordsPage}
+        />
       </section>
 
       <div className="mt-4 min-h-6" aria-live="polite">

--- a/openapi.json
+++ b/openapi.json
@@ -2091,6 +2091,41 @@
         "title": "InviteCodeOut",
         "type": "object"
       },
+      "InviteRecordOut": {
+        "description": "当前用户发出的单条邀请；身份字段已脱敏。",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "create_at": {
+            "format": "date-time",
+            "title": "Create At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "invitee": {
+            "title": "Invitee",
+            "type": "string"
+          },
+          "rewarded": {
+            "title": "Rewarded",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "invitee",
+          "code",
+          "rewarded",
+          "create_at"
+        ],
+        "title": "InviteRecordOut",
+        "type": "object"
+      },
       "ListResponse_ActionPresetOut_": {
         "properties": {
           "code": {
@@ -2325,6 +2360,65 @@
           }
         },
         "title": "ListResponse[CreditTransactionOut]",
+        "type": "object"
+      },
+      "ListResponse_InviteRecordOut_": {
+        "properties": {
+          "code": {
+            "default": 200,
+            "description": "业务状态码:成功 200,失败非 200",
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "description": "业务数据列表",
+            "items": {
+              "$ref": "#/components/schemas/InviteRecordOut"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "message": {
+            "default": "success",
+            "description": "提示信息",
+            "title": "Message",
+            "type": "string"
+          },
+          "page": {
+            "default": 1,
+            "description": "当前页码,从 1 开始",
+            "minimum": 1.0,
+            "title": "Page",
+            "type": "integer"
+          },
+          "page_size": {
+            "default": 0,
+            "description": "每页条数;0 表示不分页(全量)",
+            "minimum": 0.0,
+            "title": "Page Size",
+            "type": "integer"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "响应时间;默认不携带,不携带时省略",
+            "title": "Timestamp"
+          },
+          "total": {
+            "default": 0,
+            "description": "数据总数;分页时为查询条件总数,不分页时为 len(data)",
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "title": "ListResponse[InviteRecordOut]",
         "type": "object"
       },
       "ListResponse_ProjectListOut_": {
@@ -6084,6 +6178,63 @@
           }
         },
         "summary": "Generate Invite Code",
+        "tags": [
+          "quota"
+        ]
+      }
+    },
+    "/quota/invite/records": {
+      "get": {
+        "description": "分页查询当前登录用户发出的邀请。",
+        "operationId": "list_invite_records_quota_invite_records_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_InviteRecordOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Invite Records",
         "tags": [
           "quota"
         ]


### PR DESCRIPTION
## Summary

- 增加当前用户邀请记录分页接口
- 被邀请人身份脱敏，并根据邀请奖励流水返回到账状态
- 账号邀请页展示累计邀请、明细列表、空态、错误重试和分页
- 同步 OpenAPI 契约

## Verification

- 积分与 Schema 后端测试（72 passed）
- 邀请、账号及 API 前端测试（38 passed）
- 前端全量测试（1370 passed）
- Ruff、Import-linter、TypeScript、lint、生产构建通过
- OpenAPI 导出幂等

## Known baseline

后端全量本地测试为 2076 passed、14 skipped；另有 1 项现有 AI chat 测试因 OpenAI SDK 缺失 realtime 类型模块失败，与本 PR 改动路径无关。

Refs #783