### PR TITLE
fix(client-bake): 第一帧判黑后先重试，别把能自愈的状况变成整单报废

### DIFF
--- a/frontend/src/features/client-bake/index.test.ts
+++ b/frontend/src/features/client-bake/index.test.ts
@@ -7,6 +7,7 @@ const stage = vi.hoisted(() => ({
   clips: { walk: 1.0667 } as Record<string, number>,
   coverage: 0.01,
   luma: 148,
+  lumaFn: null as null | (() => number),
   setups: [] as Array<[string, number, number]>,
   yaw: null as number | null,
   disposed: 0,
@@ -37,7 +38,7 @@ vi.mock('./stage', async () => {
             return i * 0.1
           },
           coverage: () => stage.coverage,
-          subjectLuma: () => stage.luma,
+          subjectLuma: () => (stage.lumaFn ? stage.lumaFn() : stage.luma),
           rigInfo: () => ({
             loader: 'gltf',
             rootBone: 'Hips',
@@ -71,6 +72,7 @@ beforeEach(() => {
   stage.clips = { walk: 1.0667 }
   stage.coverage = 0.01
   stage.luma = 148
+  stage.lumaFn = null
   stage.setups = []
   stage.yaw = null
   stage.disposed = 0
@@ -118,9 +120,25 @@ describe('浏览器出帧驱动', () => {
     expect(stage.disposed).toBe(1)
   })
 
-  it('主体是纯黑时当场失败 —— 覆盖率那道闸拦不住它', async () => {
-    // 贴图还没传上 GPU 就渲的话,模型是个纯黑剪影,而它的 alpha 占比与正常帧
-    // **一模一样**(线上实测 0.101 对 0.101)—— 只数 alpha 的闸放它过去。
+  it('第一帧是黑的先等一下再看,好了就继续 —— 那是贴图还在解码,几百毫秒能自愈', async () => {
+    // compileAsync 只保证着色器编译与已解码贴图的上传,不等图片本身解码,
+    // 实测线上仍会在第 0 帧撞上。直接失败等于把一个能自愈的状况变成整单报废。
+    let calls = 0
+    stage.lumaFn = () => (++calls <= 2 ? 0 : 148)
+    const waits: number[] = []
+    const apis = stubRender3DApis({})
+    await runClientBake({
+      job: bakeJob(),
+      apis,
+      sleep: async (ms) => {
+        waits.push(ms)
+      },
+    })
+    expect(waits.length).toBeGreaterThan(0) // 确实等过
+    expect(calls).toBeGreaterThan(2) // 重试之后才拿到正常亮度
+  })
+
+  it('等满了还是黑才失败,并且不把那一帧传上去', async () => {
     stage.luma = 0
     const uploaded: number[] = []
     let failed = ''
@@ -134,7 +152,9 @@ describe('浏览器出帧驱动', () => {
         failed = reason
       },
     })
-    await expect(runClientBake({ job: bakeJob(), apis })).rejects.toThrow('纯黑')
+    await expect(runClientBake({ job: bakeJob(), apis, sleep: async () => {} })).rejects.toThrow(
+      '纯黑',
+    )
     expect(uploaded).toEqual([])
     expect(failed).toContain('纯黑')
   })

--- a/frontend/src/features/client-bake/index.ts
+++ b/frontend/src/features/client-bake/index.ts
@@ -25,6 +25,8 @@ export interface RunClientBakeOptions {
   apis: Render3DApis
   onProgress?: (progress: BakeProgress) => void
   signal?: AbortSignal
+  /** 判黑后的等待。测试注入,免得真等几秒。 */
+  sleep?: (ms: number) => Promise<void>
 }
 
 /** 出帧中途被放弃(用户离开页面 / 上层取消)。不当失败上报,任务留给期限兜底。 */
@@ -44,8 +46,13 @@ export class BakeAborted extends Error {
 /** 主体平均亮度下限。纯黑剪影量到 0.0,正常帧量到约 148 —— 取 20 只拦「全黑」。 */
 const MIN_SUBJECT_LUMA = 20
 
+/** 判黑后重试几次、每次等多久。贴图解码是几百毫秒的事,给到 3 秒是十倍余量。 */
+const BLACK_FRAME_RETRIES = 10
+const BLACK_FRAME_WAIT_MS = 300
+
 export async function runClientBake(options: RunClientBakeOptions): Promise<void> {
   const { job, apis, onProgress, signal } = options
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
   const throwIfAborted = () => {
     if (signal?.aborted) throw new BakeAborted()
   }
@@ -79,11 +86,20 @@ export async function runClientBake(options: RunClientBakeOptions): Promise<void
         )
       }
       // 纯黑主体逃得过覆盖率那道闸(它只数 alpha),所以在这里再判一次亮度。
-      // 触发点几乎只有一个:贴图还没传上 GPU 就渲了 —— 交付出去才看得见。
-      const luma = stage.subjectLuma()
+      // 触发点几乎只有一个:贴图还没解码完就渲了。
+      //
+      // **判黑之后先重试,不直接失败。** compileAsync 只保证着色器编译与已解码贴图
+      // 的上传,不等图片本身解码 —— 实测线上仍会在第 0 帧撞上。而这是个纯等待问题:
+      // 再渲一次就好了。直接失败等于把一个几百毫秒能自愈的状况变成整单报废。
+      let luma = stage.subjectLuma()
+      for (let k = 0; luma >= 0 && luma < MIN_SUBJECT_LUMA && k < BLACK_FRAME_RETRIES; k++) {
+        await sleep(BLACK_FRAME_WAIT_MS)
+        luma = stage.subjectLuma()
+      }
       if (luma >= 0 && luma < MIN_SUBJECT_LUMA) {
         throw new StageError(
-          `第 ${i} 帧主体是纯黑(平均亮度 ${luma.toFixed(1)} < ${MIN_SUBJECT_LUMA})，贴图可能还没就绪`,
+          `第 ${i} 帧主体是纯黑(平均亮度 ${luma.toFixed(1)} < ${MIN_SUBJECT_LUMA})，` +
+            `等了 ${(BLACK_FRAME_RETRIES * BLACK_FRAME_WAIT_MS) / 1000} 秒仍未就绪`,
         )
       }
       await apis.putBakeFrame(job.taskId, i, await stage.grab())


### PR DESCRIPTION
Closes #924

## 问题

#918 加的亮度闸开始拦真实任务。线上连续 4 单失败（886 / 888 / 890 / 891）：

    浏览器出帧失败:第 0 帧主体是纯黑(平均亮度 0.0 < 20)

闸拦对了，但用户从「悄悄拿到一张黑帧」变成「整单做不出来」——代价太大。

## 根因

#918 的 `compileAsync` 预热保证的是**着色器编译**与**已解码贴图的上传**，不等图片本身 decode。`FBXLoader.loadAsync()` resolve 之后内嵌贴图仍在异步解码，所以第 0 帧照样黑。

## 为什么用重试

这是个纯等待问题：再渲一次就好了。要精确等到贴图就绪，得逐个 texture 去 await decode，而 three 的贴图来源有 ImageBitmap / HTMLImageElement / CanvasTexture 好几种，覆盖不全仍会漏。

判黑后重渲对**所有**成因都有效（贴图未解码、着色器未编译、材质异步替换），不需要预测时序。

判黑后每 300ms 重渲、最多 10 次；3 秒没好才失败。`compileAsync` 保留——它仍消掉一部分情况。

## 验证

前端 format / lint / typecheck / **1382 passed** / build 全过。

两个变异方向都红：不重试直接失败（现在线上的行为）、永远不判黑（加闸之前的行为）。

## 口径更正

#918 里我说「渲第一帧前先 compileAsync 就能解决」，被线上证伪。当时只在自己的探针里验过——探针能过是因为它的贴图更小、解码更快，我没有在真实 BakeStage 里验。