### PR TITLE
fix(workflow-controller): 还没写描述也能先把参考图存下来

### DIFF
--- a/frontend/src/features/workflow-controller/controller.test.ts
+++ b/frontend/src/features/workflow-controller/controller.test.ts
@@ -696,6 +696,25 @@ describe('WorkflowController', () => {
     })
   })
 
+  it('还没写描述也能先把参考图存下来', async () => {
+    // 用户常常先传图再想文案。在这里拒空的话,上传成功了却因为描述为空而回写失败,
+    // 图就丢了 —— 而界面上参考图那栏标的是「选填」。真正必填的是提交生成那一刻,
+    // 那道闸在生成按钮上。
+    const { controller } = createController()
+
+    await controller.updateCharacterSetup('setup-1', {
+      prompt: '',
+      referenceMedia: ['https://img/my-own-character.png' as never],
+    })
+
+    expect(controller.getWorkflow().nodes[0]).toMatchObject({
+      input: {
+        prompt: '',
+        referenceMedia: ['https://img/my-own-character.png'],
+      },
+    })
+  })
+
   it('接受上传母版时完成角色设定和母版节点', async () => {
     const { controller } = createController()
 

--- a/frontend/src/features/workflow-controller/controller.ts
+++ b/frontend/src/features/workflow-controller/controller.ts
@@ -882,7 +882,11 @@ export function createWorkflowController({
     input: Pick<WorkflowCharacterInput, 'prompt' | 'referenceMedia'>,
   ) {
     ensureRunning()
-    const prompt = nonEmpty(input.prompt, 'prompt')
+    // 描述**允许为空**。这个方法既保存描述也保存参考图,而用户常常先传图再想文案 ——
+    // 在这里拒空等于「上传成功了,但因为你还没写描述,图丢了」,而界面上参考图那栏
+    // 标的是「选填」。真正必填的是**提交生成**那一刻,那道闸在生成按钮上(prompt 为空
+    // 时按钮置灰),不需要这里再拦一次。
+    const prompt = input.prompt ?? ''
     return persist((run) =>
       updateNode(run, nodeId, (node) => {
         if (node.type !== 'character-setup') throw new Error('目标节点不是角色设定')


### PR DESCRIPTION
Closes #907

`updateCharacterSetup` 既保存描述也保存参考图，却在入口 `nonEmpty(input.prompt, 'prompt')` 拒空描述。用户先传图再想文案时，上传成功了、回写却被拒——**图就丢了**，而界面上参考图那栏标的是「选填」，报错说的是「prompt 不能为空」，两个词也对不上。

实测：新建项目传了角色正面图，`referenceMedia` 落库为 `[]`，于是 #909 加的「用我上传的图当母版」那个候选压根不出现。

真正必填的是**提交生成**那一刻，那道闸在生成按钮上（prompt 为空时按钮置灰），这里不需要再拦一次。

前端 format / lint / typecheck / **1382 passed** / build 全过。新增一条用例，变异测试红（退回拒空即失败）。