### PR TITLE
fix(worker): rigged_motions 也要过 MQ，否则三渲二只出得了走路

### DIFF
--- a/backend/packages/app/src/windup_app/worker/handlers.py
+++ b/backend/packages/app/src/windup_app/worker/handlers.py
@@ -110,6 +110,10 @@ def _action_input(payload: dict) -> CharacterActionInput:
         video_model=payload.get("video_model"),
         outfit_id=payload.get("outfit_id"),
         model_3d_url=payload.get("model_3d_url"),
+        # 漏了它的后果:执行器读到空表,退回 {walk: 主产物},于是**除了走路以外的
+        # 每一个动作都出不来** —— 报错说"这个造型只烘了 walk",而库里明明三个都在,
+        # 界面上三个也都显示已就绪。落库的入参与执行时的入参必须逐字段对上。
+        rigged_motions=dict(payload.get("rigged_motions") or {}),
         stance=CharacterStance(payload["stance"]) if payload.get("stance") else None,
         direction=ActionDirection(payload.get("direction") or ActionDirection.EAST.value),
     )

--- a/backend/tests/test_mq_worker.py
+++ b/backend/tests/test_mq_worker.py
@@ -1589,3 +1589,44 @@ def test_consumer_trims_heap_after_image_not_email(engine, worker_session, monke
         "payload": {"task_id": 1, "task_type": "character_image"},
     })})
     assert trimmed == [1]
+
+
+def test_handle_generation_keeps_rigged_motions_through_the_queue(db_session, engine, monkeypatch):
+    """已烘动作表必须原样送到执行器。
+
+    丢了它的后果不是报错,是**除走路以外每个动作都出不来**:执行器读到空表会退回
+    ``{walk: 主产物}``,然后以"这个造型只烘了 walk"为由拒掉 idle / jump ——
+    而库里三个都在、界面上三个也都显示已就绪,报错与事实直接矛盾。
+    """
+    _patch_worker_session_local(monkeypatch, engine)
+    seed_credit_account(db_session, 1)
+    db_session.commit()
+
+    motions = {
+        "walk": "https://cdn.test/walk.fbx",
+        "idle": "https://cdn.test/idle.fbx",
+        "jump": "https://cdn.test/jump.fbx",
+    }
+    service = AiGenerationService()
+    task = service.generate_character_action(
+        db_session,
+        user_id=1,
+        input=CharacterActionInput(
+            character_id=1,
+            action_type=ActionType.IDLE,
+            num_frames=8,
+            outfit_id="outfit-default",
+            model_3d_url="https://cdn.test/walk.fbx",
+            rigged_motions=motions,
+        ),
+    )
+    db_session.commit()
+
+    run_action = MagicMock()
+    handle_generation(
+        {"task_id": task.id, "task_type": GenerationType.CHARACTER_ACTION.value},
+        run_image_task=MagicMock(),
+        run_action_task=run_action,
+    )
+    run_action.assert_called_once()
+    assert run_action.call_args.args[1].rigged_motions == motions


### PR DESCRIPTION
Closes #916

## 问题

造型三个动作全部烘好（`rigged_motions` 里确实是三个，界面上也都显示已就绪），提交 idle 任务却失败：

    ValueError: 该造型的 3D 资产烘了 ['walk'],出不了 'idle'

报错与事实直接矛盾。实测 user 43 的 task 876 / 877 两次都是这个错。

## 根因

`worker/handlers.py` 的 `_action_input()` 从 payload 重建入参时漏了 `rigged_motions`。执行器拿到空表后走兜底 `baked = {BUILD_MOTION: model_url}`，而 `BUILD_MOTION` 是 `walk`——于是**除走路以外的每个动作都被拒**。

这是 #853（一个造型可以烘多个动作）留下的缺口：那个 PR 贯通了「请求 → 落库」，没贯通「MQ → 执行器」，等于把自己要解决的问题悄悄抵消了。

## 验证

后端 ruff / import-linter / **2077 passed**。

新增一条用例，打的是「过一遍队列之后这张表还在不在」。撤掉修复它会红——也就是今天线上的行为。