### PR TITLE
fix(prompt): idle 只说一次呼吸，并把两条硬判据正面写进去

### DIFF
--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/__init__.py
@@ -16,7 +16,7 @@ from .walk import build_walk_prompt
 # 改动本包任何一个 build_*_prompt 的输出(包括 prompts/*.md 模板)都必须连带把这个
 # 常量加一:落库的 GeneratedAction.prompt_version 就靠它,分不清新旧模板的产出，
 # 改完提示词也没法与改前的成色对比。
-PROMPT_VERSION = "v2"
+PROMPT_VERSION = "v3"
 
 __all__ = [
     "build_walk_prompt",

--- a/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/idle.md
+++ b/backend/packages/ai_engine/src/windup_ai_engine/prompt/prompts/idle.md
@@ -1,21 +1,38 @@
 # 待机 i2v 提示词(循环类)
 
+判据取自 gold 标注(17 条,排除缺陷母版)验出来的两条,都是**性质**不是幅度:
+脚底线位移 ≈ 0(脚离地就不是站着)、无推镜(scale drift ≈ 0)。
+
+三条写法上的硬约束,都由 `prompt/lint.py` 当场拦:
+
+- **不写否定式**。这条通路没有 negative_prompt,模型不处理否定极性、只把名词当成
+  要画的东西 —— 写「不要走路」等于点名要走路。要什么就正面写什么。
+- **不写解剖学动词**。上一版把同一次呼吸说了三遍(chest breathes / ribcage
+  expanding / torso rising),而 `ribcage expanding` 是写实人体的说法,卡通角色
+  照做就是胸口一鼓一鼓;重复三次又放大了一轮。
+- **不写低于分辨率的幅度**(slightly / a little)。交付尺寸下 0.5% 的躯干起伏不到
+  一个像素,要求模型做一件看不见的事,它会拿推镜或错动作来顶。给看得见的幅度。
+
 ## side
 
 ```text
-The character stands in place, seen from the side facing right: the chest breathes in one slow,
-even rhythm, the ribcage expanding and easing back while the shoulders stay level and settled at the same height,
-the torso rising and lowering in that same slow rhythm, anything held in the hands resting steady at the side in the same grip,
-whatever the character already wears hanging and swaying in the same rhythm, both feet planted firmly on the ground,
-weight centered, the character stays in the same spot and keeps facing right.
+The character holds a settled standing idle in place, seen from the side facing right.
+The upper body eases down and lifts back up in one slow even rhythm, arms and worn cloth
+hanging loose and drifting along with it, anything held in the hands kept in the same grip.
+Both feet stay flat and planted on the ground for every frame, the stance and the gap
+between the feet held constant, the body weight centered between them. The whole figure
+stays at the same spot in frame and at the same size. The camera holds one fixed position,
+angle, distance and projection for every frame.
 ```
 
 ## front
 
 ```text
-The character stands in place facing the viewer: the chest breathes in one slow, even rhythm,
-the ribcage expanding and easing back while the shoulders stay level and settled at the same height,
-the torso rising and lowering in that same slow rhythm, anything held in the hands resting steady at the side in the same grip,
-whatever the character already wears hanging and swaying in the same rhythm, both feet planted firmly on the ground,
-weight centered, the character keeps FACING THE VIEWER and stays in the same spot.
+The character holds a settled standing idle in place, facing the viewer. The upper body
+eases down and lifts back up in one slow even rhythm, arms and worn cloth hanging loose and
+drifting along with it, anything held in the hands kept in the same grip. Both feet stay
+flat and planted on the ground for every frame, the stance and the gap between the feet
+held constant, the body weight centered between them. The character keeps FACING THE VIEWER,
+stays at the same spot in frame and at the same size. The camera holds one fixed position,
+angle, distance and projection for every frame.
 ```


### PR DESCRIPTION
Closes #920

旧版把同一次呼吸说了三遍（chest breathes / ribcage expanding / torso rising），重复被模型放大，做出来是胸口一鼓一鼓；`ribcage expanding` 还是写实人体的说法，卡通角色照做与美术风格冲突。

更根本的是**管错了东西**：gold 标注（17 条，排除缺陷母版）验出来 idle 的硬判据只有两条，都是性质不是幅度——脚底线位移 ≈ 0、无推镜。旧版花三句写幅度，一句没写这两条。

重写后：呼吸只说一次且说整体不说器官；两条硬判据正面写进去；全程不用否定式（这条通路没有 negative_prompt，写「不要走路」等于点名要走路），不用低于分辨率的幅度词。`PROMPT_VERSION` v2 → v3，否则新旧产物没法对比。

## 顺带

第一版重写被仓库自己的 `prompt/lint.py` 拦下三条，三条都对（否定式 / `slightly` / 装备词）。第三条 `axe` 是误报——`relaxed` 里含这个子串，检测按子串不按词边界。已另记。

后端 ruff / import-linter / **2076 passed**。