### PR TITLE
fix(client-bake): 渲第一帧之前先把贴图传上 GPU，并加一道亮度闸

### DIFF
--- a/frontend/src/features/client-bake/attach.test.ts
+++ b/frontend/src/features/client-bake/attach.test.ts
@@ -13,6 +13,7 @@ vi.mock('./stage', async () => {
         setCamYaw: () => undefined,
         setup: (_clip: string, i: number) => i * 0.1,
         coverage: () => 0.01,
+        subjectLuma: () => 148,
         rigInfo: () => ({
           loader: 'gltf',
           rootBone: 'Hips',

--- a/frontend/src/features/client-bake/index.test.ts
+++ b/frontend/src/features/client-bake/index.test.ts
@@ -6,6 +6,7 @@ import { bakeJob, stubRender3DApis } from '@/test/render3d-apis'
 const stage = vi.hoisted(() => ({
   clips: { walk: 1.0667 } as Record<string, number>,
   coverage: 0.01,
+  luma: 148,
   setups: [] as Array<[string, number, number]>,
   yaw: null as number | null,
   disposed: 0,
@@ -36,6 +37,7 @@ vi.mock('./stage', async () => {
             return i * 0.1
           },
           coverage: () => stage.coverage,
+          subjectLuma: () => stage.luma,
           rigInfo: () => ({
             loader: 'gltf',
             rootBone: 'Hips',
@@ -68,6 +70,7 @@ const { runClientBake, BakeAborted } = await import('.')
 beforeEach(() => {
   stage.clips = { walk: 1.0667 }
   stage.coverage = 0.01
+  stage.luma = 148
   stage.setups = []
   stage.yaw = null
   stage.disposed = 0
@@ -113,6 +116,27 @@ describe('浏览器出帧驱动', () => {
       [0.1, 0],
     ])
     expect(stage.disposed).toBe(1)
+  })
+
+  it('主体是纯黑时当场失败 —— 覆盖率那道闸拦不住它', async () => {
+    // 贴图还没传上 GPU 就渲的话,模型是个纯黑剪影,而它的 alpha 占比与正常帧
+    // **一模一样**(线上实测 0.101 对 0.101)—— 只数 alpha 的闸放它过去。
+    stage.luma = 0
+    const uploaded: number[] = []
+    let failed = ''
+    const apis = stubRender3DApis({
+      putBakeFrame: async (_t, index) => {
+        uploaded.push(index)
+        return 1
+      },
+      completeBake: async () => expect.unreachable('纯黑帧却报了交齐'),
+      failBake: async (_t, reason) => {
+        failed = reason
+      },
+    })
+    await expect(runClientBake({ job: bakeJob(), apis })).rejects.toThrow('纯黑')
+    expect(uploaded).toEqual([])
+    expect(failed).toContain('纯黑')
   })
 
   it('覆盖率不足当场失败,并且不把那一帧传上去', async () => {

--- a/frontend/src/features/client-bake/index.ts
+++ b/frontend/src/features/client-bake/index.ts
@@ -41,6 +41,9 @@ export class BakeAborted extends Error {
  * 任何一步失败都要**主动告诉后端**,否则这笔冻结的积分要等满期限才解冻,用户在界面上
  * 看到的是一个一直转的进度条。只有"取消"不上报 —— 那是用户自己的动作。
  */
+/** 主体平均亮度下限。纯黑剪影量到 0.0,正常帧量到约 148 —— 取 20 只拦「全黑」。 */
+const MIN_SUBJECT_LUMA = 20
+
 export async function runClientBake(options: RunClientBakeOptions): Promise<void> {
   const { job, apis, onProgress, signal } = options
   const throwIfAborted = () => {
@@ -73,6 +76,14 @@ export async function runClientBake(options: RunClientBakeOptions): Promise<void
         // 角色出画或片段选错都会安静地产出全透明帧,而外面照样以为成功了。
         throw new StageError(
           `第 ${i} 帧几乎全透明(覆盖率 ${coverage.toFixed(5)} < ${job.minCoverage})`,
+        )
+      }
+      // 纯黑主体逃得过覆盖率那道闸(它只数 alpha),所以在这里再判一次亮度。
+      // 触发点几乎只有一个:贴图还没传上 GPU 就渲了 —— 交付出去才看得见。
+      const luma = stage.subjectLuma()
+      if (luma >= 0 && luma < MIN_SUBJECT_LUMA) {
+        throw new StageError(
+          `第 ${i} 帧主体是纯黑(平均亮度 ${luma.toFixed(1)} < ${MIN_SUBJECT_LUMA})，贴图可能还没就绪`,
         )
       }
       await apis.putBakeFrame(job.taskId, i, await stage.grab())

--- a/frontend/src/features/client-bake/stage.ts
+++ b/frontend/src/features/client-bake/stage.ts
@@ -162,6 +162,32 @@ export class BakeStage {
     if (this.rootBone) for (const clip of animations) this.flattenRootXZ(clip, this.rootBone)
     this.unionBox = this.computeUnionBox()
     this.placeCam()
+    await this.warmUp()
+  }
+
+  /**
+   * 编译着色器并把贴图传上 GPU,**在渲第一帧之前**。
+   *
+   * 不做的后果是第 0 帧渲出一个没上贴图的**纯黑剪影** —— 而它逃得过所有闸:
+   * ``coverage()`` 只数 alpha,黑剪影的不透明像素占比与正常帧一模一样(实测
+   * 0.101 对 0.101);``grab()`` 拿到的是一张体积正常的 PNG。交付出去才看得见。
+   *
+   * ``loadAsync`` 在模型解析完就 resolve,内嵌贴图的解码是另一条异步路,没人等它。
+   */
+  private async warmUp(): Promise<void> {
+    const compileAsync = (
+      this.renderer as unknown as {
+        compileAsync?: (s: THREE.Scene, c: THREE.Camera) => Promise<unknown>
+      }
+    ).compileAsync
+    if (typeof compileAsync === 'function') {
+      await compileAsync.call(this.renderer, this.scene, this.cam)
+      return
+    }
+    // 老版本没有 compileAsync:退回同步 compile + 一次渲染。挡不住"贴图还在解码"
+    // 那一档,但比什么都不做强,而且不会让整条链路失败。
+    this.renderer.compile(this.scene, this.cam)
+    this.renderer.render(this.scene, this.cam)
   }
 
   /** 总高缩到 1.0、脚底落在 y=0 —— 1.0 与 root_motion 的单位一致。 */
@@ -447,6 +473,34 @@ export class BakeStage {
     let n = 0
     for (let i = 3; i < data.length; i += 4) if (data[i] > 8) n++
     return n / (w * h)
+  }
+
+  /**
+   * 主体的平均亮度。**贴图没传上 GPU 时模型渲成纯黑**,而那样的帧覆盖率与正常帧
+   * 一模一样(实测 0.101 对 0.101)—— 只数 alpha 的闸放它过去,交付出去才看得见。
+   *
+   * 返回 0–255;主体为空时返回 -1,交给覆盖率那道去判。
+   */
+  subjectLuma(): number {
+    this.renderer.render(this.scene, this.cam)
+    const src = this.renderer.domElement
+    const w = 128
+    const h = Math.max(1, Math.round((src.height / src.width) * w))
+    if (!this.probe) this.probe = document.createElement('canvas')
+    this.probe.width = w
+    this.probe.height = h
+    const ctx = this.probe.getContext('2d', { willReadFrequently: true })!
+    ctx.clearRect(0, 0, w, h)
+    ctx.drawImage(src, 0, 0, w, h)
+    const data = ctx.getImageData(0, 0, w, h).data
+    let sum = 0
+    let n = 0
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i + 3] <= 8) continue
+      sum += 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2]
+      n++
+    }
+    return n ? sum / n : -1
   }
 
   /** 取这一帧的 PNG。**从 WebGL 缓冲取,不截页面** —— 见文件头第 1 条。 */


### PR DESCRIPTION
Closes #918

## 问题

生产任务 878（待机，12 帧）交付产物里第 0 帧是纯黑剪影：

    f00  不透明占比 0.101  主体平均亮度   0.0   ← 纯黑
    f01  不透明占比 0.101  主体平均亮度 148.0
    …

**两道自检都放它过去**：`coverage()` 只数 alpha，黑剪影的不透明占比与正常帧一模一样（0.101 对 0.101）；`grab()` 只判空 blob，黑帧是张体积正常的 PNG。

## 根因

`load()` 在渲第一帧之前没有任何 warm-up。`FBXLoader.loadAsync()` 在模型解析完就 resolve，而内嵌贴图的解码与上传 GPU 是另一条异步路，没人等它。

## 修法

1. `load()` 末尾 `warmUp()`：优先 `compileAsync(scene, camera)`（着色器 + 贴图一起备好），无该方法时退回同步 `compile()` + 一次渲染。
2. 出帧循环加**亮度闸**：主体平均亮度 < 20 判纯黑，当场失败、不交帧。

第 2 道不是冗余——只看 alpha 的闸对「材质丢失」「着色器编译失败」这一整类都是瞎的，必须有一道看颜色的。

## 一条口径更正

此前排查另一批产物时，我把首帧全黑归因为「探针每帧渲一次、生产渲三次所以不会有」。生产这次证伪了：三次渲染都在同一个 tick 内，贴图仍可能没解码完。

## 验证

前端 format / lint / typecheck / **1371 passed** / build 全过。新增一条用例，变异测试红（去掉亮度闸即失败）。