### PR TITLE
fix(header): 账号菜单不再在指针移出头像时关闭

### DIFF
--- a/frontend/src/app/layout/app-header.test.tsx
+++ b/frontend/src/app/layout/app-header.test.tsx
@@ -486,13 +486,12 @@ describe('AppHeader', () => {
     )
   })
 
-  it('账号菜单在点击外部、按 Escape 或指针移出账号区域时关闭', async () => {
+  it('账号菜单在点击外部或按 Escape 时关闭', async () => {
     window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
     renderHeader('/workspace')
 
     const trigger = await screen.findByRole('button', { name: '打开账号菜单' })
     const menu = screen.getByTestId('account-menu')
-    const accountRegion = screen.getByLabelText('账号')
 
     fireEvent.click(trigger)
     fireEvent.pointerDown(document.body)
@@ -502,11 +501,22 @@ describe('AppHeader', () => {
     fireEvent.click(trigger)
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(menu.getAttribute('data-state')).toBe('closing')
-    fireEvent.animationEnd(menu)
+  })
+
+  it('指针移出头像所在区域时账号菜单保持打开，否则鼠标够不到菜单项', async () => {
+    window.localStorage.setItem('windup.auth.refresh-token', 'stored-refresh-token')
+    renderHeader('/workspace')
+
+    const trigger = await screen.findByRole('button', { name: '打开账号菜单' })
+    const menu = screen.getByTestId('account-menu')
+    const accountRegion = screen.getByLabelText('账号')
 
     fireEvent.click(trigger)
+    expect(menu.getAttribute('data-state')).toBe('open')
+
     fireEvent.pointerLeave(accountRegion)
-    expect(menu.getAttribute('data-state')).toBe('closing')
+    expect(menu.getAttribute('data-state')).toBe('open')
+    expect(screen.getByRole('link', { name: '打开账号中心' })).toBeTruthy()
   })
 
   it('让登录用户从 Header 的账号信息进入账号中心', async () => {

--- a/frontend/src/app/layout/app-header.tsx
+++ b/frontend/src/app/layout/app-header.tsx
@@ -348,10 +348,15 @@ export function AppHeader({
           })}
         </nav>
 
+        {/*
+          不挂 pointerleave 关闭：菜单是点击打开的，而它右对齐、比头像宽，
+          与头像之间还隔着 0.5rem。鼠标从头像走向菜单的任何一条路径都会先离开本区域，
+          于是菜单在指针到达之前就关掉，鼠标用户永远点不到里面的项。
+          关闭交给区域外 pointerdown、Escape 和焦点移出。
+        */}
         <div
           ref={accountRegionRef}
           aria-label="账号"
-          onPointerLeave={accountMenu.close}
           onBlur={(event) => {
             if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
               accountMenu.close()


### PR DESCRIPTION
## Summary

移除账号区域的 `onPointerLeave={accountMenu.close}`。菜单是点击打开的，却按 hover 菜单的方式关闭；而菜单绝对定位在区域外（8px 垂直空隙 + 向左探出约 66px），鼠标从头像走向菜单必然先离开区域，菜单在指针到达前就关掉，「账号中心」「修改密码」「退出登录」三项鼠标点不到。

关闭仍由区域外 `pointerdown`、`Escape`、焦点移出、点击菜单项四条路径覆盖。

原测试断言「指针移出即关闭」，改为断言「指针移出后保持打开」，并在用例名里写清为什么。

## Verification

真实构建产物 + 真实鼠标轨迹（Chromium 1440×900，从头像中心分 20 步移到「账号中心」）：

    未修复：点开=open → 移到菜单项上=closed → 点击无效，仍停在 /workspace
    本 PR ：点开=open → 移到菜单项上=open   → 点击进入 /account

新增的回归用例在未修复代码上失败（`expected 'closing' to be 'open'`），在本 PR 上通过。

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage`（89 files / 1387 tests passed）
- `npm run build`

Closes #932
