### PR TITLE
fix(playtest): 长动作提示词不再撑变控制栏

### DIFF
--- a/frontend/src/pages/playtest/workbench/index.tsx
+++ b/frontend/src/pages/playtest/workbench/index.tsx
@@ -477,9 +477,12 @@ function PlaytestExperience({
                 )
               })}
             </div>
-            <div className="hidden min-w-[116px] px-3 sm:block">
+            <div className="hidden w-56 min-w-0 px-3 sm:block lg:w-80">
               <p className="text-[10px] text-app-faint">当前动作</p>
-              <p className="mt-0.5 truncate text-xs font-semibold">
+              <p
+                className="mt-0.5 truncate text-xs font-semibold"
+                title={runtime.action?.name ?? '无'}
+              >
                 {runtime.action?.name ?? '无'}
               </p>
             </div>

--- a/frontend/src/pages/playtest/workbench/minimal-workbench.test.tsx
+++ b/frontend/src/pages/playtest/workbench/minimal-workbench.test.tsx
@@ -133,6 +133,34 @@ describe('PlaytestWorkbench minimal control path', () => {
     expect(screen.getByRole('button', { name: '绑定动作：行走' })).toBeTruthy()
   })
 
+  it('keeps a long current action name inside a bounded control slot', () => {
+    const longActionName =
+      '32帧原地呼吸循环：东向站立，胸腔与肩部缓慢起伏，重心轻微上下移动，保持单角色与脚底线稳定。'
+    const characterWithLongActionName: Character = {
+      ...character,
+      outfits: character.outfits.map((outfit) => ({
+        ...outfit,
+        actions: outfit.actions.map((action) =>
+          action.id === IDLE_ACTION_ID ? { ...action, name: longActionName } : action,
+        ),
+      })),
+    }
+
+    render(
+      <PlaytestWorkbench
+        character={characterWithLongActionName}
+        outfitId={OUTFIT_ID}
+        movementMode="single"
+        initialActionId={IDLE_ACTION_ID}
+      />,
+    )
+
+    const currentActionSlot = screen.getByText('当前动作').parentElement
+    expect(currentActionSlot?.className).toContain('w-56')
+    expect(currentActionSlot?.className).toContain('min-w-0')
+    expect(currentActionSlot?.querySelector(`[title="${longActionName}"]`)).toBeTruthy()
+  })
+
   it('uses the same bound character actions for keyboard movement', () => {
     renderWorkbench()
 


### PR DESCRIPTION
## Summary

- constrain the Playtest current-action slot to a stable responsive width
- truncate prompt-like action names without stretching the control dock
- preserve the full action name on hover and add regression coverage

## Testing

- `npm test` (89 files, 1377 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build`